### PR TITLE
core: make ParametrizedAttribute parameters dynamic

### DIFF
--- a/tests/filecheck/utils/codegen/simple.py
+++ b/tests/filecheck/utils/codegen/simple.py
@@ -256,9 +256,9 @@ dump_dialect_pyfile(
 # CHECK-NEXT:      a = operand_def(EqAttrConstraint(attr=IntegerType(32)))
 # CHECK-NEXT:      b = operand_def(EqAttrConstraint(attr=IntegerType(64, Signedness.SIGNED)))
 # CHECK-NEXT:      c = operand_def(EqAttrConstraint(attr=IntegerType(8, Signedness.UNSIGNED)))
-# CHECK-NEXT:      d = operand_def(EqAttrConstraint(attr=IndexType(parameters=())))
-# CHECK-NEXT:      e = operand_def(EqAttrConstraint(attr=Float32Type(parameters=())))
-# CHECK-NEXT:      f = operand_def(EqAttrConstraint(attr=NoneType(parameters=())))
+# CHECK-NEXT:      d = operand_def(EqAttrConstraint(attr=IndexType()))
+# CHECK-NEXT:      e = operand_def(EqAttrConstraint(attr=Float32Type()))
+# CHECK-NEXT:      f = operand_def(EqAttrConstraint(attr=NoneType()))
 # CHECK-NEXT:      v1 = operand_def(ParamAttrConstraint(ComplexType, (AnyAttr(),)))
 
 # CHECK:       @irdl_op_definition

--- a/xdsl/backend/register_type.py
+++ b/xdsl/backend/register_type.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
+from dataclasses import dataclass
 
 from typing_extensions import Self
 
@@ -21,6 +22,7 @@ from xdsl.printer import Printer
 from xdsl.utils.exceptions import VerifyException
 
 
+@dataclass(frozen=True, init=False)
 class RegisterType(ParametrizedAttribute, TypeAttribute, ABC):
     """
     An abstract register type for target ISA-specific dialects.

--- a/xdsl/dialects/stencil.py
+++ b/xdsl/dialects/stencil.py
@@ -254,6 +254,7 @@ class StencilBoundsAttr(ParametrizedAttribute):
         return self + o
 
 
+@dataclass(frozen=True, init=False)
 class StencilType(
     Generic[_FieldTypeElement],
     ParametrizedAttribute,

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -391,11 +391,21 @@ class BitEnumAttribute(Generic[EnumType], Data[tuple[EnumType, ...]]):
 class ParametrizedAttribute(Attribute):
     """An attribute parametrized by other attributes."""
 
-    parameters: tuple[Attribute, ...] = field()
-
     def __init__(self, parameters: Sequence[Attribute] = ()):
-        object.__setattr__(self, "parameters", tuple(parameters))
+        for (f, _), param in zip(
+            self.get_irdl_definition().parameters, parameters, strict=True
+        ):
+            object.__setattr__(self, f, param)
         super().__init__()
+
+    @property
+    def parameters(self) -> tuple[Attribute, ...]:
+        return (
+            *(
+                self.__getattribute__(field)
+                for field, _ in self.get_irdl_definition().parameters
+            ),
+        )
 
     @classmethod
     def new(cls: type[Self], params: Sequence[Attribute]) -> Self:

--- a/xdsl/irdl/attributes.py
+++ b/xdsl/irdl/attributes.py
@@ -36,7 +36,7 @@ from xdsl.ir import (
     ParametrizedAttribute,
     TypedAttribute,
 )
-from xdsl.utils.exceptions import PyRDLAttrDefinitionError, VerifyException
+from xdsl.utils.exceptions import PyRDLAttrDefinitionError
 from xdsl.utils.hints import (
     PropertyType,
     get_type_var_from_generic_class,
@@ -202,15 +202,9 @@ class ParamAttrDef:
     def verify(self, attr: ParametrizedAttribute):
         """Verify that `attr` satisfies the invariants."""
 
-        if len(attr.parameters) != len(self.parameters):
-            raise VerifyException(
-                f"In {self.name} attribute verifier: "
-                f"{len(self.parameters)} parameters expected, got "
-                f"{len(attr.parameters)}"
-            )
         constraint_context = ConstraintContext()
-        for param, (_, param_def) in zip(attr.parameters, self.parameters):
-            param_def.verify(param, constraint_context)
+        for field, param_def in self.parameters:
+            param_def.verify(getattr(attr, field), constraint_context)
 
 
 _PAttrTT = TypeVar("_PAttrTT", bound=type[ParametrizedAttribute])

--- a/xdsl/irdl/attributes.py
+++ b/xdsl/irdl/attributes.py
@@ -216,26 +216,12 @@ class ParamAttrDef:
 _PAttrTT = TypeVar("_PAttrTT", bound=type[ParametrizedAttribute])
 
 
-def get_accessors_from_param_attr_def(attr_def: ParamAttrDef):
-    # New fields and methods added to the attribute
-    new_fields = dict[str, Any]()
-
-    def param_name_field(idx: int):
-        @property
-        def field(self: ParametrizedAttribute):
-            return self.parameters[idx]
-
-        return field
-
-    for idx, (param_name, _) in enumerate(attr_def.parameters):
-        new_fields[param_name] = param_name_field(idx)
-
+def get_accessors_from_param_attr_def(attr_def: ParamAttrDef) -> dict[str, Any]:
     @classmethod
     def get_irdl_definition(cls: type[ParametrizedAttribute]):
         return attr_def
 
-    new_fields["get_irdl_definition"] = get_irdl_definition
-    return new_fields
+    return {"get_irdl_definition": get_irdl_definition}
 
 
 def irdl_param_attr_definition(cls: _PAttrTT) -> _PAttrTT:

--- a/xdsl/irdl/constraints.py
+++ b/xdsl/irdl/constraints.py
@@ -597,13 +597,14 @@ class ParamAttrConstraint(
             raise VerifyException(
                 f"{attr} should be of base attribute {self.base_attr.name}"
             )
-        if len(self.param_constrs) != len(attr.parameters):
+        parameters = attr.parameters
+        if len(self.param_constrs) != len(parameters):
             raise VerifyException(
                 f"{len(self.param_constrs)} parameters expected, "
-                f"but got {len(attr.parameters)}"
+                f"but got {len(parameters)}"
             )
         for idx, param_constr in enumerate(self.param_constrs):
-            param_constr.verify(attr.parameters[idx], constraint_context)
+            param_constr.verify(parameters[idx], constraint_context)
 
     @dataclass(frozen=True)
     class _Extractor(VarExtractor[Attribute]):


### PR DESCRIPTION
As far as I can tell this has no impact on perf.

@EdmundGoodman, what's the easiest way to do before/after comparisons locally in xDSL?