### PR TITLE
core: (SSAValue) make `get` generic

### DIFF
--- a/xdsl/dialects/accfg.py
+++ b/xdsl/dialects/accfg.py
@@ -137,10 +137,10 @@ class LaunchOp(IRDLOperation):
         param_names: Iterable[str] | Iterable[StringAttr],
         state: SSAValue | Operation,
     ):
-        state_val: SSAValue = SSAValue.get(state)
+        state_val = SSAValue.get(state, type=StateType)
 
-        if not isinstance(state_val.type, StateType):
-            raise ValueError("`state` SSA Value must be of type `accfg.state`!")
+        # if not isinstance(state_val.type, StateType):
+        #     raise ValueError("`state` SSA Value must be of type `accfg.state`!")
 
         param_names_tuple: tuple[StringAttr, ...] = tuple(
             StringAttr(name) if isinstance(name, str) else name for name in param_names

--- a/xdsl/dialects/accfg.py
+++ b/xdsl/dialects/accfg.py
@@ -139,9 +139,6 @@ class LaunchOp(IRDLOperation):
     ):
         state_val = SSAValue.get(state, type=StateType)
 
-        # if not isinstance(state_val.type, StateType):
-        #     raise ValueError("`state` SSA Value must be of type `accfg.state`!")
-
         param_names_tuple: tuple[StringAttr, ...] = tuple(
             StringAttr(name) if isinstance(name, str) else name for name in param_names
         )

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -1010,11 +1010,8 @@ class GEPOp(IRDLOperation):
             ssa_indices = []
 
         # convert a potential Operation into an SSAValue
-        ptr_val = SSAValue.get(ptr)
+        ptr_val = SSAValue.get(ptr, type=LLVMPointerType)
         ptr_type = ptr_val.type
