### PR TITLE
backend: (x86) add x86 register queue

### DIFF
--- a/tests/backend/x86/test_register_queue.py
+++ b/tests/backend/x86/test_register_queue.py
@@ -1,0 +1,33 @@
+from xdsl.backend.x86.register_queue import X86RegisterQueue
+from xdsl.dialects import x86
+
+
+def test_default_reserved_registers():
+    register_queue = X86RegisterQueue.default()
+
+    for reg in (
+        x86.register.RAX,
+        x86.register.RDX,
+        x86.register.RSP,
+    ):
+        available_before = register_queue.available_registers.copy()
+        register_queue.push(reg)
+        assert available_before == register_queue.available_registers
+
+
+def test_push_infinite_register():
+    register_queue = X86RegisterQueue()
+
+    infinite0 = x86.GeneralRegisterType.infinite_register(0)
+    register_queue.push(infinite0)
+    assert register_queue.pop(x86.GeneralRegisterType) == infinite0
+
+
+def test_push_register():
+    register_queue = X86RegisterQueue()
+
+    register_queue.push(x86.register.RBX)
+    assert register_queue.pop(x86.GeneralRegisterType) == x86.register.RBX
+
+    register_queue.push(x86.register.YMM0)
+    assert register_queue.pop(x86.AVX2RegisterType) == x86.register.YMM0

--- a/xdsl/backend/x86/register_queue.py
+++ b/xdsl/backend/x86/register_queue.py
@@ -1,0 +1,27 @@
+from dataclasses import dataclass
+
+from xdsl.backend.register_queue import LIFORegisterQueue
+from xdsl.dialects.x86 import register
+
+
+@dataclass
+class X86RegisterQueue(LIFORegisterQueue):
+    """
+    LIFO queue of x86-specific registers.
+    """
+
+    DEFAULT_RESERVED_REGISTERS = {
+        register.RAX,
+        register.RDX,
+        register.RSP,
+    }
+
+    DEFAULT_AVAILABLE_REGISTERS = (*reversed(register.YMM),)
+
+    @classmethod
+    def default_reserved_registers(cls):
+        return cls.DEFAULT_RESERVED_REGISTERS
+
+    @classmethod
+    def default_available_registers(cls):
+        return cls.DEFAULT_AVAILABLE_REGISTERS

--- a/xdsl/dialects/x86/register.py
+++ b/xdsl/dialects/x86/register.py
@@ -226,22 +226,25 @@ See external # [documentation](https://wiki.osdev.org/X86-64_Instruction_Encodin
 """
 
 UNALLOCATED_AVX2 = AVX2RegisterType.unallocated()
-YMM0 = AVX2RegisterType.from_name("ymm0")
-YMM1 = AVX2RegisterType.from_name("ymm1")
-YMM2 = AVX2RegisterType.from_name("ymm2")
-YMM3 = AVX2RegisterType.from_name("ymm3")
-YMM4 = AVX2RegisterType.from_name("ymm4")
-YMM5 = AVX2RegisterType.from_name("ymm5")
-YMM6 = AVX2RegisterType.from_name("ymm6")
-YMM7 = AVX2RegisterType.from_name("ymm7")
-YMM8 = AVX2RegisterType.from_name("ymm8")
-YMM9 = AVX2RegisterType.from_name("ymm9")
-YMM10 = AVX2RegisterType.from_name("ymm10")
-YMM11 = AVX2RegisterType.from_name("ymm11")
-YMM12 = AVX2RegisterType.from_name("ymm12")
-YMM13 = AVX2RegisterType.from_name("ymm13")
-YMM14 = AVX2RegisterType.from_name("ymm14")
-YMM15 = AVX2RegisterType.from_name("ymm15")
+YMM = tuple(AVX2RegisterType.from_name(f"ymm{i}") for i in range(16))
+(
+    YMM0,
+    YMM1,
+    YMM2,
+    YMM3,
+    YMM4,
+    YMM5,
+    YMM6,
+    YMM7,
+    YMM8,
+    YMM9,
+    YMM10,
+    YMM11,
+    YMM12,
+    YMM13,
+    YMM14,
+    YMM15,
+) = YMM
 
 
 @irdl_attr_definition


### PR DESCRIPTION
I'm certain I didn't add all the registers that can be used during register allocation, would appreciate suggestions and any pointers to resources on what registers can be used when!