### PR TITLE
dialects: (bufferization) fix ToTensorOp init

### DIFF
--- a/tests/irdl/test_attr_constraint.py
+++ b/tests/irdl/test_attr_constraint.py
@@ -2,7 +2,15 @@ from abc import ABC
 
 import pytest
 
-from xdsl.dialects.builtin import StringAttr
+from xdsl.dialects.bufferization import TensorFromMemRefConstraint
+from xdsl.dialects.builtin import (
+    MemRefType,
+    StringAttr,
+    TensorType,
+    UnrankedMemRefType,
+    UnrankedTensorType,
+    i32,
+)
 from xdsl.ir import Attribute, Data, ParametrizedAttribute
 from xdsl.irdl import (
     AllOf,
@@ -153,3 +161,29 @@ def test_base_attr_constraint_inference():
 def test_constraint_repr(constr: AttrConstraint, expected: str):
     assert repr(constr) == expected
     assert eval(repr(constr)) == constr
+
+
+@pytest.mark.parametrize(
+    "input, output",
+    [
+        (TensorType(i32, [2, 2]), MemRefType(i32, [2, 2])),
+        (UnrankedTensorType(i32), UnrankedMemRefType.from_type(i32)),
+    ],
+)
+def test_tensor_to_memref(
+    input: TensorType | UnrankedTensorType, output: MemRefType | UnrankedMemRefType
+):
+    assert TensorFromMemRefConstraint.tensor_to_memref(input) == output
+
+
+@pytest.mark.parametrize(
+    "input, output",
+    [
+        (MemRefType(i32, [2, 2]), TensorType(i32, [2, 2])),
+        (UnrankedMemRefType.from_type(i32), UnrankedTensorType(i32)),
+    ],
+)
+def test_memref_to_tensor(
+    input: MemRefType | UnrankedMemRefType, output: TensorType | UnrankedTensorType
+):
+    assert TensorFromMemRefConstraint.memref_to_tensor(input) == output

--- a/xdsl/dialects/bufferization.py
+++ b/xdsl/dialects/bufferization.py
@@ -1,15 +1,13 @@
 from collections.abc import Sequence, Set
 from dataclasses import dataclass
-from typing import Any, ClassVar
+from typing import ClassVar
 
 from xdsl.dialects.builtin import (
     AnyTensorTypeConstr,
     AnyUnrankedMemRefTypeConstr,
     AnyUnrankedTensorTypeConstr,
-    ContainerType,
     IndexType,
     MemRefType,
-    ShapedType,
     TensorType,
     UnitAttr,
     UnrankedMemRefType,
@@ -48,6 +46,24 @@ class TensorFromMemRefConstraint(
         MemRefType[Attribute] | UnrankedMemRefType[Attribute]
     ]
 
+    @staticmethod
+    def tensor_to_memref(
+        tensor: TensorType | UnrankedTensorType,
+    ) -> MemRefType | UnrankedMemRefType:
+        if isinstance(tensor, TensorType):
+            return MemRefType(tensor.element_type, tensor.shape)
+        else:
+            return UnrankedMemRefType.from_type(tensor.element_type)
+
+    @staticmethod
+    def memref_to_tensor(
+        memref: MemRefType | UnrankedMemRefType,
+    ) -> TensorType | UnrankedTensorType:
+        if isinstance(memref, MemRefType):
+            return TensorType(memref.element_type, memref.shape)
+        else:
+            return UnrankedTensorType(memref.element_type)
+
     def can_infer(self, var_constraint_names: Set[str]) -> bool:
         return self.memref_constraint.can_infer(var_constraint_names)
 
@@ -55,15 +71,11 @@ class TensorFromMemRefConstraint(
         self, context: ConstraintContext
     ) -> TensorType[Attribute] | UnrankedTensorType[Attribute]:
         memref_type = self.memref_constraint.infer(context)
-        if isinstance(memref_type, MemRefType):
-            return TensorType(memref_type.element_type, memref_type.shape)
-        return UnrankedTensorType(memref_type.element_type)
+        return self.memref_to_tensor(memref_type)
 
     def verify(self, attr: Attribute, constraint_context: ConstraintContext) -> None:
-        if isa(attr, TensorType[Attribute]):
-            memref_type = MemRefType(attr.element_type, attr.shape)
-        elif isa(attr, UnrankedTensorType[Attribute]):
-            memref_type = UnrankedMemRefType.from_type(attr.element_type)
+        if isa(attr, TensorType | UnrankedTensorType):
+            memref_type = self.tensor_to_memref(attr)
         else:
             raise VerifyException(
                 f"Expected tensor or unranked tensor type, got {attr}"
@@ -170,12 +182,7 @@ class ToTensorOp(IRDLOperation):
         restrict: bool = False,
         writable: bool = False,
     ):
-        memref_v = SSAValue.get(memref)
-        memref_t = memref_v.type
-        if not isinstance(memref_t, ContainerType):
-            raise ValueError(f"Expected ContainerType, got {memref_t}")
-        if not isinstance(memref_t, ShapedType):
-            raise ValueError(f"Expected ShapedType, got {memref_t}")
+        memref_v = SSAValue.get(memref, type=MemRefType | UnrankedMemRefType)
         properties = dict[str, Attribute]()
         if restrict:
             properties["restrict"] = UnitAttr()
@@ -183,9 +190,7 @@ class ToTensorOp(IRDLOperation):
             properties["writable"] = UnitAttr()
         super().__init__(
             operands=(memref,),
-            result_types=(
-                TensorType[Any](memref_t.get_element_type(), memref_t.get_shape()),
-            ),
+            result_types=(TensorFromMemRefConstraint.memref_to_tensor(memref_v.type),),
             properties=properties,
         )
 


### PR DESCRIPTION
Fixes the init method for `ToTensorOp`. Factors out the logic for converting to and from memref and tensor types to static methods on `TensorFromMemRefType`. 

Stacked on #4428 