### PR TITLE
dialects: (emitc) remove duplicated empty shape error

### DIFF
--- a/tests/filecheck/dialects/emitc/emitc_types_invalid.mlir
+++ b/tests/filecheck/dialects/emitc/emitc_types_invalid.mlir
@@ -1,0 +1,8 @@
+// RUN: xdsl-opt %s --split-input-file --verify-diagnostics | filecheck %s
+
+// Check that the right diagnostics are emitted when verify EmitC types with invalid definition.
+
+// CHECK: EmitC array shape must not be empty
+"test.op"() {
+  empty = !emitc.array<f32>
+}: ()->()

--- a/tests/filecheck/dialects/emitc/emitc_types_invalid_parsing.mlir
+++ b/tests/filecheck/dialects/emitc/emitc_types_invalid_parsing.mlir
@@ -1,8 +1,0 @@
-// RUN: xdsl-opt %s --split-input-file --parsing-diagnostics | filecheck %s
-
-// Check that the right diagnostics are emitted when parsing EmitC types with invalid definition.
-
-// CHECK: EmitC array shape must not be empty
-"test.op"() {
-  empty = !emitc.array<f32>
-}: ()->()

--- a/xdsl/dialects/emitc.py
+++ b/xdsl/dialects/emitc.py
@@ -74,8 +74,6 @@ class EmitC_ArrayType(
     def parse_parameters(cls, parser: AttrParser):
         with parser.in_angle_brackets():
             shape, type = parser.parse_ranked_shape()
-            if not shape:
-                raise parser.raise_error("EmitC array shape must not be empty")
             return ArrayAttr(IntAttr(dim) for dim in shape), type
 
     def print_parameters(self, printer: Printer) -> None:


### PR DESCRIPTION
The empty shape verification happens already in the verify method