-
-        if not isinstance(ptr_type, LLVMPointerType):
-            raise ValueError("Input must be a pointer")
 
         props: dict[str, Attribute] = {
             "rawConstantIndices": DenseArrayBase.create_dense_int(i32, indices),
@@ -1196,8 +1193,7 @@ class LoadOp(IRDLOperation):
 
     def __init__(self, ptr: SSAValue | Operation, result_type: Attribute | None = None):
         if result_type is None:
-            ptr = SSAValue.get(ptr)
-            assert isinstance(ptr.type, LLVMPointerType)
+            ptr = SSAValue.get(ptr, type=LLVMPointerType)
 
             if isinstance(ptr.type.type, NoneAttr):
                 raise ValueError(

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -103,10 +103,8 @@ class LoadOp(IRDLOperation):
     def get(
         cls, ref: SSAValue | Operation, indices: Sequence[SSAValue | Operation]
     ) -> Self:
-        ssa_value = SSAValue.get(ref)
-        ssa_value_type = ssa_value.type
-        ssa_value_type = cast(MemRefType[Attribute], ssa_value_type)
-        return cls(operands=[ref, indices], result_types=[ssa_value_type.element_type])
+        ssa_value = SSAValue.get(ref, type=MemRefType)
+        return cls(operands=[ref, indices], result_types=[ssa_value.type.element_type])
 
 
 @irdl_op_definition
@@ -601,8 +599,7 @@ class ExtractStridedMetaDataOp(IRDLOperation):
         Create an ExtractStridedMetaDataOp that extracts the metadata from the
         operation (source) that produces a memref.
         """
-        source_type = SSAValue.get(source).type
-        assert isa(source_type, MemRefType[Attribute])
+        source_type = SSAValue.get(source, type=MemRefType).type
         source_shape = source_type.get_shape()
         # Return a rank zero memref with the memref type
         base_buffer_type = MemRefType(

--- a/xdsl/dialects/stencil.py
+++ b/xdsl/dialects/stencil.py
@@ -748,8 +748,7 @@ class CastOp(IRDLOperation):
         res_type: FieldType[_FieldTypeElement] | FieldType[Attribute] | None = None,
     ) -> CastOp:
         """ """
-        field_ssa = SSAValue.get(field)
-        assert isa(field_ssa.type, FieldType[Attribute])
+        field_ssa = SSAValue.get(field, type=FieldType)
         if res_type is None:
             res_type = FieldType(
                 bounds,
@@ -898,8 +897,7 @@ class DynAccessOp(IRDLOperation):
         lb: IndexAttr,
         ub: IndexAttr,
     ):
-        temp_type = SSAValue.get(temp).type
-        assert isa(temp_type, TempType[Attribute])
+        temp_type = SSAValue.get(temp, type=TempType).type
         super().__init__(
             operands=[temp, list(offset)],
             attributes={"lb": lb, "ub": ub},
@@ -1108,9 +1106,7 @@ class AccessOp(IRDLOperation):
         offset: Sequence[int],
         offset_mapping: Sequence[int] | IndexAttr | None = None,
     ):
-        temp_type = SSAValue.get(temp).type
-        assert isinstance(temp_type, StencilType)
-        temp_type = cast(StencilType[Attribute], temp_type)
+        temp_type = SSAValue.get(temp, type=StencilType).type
 
         attributes: dict[str, Attribute] = {
             "offset": IndexAttr(
@@ -1274,8 +1270,7 @@ class LoadOp(IRDLOperation):
         lb: IndexAttr | None = None,
         ub: IndexAttr | None = None,
     ):
-        field_type = SSAValue.get(field).type
-        assert isa(field_type, FieldType[Attribute])
+        field_type = SSAValue.get(field, type=FieldType).type
 
         if lb is None or ub is None:
             res_type = TempType(field_type.get_num_dims(), field_type.element_type)

--- a/xdsl/dialects/tensor.py
+++ b/xdsl/dialects/tensor.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import math
 from collections.abc import Mapping, Sequence
-from typing import Any, cast
+from typing import cast
 
 from typing_extensions import Self
 
@@ -11,7 +11,6 @@ from xdsl.dialects.builtin import (
     Annotated,
     AnySignlessIntegerOrIndexType,
     ArrayAttr,
-    ContainerType,
     DenseArrayBase,
     IndexType,
     IntegerAttr,
@@ -320,17 +319,15 @@ class ExtractSliceOp(IRDLOperation):
     ) -> ExtractSliceOp:
         if strides is None:
             strides = [1] * len(offsets)
-        source_v = SSAValue.get(source)
+        source_v = SSAValue.get(source, type=TensorType)
         source_t = source_v.type
-        if not isinstance(source_t, ContainerType):
-            raise ValueError(f"Expected ContainerType, got {source_t}")
 
         if reduce_rank:
             result_sizes = list(s for s in sizes if s != 1)
         else:
             result_sizes = list(sizes)
 
-        return_type = TensorType[Any](source_t.get_element_type(), result_sizes)
+        return_type = TensorType(source_t.get_element_type(), result_sizes)
 
         return ExtractSliceOp.build(
             operands=[source, [], [], []],

--- a/xdsl/dialects/vector.py
+++ b/xdsl/dialects/vector.py
@@ -51,7 +51,7 @@ from xdsl.parser import Parser, UnresolvedOperand
 from xdsl.printer import Printer
 from xdsl.traits import Pure
 from xdsl.utils.exceptions import VerifyException
-from xdsl.utils.hints import assert_isa, isa
+from xdsl.utils.hints import isa
 from xdsl.utils.lexer import Position
 
 DYNAMIC_INDEX: int = -(2**63)
@@ -86,8 +86,7 @@ class LoadOp(IRDLOperation):
     def get(
         ref: SSAValue | Operation, indices: Sequence[SSAValue | Operation]
     ) -> LoadOp:
-        ref = SSAValue.get(ref)
-        assert assert_isa(ref.type, MemRefType[Attribute])
+        ref = SSAValue.get(ref, type=MemRefType)
 
         return LoadOp.build(
             operands=[ref, indices],
@@ -172,8 +171,7 @@ class FMAOp(IRDLOperation):
     def get(
         lhs: Operation | SSAValue, rhs: Operation | SSAValue, acc: Operation | SSAValue
     ) -> FMAOp:
-        lhs = SSAValue.get(lhs)
-        assert assert_isa(lhs.type, VectorType[Attribute])
+        lhs = SSAValue.get(lhs, type=VectorType)
 
         return FMAOp.build(
             operands=[lhs, rhs, acc],
@@ -226,8 +224,7 @@ class MaskedLoadOp(IRDLOperation):
         mask: SSAValue | Operation,
         passthrough: SSAValue | Operation,
     ) -> MaskedLoadOp:
-        memref = SSAValue.get(memref)
-        assert assert_isa(memref.type, MemRefType[Attribute])
+        memref = SSAValue.get(memref, type=MemRefType)
 
         return MaskedLoadOp.build(
             operands=[memref, indices, mask, passthrough],
@@ -461,8 +458,7 @@ class ExtractElementOp(IRDLOperation):
         vector: SSAValue | Operation,
         position: SSAValue | Operation | None = None,
     ):
-        vector = SSAValue.get(vector)
-        assert isa(vector.type, VectorType[Attribute])
+        vector = SSAValue.get(vector, type=VectorType)
 
         result_type = vector.type.element_type
 
@@ -635,8 +631,7 @@ class InsertElementOp(IRDLOperation):
         dest: SSAValue | Operation,
         position: SSAValue | Operation | None = None,
     ):
-        dest = SSAValue.get(dest)
-        assert isa(dest.type, VectorType[Attribute])
+        dest = SSAValue.get(dest, type=VectorType)
 
         result_type = SSAValue.get(dest).type
 

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -27,7 +27,7 @@ from typing import (
     overload,
 )
 
-from typing_extensions import Self, TypeVar
+from typing_extensions import Self, TypeForm, TypeVar
 
 from xdsl.traits import IsTerminator, NoTerminator, OpTrait, OpTraitInvT
 from xdsl.utils.exceptions import VerifyException
@@ -543,18 +543,20 @@ class SSAValue(Generic[AttributeCovT], IRWithUses, ABC):
 
     @staticmethod
     def get(
-        arg: SSAValue | Operation, *, type: type[AttributeInvT] = Attribute
+        arg: SSAValue | Operation, *, type: TypeForm[AttributeInvT] = Attribute
     ) -> SSAValue[AttributeInvT]:
         """
         Get a new SSAValue from either a SSAValue, or an operation with a single result.
         Checks that the resulting SSAValue is of the supplied type, if provided.
         """
+        from xdsl.utils.hints import isa
+
         match arg:
             case SSAValue():
-                if type is Attribute or isinstance(arg.type, type):
+                if type is Attribute or isa(arg.type, type):
                     return cast(SSAValue[AttributeInvT], arg)
                 raise ValueError(
-                    f"SSAValue.get: Expected {type.name} type but got SSAValue with type {arg.type}."
+                    f"SSAValue.get: Expected {type} but got SSAValue with type {arg.type}."
                 )
             case Operation():
                 if len(arg.results) == 1:

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -548,7 +548,7 @@ class SSAValue(Generic[AttributeCovT], IRWithUses, ABC):
         "Get a new SSAValue from either a SSAValue, or an operation with a single result."
         match arg:
             case SSAValue():
-                if type == Attribute or isinstance(arg.type, type):
+                if type is Attribute or isinstance(arg.type, type):
                     return cast(SSAValue[AttributeInvT], arg)
                 raise ValueError(
                     f"SSAValue.get: Expected {type.name} type but got SSAValue with type {arg.type}."

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -551,7 +551,7 @@ class SSAValue(Generic[AttributeCovT], IRWithUses, ABC):
                 if type == Attribute or isinstance(arg.type, type):
                     return cast(SSAValue[AttributeInvT], arg)
                 raise ValueError(
-                    f"SSAValue.get: Expected type {type} but got SSAValue with type {arg.type}."
+                    f"SSAValue.get: Expected {type.name} type but got SSAValue with type {arg.type}."
                 )
             case Operation():
                 if len(arg.results) == 1:

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -545,7 +545,10 @@ class SSAValue(Generic[AttributeCovT], IRWithUses, ABC):
     def get(
         arg: SSAValue | Operation, *, type: type[AttributeInvT] = Attribute
     ) -> SSAValue[AttributeInvT]:
-        "Get a new SSAValue from either a SSAValue, or an operation with a single result."
+        """
+        Get a new SSAValue from either a SSAValue, or an operation with a single result.
+        Checks that the resulting SSAValue is of the supplied type, if provided.
+        """
         match arg:
             case SSAValue():
                 if type is Attribute or isinstance(arg.type, type):

--- a/xdsl/transforms/experimental/convert_stencil_to_ll_mlir.py
+++ b/xdsl/transforms/experimental/convert_stencil_to_ll_mlir.py
@@ -497,7 +497,9 @@ class AccessOpToMemRef(RewritePattern):
             else:
                 memref_load_args.append(arg.idx)
 
-        load = memref.LoadOp.get(op.temp, memref_load_args)
+        load = memref.LoadOp(
+            operands=[op.temp, memref_load_args], result_types=[temp.element_type]
+        )
 
         rewriter.insert_op_before_matched_op(args)
         rewriter.replace_matched_op([*off_const_ops, load], [load.res])


### PR DESCRIPTION
Add a `type` argument to `SSAValue.get` allowing it to return `SSAValue`s with a more specialised generic paremeter.

This allows us to simplify a lot of cases where an SSAValue is obtained before checking its type.