### PR TITLE
misc: swap comparison in disjoint set

### DIFF
--- a/xdsl/utils/disjoint_set.py
+++ b/xdsl/utils/disjoint_set.py
@@ -90,7 +90,7 @@ class IntDisjointSet:
         rhs_count = self._count[rhs_root]
         # Choose the root of the larger tree as the new parent
         new_parent, new_child = (
-            (lhs_root, rhs_root) if lhs_count <= rhs_count else (rhs_root, lhs_root)
+            (lhs_root, rhs_root) if lhs_count >= rhs_count else (rhs_root, lhs_root)
         )
         self._parent[new_child] = new_parent
         self._count[new_parent] = lhs_count + rhs_count


### PR DESCRIPTION
This was a bug in the disjoint set. Now, it should do union by size correctly.

