### PR TITLE
dialects: Allow range constraints in ArrayOfConstraint

### DIFF
--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -228,6 +228,21 @@ class ArrayOfConstraint(GenericAttrConstraint[ArrayAttr[AttributeCovT]]):
     def get_unique_base(self) -> type[Attribute] | None:
         return ArrayAttr
 
+    @dataclass(frozen=True)
+    class _Extractor(VarExtractor[Attribute]):
+        inner: VarExtractor[Sequence[Attribute]]
+
+        def extract_var(self, a: Attribute) -> ConstraintVariableType:
+            assert isinstance(a, ArrayAttr)
+            a = cast(ArrayAttr[Attribute], a)
+            return self.inner.extract_var(a.data)
+
+    def get_variable_extractors(self) -> dict[str, VarExtractor[Attribute]]:
+        return {
+            k: self._Extractor(v)
+            for k, v in self.elem_range_constraint.get_variable_extractors().items()
+        }
+
 
 @irdl_attr_definition
 class StringAttr(Data[str], BuiltinAttribute):

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -23,6 +23,7 @@ from typing_extensions import Self, TypeVar, deprecated
 from xdsl.ir import (
     Attribute,
     AttributeCovT,
+    AttributeInvT,
     Block,
     BlockOps,
     BuiltinAttribute,
@@ -177,10 +178,10 @@ class ArrayAttr(
     @staticmethod
     def constr(
         constr: (
-            IRDLGenericAttrConstraint[AttributeCovT]
-            | GenericRangeConstraint[AttributeCovT]
+            IRDLGenericAttrConstraint[AttributeInvT]
+            | GenericRangeConstraint[AttributeInvT]
         ),
-    ) -> GenericAttrConstraint[ArrayAttr[AttributeCovT]]:
+    ) -> GenericAttrConstraint[ArrayAttr[AttributeInvT]]:
         return ArrayOfConstraint(constr)
 
 

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -188,8 +188,8 @@ class ArrayAttr(
 class ArrayOfConstraint(GenericAttrConstraint[ArrayAttr[AttributeCovT]]):
     elem_range_constraint: GenericRangeConstraint[AttributeCovT]
     """
-    A constraint that enforces an ArrayData whose elements all satisfy
-    the elem_constr.
+    A constraint that enforces an ArrayData whose elements satisfy
+    the underlying range constraint.
     """
 
     def __init__(
@@ -210,11 +210,10 @@ class ArrayOfConstraint(GenericAttrConstraint[ArrayAttr[AttributeCovT]]):
         attr: Attribute,
         constraint_context: ConstraintContext,
     ) -> None:
-        if not isinstance(attr, ArrayAttr):
+        if not isa(attr, ArrayAttr):
             raise VerifyException(
                 f"expected ArrayAttr attribute, but got '{type(attr)}'"
             )
-        attr = cast(ArrayAttr[Attribute], attr)
         self.elem_range_constraint.verify(attr.data, constraint_context)
 
     def can_infer(self, var_constraint_names: Set[str]) -> bool:

--- a/xdsl/utils/dialect_stub.py
+++ b/xdsl/utils/dialect_stub.py
@@ -26,6 +26,7 @@ from xdsl.irdl import (
     OptSuccessorDef,
     ParamAttrConstraint,
     PropertyDef,
+    RangeOf,
     RegionDef,
     ResultDef,
     SuccessorDef,
@@ -97,7 +98,7 @@ class DialectStubGenerator:
             case AllOf(constraints):
                 self._import(typing, "Annotated")
                 return f"Annotated[{', '.join(self._generate_constraint_type(c) for c in reversed(constraints))}]"  # noqa: E501
-            case ArrayOfConstraint(constraint):
+            case ArrayOfConstraint(RangeOf(constraint)):
                 self._import(xdsl.dialects.builtin, ArrayAttr)
                 return f"ArrayAttr[{self._generate_constraint_type(constraint)}]"
             case AnyAttr():


### PR DESCRIPTION
ArrayOfConstraint can now take a range constraint. This means in particular that we can use a RangeVarConstraint in it, which is quite useful for some operations.