### PR TITLE
dialects: (emitc) Remove duplicated testcase

### DIFF
--- a/tests/dialects/test_emitc.py
+++ b/tests/dialects/test_emitc.py
@@ -5,11 +5,6 @@ from xdsl.dialects.emitc import EmitC_ArrayType
 from xdsl.utils.exceptions import VerifyException
 
 
-def test_emitc_array_empty_shape():
-    with pytest.raises(VerifyException, match="EmitC array shape must not be empty"):
-        EmitC_ArrayType([], i32)
-
-
 def test_emitc_array_negative_dimension():
     with pytest.raises(
         VerifyException, match="EmitC array dimensions must have non-negative size"


### PR DESCRIPTION
Remove the duplicated verification test for the emitc array type.
That testcase already exists in the [file check test](https://github.com/xdslproject/xdsl/blob/main/tests/filecheck/dialects/emitc/emitc_types_invalid.mlir#L5)