### PR TITLE
rewriting: Don't `insert_op` operations if no new_ops are provided.

### DIFF
--- a/tests/pattern_rewriter/test_pattern_rewriter.py
+++ b/tests/pattern_rewriter/test_pattern_rewriter.py
@@ -1901,7 +1901,6 @@ def test_pattern_rewriter_replace_external_op():
             operands=external_op.results,
         )
 
-    pr = PatternRewriter(user)
-    pr.current_operation = external_op
+    pr = PatternRewriter(external_op)
     pr.replace_op(external_op, (), new_op.results)
     assert tuple(user.operands) == new_op.results

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -182,7 +182,8 @@ class PatternRewriter(Builder, PatternRewriterListener):
             new_ops = (new_ops,)
 
         # First, insert the new operations before the matched operation
-        self.insert_op(new_ops, InsertPoint.before(op))
+        if new_ops:
+            self.insert_op(new_ops, InsertPoint.before(op))
 
         if new_results is None:
             new_results = new_ops[-1].results if new_ops else []

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -95,7 +95,8 @@ class PatternRewriter(Builder, PatternRewriterListener):
     def __init__(self, current_operation: Operation):
         PatternRewriterListener.__init__(self)
         self.current_operation = current_operation
-        Builder.__init__(self, InsertPoint.before(current_operation))
+        if current_operation.parent is not None:
+            Builder.__init__(self, InsertPoint.before(current_operation))
 
     def insert_op(
         self, op: Operation | Sequence[Operation], insertion_point: InsertPoint


### PR DESCRIPTION
This way, `InsertPoint.before` is not called and a replace can work when the op being replaced is not part of the module.
