### PR TITLE
dialects: Add `smt.declare_fun` and `!smt.func`

### DIFF
--- a/tests/dialects/test_smt.py
+++ b/tests/dialects/test_smt.py
@@ -1,14 +1,16 @@
 import pytest
 
-from xdsl.dialects.builtin import IntegerAttr
+from xdsl.dialects.builtin import IntegerAttr, StringAttr
 from xdsl.dialects.smt import (
     AndOp,
     BoolType,
     ConstantBoolOp,
+    DeclareFunOp,
     DistinctOp,
     EqOp,
     ExistsOp,
     ForallOp,
+    FuncType,
     OrOp,
     QuantifierOp,
     VariadicBoolOp,
@@ -29,6 +31,12 @@ def test_constant_bool():
     assert op.value_attr == IntegerAttr(0, 1)
 
 
+def test_function_type():
+    func_type = FuncType([BoolType(), BoolType()], BoolType())
+    assert list(func_type.domain_types) == [BoolType(), BoolType()]
+    assert func_type.range_type == BoolType()
+
+
 @pytest.mark.parametrize("op_type", [AndOp, OrOp, XOrOp, EqOp, DistinctOp])
 def test_variadic_bool_op(op_type: type[VariadicBoolOp]):
     arg1 = create_ssa_value(BoolType())
@@ -46,3 +54,13 @@ def test_quantifier_op(op_type: type[QuantifierOp]):
     region.block.add_op(YieldOp(arg1))
     op = op_type(body=region)
     assert op.returned_value == arg1
+
+
+def test_declare_fun():
+    op = DeclareFunOp(BoolType(), "foo")
+    assert op.name_prefix == StringAttr("foo")
+    assert op.result.type == BoolType()
+
+    op = DeclareFunOp(BoolType())
+    assert op.name_prefix is None
+    assert op.result.type == BoolType()

--- a/tests/filecheck/dialects/smt/ops.mlir
+++ b/tests/filecheck/dialects/smt/ops.mlir
@@ -1,5 +1,10 @@
 // RUN: XDSL_ROUNDTRIP
 
+%const1 = smt.declare_fun : !smt.bool
+%const_with_name = smt.declare_fun "bool_name": !smt.bool
+%func1 = smt.declare_fun : !smt.func<() !smt.bool>
+%func2 = smt.declare_fun : !smt.func<(!smt.bool) !smt.bool>
+
 %arg1 = smt.constant true
 %arg2 = smt.constant false
 %arg3 = smt.constant false

--- a/tests/filecheck/dialects/smt/ops.mlir
+++ b/tests/filecheck/dialects/smt/ops.mlir
@@ -1,43 +1,36 @@
 // RUN: XDSL_ROUNDTRIP
 
-%const1 = smt.declare_fun : !smt.bool
-%const_with_name = smt.declare_fun "bool_name" : !smt.bool
-%func1 = smt.declare_fun : !smt.func<() !smt.bool>
-%func2 = smt.declare_fun : !smt.func<(!smt.bool) !smt.bool>
-
 // CHECK: %const1 = smt.declare_fun : !smt.bool
 // CHECK-NEXT: %const_with_name = smt.declare_fun "bool_name" : !smt.bool
 // CHECK-NEXT: %func1 = smt.declare_fun : !smt.func<() !smt.bool>
 // CHECK-NEXT: %func2 = smt.declare_fun : !smt.func<(!smt.bool) !smt.bool
 
-%arg1 = smt.constant true
-%arg2 = smt.constant false
-%arg3 = smt.constant false
+%const1 = smt.declare_fun : !smt.bool
+%const_with_name = smt.declare_fun "bool_name" : !smt.bool
+%func1 = smt.declare_fun : !smt.func<() !smt.bool>
+%func2 = smt.declare_fun : !smt.func<(!smt.bool) !smt.bool>
 
 // CHECK-NEXT:    %arg1 = smt.constant true
 // CHECK-NEXT:    %arg2 = smt.constant false
 // CHECK-NEXT:    %arg3 = smt.constant false
 
-%and = smt.or %arg1, %arg2, %arg3
-%or = smt.and %arg1, %arg2, %arg3
-%xor = smt.xor %arg1, %arg2, %arg3
+%arg1 = smt.constant true
+%arg2 = smt.constant false
+%arg3 = smt.constant false
 
 // CHECK-NEXT:    %and = smt.or %arg1, %arg2, %arg3
 // CHECK-NEXT:    %or = smt.and %arg1, %arg2, %arg3
 // CHECK-NEXT:    %xor = smt.xor %arg1, %arg2, %arg3
 
-%eq = smt.eq %arg1, %arg2, %arg3 : !smt.bool
-%distinct = smt.distinct %arg1, %arg2, %arg3 : !smt.bool
+%and = smt.or %arg1, %arg2, %arg3
+%or = smt.and %arg1, %arg2, %arg3
+%xor = smt.xor %arg1, %arg2, %arg3
 
 // CHECK-NEXT:    %eq = smt.eq %arg1, %arg2, %arg3 : !smt.bool
 // CHECK-NEXT:    %distinct = smt.distinct %arg1, %arg2, %arg3 : !smt.bool
 
-%exists = smt.exists {
-    smt.yield %arg1 : !smt.bool
-}
-%forall = smt.forall {
-    smt.yield %arg1 : !smt.bool
-}
+%eq = smt.eq %arg1, %arg2, %arg3 : !smt.bool
+%distinct = smt.distinct %arg1, %arg2, %arg3 : !smt.bool
 
 // CHECK-NEXT:    %exists = smt.exists {
 // CHECK-NEXT:      smt.yield %arg1 : !smt.bool
@@ -45,3 +38,10 @@
 // CHECK-NEXT:    %forall = smt.forall {
 // CHECK-NEXT:      smt.yield %arg1 : !smt.bool
 // CHECK-NEXT:    }
+
+%exists = smt.exists {
+    smt.yield %arg1 : !smt.bool
+}
+%forall = smt.forall {
+    smt.yield %arg1 : !smt.bool
+}

--- a/tests/filecheck/dialects/smt/ops.mlir
+++ b/tests/filecheck/dialects/smt/ops.mlir
@@ -1,20 +1,36 @@
 // RUN: XDSL_ROUNDTRIP
 
 %const1 = smt.declare_fun : !smt.bool
-%const_with_name = smt.declare_fun "bool_name": !smt.bool
+%const_with_name = smt.declare_fun "bool_name" : !smt.bool
 %func1 = smt.declare_fun : !smt.func<() !smt.bool>
 %func2 = smt.declare_fun : !smt.func<(!smt.bool) !smt.bool>
+
+// CHECK: %const1 = smt.declare_fun : !smt.bool
+// CHECK-NEXT: %const_with_name = smt.declare_fun "bool_name" : !smt.bool
+// CHECK-NEXT: %func1 = smt.declare_fun : !smt.func<() !smt.bool>
+// CHECK-NEXT: %func2 = smt.declare_fun : !smt.func<(!smt.bool) !smt.bool
 
 %arg1 = smt.constant true
 %arg2 = smt.constant false
 %arg3 = smt.constant false
 
+// CHECK-NEXT:    %arg1 = smt.constant true
+// CHECK-NEXT:    %arg2 = smt.constant false
+// CHECK-NEXT:    %arg3 = smt.constant false
+
 %and = smt.or %arg1, %arg2, %arg3
 %or = smt.and %arg1, %arg2, %arg3
 %xor = smt.xor %arg1, %arg2, %arg3
 
+// CHECK-NEXT:    %and = smt.or %arg1, %arg2, %arg3
+// CHECK-NEXT:    %or = smt.and %arg1, %arg2, %arg3
+// CHECK-NEXT:    %xor = smt.xor %arg1, %arg2, %arg3
+
 %eq = smt.eq %arg1, %arg2, %arg3 : !smt.bool
 %distinct = smt.distinct %arg1, %arg2, %arg3 : !smt.bool
+
+// CHECK-NEXT:    %eq = smt.eq %arg1, %arg2, %arg3 : !smt.bool
+// CHECK-NEXT:    %distinct = smt.distinct %arg1, %arg2, %arg3 : !smt.bool
 
 %exists = smt.exists {
     smt.yield %arg1 : !smt.bool
@@ -23,14 +39,6 @@
     smt.yield %arg1 : !smt.bool
 }
 
-// CHECK:         %arg1 = smt.constant true
-// CHECK-NEXT:    %arg2 = smt.constant false
-// CHECK-NEXT:    %arg3 = smt.constant false
-// CHECK-NEXT:    %and = smt.or %arg1, %arg2, %arg3
-// CHECK-NEXT:    %or = smt.and %arg1, %arg2, %arg3
-// CHECK-NEXT:    %xor = smt.xor %arg1, %arg2, %arg3
-// CHECK-NEXT:    %eq = smt.eq %arg1, %arg2, %arg3 : !smt.bool
-// CHECK-NEXT:    %distinct = smt.distinct %arg1, %arg2, %arg3 : !smt.bool
 // CHECK-NEXT:    %exists = smt.exists {
 // CHECK-NEXT:      smt.yield %arg1 : !smt.bool
 // CHECK-NEXT:    }

--- a/xdsl/dialects/smt.py
+++ b/xdsl/dialects/smt.py
@@ -112,10 +112,9 @@ class DeclareFunOp(IRDLOperation):
     ):
         if isinstance(name_prefix, str):
             name_prefix = StringAttr(name_prefix)
