### PR TITLE
backend: lowering of vector.broadcast to x86

### DIFF
--- a/tests/filecheck/backend/x86/convert_vector_to_x86.mlir
+++ b/tests/filecheck/backend/x86/convert_vector_to_x86.mlir
@@ -49,3 +49,39 @@
 %rhs = "test.op"(): () -> vector<2xf128>
 %acc = "test.op"(): () -> vector<2xf128>
 %fma = vector.fma %lhs,%rhs,%acc: vector<2xf128>
+
+// -----
+
+%s = "test.op"(): () -> f64
+%broadcast = vector.broadcast %s: f64 to vector<4xf64>
+// CHECK:      builtin.module {
+// CHECK-NEXT:   %s = "test.op"() : () -> f64
+// CHECK-NEXT:   %broadcast = builtin.unrealized_conversion_cast %s : f64 to !x86.reg
+// CHECK-NEXT:   %broadcast_1 = x86.ds.vpbroadcastq %broadcast : (!x86.reg) -> !x86.avx2reg
+// CHECK-NEXT:   %broadcast_2 = builtin.unrealized_conversion_cast %broadcast_1 : !x86.avx2reg to vector<4xf64>
+// CHECK-NEXT: }
+
+// -----
+
+%s = "test.op"(): () -> f32
+%broadcast = vector.broadcast %s: f32 to vector<8xf32>
+// CHECK:      builtin.module {
+// CHECK-NEXT:   %s = "test.op"() : () -> f32
+// CHECK-NEXT:   %broadcast = builtin.unrealized_conversion_cast %s : f32 to !x86.reg
+// CHECK-NEXT:   %broadcast_1 = x86.ds.vpbroadcastd %broadcast : (!x86.reg) -> !x86.avx2reg
+// CHECK-NEXT:   %broadcast_2 = builtin.unrealized_conversion_cast %broadcast_1 : !x86.avx2reg to vector<8xf32>
+// CHECK-NEXT: }
+
+// -----
+
+// CHECK: Half-precision vector broadcast is not implemented yet.
+%ptr = "test.op"(): () -> !ptr_xdsl.ptr
+%s = ptr_xdsl.load %ptr : !ptr_xdsl.ptr -> f16
+%broadcast = vector.broadcast %s: f16 to vector<16xf16>
+
+// -----
+
+// CHECK: Float precision must be half, single or double.
+%ptr = "test.op"(): () -> !ptr_xdsl.ptr
+%s = ptr_xdsl.load %ptr : !ptr_xdsl.ptr -> f128
+%broadcast = vector.broadcast %s: f128 to vector<2xf128>


### PR DESCRIPTION
Convert ```vector.broadcast``` operations into x86 assembly instructions.
