### PR TITLE
backend: (x86) vector.fma to x86 instructions

### DIFF
--- a/tests/filecheck/backend/x86/convert_vector_to_x86.mlir
+++ b/tests/filecheck/backend/x86/convert_vector_to_x86.mlir
@@ -1,0 +1,51 @@
+// RUN: xdsl-opt -p convert-vector-to-x86{arch=avx512} --verify-diagnostics --split-input-file  %s | filecheck %s
+
+%lhs = "test.op"(): () -> vector<8xf32>
+%rhs = "test.op"(): () -> vector<8xf32>
+%acc = "test.op"(): () -> vector<8xf32>
+%fma = vector.fma %lhs,%rhs,%acc: vector<8xf32>
+
+// CHECK:      builtin.module {
+// CHECK-NEXT:   %lhs = "test.op"() : () -> vector<8xf32>
+// CHECK-NEXT:   %rhs = "test.op"() : () -> vector<8xf32>
+// CHECK-NEXT:   %acc = "test.op"() : () -> vector<8xf32>
+// CHECK-NEXT:   %fma = builtin.unrealized_conversion_cast %lhs : vector<8xf32> to !x86.avx2reg
+// CHECK-NEXT:   %fma_1 = builtin.unrealized_conversion_cast %rhs : vector<8xf32> to !x86.avx2reg
+// CHECK-NEXT:   %fma_2 = builtin.unrealized_conversion_cast %acc : vector<8xf32> to !x86.avx2reg
+// CHECK-NEXT:   %fma_3 = x86.rrr.vfmadd231ps %fma_2, %fma, %fma_1 : (!x86.avx2reg, !x86.avx2reg, !x86.avx2reg) -> !x86.avx2reg
+// CHECK-NEXT:   %fma_4 = builtin.unrealized_conversion_cast %fma_3 : !x86.avx2reg to vector<8xf32>
+// CHECK-NEXT: }
+
+// -----
+
+%lhs = "test.op"(): () -> vector<4xf64>
+%rhs = "test.op"(): () -> vector<4xf64>
+%acc = "test.op"(): () -> vector<4xf64>
+%fma = vector.fma %lhs,%rhs,%acc: vector<4xf64>
+
+// CHECK:      builtin.module {
+// CHECK-NEXT:   %lhs = "test.op"() : () -> vector<4xf64>
+// CHECK-NEXT:   %rhs = "test.op"() : () -> vector<4xf64>
+// CHECK-NEXT:   %acc = "test.op"() : () -> vector<4xf64>
+// CHECK-NEXT:   %fma = builtin.unrealized_conversion_cast %lhs : vector<4xf64> to !x86.avx2reg
+// CHECK-NEXT:   %fma_1 = builtin.unrealized_conversion_cast %rhs : vector<4xf64> to !x86.avx2reg
+// CHECK-NEXT:   %fma_2 = builtin.unrealized_conversion_cast %acc : vector<4xf64> to !x86.avx2reg
+// CHECK-NEXT:   %fma_3 = x86.rrr.vfmadd231pd %fma_2, %fma, %fma_1 : (!x86.avx2reg, !x86.avx2reg, !x86.avx2reg) -> !x86.avx2reg
+// CHECK-NEXT:   %fma_4 = builtin.unrealized_conversion_cast %fma_3 : !x86.avx2reg to vector<4xf64>
+// CHECK-NEXT: }
+
+// -----
+
+// CHECK: Half-precision vector load is not implemented yet.
+%lhs = "test.op"(): () -> vector<8xf16>
+%rhs = "test.op"(): () -> vector<8xf16>
+%acc = "test.op"(): () -> vector<8xf16>
+%fma = vector.fma %lhs,%rhs,%acc: vector<8xf16>
+
+// -----
+
+// CHECK: Float precision must be half, single or double.
+%lhs = "test.op"(): () -> vector<2xf128>
+%rhs = "test.op"(): () -> vector<2xf128>
+%acc = "test.op"(): () -> vector<2xf128>
+%fma = vector.fma %lhs,%rhs,%acc: vector<2xf128>

--- a/xdsl/backend/x86/lowering/convert_ptr_to_x86.py
+++ b/xdsl/backend/x86/lowering/convert_ptr_to_x86.py
@@ -8,7 +8,6 @@ from xdsl.dialects.builtin import (
     UnrealizedConversionCastOp,
     VectorType,
 )
-from xdsl.dialects.x86.register import X86VectorRegisterType
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
     GreedyRewritePatternApplier,
@@ -19,28 +18,7 @@ from xdsl.pattern_rewriter import (
 )
 from xdsl.utils.exceptions import DiagnosticException
 
-
-def vector_type_to_register_type(
-    value_type: VectorType,
-    arch: str,
-) -> X86VectorRegisterType:
-    vector_num_elements = value_type.element_count()
-    element_type = cast(FixedBitwidthType, value_type.get_element_type())
-    element_size = element_type.bitwidth
-    vector_size = vector_num_elements * element_size
-    # Choose the x86 vector register according to the
-    # target architecture and the abstract vector size
-    if vector_size == 128:
-        vect_reg_type = x86.register.UNALLOCATED_SSE
-    elif vector_size == 256 and (arch == "avx2" or arch == "avx512"):
-        vect_reg_type = x86.register.UNALLOCATED_AVX2
-    elif vector_size == 512 and arch == "avx512":
-        vect_reg_type = x86.register.UNALLOCATED_AVX512
-    else:
-        raise DiagnosticException(
-            "The vector size and target architecture are inconsistent."
-        )
-    return vect_reg_type
+from .helpers import vector_type_to_register_type
 
 
 @dataclass