-        properties: dict[str, Attribute] = (
-            {"namePrefix": name_prefix} if name_prefix else {}
+        super().__init__(
+            result_types=[result_type], properties={"namePrefix": name_prefix}
         )
-        super().__init__(result_types=[result_type], properties=properties)
 
 
 @irdl_op_definition

--- a/xdsl/dialects/smt.py
+++ b/xdsl/dialects/smt.py
@@ -71,9 +71,9 @@ class FuncType(ParametrizedAttribute, TypeAttribute):
             domain_types = parser.parse_comma_separated_list(
                 parser.Delimiter.PAREN, parser.parse_type
             )
-            range_types = parser.parse_type()
+            range_type = parser.parse_type()
 
-        return (ArrayAttr(domain_types), range_types)
+        return (ArrayAttr(domain_types), range_type)
 
     def print_parameters(self, printer: Printer) -> None:
         printer.print_string("<(")
@@ -107,9 +107,13 @@ class DeclareFunOp(IRDLOperation):
 
     assembly_format = "($namePrefix^)? attr-dict `:` type($result)"
 
-    def __init__(self, result_type: SMTType, name_prefix: str | None = None):
+    def __init__(
+        self, result_type: SMTType, name_prefix: StringAttr | str | None = None
+    ):
+        if isinstance(name_prefix, str):
+            name_prefix = StringAttr(name_prefix)
         properties: dict[str, Attribute] = (
-            {"namePrefix": StringAttr(name_prefix)} if name_prefix else {}
+            {"namePrefix": name_prefix} if name_prefix else {}
         )
         super().__init__(result_types=[result_type], properties=properties)
 
@@ -377,5 +381,8 @@ SMT = Dialect(
         ForallOp,
         YieldOp,
     ],
-    [BoolType, FuncType],
+    [
+        BoolType,
+        FuncType,
+    ],
 )


### PR DESCRIPTION
Add the `smt.declare_fun` operation, which is used to declare constants and functions.
Also add the `smt.func` type