### PR TITLE
transformations: (convert-memref-to-ptr) lower static offset

### DIFF
--- a/tests/filecheck/transforms/convert_memref_to_ptr.mlir
+++ b/tests/filecheck/transforms/convert_memref_to_ptr.mlir
@@ -67,6 +67,18 @@ memref.store %fv, %farr[%idx] {"nontemporal" = false} : memref<10xf64>
 // CHECK-NEXT:  %fmem_1 = ptr_xdsl.to_ptr %fmem : memref<f64> -> !ptr_xdsl.ptr
 // CHECK-NEXT:  %flv2 = ptr_xdsl.load %fmem_1 : !ptr_xdsl.ptr -> f64
 
+%idx3, %offsetmem = "test.op"() : () -> (index, memref<16xf64, strided<[1], offset: 4>>)
+%flv3 = memref.load %offsetmem[%idx3] {"nontemporal" = false} : memref<16xf64, strided<[1], offset: 4>>
+
+// CHECK-NEXT:  %idx3, %offsetmem = "test.op"() : () -> (index, memref<16xf64, strided<[1], offset: 4>>
+// CHECK-NEXT:  %offsetmem_1 = ptr_xdsl.to_ptr %offsetmem : memref<16xf64, strided<[1], offset: 4>> -> !ptr_xdsl.ptr
+// CHECK-NEXT:  %memref_base_offset = arith.constant 4 : index
+// CHECK-NEXT:  %flv3 = arith.addi %idx3, %memref_base_offset : index
+// CHECK-NEXT:  %bytes_per_element_6 = ptr_xdsl.type_offset f64 : index
+// CHECK-NEXT:  %scaled_pointer_offset_6 = arith.muli %flv3, %bytes_per_element_6 : index
+// CHECK-NEXT:  %offset_pointer_6 = ptr_xdsl.ptradd %offsetmem_1, %scaled_pointer_offset_6 : (!ptr_xdsl.ptr, index) -> !ptr_xdsl.ptr
+// CHECK-NEXT:  %flv3_1 = ptr_xdsl.load %offset_pointer_6 : !ptr_xdsl.ptr -> f64
+
 // -----
 
 %fv, %idx, %mstr = "test.op"() : () -> (f64, index, memref<2xf64, strided<[?]>>)
@@ -80,3 +92,10 @@ memref.store %fv, %mstr[%idx] {"nontemporal" = false} : memref<2xf64, strided<[?
 memref.store %fv, %mstr[%idx] {"nontemporal" = false} : memref<2xf64, affine_map<(d0) -> (d0 * 10)>>
 
 // CHECK: Unsupported layout type affine_map<(d0) -> ((d0 * 10))>
+
+// -----
+
+%fv, %idx, %mstr = "test.op"() : () -> (f32, index, memref<2xf32, strided<[1], offset: ?>>)
+memref.store %fv, %mstr[%idx] {"nontemporal" = false} : memref<2xf32, strided<[1], offset: ?>>
+
+// CHECK: Unsupported layout with dynamic offset strided<[1], offset: ?>

--- a/xdsl/transforms/convert_memref_to_ptr.py
+++ b/xdsl/transforms/convert_memref_to_ptr.py
@@ -37,8 +37,13 @@ def get_target_ptr(
     match memref_type.layout:
         case builtin.NoneAttr():
             strides = builtin.ShapedType.strides_for_shape(memref_type.get_shape())
+            offset = 0
         case builtin.StridedLayoutAttr():
             strides = memref_type.layout.get_strides()
+            if (offset := memref_type.layout.get_offset()) is None:
+                raise DiagnosticException(
+                    f"Unsupported layout with dynamic offset {memref_type.layout}"
+                )
         case _:
             raise DiagnosticException(f"Unsupported layout type {memref_type.layout}")
 
@@ -83,25 +88,36 @@ def get_target_ptr(
         ops.append(add_op)
         head = add_op.result
 
-    if head is None:
-        raise DiagnosticException("Got empty indices for offset calculations.")
+    if offset:
+        ops.append(
+            memref_offset_op := arith.ConstantOp.from_int_and_width(
+                offset, builtin.IndexType()
+            )
+        )
+        memref_offset_op.result.name_hint = "memref_base_offset"
+        if head is not None:
+            ops.append(add_op := arith.AddiOp(head, memref_offset_op.result))
+            head = add_op.result
 
-    ops.extend(
-        [
-            bytes_per_element_op := ptr.TypeOffsetOp(
-                memref_type.element_type, builtin.IndexType()
-            ),
-            final_offset := arith.MuliOp(head, bytes_per_element_op),
-        ]
-    )
+    if head is not None:
+        ops.extend(
+            [
+                bytes_per_element_op := ptr.TypeOffsetOp(
+                    memref_type.element_type, builtin.IndexType()
+                ),
+                final_offset := arith.MuliOp(head, bytes_per_element_op),
+                target_ptr := ptr.PtrAddOp(memref_ptr.res, final_offset.result),
+            ]
+        )
 
-    bytes_per_element_op.offset.name_hint = "bytes_per_element"
-    final_offset.result.name_hint = "scaled_pointer_offset"
+        bytes_per_element_op.offset.name_hint = "bytes_per_element"
+        final_offset.result.name_hint = "scaled_pointer_offset"
+        target_ptr.result.name_hint = "offset_pointer"
+        pointer = target_ptr.result
+    else:
+        pointer = memref_ptr.res
 
-    ops.append(target_ptr := ptr.PtrAddOp(memref_ptr.res, final_offset.result))
-
-    target_ptr.result.name_hint = "offset_pointer"
-    return ops, target_ptr.result
+    return ops, pointer
 
 
 @dataclass


### PR DESCRIPTION
Strided layouts in memrefs have strides and offsets, each of which could be dynamic. When we lower memrefs to pointers, dynamic values are unknown, so cannot actually be handled. We already have a check for dynamic strides, but not for a dynamic offset, this PR adds that, as well as a lowering for the offset in the case where it is known.