### PR TITLE
dialects: Add `smt.exists` and `smt.forall` operations

### DIFF
--- a/tests/dialects/test_smt.py
+++ b/tests/dialects/test_smt.py
@@ -3,6 +3,7 @@ import pytest
 from xdsl.dialects.builtin import IntegerAttr
 from xdsl.dialects.smt import (
     AndOp,
+    Block,
     BoolType,
     ConstantBoolOp,
     DistinctOp,
@@ -11,6 +12,7 @@ from xdsl.dialects.smt import (
     ForallOp,
     OrOp,
     QuantifierOp,
+    Region,
     VariadicBoolOp,
     XOrOp,
     YieldOp,
@@ -41,6 +43,7 @@ def test_variadic_bool_op(op_type: type[VariadicBoolOp]):
 @pytest.mark.parametrize("op_type", [ExistsOp, ForallOp])
 def test_quantifier_op(op_type: type[QuantifierOp]):
     arg1 = create_ssa_value(BoolType())
-    op = op_type()
-    op.body.block.add_op(YieldOp(arg1))
+    region = Region([Block()])
+    region.block.add_op(YieldOp(arg1))
+    op = op_type(body=region)
     assert op.returned_value == arg1

--- a/tests/dialects/test_smt.py
+++ b/tests/dialects/test_smt.py
@@ -7,9 +7,13 @@ from xdsl.dialects.smt import (
     ConstantBoolOp,
     DistinctOp,
     EqOp,
+    ExistsOp,
+    ForallOp,
     OrOp,
+    QuantifierOp,
     VariadicBoolOp,
     XOrOp,
+    YieldOp,
 )
 from xdsl.utils.test_value import create_ssa_value
 
@@ -32,3 +36,11 @@ def test_variadic_bool_op(op_type: type[VariadicBoolOp]):
     op = op_type(arg1, arg2, arg3)
     assert op.result.type == BoolType()
     assert list(op.inputs) == [arg1, arg2, arg3]
+
+
+@pytest.mark.parametrize("op_type", [ExistsOp, ForallOp])
+def test_quantifier_op(op_type: type[QuantifierOp]):
+    arg1 = create_ssa_value(BoolType())
+    op = op_type()
+    op.body.block.add_op(YieldOp(arg1))
+    assert op.returned_value == arg1

--- a/tests/dialects/test_smt.py
+++ b/tests/dialects/test_smt.py
@@ -3,7 +3,6 @@ import pytest
 from xdsl.dialects.builtin import IntegerAttr
 from xdsl.dialects.smt import (
     AndOp,
-    Block,
     BoolType,
     ConstantBoolOp,
     DistinctOp,
@@ -12,11 +11,11 @@ from xdsl.dialects.smt import (
     ForallOp,
     OrOp,
     QuantifierOp,
-    Region,
     VariadicBoolOp,
     XOrOp,
     YieldOp,
 )
+from xdsl.ir import Block, Region
 from xdsl.utils.test_value import create_ssa_value
 
 

--- a/tests/filecheck/dialects/smt/invalid.mlir
+++ b/tests/filecheck/dialects/smt/invalid.mlir
@@ -42,3 +42,37 @@
 // CHECK: operand at position 0 does not verify:
 // CHECK-NEXT: incorrect length for range variable:
 // CHECK-NEXT: expected integer >= 2, got 1
+
+// -----
+
+%forall = smt.forall {^bb0:}
+// CHECK: Operation smt.forall contains empty block in single-block
+// CHECK-SAME: region that expects at least a terminator
+
+// -----
+
+%arg1 = smt.constant true
+%arg2 = smt.constant false
+%forall = smt.forall {
+    smt.yield %arg1, %arg2 : !smt.bool, !smt.bool
+}
+// CHECK: region yield terminator must have a single boolean operand,
+// CHECK-SAME: got ('!smt.bool', '!smt.bool')
+
+// -----
+
+%arg1 = smt.constant true
+
+%exists = smt.exists {^bb0:}
+// CHECK: Operation smt.exists contains empty block in single-block
+// CHECK-SAME: region that expects at least a terminator
+
+// -----
+
+%arg1 = smt.constant true
+%arg2 = smt.constant false
+%exists = smt.exists {
+    smt.yield %arg1, %arg2 : !smt.bool, !smt.bool
+}
+// CHECK: region yield terminator must have a single boolean operand,
+// CHECK-SAME: got ('!smt.bool', '!smt.bool')

--- a/tests/filecheck/dialects/smt/ops.mlir
+++ b/tests/filecheck/dialects/smt/ops.mlir
@@ -11,6 +11,13 @@
 %eq = smt.eq %arg1, %arg2, %arg3 : !smt.bool
 %distinct = smt.distinct %arg1, %arg2, %arg3 : !smt.bool
 
+%exists = smt.exists {
+    smt.yield %arg1 : !smt.bool
+}
+%forall = smt.forall {
+    smt.yield %arg1 : !smt.bool
+}
+
 // CHECK:         %arg1 = smt.constant true
 // CHECK-NEXT:    %arg2 = smt.constant false
 // CHECK-NEXT:    %arg3 = smt.constant false
@@ -19,3 +26,9 @@
 // CHECK-NEXT:    %xor = smt.xor %arg1, %arg2, %arg3
 // CHECK-NEXT:    %eq = smt.eq %arg1, %arg2, %arg3 : !smt.bool
 // CHECK-NEXT:    %distinct = smt.distinct %arg1, %arg2, %arg3 : !smt.bool
+// CHECK-NEXT:    %exists = smt.exists {
+// CHECK-NEXT:      smt.yield %arg1 : !smt.bool
+// CHECK-NEXT:    }
+// CHECK-NEXT:    %forall = smt.forall {
+// CHECK-NEXT:      smt.yield %arg1 : !smt.bool
+// CHECK-NEXT:    }

--- a/xdsl/dialects/smt.py
+++ b/xdsl/dialects/smt.py
@@ -9,7 +9,6 @@ from typing_extensions import Self
 from xdsl.dialects.builtin import BoolAttr
 from xdsl.ir import (
     Attribute,
-    Block,
     Dialect,
     ParametrizedAttribute,
     Region,
@@ -230,15 +229,15 @@ class EqOp(VariadicPredicateOp):
 
 
 class QuantifierOp(IRDLOperation, ABC):
-    result = result_def(BoolType())
+    result = result_def(BoolType)
     body = region_def("single_block")
 
     traits = traits_def(Pure())
 
     assembly_format = "attr-dict-with-keyword $body"
 
-    def __init__(self) -> None:
-        super().__init__(result_types=[BoolType()], regions=[Region([Block()])])
+    def __init__(self, body: Region) -> None:
+        super().__init__(result_types=[BoolType()], regions=[body])
 
     def verify_(self) -> None:
         if not isinstance(yield_op := self.body.block.last_op, YieldOp):

--- a/xdsl/dialects/smt.py
+++ b/xdsl/dialects/smt.py
@@ -7,7 +7,15 @@ from typing import ClassVar, TypeAlias
 from typing_extensions import Self
 
 from xdsl.dialects.builtin import BoolAttr
-from xdsl.ir import Attribute, Dialect, ParametrizedAttribute, SSAValue, TypeAttribute
+from xdsl.ir import (
+    Attribute,
+    Block,
+    Dialect,
+    ParametrizedAttribute,
+    Region,
+    SSAValue,
+    TypeAttribute,
+)
 from xdsl.irdl import (
     AtLeast,
     IRDLOperation,
@@ -17,13 +25,16 @@ from xdsl.irdl import (
     irdl_attr_definition,
     irdl_op_definition,
     prop_def,
+    region_def,
     result_def,
     traits_def,
     var_operand_def,
 )
 from xdsl.parser import Parser
 from xdsl.printer import Printer
-from xdsl.traits import ConstantLike, Pure
+from xdsl.traits import ConstantLike, HasParent, IsTerminator, Pure
+from xdsl.utils.exceptions import VerifyException
+from xdsl.utils.hints import isa
 
 
 @irdl_attr_definition
@@ -218,6 +229,73 @@ class EqOp(VariadicPredicateOp):
     name = "smt.eq"
 
 
+class QuantifierOp(IRDLOperation, ABC):
+    result = result_def(BoolType())
+    body = region_def("single_block")
+
+    traits = traits_def(Pure())
+
+    assembly_format = "attr-dict-with-keyword $body"
+
+    def __init__(self) -> None:
+        super().__init__(result_types=[BoolType()], regions=[Region([Block()])])
+
+    def verify_(self) -> None:
+        if not isinstance(yield_op := self.body.block.last_op, YieldOp):
+            raise VerifyException("region expects an `smt.yield` terminator")
+        if tuple(yield_op.operand_types) != (BoolType(),):
+            raise VerifyException(
+                "region yield terminator must have a single boolean operand, "
+                f"got {tuple(str(type) for type in yield_op.operand_types)}"
+            )
+
+    @property
+    def returned_value(self) -> SSAValue[BoolType]:
+        """
+        The value returned by the quantifier. This is the value that is passed
+        to the `smt.yield` terminator of the operation region.
+        This function will asserts if the region is not correctly terminated by
+        an `smt.yield` operation with a single boolean operand.
+        """
+        assert isinstance(yield_op := self.body.block.last_op, YieldOp)
+        assert isa(ret_value := yield_op.values[0], SSAValue[BoolType])
+        return ret_value
+
+
+@irdl_op_definition
+class ExistsOp(QuantifierOp):
+    """
+    This operation represents the `exists` quantifier as described in the SMT-LIB 2.7
+    standard. It is part of the language itself rather than a theory or logic.
+    """
+
+    name = "smt.exists"
+
+
+@irdl_op_definition
+class ForallOp(QuantifierOp):
+    """
+    This operation represents the `forall` quantifier as described in the SMT-LIB 2.7
+    standard. It is part of the language itself rather than a theory or logic.
+    """
+
+    name = "smt.forall"
+
+
+@irdl_op_definition
+class YieldOp(IRDLOperation):
+    name = "smt.yield"
+
+    values = var_operand_def(NonFuncSMTType)
+
+    assembly_format = "($values^ `:` type($values))? attr-dict"
+
+    traits = traits_def(IsTerminator(), HasParent(ExistsOp, ForallOp))
+
+    def __init__(self, *values: SSAValue):
+        super().__init__(operands=[values], result_types=[])
+
+
 SMT = Dialect(
     "smt",
     [
@@ -227,6 +305,9 @@ SMT = Dialect(
         XOrOp,
         DistinctOp,
         EqOp,
+        ExistsOp,
+        ForallOp,
+        YieldOp,
     ],
     [BoolType],
 )


### PR DESCRIPTION
This adds the two quantifier operations to the `smt` dialect