### PR TITLE
backend: add allocate_registers abstract method to RegisterAllocatableOperation

### DIFF
--- a/tests/backend/riscv/test_register_allocation.py
+++ b/tests/backend/riscv/test_register_allocation.py
@@ -107,7 +107,7 @@ def test_allocate_with_inout_constraints():
         ]
     ).results
     op0 = MyInstructionOp.get(rs0, rs1, "", "")
-    register_allocator.process_riscv_op(op0)
+    op0.allocate_registers(register_allocator)
     assert op0.rs0.type == riscv.IntRegisterType.infinite_register(1)
     assert op0.rs1.type == riscv.IntRegisterType.infinite_register(0)
     assert op0.rd0.type == riscv.IntRegisterType.infinite_register(1)
@@ -122,7 +122,7 @@ def test_allocate_with_inout_constraints():
         ]
     ).results
     op1 = MyInstructionOp.get(rs0, rs1, "", "a0")
-    register_allocator.process_riscv_op(op1)
+    op1.allocate_registers(register_allocator)
     assert op1.rs0.type == riscv.IntRegisterType.infinite_register(2)
     assert op1.rs1.type == riscv.IntRegisterType.from_name("a0")
     assert op1.rd0.type == riscv.IntRegisterType.infinite_register(2)

--- a/xdsl/backend/riscv/register_allocation.py
+++ b/xdsl/backend/riscv/register_allocation.py
@@ -1,15 +1,14 @@
 import json
 from collections import defaultdict
 from collections.abc import Iterable
-from typing import cast
 
 from xdsl.backend.register_allocatable import RegisterAllocatableOperation
 from xdsl.backend.register_allocator import BlockAllocator, live_ins_per_block
 from xdsl.backend.register_queue import RegisterQueue
 from xdsl.backend.register_type import RegisterType
-from xdsl.dialects import riscv, riscv_func, riscv_scf, riscv_snitch
-from xdsl.dialects.riscv import Registers, RISCVAsmOperation, RISCVRegisterType
-from xdsl.ir import Block, Operation, SSAValue
+from xdsl.dialects import riscv, riscv_func
+from xdsl.dialects.riscv import Registers, RISCVRegisterType
+from xdsl.ir import Block, SSAValue
 from xdsl.rewriter import InsertPoint, Rewriter
 from xdsl.transforms.canonicalization_patterns.riscv import get_constant_value
 
@@ -65,127 +64,10 @@ class RegisterAllocatorLivenessBlockNaive(BlockAllocator):
             return Registers.ZERO
         return super().new_type_for_value(reg)
 
-    def process_operation(self, op: Operation) -> None:
-        """
-        Allocate registers for one operation.
-        """
-        match op:
-            case riscv_scf.ForOp():
-                self.allocate_for_loop(op)
-            case riscv_snitch.FRepOperation():
-                self.allocate_frep_loop(op)
-            case RISCVAsmOperation():
-                self.process_riscv_op(op)
-            case _:
-                # Ignore non-riscv operations
-                return
-
-    def process_riscv_op(self, op: RISCVAsmOperation) -> None:
-        """
-        Allocate registers for RISC-V Instruction.
-        """
-        ins, outs, inouts = op.get_register_constraints()
-
-        # Allocate registers to inout operand groups since they are defined further up
-        # in the use-def SSA chain
-        for operand_group in inouts:
-            self.allocate_values_same_reg(operand_group)
-
-        for result in outs:
-            # Allocate registers to result if not already allocated
-            if (new_result := self.allocate_value(result)) is not None:
-                result = new_result
-            self.free_value(result)
-
-        # Allocate registers to operands since they are defined further up
-        # in the use-def SSA chain
-        for operand in ins:
-            self.allocate_value(operand)
-
-    def allocate_for_loop(self, loop: riscv_scf.ForOp) -> None:
-        """
-        Allocate registers for riscv_scf for loop, recursively calling process_operation
-        for operations in the loop.
-        """
-        # Allocate values used inside the body but defined outside.
-        # Their scope lasts for the whole body execution scope
-        live_ins = self.live_ins_per_block[loop.body.block]
-        for live_in in live_ins:
-            self.allocate_value(live_in)
-
-        yield_op = loop.body.block.last_op
-        assert yield_op is not None, (
-            "last op of riscv_scf.ForOp is guaranteed to be riscv_scf.Yield"
-        )
-        block_args = loop.body.block.args
-
-        # The loop-carried variables are trickier
-        # The for op operand, block arg, and yield operand must have the same type
-        for block_arg, operand, yield_operand, op_result in zip(
-            block_args[1:], loop.iter_args, yield_op.operands, loop.results
-        ):
-            self.allocate_values_same_reg(
-                (block_arg, operand, yield_operand, op_result)
-            )
-
-        # Induction variable
-        self.allocate_value(block_args[0])
-
-        # Step and ub are used throughout loop
-        self.allocate_value(loop.ub)
-        self.allocate_value(loop.step)
-
-        # Reserve the loop carried variables for allocation within the body
-        regs = loop.iter_args.types
-        assert all(isinstance(reg, RISCVRegisterType) for reg in regs)
-        regs = cast(tuple[RISCVRegisterType, ...], regs)
-        with self.available_registers.reserve_registers(regs):
-            self.allocate_block(loop.body.block)
-
-        # lb is only used as an input to the loop, so free induction variable before
-        # allocating lb to it in case it's not yet allocated
-        self.free_value(loop.body.block.args[0])
-        self.allocate_value(loop.lb)
-
-    def allocate_frep_loop(self, loop: riscv_snitch.FRepOperation) -> None:
-        """
-        Allocate registers for riscv_snitch frep_outer or frep_inner loop, recursively
-        calling process_operation for operations in the loop.
-        """
-        # Allocate values used inside the body but defined outside.
-        # Their scope lasts for the whole body execution scope
-        live_ins = self.live_ins_per_block[loop.body.block]
-        for live_in in live_ins:
-            self.allocate_value(live_in)
-
-        yield_op = loop.body.block.last_op
-        assert yield_op is not None, (
-            "last op of riscv_snitch.frep_outer and riscv_snitch.frep_inner is guaranteed"
-            " to be riscv_scf.Yield"
-        )
-        block_args = loop.body.block.args
-
-        # The loop-carried variables are trickier
-        # The for op operand, block arg, and yield operand must have the same type
-        for block_arg, operand, yield_operand, op_result in zip(
-            block_args, loop.iter_args, yield_op.operands, loop.results
-        ):
-            self.allocate_values_same_reg(
-                (block_arg, operand, yield_operand, op_result)
-            )
-
-        self.allocate_value(loop.max_rep)
-
-        # Reserve the loop carried variables for allocation within the body
-        regs = loop.iter_args.types
-        assert all(isinstance(reg, RISCVRegisterType) for reg in regs)
-        regs = cast(tuple[RISCVRegisterType, ...], regs)
-        with self.available_registers.reserve_registers(regs):
-            self.allocate_block(loop.body.block)
-
     def allocate_block(self, block: Block):
         for op in reversed(block.ops):
