### PR TITLE
core: (constraints) introduce get_bases

### DIFF
--- a/tests/dialects/test_builtin.py
+++ b/tests/dialects/test_builtin.py
@@ -807,4 +807,4 @@ def test_array_constr():
     ctx.set_range_variable("T", (i32, i32))
     assert constr.infer(ctx) == ArrayAttr([i32, i32])
 
-    assert constr.get_unique_base() == ArrayAttr
+    assert constr.get_bases() == {ArrayAttr}

--- a/tests/irdl/test_attr_constraint.py
+++ b/tests/irdl/test_attr_constraint.py
@@ -62,28 +62,39 @@ class AttrB(Base):
     param: ParameterDef[AttrA]
 
 
+@irdl_attr_definition
+class AttrC(Base):
+    name = "test.attr_c"
+
+
 @pytest.mark.parametrize(
     "constraint, expected",
     [
         (AnyAttr(), None),
-        (EqAttrConstraint(AttrB([AttrA()])), AttrB),
+        (EqAttrConstraint(AttrB([AttrA()])), {AttrB}),
         (BaseAttr(Base), None),
-        (BaseAttr(AttrA), AttrA),
+        (BaseAttr(AttrA), {AttrA}),
         (EqAttrConstraint(AttrB([AttrA()])) | AnyAttr(), None),
-        (EqAttrConstraint(AttrB([AttrA()])) | BaseAttr(AttrA), None),
-        (EqAttrConstraint(AttrB([AttrA()])) | BaseAttr(AttrB), AttrB),
+        (EqAttrConstraint(AttrB([AttrA()])) | BaseAttr(AttrA), {AttrA, AttrB}),
+        (EqAttrConstraint(AttrB([AttrA()])) | BaseAttr(AttrB), {AttrB}),
         (AllOf((AnyAttr(), BaseAttr(Base))), None),
-        (AllOf((AnyAttr(), BaseAttr(AttrA))), AttrA),
-        (ParamAttrConstraint(AttrA, [BaseAttr(AttrB)]), AttrA),
+        (AllOf((AnyAttr(), BaseAttr(AttrA))), {AttrA}),
+        (ParamAttrConstraint(AttrA, [BaseAttr(AttrB)]), {AttrA}),
         (ParamAttrConstraint(Base, [BaseAttr(AttrA)]), None),
         (VarConstraint("T", BaseAttr(Base)), None),
-        (VarConstraint("T", BaseAttr(AttrA)), AttrA),
+        (VarConstraint("T", BaseAttr(AttrA)), {AttrA}),
+        (
+            AllOf(
+                (BaseAttr(AttrA) | BaseAttr(AttrB), BaseAttr(AttrB) | BaseAttr(AttrC))
+            ),
+            {AttrB},
+        ),
     ],
 )
-def test_attr_constraint_get_unique_base(
-    constraint: AttrConstraint, expected: type[Attribute] | None
+def test_attr_constraint_get_bases(
+    constraint: AttrConstraint, expected: set[type[Attribute]] | None
 ):
-    assert constraint.get_unique_base() == expected
+    assert constraint.get_bases() == expected
 
 
 def test_param_attr_constraint_inference():

--- a/tests/irdl/test_attribute_definition.py
+++ b/tests/irdl/test_attribute_definition.py
@@ -586,7 +586,7 @@ def test_informative_constraint():
     ):
         constr.verify(IntAttr(1), ConstraintContext())
     assert constr.can_infer(set())
-    assert constr.get_unique_base() == NoneAttr
+    assert constr.get_bases() == {NoneAttr}
 
 
 ################################################################################

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -223,8 +223,8 @@ class ArrayOfConstraint(GenericAttrConstraint[ArrayAttr[AttributeCovT]]):
     def infer(self, context: ConstraintContext) -> ArrayAttr[AttributeCovT]:
         return ArrayAttr(self.elem_range_constraint.infer(context, length=None))
 
-    def get_unique_base(self) -> type[Attribute] | None:
-        return ArrayAttr
+    def get_bases(self) -> set[type[Attribute]] | None:
+        return {ArrayAttr}
 
     def variables(self) -> set[str]:
         return self.elem_range_constraint.variables()
@@ -359,8 +359,8 @@ class IntAttrConstraint(GenericAttrConstraint[IntAttr]):
     def infer(self, context: ConstraintContext) -> IntAttr:
         return IntAttr(self.int_constraint.infer(context))
 
-    def get_unique_base(self) -> type[Attribute] | None:
-        return IntAttr
+    def get_bases(self) -> set[type[Attribute]] | None:
+        return {IntAttr}
 
 
 class Signedness(Enum):

--- a/xdsl/irdl/declarative_assembly_format_parser.py
+++ b/xdsl/irdl/declarative_assembly_format_parser.py
@@ -491,7 +491,10 @@ class FormatParser(BaseParser):
                 else self.op_def.attributes.get(attr_name)
             )
             if isinstance(attr_def, AttrOrPropDef):
-                unique_base = attr_def.constr.get_unique_base()
+                bases = attr_def.constr.get_bases()
+                unique_base = (
+                    bases.pop() if bases is not None and len(bases) == 1 else None
+                )
                 if unique_base == UnitAttr:
                     return OptionalUnitAttrVariable(
                         variable_name, is_property, None, None


### PR DESCRIPTION
Generalises `get_unique_base` to return a set of all possible bases, or `None` if there is no known finite list of bases.