### PR TITLE
dialects: (emitc) add emitc array verify and parsing checks

### DIFF
--- a/tests/dialects/test_emitc.py
+++ b/tests/dialects/test_emitc.py
@@ -1,6 +1,6 @@
 import pytest
 
-from xdsl.dialects.builtin import i32
+from xdsl.dialects.builtin import MemRefType, i32
 from xdsl.dialects.emitc import EmitC_ArrayType
 from xdsl.utils.exceptions import VerifyException
 
@@ -10,3 +10,22 @@ def test_emitc_array_negative_dimension():
         VerifyException, match="EmitC array dimensions must have non-negative size"
     ):
         EmitC_ArrayType([-1], i32)
+
+
+def test_emitc_array_nested_array_type():
+    nested_array = EmitC_ArrayType([2], i32)
+    with pytest.raises(
+        VerifyException,
+        match="EmitC array element type cannot be another EmitC_ArrayType.",
+    ):
+        EmitC_ArrayType([1], nested_array)
+
+
+def test_emitc_array_unsupported_element_type():
+    unsupported_type = MemRefType(element_type=i32, shape=[1])
+
+    with pytest.raises(
+        VerifyException,
+        match=f"EmitC array element type '{unsupported_type}' is not a supported EmitC type.",
+    ):
+        EmitC_ArrayType([1], unsupported_type)

--- a/tests/dialects/test_emitc.py
+++ b/tests/dialects/test_emitc.py
@@ -1,6 +1,6 @@
 import pytest
 
-from xdsl.dialects.builtin import MemRefType, i32
+from xdsl.dialects.builtin import i32
 from xdsl.dialects.emitc import EmitC_ArrayType
 from xdsl.utils.exceptions import VerifyException
 
@@ -10,22 +10,3 @@ def test_emitc_array_negative_dimension():
         VerifyException, match="EmitC array dimensions must have non-negative size"
     ):
         EmitC_ArrayType([-1], i32)
-
-
-def test_emitc_array_nested_array_type():
-    nested_array = EmitC_ArrayType([2], i32)
-    with pytest.raises(
-        VerifyException,
-        match="EmitC array element type cannot be another EmitC_ArrayType.",
-    ):
-        EmitC_ArrayType([1], nested_array)
-
-
-def test_emitc_array_unsupported_element_type():
-    unsupported_type = MemRefType(element_type=i32, shape=[1])
-
-    with pytest.raises(
-        VerifyException,
-        match=f"EmitC array element type '{unsupported_type}' is not a supported EmitC type.",
-    ):
-        EmitC_ArrayType([1], unsupported_type)

--- a/tests/dialects/test_emitc.py
+++ b/tests/dialects/test_emitc.py
@@ -5,11 +5,6 @@ from xdsl.dialects.emitc import EmitC_ArrayType
 from xdsl.utils.exceptions import VerifyException
 
 
