### PR TITLE
dialects: (smt) Implement `smt.apply_func`

### DIFF
--- a/tests/dialects/test_smt.py
+++ b/tests/dialects/test_smt.py
@@ -3,6 +3,7 @@ import pytest
 from xdsl.dialects.builtin import IntegerAttr, StringAttr
 from xdsl.dialects.smt import (
     AndOp,
+    ApplyFuncOp,
     BoolType,
     ConstantBoolOp,
     DeclareFunOp,
@@ -63,4 +64,13 @@ def test_declare_fun():
 
     op = DeclareFunOp(BoolType())
     assert op.name_prefix is None
+    assert op.result.type == BoolType()
+
+
+def test_apply_func():
+    func = create_ssa_value(FuncType([BoolType(), BoolType()], BoolType()))
+    arg1 = create_ssa_value(BoolType())
+    arg2 = create_ssa_value(BoolType())
+    op = ApplyFuncOp(func, (arg1, arg2))
+
     assert op.result.type == BoolType()

--- a/tests/dialects/test_smt.py
+++ b/tests/dialects/test_smt.py
@@ -71,6 +71,6 @@ def test_apply_func():
     func = create_ssa_value(FuncType([BoolType(), BoolType()], BoolType()))
     arg1 = create_ssa_value(BoolType())
     arg2 = create_ssa_value(BoolType())
-    op = ApplyFuncOp(func, (arg1, arg2))
+    op = ApplyFuncOp(func, arg1, arg2)
 
     assert op.result.type == BoolType()

--- a/tests/filecheck/dialects/smt/ops.mlir
+++ b/tests/filecheck/dialects/smt/ops.mlir
@@ -10,6 +10,11 @@
 %func1 = smt.declare_fun : !smt.func<() !smt.bool>
 %func2 = smt.declare_fun : !smt.func<(!smt.bool) !smt.bool>
 
+// CHECK-NEXT:    smt.apply_func %func1() : !smt.func<() !smt.bool>
+// CHECK-NEXT:    smt.apply_func %func2(%const1) : !smt.func<(!smt.bool) !smt.bool>
+smt.apply_func %func1() : !smt.func<() !smt.bool>
+smt.apply_func %func2(%const1) : !smt.func<(!smt.bool) !smt.bool>
+
 // CHECK-NEXT:    %arg1 = smt.constant true
 // CHECK-NEXT:    %arg2 = smt.constant false
 // CHECK-NEXT:    %arg3 = smt.constant false

--- a/xdsl/dialects/smt.py
+++ b/xdsl/dialects/smt.py
@@ -17,13 +17,18 @@ from xdsl.ir import (
 )
 from xdsl.irdl import (
     AtLeast,
+    GenericAttrConstraint,
+    GenericRangeConstraint,
     IRDLOperation,
+    ParamAttrConstraint,
     ParameterDef,
     RangeOf,
+    RangeVarConstraint,
     VarConstraint,
     base,
     irdl_attr_definition,
     irdl_op_definition,
+    operand_def,
     opt_prop_def,
     prop_def,
     region_def,
@@ -82,6 +87,13 @@ class FuncType(ParametrizedAttribute, TypeAttribute):
         printer.print_attribute(self.range_type)
         printer.print_string(">")
 
+    @staticmethod
+    def constr(
+        domain: GenericRangeConstraint[NonFuncSMTType],
+        range: GenericAttrConstraint[NonFuncSMTType],
+    ) -> GenericAttrConstraint[FuncType]:
+        return ParamAttrConstraint(FuncType, (ArrayAttr.constr(domain), range))
+
 
 SMTType: TypeAlias = NonFuncSMTType | FuncType
 
@@ -115,6 +127,26 @@ class DeclareFunOp(IRDLOperation):
         super().__init__(
             result_types=[result_type], properties={"namePrefix": name_prefix}
         )
+
+
+@irdl_op_definition
+class ApplyFuncOp(IRDLOperation):
+    """ """
+
+    name = "smt.apply_func"
+
+    DOMAIN: ClassVar = RangeVarConstraint("DOMAIN", RangeOf(base(NonFuncSMTType)))
+    RANGE: ClassVar = VarConstraint("RANGE", base(NonFuncSMTType))
+
+    func = operand_def(FuncType.constr(DOMAIN, RANGE))
+    args = var_operand_def(DOMAIN)
+
+    result = result_def(RANGE)
+
+    assembly_format = "$func `(` $args `)` attr-dict `:` type($func)"
+
+    def __init__(self, func: SSAValue[FuncType], args: Sequence[SSAValue]):
+        super().__init__(operands=[func, args], result_types=[func.type.range_type])
 
 
 @irdl_op_definition
@@ -370,6 +402,7 @@ SMT = Dialect(
     "smt",
     [
         DeclareFunOp,
+        ApplyFuncOp,
         ConstantBoolOp,
         AndOp,
         OrOp,

--- a/xdsl/dialects/smt.py
+++ b/xdsl/dialects/smt.py
@@ -148,8 +148,10 @@ class ApplyFuncOp(IRDLOperation):
 
     assembly_format = "$func `(` $args `)` attr-dict `:` type($func)"
 
-    def __init__(self, func: SSAValue[FuncType], args: Sequence[SSAValue]):
-        super().__init__(operands=[func, args], result_types=[func.type.range_type])
+    def __init__(self, func: SSAValue[FuncType], *args: SSAValue):
+        super().__init__(
+            operands=[func, tuple(args)], result_types=[func.type.range_type]
+        )
 
 
 @irdl_op_definition

--- a/xdsl/dialects/smt.py
+++ b/xdsl/dialects/smt.py
@@ -131,7 +131,10 @@ class DeclareFunOp(IRDLOperation):
 
 @irdl_op_definition
 class ApplyFuncOp(IRDLOperation):
-    """ """
+    """
+    This operation performs a function application as described in the SMT-LIB
+    2.7 standard. It is part of the SMT-LIB core theory.
+    """
 
     name = "smt.apply_func"
 


### PR DESCRIPTION
`smt.apply_func` is the operation to apply a function to a list of arguments.