--- a/xdsl/backend/x86/lowering/convert_vector_to_x86.py
+++ b/xdsl/backend/x86/lowering/convert_vector_to_x86.py
@@ -1,0 +1,75 @@
+from dataclasses import dataclass
+from typing import cast
+
+from xdsl.context import Context
+from xdsl.dialects import builtin, vector, x86
+from xdsl.dialects.builtin import (
+    FixedBitwidthType,
+    UnrealizedConversionCastOp,
+    VectorType,
+)
+from xdsl.passes import ModulePass
+from xdsl.pattern_rewriter import (
+    GreedyRewritePatternApplier,
+    PatternRewriter,
+    PatternRewriteWalker,
+    RewritePattern,
+    op_type_rewrite_pattern,
+)
+from xdsl.utils.exceptions import DiagnosticException
+
+from .helpers import vector_type_to_register_type
+
+
+@dataclass
+class VectorFMAToX86(RewritePattern):
+    arch: str
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: vector.FMAOp, rewriter: PatternRewriter):
+        vect_type = cast(VectorType, op.acc.type)
+        x86_vect_type = vector_type_to_register_type(vect_type, self.arch)
+        # Pointer casts
+        lhs_cast_op = UnrealizedConversionCastOp.get((op.lhs,), (x86_vect_type,))
+        rhs_cast_op = UnrealizedConversionCastOp.get((op.rhs,), (x86_vect_type,))
+        acc_cast_op = UnrealizedConversionCastOp.get((op.acc,), (x86_vect_type,))
+        # Instruction selection
+        element_size = cast(FixedBitwidthType, vect_type.get_element_type()).bitwidth
+        match element_size:
+            case 16:
+                raise DiagnosticException(
+                    "Half-precision vector load is not implemented yet."
+                )
+            case 32:
+                fma = x86.ops.RRR_Vfmadd231psOp
+            case 64:
+                fma = x86.ops.RRR_Vfmadd231pdOp
+            case _:
+                raise DiagnosticException(
+                    "Float precision must be half, single or double."
+                )
+        fma_op = fma(
+            r1=acc_cast_op, r2=lhs_cast_op, r3=rhs_cast_op, result=x86_vect_type
+        )
+
+        res_cast_op = UnrealizedConversionCastOp.get((fma_op.result,), (vect_type,))
+        rewriter.replace_matched_op(
+            [lhs_cast_op, rhs_cast_op, acc_cast_op, fma_op, res_cast_op]
+        )
+
+
+@dataclass(frozen=True)
+class ConvertVectorToX86Pass(ModulePass):
+    name = "convert-vector-to-x86"
+
+    arch: str
+
+    def apply(self, ctx: Context, op: builtin.ModuleOp) -> None:
+        PatternRewriteWalker(
+            GreedyRewritePatternApplier(
+                [
+                    VectorFMAToX86(self.arch),
+                ]
+            ),
+            apply_recursively=False,
+        ).rewrite_module(op)

--- a/xdsl/backend/x86/lowering/helpers.py
+++ b/xdsl/backend/x86/lowering/helpers.py
@@ -1,0 +1,32 @@
+from typing import cast
+
+from xdsl.dialects import x86
+from xdsl.dialects.builtin import (
+    FixedBitwidthType,
+    VectorType,
+)
+from xdsl.dialects.x86.register import X86VectorRegisterType
+from xdsl.utils.exceptions import DiagnosticException
+
+
+def vector_type_to_register_type(
+    value_type: VectorType,
+    arch: str,
+) -> X86VectorRegisterType:
+    vector_num_elements = value_type.element_count()
+    element_type = cast(FixedBitwidthType, value_type.get_element_type())
+    element_size = element_type.bitwidth
+    vector_size = vector_num_elements * element_size
+    # Choose the x86 vector register according to the
+    # target architecture and the abstract vector size
+    if vector_size == 128:
+        vect_reg_type = x86.register.UNALLOCATED_SSE
+    elif vector_size == 256 and (arch == "avx2" or arch == "avx512"):
+        vect_reg_type = x86.register.UNALLOCATED_AVX2
+    elif vector_size == 512 and arch == "avx512":
+        vect_reg_type = x86.register.UNALLOCATED_AVX512
+    else:
+        raise DiagnosticException(
+            "The vector size and target architecture are inconsistent."
+        )
+    return vect_reg_type

--- a/xdsl/transforms/__init__.py
+++ b/xdsl/transforms/__init__.py
@@ -188,6 +188,11 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
 
         return convert_vector_to_ptr.ConvertVectorToPtrPass
 
+    def get_convert_vector_to_x86():
+        from xdsl.backend.x86.lowering import convert_vector_to_x86
+
+        return convert_vector_to_x86.ConvertVectorToX86Pass
+
     def get_jax_use_donated_arguments():
         from xdsl.transforms import jax_use_donated_arguments
 
@@ -562,6 +567,7 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
         "convert-stencil-to-ll-mlir": get_convert_stencil_to_ll_mlir,
         "convert-varith-to-arith": get_convert_varith_to_arith,
         "convert-vector-to-ptr": get_convert_vector_to_ptr,
+        "convert-vector-to-x86": get_convert_vector_to_x86,
         "jax-use-donated-arguments": get_jax_use_donated_arguments,
         "cse": get_cse,
         "csl-stencil-bufferize": get_csl_stencil_bufferize,


### PR DESCRIPTION
Lowering of ```vector.fma``` for x86 architectures
