### PR TITLE
core: Improve typing of `irdl_to_attr_constraint`

### DIFF
--- a/xdsl/irdl/attributes.py
+++ b/xdsl/irdl/attributes.py
@@ -22,6 +22,7 @@ from typing import (
     get_args,
     get_origin,
     get_type_hints,
+    overload,
 )
 
 if TYPE_CHECKING:
@@ -334,6 +335,29 @@ def irdl_list_to_attr_constraint(
     return constraints[0]
 
 
+@overload
+def irdl_to_attr_constraint(
+    irdl: (
+        GenericAttrConstraint[AttributeInvT]
+        | "TypeForm[AttributeInvT]"
+        | type[AttributeInvT]
+        | AttributeInvT
+    ),
+    *,
+    allow_type_var: bool = False,
+    type_var_mapping: dict[TypeVar, AttrConstraint] | None = None,
+) -> GenericAttrConstraint[AttributeInvT]: ...
+
+
+@overload
+def irdl_to_attr_constraint(
+    irdl: Attribute | TypeVar | ConstraintVar,
+    *,
+    allow_type_var: bool = False,
+    type_var_mapping: dict[TypeVar, AttrConstraint] | None = None,
+) -> AttrConstraint: ...
+
+
 def irdl_to_attr_constraint(
     irdl: IRDLAttrConstraint,
     *,
@@ -466,11 +490,11 @@ def base(irdl: type[AttributeInvT]) -> GenericAttrConstraint[AttributeInvT]:
     Converts an attribute type into the equivalent constraint, detecting generic
     parameters if present.
     """
-    return cast(GenericAttrConstraint[AttributeInvT], irdl_to_attr_constraint(irdl))
+    return irdl_to_attr_constraint(irdl)
 
 
 def eq(irdl: AttributeInvT) -> GenericAttrConstraint[AttributeInvT]:
     """
     Converts an attribute instance into the equivalent constraint.
     """
-    return cast(GenericAttrConstraint[AttributeInvT], irdl_to_attr_constraint(irdl))
+    return irdl_to_attr_constraint(irdl)

--- a/xdsl/utils/hints.py
+++ b/xdsl/utils/hints.py
@@ -93,9 +93,7 @@ def isa(arg: Any, hint: "TypeForm[_T]") -> TypeGuard[_T]:
     from xdsl.irdl import GenericData, irdl_to_attr_constraint
 
     if (origin is not None) and issubclass(origin, GenericData | ParametrizedAttribute):
-        constraint = irdl_to_attr_constraint(
-            hint  # pyright: ignore[reportArgumentType]
-        )
+        constraint = irdl_to_attr_constraint(hint)
         try:
             constraint.verify(arg, ConstraintContext())
             return True


### PR DESCRIPTION
Stacked PRs:
 * #4482
 * #4481
 * #4480
 * #4479
 * __->__#4478


--- --- ---

### core: Improve typing of `irdl_to_attr_constraint`


Now, irdl_to_attr_constraint will correctly propagate the expected generic
type if it can be inferred from the inputs.