-def test_emitc_array_empty_shape():
-    with pytest.raises(VerifyException, match="EmitC array shape must not be empty"):
-        EmitC_ArrayType([], i32)
-
-
 def test_emitc_array_negative_dimension():
     with pytest.raises(
         VerifyException, match="EmitC array dimensions must have non-negative size"

--- a/tests/filecheck/dialects/emitc/emitc_types.mlir
+++ b/tests/filecheck/dialects/emitc/emitc_types.mlir
@@ -1,14 +1,18 @@
 // RUN: XDSL_ROUNDTRIP
 
-// CHECK: f32_2D = !emitc.array<4x2xf32>
-// CHECK-SAME: i32_1D = !emitc.array<10xi32>
+// CHECK: bf16_1D = !emitc.array<1xbf16>
+// CHECK-SAME: f32_2D = !emitc.array<4x2xf32>
 // CHECK-SAME: f64_1D = !emitc.array<5xf64>
-// CHECK-SAME: i1_3D = !emitc.array<3x4x5xi1>
 // CHECK-SAME: i1_0D = !emitc.array<0xi1>
+// CHECK-SAME: i1_3D = !emitc.array<3x4x5xi1>
+// CHECK-SAME: i32_1D = !emitc.array<10xi32>
+// CHECK-SAME: index_1D = !emitc.array<1xindex>
 "test.op"() {
+  bf16_1D = !emitc.array<1xbf16>,
   f32_2D = !emitc.array<4x2xf32>,
-  i32_1D = !emitc.array<10xi32>,
   f64_1D = !emitc.array<5xf64>,
+  i1_0D = !emitc.array<0xi1>,
   i1_3D = !emitc.array<3x4x5xi1>,
-  i1_0D = !emitc.array<0xi1>
+  i32_1D = !emitc.array<10xi32>,
+  index_1D = !emitc.array<1xindex>
 }: ()->()

--- a/tests/filecheck/dialects/emitc/emitc_types.mlir
+++ b/tests/filecheck/dialects/emitc/emitc_types.mlir
@@ -4,9 +4,11 @@
 // CHECK-SAME: i32_1D = !emitc.array<10xi32>
 // CHECK-SAME: f64_1D = !emitc.array<5xf64>
 // CHECK-SAME: i1_3D = !emitc.array<3x4x5xi1>
+// CHECK-SAME: i1_0D = !emitc.array<0xi1>
 "test.op"() {
   f32_2D = !emitc.array<4x2xf32>,
   i32_1D = !emitc.array<10xi32>,
   f64_1D = !emitc.array<5xf64>,
-  i1_3D = !emitc.array<3x4x5xi1>
+  i1_3D = !emitc.array<3x4x5xi1>,
+  i1_0D = !emitc.array<0xi1>
 }: ()->()

--- a/tests/filecheck/dialects/emitc/emitc_types_invalid.mlir
+++ b/tests/filecheck/dialects/emitc/emitc_types_invalid.mlir
@@ -13,3 +13,17 @@
 "test.op"() {
   bad_type = !emitc.array<1xi0>>
 }: ()->()
+
+// -----
+
+// CHECK: EmitC array element type 'memref<1xi32>' is not a supported EmitC type.
+"test.op"() {
+  bad_type = !emitc.array<1xmemref<1xi32>>
+}: ()->()
+
+// -----
+
+// CHECK: EmitC array element type cannot be another EmitC_ArrayType.
+"test.op"() {
+  nested = !emitc.array<2x!emitc.array<3xf32>>
+}: ()->()

--- a/tests/filecheck/dialects/emitc/emitc_types_invalid.mlir
+++ b/tests/filecheck/dialects/emitc/emitc_types_invalid.mlir
@@ -27,3 +27,10 @@
 "test.op"() {
   nested = !emitc.array<2x!emitc.array<3xf32>>
 }: ()->()
+
+// -----
+
+// CHECK: EmitC array element type 'tensor<1x!emitc.array<1xf32>>' is not a supported EmitC type.
+"test.op"() {
+  tensor_with_emitc_array = !emitc.array<1xtensor<1x!emitc.array<1xf32>>>
+}: ()->()

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/emitc/emitc_types.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/emitc/emitc_types.mlir
@@ -2,11 +2,13 @@
 
 // CHECK: f32_2D = !emitc.array<4x2xf32>
 // CHECK-SAME: f64_1D = !emitc.array<5xf64>
+// CHECK-SAME: i1_0D = !emitc.array<0xi1>
 // CHECK-SAME: i1_3D = !emitc.array<3x4x5xi1>
 // CHECK-SAME: i32_1D = !emitc.array<10xi32>
 "test.op"() {
   f32_2D = !emitc.array<4x2xf32>,
-  i32_1D = !emitc.array<10xi32>,
   f64_1D = !emitc.array<5xf64>,
-  i1_3D = !emitc.array<3x4x5xi1>
+  i1_0D = !emitc.array<0xi1>,
+  i1_3D = !emitc.array<3x4x5xi1>,
+  i32_1D = !emitc.array<10xi32>
 }: ()->()

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/emitc/emitc_types.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/emitc/emitc_types.mlir
@@ -1,14 +1,18 @@
 // RUN: mlir-opt %s --mlir-print-op-generic --allow-unregistered-dialect | xdsl-opt --print-op-generic | filecheck %s
 
-// CHECK: f32_2D = !emitc.array<4x2xf32>
+// CHECK: bf16_1D = !emitc.array<1xbf16>
+// CHECK-SAME: f32_2D = !emitc.array<4x2xf32>
 // CHECK-SAME: f64_1D = !emitc.array<5xf64>
 // CHECK-SAME: i1_0D = !emitc.array<0xi1>
 // CHECK-SAME: i1_3D = !emitc.array<3x4x5xi1>
 // CHECK-SAME: i32_1D = !emitc.array<10xi32>
+// CHECK-SAME: index_1D = !emitc.array<1xindex>
 "test.op"() {
+  bf16_1D = !emitc.array<1xbf16>,
   f32_2D = !emitc.array<4x2xf32>,
   f64_1D = !emitc.array<5xf64>,
   i1_0D = !emitc.array<0xi1>,
   i1_3D = !emitc.array<3x4x5xi1>,
-  i32_1D = !emitc.array<10xi32>
+  i32_1D = !emitc.array<10xi32>,
+  index_1D = !emitc.array<1xindex>
 }: ()->()

--- a/xdsl/dialects/emitc.py
+++ b/xdsl/dialects/emitc.py
@@ -22,7 +22,6 @@ from xdsl.dialects.builtin import (
     IntegerType,
     ShapedType,
     TensorType,
-    TupleType,
 )
 from xdsl.ir import (
     Attribute,
@@ -141,11 +140,6 @@ def is_supported_emitc_type(type_attr: Attribute) -> bool:
             if isinstance(elem_type, EmitC_ArrayType):
                 return False
             return is_supported_emitc_type(elem_type)
-        case TupleType():
-            return all(
-                not isinstance(t, EmitC_ArrayType) and is_supported_emitc_type(t)
-                for t in type_attr.types
-            )
         case _:
             return False
 


### PR DESCRIPTION
Add additional checks to the emitc array shape and type verification as implemented in the [reference](https://github.com/llvm/llvm-project/blob/main/mlir/lib/Dialect/EmitC/IR/EmitC.cpp)
