### PR TITLE
bug: (x86) cast back the result of an ptr operation after lowering to x86

### DIFF
--- a/tests/filecheck/backend/x86/convert_ptr_to_x86.mlir
+++ b/tests/filecheck/backend/x86/convert_ptr_to_x86.mlir
@@ -6,6 +6,7 @@
 // CHECK-NEXT:    %ptr0 = "test.op"() : () -> !ptr_xdsl.ptr
 // CHECK-NEXT:    %v0 = builtin.unrealized_conversion_cast %ptr0 : !ptr_xdsl.ptr to !x86.reg
 // CHECK-NEXT:    %v0_1 = x86.rm.vmovups %v0, 0 : (!x86.reg) -> !x86.avx2reg
+// CHECK-NEXT:    %v0_2 = builtin.unrealized_conversion_cast %v0_1 : !x86.avx2reg to vector<8xf32>
 // CHECK-NEXT:  }
 
 // -----
@@ -16,6 +17,7 @@
 // CHECK-NEXT:    %ptr0b = "test.op"() : () -> !ptr_xdsl.ptr
 // CHECK-NEXT:    %v0b = builtin.unrealized_conversion_cast %ptr0b : !ptr_xdsl.ptr to !x86.reg
 // CHECK-NEXT:    %v0b_1 = x86.rm.vmovups %v0b, 0 : (!x86.reg) -> !x86.avx512reg
+// CHECK-NEXT:    %v0b_2 = builtin.unrealized_conversion_cast %v0b_1 : !x86.avx512reg to vector<16xf32>
 // CHECK-NEXT:  }
 
 // -----
@@ -123,4 +125,5 @@ ptr_xdsl.store %v6, %ptr6 : f32, !ptr_xdsl.ptr
 // CHECK-NEXT:   %r0 = builtin.unrealized_conversion_cast %p : !ptr_xdsl.ptr to !x86.reg
 // CHECK-NEXT:   %r0_1 = builtin.unrealized_conversion_cast %idx : index to !x86.reg
 // CHECK-NEXT:   %r0_2 = x86.rr.add %r0, %r0_1 : (!x86.reg, !x86.reg) -> !x86.reg
+// CHECK-NEXT:   %r0_3 = builtin.unrealized_conversion_cast %r0_2 : !x86.reg to !ptr_xdsl.ptr
 // CHECK-NEXT: }

--- a/xdsl/backend/x86/lowering/convert_ptr_to_x86.py
+++ b/xdsl/backend/x86/lowering/convert_ptr_to_x86.py
@@ -29,7 +29,8 @@ class PtrAddToX86(RewritePattern):
         ptr_cast_op = UnrealizedConversionCastOp.get((op.addr,), (x86_reg_type,))
         offset_cast_op = UnrealizedConversionCastOp.get((op.offset,), (x86_reg_type,))
         add_op = x86.RR_AddOp(ptr_cast_op, offset_cast_op, result=x86_reg_type)
-        rewriter.replace_matched_op([ptr_cast_op, offset_cast_op, add_op])
+        res_cast_op = UnrealizedConversionCastOp.get((add_op.result,), (ptr.PtrType(),))
+        rewriter.replace_matched_op([ptr_cast_op, offset_cast_op, add_op, res_cast_op])
 
 
 @dataclass
@@ -109,7 +110,8 @@ class PtrLoadToX86(RewritePattern):
             offset=0,
             result=vector_type_to_register_type(value_type, self.arch),
         )
-        rewriter.replace_matched_op([cast_op, mov_op])
+        res_cast_op = UnrealizedConversionCastOp.get(mov_op.results, (value_type,))
+        rewriter.replace_matched_op([cast_op, mov_op, res_cast_op])
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Composition of lowering to x86 passes fixed
