### PR TITLE
core: Support optional attrs in assembly format

### DIFF
--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -527,6 +527,37 @@ def test_optional_property(program: str, generic_program: str):
     "program, generic_program",
     [
         (
+            "test.optional_property",
+            '"test.optional_property"() : () -> ()',
+        ),
+        (
+            "test.optional_property i32",
+            '"test.optional_property"() <{prop = i32}> : () -> ()',
+        ),
+    ],
+)
+def test_optional_qualified_property(program: str, generic_program: str):
+    """Test the parsing of optional operands"""
+
+    @irdl_op_definition
+    class OptionalPropertyOp(IRDLOperation):
+        name = "test.optional_property"
+        prop = opt_prop_def(Attribute)
+
+        assembly_format = "($prop^)? attr-dict"
+
+    ctx = Context()
+    ctx.load_op(OptionalPropertyOp)
+    ctx.load_dialect(Test)
+
+    check_roundtrip(program, ctx)
+    check_equivalence(program, generic_program, ctx)
+
+
+@pytest.mark.parametrize(
+    "program, generic_program",
+    [
+        (
             "test.optional_property()",
             '"test.optional_property"() : () -> ()',
         ),

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -1145,6 +1145,20 @@ class OptionalAttributeVariable(AttributeVariable):
     The directive will request a space to be printed after.
     """
 
+    def parse(self, parser: Parser, state: ParsingState) -> bool:
+        # Only qualified optional attributes can be optionally parsed currently.
+        # Other attributes are parsed as required attributes.
+        if self.unique_base is None:
+            attr = parser.parse_optional_attribute()
+            if attr is None:
+                return False
+            if self.is_property:
+                state.properties[self.name] = attr
+            else:
+                state.attributes[self.name] = attr
+            return True
+        return super().parse(parser, state)
+
     def is_present(self, op: IRDLOperation) -> bool:
         if self.is_property:
             attr = op.properties.get(self.name)
@@ -1154,6 +1168,9 @@ class OptionalAttributeVariable(AttributeVariable):
 
     def is_anchorable(self) -> bool:
         return True
+
+    def is_optional_like(self) -> bool:
+        return self.unique_base is None
 
 
 class OptionalUnitAttrVariable(OptionalAttributeVariable):


### PR DESCRIPTION
This adds support for anchoring operation attributes and properties in the declarative assembly format. This allows writing `($optAttr^)?` in `assembly_format`.

For now, only qualified attributes are supported.

