### PR TITLE
transformations: (convert-memref-to-ptr) inline offset_calculations helper

### DIFF
--- a/xdsl/transforms/convert_memref_to_ptr.py
+++ b/xdsl/transforms/convert_memref_to_ptr.py
@@ -19,15 +19,20 @@ from xdsl.utils.exceptions import DiagnosticException
 from xdsl.utils.hints import isa
 
 
-def offset_calculations(
-    memref_type: memref.MemRefType[Any], indices: Iterable[SSAValue]
+def get_target_ptr(
+    target_memref: SSAValue,
+    memref_type: memref.MemRefType[Any],
+    indices: Iterable[SSAValue],
 ) -> tuple[list[Operation], SSAValue]:
     """
-    Get operations calculating an offset which needs to be added to memref's base
-    pointer to access an element referenced by indices.
+    Get operations returning a pointer to an element of a memref referenced by indices.
     """
 
-    assert isinstance(memref_type.element_type, builtin.FixedBitwidthType)
+    ops: list[Operation] = [memref_ptr := ptr.ToPtrOp(target_memref)]
+    memref_ptr.res.name_hint = target_memref.name_hint
+
+    if not indices:
+        return ops, memref_ptr.res
 
     match memref_type.layout:
         case builtin.NoneAttr():
@@ -36,8 +41,6 @@ def offset_calculations(
             strides = memref_type.layout.get_strides()
         case _:
             raise DiagnosticException(f"Unsupported layout type {memref_type.layout}")
-
-    ops: list[Operation] = []
 
     head: SSAValue | None = None
 
@@ -95,25 +98,7 @@ def offset_calculations(
     bytes_per_element_op.offset.name_hint = "bytes_per_element"
     final_offset.result.name_hint = "scaled_pointer_offset"
 
-    return ops, final_offset.result
-
-
-def get_target_ptr(
-    target_memref: SSAValue,
-    memref_type: memref.MemRefType[Any],
-    indices: Iterable[SSAValue],
-) -> tuple[list[Operation], SSAValue]:
-    """Get operations returning a pointer to an element of a memref referenced by indices."""
-
-    ops: list[Operation] = [memref_ptr := ptr.ToPtrOp(target_memref)]
-    memref_ptr.res.name_hint = target_memref.name_hint
-
-    if not indices:
-        return ops, memref_ptr.res
-
-    offset_ops, offset = offset_calculations(memref_type, indices)
-    ops.extend(offset_ops)
-    ops.append(target_ptr := ptr.PtrAddOp(memref_ptr.res, offset))
+    ops.append(target_ptr := ptr.PtrAddOp(memref_ptr.res, final_offset.result))
 
     target_ptr.result.name_hint = "offset_pointer"
     return ops, target_ptr.result


### PR DESCRIPTION
This gets rid of the `offset_calculations` helper used in vector and memref lowerings, instead just keeping the `get_ptr` helper that directly gives the new pointer, instead of calculating the offsets separately. This is motivated by the fact that sometimes the offset is 0 in a way that is tedious to calculate before calling the helper itself. An alternative would be to change the type signature to return `None` in the case where no offset ops need to be created, but this seemed simpler.