-            self.process_operation(op)
+            if isinstance(op, RegisterAllocatableOperation):
+                op.allocate_registers(self)
 
     def allocate_func(
         self, func: riscv_func.FuncOp, *, add_regalloc_stats: bool = False

--- a/xdsl/dialects/riscv_scf.py
+++ b/xdsl/dialects/riscv_scf.py
@@ -5,10 +5,14 @@ RISC-V SCF dialect
 from __future__ import annotations
 
 from abc import ABC
-from collections.abc import Sequence
+from collections.abc import Generator, Sequence
+from typing import cast
 
 from typing_extensions import Self
 
+from xdsl.backend.register_allocatable import RegisterAllocatableOperation
+from xdsl.backend.register_allocator import BlockAllocator
+from xdsl.backend.register_type import RegisterType
 from xdsl.dialects.riscv import IntRegisterType, RISCVRegisterType
 from xdsl.dialects.utils import (
     AbstractYieldOperation,
@@ -50,7 +54,7 @@ class YieldOp(AbstractYieldOperation[RISCVRegisterType]):
     )
 
 
-class ForRofOperation(IRDLOperation, ABC):
+class ForRofOperation(RegisterAllocatableOperation, IRDLOperation, ABC):
     lb = operand_def(IntRegisterType)
     ub = operand_def(IntRegisterType)
     step = operand_def(IntRegisterType)
@@ -117,6 +121,52 @@ class ForRofOperation(IRDLOperation, ABC):
                         f"riscv_scf.for's riscv_scf.yield must match carried"
                         f"variables types."
                     )
+
+    def iter_used_registers(self) -> Generator[RegisterType, None, None]:
+        # We know that all the registers for the inputs and outputs are the same, and
+        # that these registers will have been iterated earlier in the IR.
+        yield from ()
+
+    def allocate_registers(self, allocator: BlockAllocator) -> None:
+        # Allocate values used inside the body but defined outside.
+        # Their scope lasts for the whole body execution scope
+        live_ins = allocator.live_ins_per_block[self.body.block]
+        for live_in in live_ins:
+            allocator.allocate_value(live_in)
+
+        yield_op = self.body.block.last_op
+        assert yield_op is not None, (
+            "last op of riscv_scf.ForOp is guaranteed to be riscv_scf.Yield"
+        )
+        block_args = self.body.block.args
+
+        # The loop-carried variables are trickier
+        # The for op operand, block arg, and yield operand must have the same type
+        for block_arg, operand, yield_operand, op_result in zip(
+            block_args[1:], self.iter_args, yield_op.operands, self.results
+        ):
+            allocator.allocate_values_same_reg(
+                (block_arg, operand, yield_operand, op_result)
+            )
+
+        # Induction variable
+        allocator.allocate_value(block_args[0])
+
+        # Step and ub are used throughout loop
+        allocator.allocate_value(self.ub)
+        allocator.allocate_value(self.step)
+
+        # Reserve the loop carried variables for allocation within the body
+        regs = self.iter_args.types
+        assert all(isinstance(reg, RISCVRegisterType) for reg in regs)
+        regs = cast(tuple[RISCVRegisterType, ...], regs)
+        with allocator.available_registers.reserve_registers(regs):
+            allocator.allocate_block(self.body.block)
+
+        # lb is only used as an input to the loop, so free induction variable before
+        # allocating lb to it in case it's not yet allocated
+        allocator.free_value(self.body.block.args[0])
+        allocator.allocate_value(self.lb)
 
 
 @irdl_op_definition


### PR DESCRIPTION
Moves a bunch of per-op logic to the op rather than a shared class! Most importantly this removes the dependency on snitch for the RISC-V register allocator, but it also opens the door for future customisation in the dialect itself vs shared infrastructure.