### PR TITLE
dialects: (x86) use typed SSA values for inference in inits

### DIFF
--- a/tests/dialects/test_x86.py
+++ b/tests/dialects/test_x86.py
@@ -2,6 +2,7 @@ import pytest
 
 from xdsl.dialects import x86
 from xdsl.dialects.builtin import IntegerAttr
+from xdsl.utils.test_value import create_ssa_value
 
 
 def test_unallocated_register():
@@ -189,13 +190,13 @@ def test_rrr_vops(
     operand1: x86.register.X86VectorRegisterType,
     operand2: x86.register.X86VectorRegisterType,
 ):
-    output = x86.ops.GetAVXRegisterOp(dest)
-    param1 = x86.ops.GetAVXRegisterOp(operand1)
-    param2 = x86.ops.GetAVXRegisterOp(operand2)
+    output = create_ssa_value(dest)
+    param1 = create_ssa_value(operand1)
+    param2 = create_ssa_value(operand2)
     op = OpClass(
-        source2=output.result,
-        register_in=param1.result,
-        source1=param2.result,
+        source2=output,
+        register_in=param1,
+        source1=param2,
         register_out=dest,
     )
     assert op.register_in.type == operand1

--- a/xdsl/backend/x86/lowering/convert_vector_to_x86.py
+++ b/xdsl/backend/x86/lowering/convert_vector_to_x86.py
@@ -30,9 +30,15 @@ class VectorFMAToX86(RewritePattern):
         vect_type = cast(VectorType, op.acc.type)
         x86_vect_type = vector_type_to_register_type(vect_type, self.arch)
         # Pointer casts
-        lhs_cast_op = UnrealizedConversionCastOp.get((op.lhs,), (x86_vect_type,))
-        rhs_cast_op = UnrealizedConversionCastOp.get((op.rhs,), (x86_vect_type,))
-        acc_cast_op = UnrealizedConversionCastOp.get((op.acc,), (x86_vect_type,))
+        lhs_cast_op, lhs_new = UnrealizedConversionCastOp.cast_one(
+            op.lhs, x86_vect_type
+        )
+        rhs_cast_op, rhs_new = UnrealizedConversionCastOp.cast_one(
+            op.rhs, x86_vect_type
+        )
+        acc_cast_op, acc_new = UnrealizedConversionCastOp.cast_one(
+            op.acc, x86_vect_type
+        )
         # Instruction selection
         element_size = cast(FixedBitwidthType, vect_type.get_element_type()).bitwidth
         match element_size:
@@ -48,7 +54,7 @@ class VectorFMAToX86(RewritePattern):
                 raise DiagnosticException(
                     "Float precision must be half, single or double."
                 )
-        fma_op = fma(acc_cast_op, lhs_cast_op, rhs_cast_op, register_out=x86_vect_type)
+        fma_op = fma(acc_new, lhs_new, rhs_new)
 
         res_cast_op = UnrealizedConversionCastOp.get(
             (fma_op.register_out,), (vect_type,)

--- a/xdsl/dialects/x86/ops.py
+++ b/xdsl/dialects/x86/ops.py
@@ -273,13 +273,15 @@ class R_Operation(Generic[R1InvT], X86Instruction, X86CustomFormatOperation, ABC
 
     def __init__(
         self,
-        register_in: Operation | SSAValue | None = None,
+        register_in: SSAValue[R1InvT],
         *,
         comment: str | StringAttr | None = None,
         register_out: R1InvT | None = None,
     ):
         if isinstance(comment, str):
             comment = StringAttr(comment)
+        if register_out is None:
+            register_out = register_in.type
         super().__init__(
             operands=[register_in],
             attributes={
@@ -861,15 +863,18 @@ class RSS_Operation(
 
     def __init__(
         self,
-        register_in: Operation | SSAValue,
+        register_in: SSAValue[R1InvT],
         source1: Operation | SSAValue,
         source2: Operation | SSAValue,
         *,
         comment: str | StringAttr | None = None,
-        register_out: R1InvT,
+        register_out: R1InvT | None = None,
     ):
         if isinstance(comment, str):
             comment = StringAttr(comment)
+
+        if register_out is None:
+            register_out = register_in.type
 
         super().__init__(
             operands=[register_in, source1, source2],


### PR DESCRIPTION
This makes pyright happy and the API less broken.