### PR TITLE
core: avoid pipeline tuples when parsing pass spec

### DIFF
--- a/xdsl/interactive/app.py
+++ b/xdsl/interactive/app.py
@@ -724,12 +724,7 @@ def main():
 
     pass_spec_pipeline = list(parse_pipeline(args.passes))
     pass_list = get_all_passes()
-    pipeline = tuple(
-        pass_type.from_pass_spec(spec)
-        for pass_type, spec in PipelinePass.build_pipeline_tuples(
-            pass_list, pass_spec_pipeline
-        )
-    )
+    pipeline = tuple(PipelinePass.iter_passes(pass_list, pass_spec_pipeline))
 
     return InputApp(
         tuple(get_all_dialects().items()),

--- a/xdsl/passes.py
+++ b/xdsl/passes.py
@@ -1,6 +1,6 @@
 import dataclasses
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Iterable, Iterator
+from collections.abc import Callable, Iterable
 from dataclasses import Field, dataclass, field
 from types import NoneType, UnionType
 from typing import (
@@ -210,15 +210,15 @@ class PipelinePass(ModulePass):
         self.passes[-1].apply(ctx, op)
 
     @classmethod
-    def build_pipeline_tuples(
+    def iter_passes(
         cls,
         available_passes: dict[str, Callable[[], type[ModulePass]]],
         pass_spec_pipeline: Iterable[PipelinePassSpec],
-    ) -> Iterator[tuple[type[ModulePass], PipelinePassSpec]]:
+    ) -> Iterable[ModulePass]:
         for p in pass_spec_pipeline:
             if p.name not in available_passes:
                 raise Exception(f"Unrecognized pass: {p.name}")
-            yield (available_passes[p.name](), p)
+            yield available_passes[p.name]().from_pass_spec(p)
 
 
 def _convert_pass_arg_to_type(

--- a/xdsl/xdsl_opt_main.py
+++ b/xdsl/xdsl_opt_main.py
@@ -299,8 +299,7 @@ class xDSLOptMain(CommandLineTool):
 
         self.pipeline = PipelinePass(
             tuple(
-                pass_type.from_pass_spec(spec)
-                for pass_type, spec in PipelinePass.build_pipeline_tuples(
+                PipelinePass.iter_passes(
                     self.available_passes, parse_pipeline(self.args.passes)
                 )
             ),


### PR DESCRIPTION
Once upon a time passes were mutable, so `xdsl-gui` needed an immutable representation. Now that this is not needed we can simplify the parsing a bit in both the gui and `xdsl-opt`.