### PR TITLE
bug: (x86) possibly different register types for DS_Operation

### DIFF
--- a/tests/backend/x86/test_register_allocation.py
+++ b/tests/backend/x86/test_register_allocation.py
@@ -264,7 +264,7 @@ def test_rss_operation_register_constraints():
 
 
 @irdl_op_definition
-class TestDSOperation(DS_Operation[GeneralRegisterType]):
+class TestDSOperation(DS_Operation[GeneralRegisterType, GeneralRegisterType]):
     """Test operation that inherits from DS_Operation for testing register constraints."""
 
     name = "test.ds_operation"

--- a/xdsl/dialects/x86/ops.py
+++ b/xdsl/dialects/x86/ops.py
@@ -286,14 +286,16 @@ class RS_Operation(
         )
 
 
-class DS_Operation(Generic[R1InvT], X86Instruction, X86CustomFormatOperation, ABC):
+class DS_Operation(
+    Generic[R1InvT, R2InvT], X86Instruction, X86CustomFormatOperation, ABC
+):
     """
     A base class for x86 operations that have one destination register and one source
     register.
     """
 
     destination = result_def(R1InvT)
-    source = operand_def(R1InvT)
+    source = operand_def(R2InvT)
 
     def __init__(
         self,
@@ -1094,7 +1096,7 @@ class RS_XorOp(RS_Operation[GeneralRegisterType, GeneralRegisterType]):
 
 
 @irdl_op_definition
-class DS_MovOp(DS_Operation[GeneralRegisterType]):
+class DS_MovOp(DS_Operation[X86RegisterType, GeneralRegisterType]):
     """
     Copies the value of s into r.
     ```C


### PR DESCRIPTION
Make it possible to make a difference between the destination and the source (in termes of register types)
