### PR TITLE
misc: enforce use of typing_extensions.TypeVar

### DIFF
--- a/docs/Toy/toy/rewrites/lower_toy_affine.py
+++ b/docs/Toy/toy/rewrites/lower_toy_affine.py
@@ -6,7 +6,9 @@ expects that all calls have been inlined, and all shapes have been resolved.
 
 from collections.abc import Callable, Sequence
 from itertools import product
-from typing import TypeAlias, TypeVar, cast
+from typing import TypeAlias, cast
+
+from typing_extensions import TypeVar
 
 from xdsl.builder import Builder, InsertPoint
 from xdsl.context import Context

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,6 +150,7 @@ max-line-length = 130
 "xdsl.parser.base_parser".msg = "Use xdsl.parser instead."
 "xdsl.parser.core".msg = "Use xdsl.parser instead."
 "xdsl.parser.generic_parser".msg = "Use xdsl.parser instead."
+"typing.TypeVar".msg = "Use typing_extensions.TypeVar instead."
 
 
 [tool.ruff.lint.per-file-ignores]

--- a/tests/dialects/test_arith.py
+++ b/tests/dialects/test_arith.py
@@ -1,6 +1,5 @@
-from typing import TypeVar
-
 import pytest
+from typing_extensions import TypeVar
 
 from xdsl.dialects.arith import (
     AddfOp,

--- a/tests/irdl/test_attribute_definition.py
+++ b/tests/irdl/test_attribute_definition.py
@@ -8,9 +8,10 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from enum import auto
 from io import StringIO
-from typing import Annotated, Any, Generic, TypeAlias, TypeVar, cast
+from typing import Annotated, Any, Generic, TypeAlias, cast
 
 import pytest
+from typing_extensions import TypeVar
 
 from xdsl.dialects.builtin import (
     IndexType,

--- a/tests/irdl/test_operation_definition.py
+++ b/tests/irdl/test_operation_definition.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from typing import Annotated, ClassVar, Generic, TypeVar
+from typing import Annotated, ClassVar, Generic
 
 import pytest
+from typing_extensions import TypeVar
 
 from xdsl.context import Context
 from xdsl.dialects.builtin import (

--- a/tests/test_frontend_type_conversion.py
+++ b/tests/test_frontend_type_conversion.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import ast
 from collections.abc import Callable
 from sys import _getframe  # pyright: ignore[reportPrivateUsage]
-from typing import Any, Generic, Literal, TypeAlias, TypeVar
+from typing import Any, Generic, Literal, TypeAlias
 
 import pytest
+from typing_extensions import TypeVar
 
 from xdsl.frontend.pyast.dialects.builtin import (
     _FrontendType,  # pyright: ignore[reportPrivateUsage]

--- a/tests/test_is_satisfying_hint.py
+++ b/tests/test_is_satisfying_hint.py
@@ -1,4 +1,6 @@
-from typing import Any, Generic, Literal, TypeAlias, TypeVar
+from typing import Any, Generic, Literal, TypeAlias
+
+from typing_extensions import TypeVar
 
 from xdsl.dialects.builtin import (
     ArrayAttr,

--- a/xdsl/backend/jax_executable.py
+++ b/xdsl/backend/jax_executable.py
@@ -1,6 +1,6 @@
 from collections.abc import Callable, Sequence
 from inspect import signature
-from typing import Any, ParamSpec, TypeVar, cast, get_args, get_origin
+from typing import Any, ParamSpec, cast, get_args, get_origin
 
 import jax.numpy as jnp
 import numpy as np
@@ -10,6 +10,7 @@ from jax._src.interpreters import mlir
 from jax._src.typing import SupportsDType
 from jaxlib.mlir import ir
 from jaxlib.xla_client import LoadedExecutable
+from typing_extensions import TypeVar
 
 from xdsl.dialects.builtin import FunctionType, ModuleOp
 from xdsl.dialects.func import FuncOp

--- a/xdsl/backend/register_stack.py
+++ b/xdsl/backend/register_stack.py
@@ -2,7 +2,8 @@ from collections import defaultdict
 from collections.abc import Iterable, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass, field
-from typing import TypeVar
+
+from typing_extensions import TypeVar
 
 from xdsl.backend.register_type import RegisterType
 from xdsl.dialects.builtin import IntAttr

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import abc
 from collections.abc import Mapping, Sequence
-from typing import ClassVar, Literal, TypeVar, cast
+from typing import ClassVar, Literal, cast
+
+from typing_extensions import TypeVar
 
 from xdsl.dialects.builtin import (
     AnyFloat,

--- a/xdsl/dialects/gpu.py
+++ b/xdsl/dialects/gpu.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from enum import auto
-from typing import TypeVar
+
+from typing_extensions import TypeVar
 
 from xdsl.dialects import memref
 from xdsl.dialects.builtin import (

--- a/xdsl/dialects/pdl.py
+++ b/xdsl/dialects/pdl.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from collections.abc import Iterable, Sequence
-from typing import Generic, TypeVar
+from typing import Generic
+
+from typing_extensions import TypeVar
 
 from xdsl.dialects.builtin import (
     I16,

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -4,9 +4,9 @@ from abc import ABC, abstractmethod
 from collections.abc import Sequence, Set
 from io import StringIO
 from itertools import chain
-from typing import IO, Annotated, Generic, Literal, TypeAlias, TypeVar
+from typing import IO, Annotated, Generic, Literal, TypeAlias
 
-from typing_extensions import Self, assert_never
+from typing_extensions import Self, TypeVar, assert_never
 
 from xdsl.backend.assembly_printer import (
     AssemblyPrintable,

--- a/xdsl/dialects/snitch_runtime.py
+++ b/xdsl/dialects/snitch_runtime.py
@@ -1,6 +1,8 @@
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
-from typing import Annotated, Generic, TypeVar
+from typing import Annotated, Generic
+
+from typing_extensions import TypeVar
 
 from xdsl.dialects.builtin import (
     I32,

--- a/xdsl/dialects/stim/stim_parser.py
+++ b/xdsl/dialects/stim/stim_parser.py
@@ -1,6 +1,7 @@
 import re
 from collections.abc import Callable, Sequence
-from typing import TypeVar
+
+from typing_extensions import TypeVar
 
 from xdsl.dialects.builtin import ArrayAttr, FloatData, IntAttr
 from xdsl.dialects.stim import (

--- a/xdsl/dialects/x86/ops.py
+++ b/xdsl/dialects/x86/ops.py
@@ -30,9 +30,9 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections.abc import Sequence, Set
 from io import StringIO
-from typing import IO, Generic, TypeVar, cast
+from typing import IO, Generic, cast
 
-from typing_extensions import Self
+from typing_extensions import Self, TypeVar
 
 from xdsl.backend.assembly_printer import AssemblyPrinter, OneLineAssemblyPrintable
 from xdsl.backend.register_allocatable import (

--- a/xdsl/frontend/pyast/const.py
+++ b/xdsl/frontend/pyast/const.py
@@ -1,5 +1,7 @@
 import ast
-from typing import Generic, TypeVar
+from typing import Generic
+
+from typing_extensions import TypeVar
 
 _T = TypeVar("_T")
 

--- a/xdsl/frontend/pyast/dialects/arith.py
+++ b/xdsl/frontend/pyast/dialects/arith.py
@@ -1,5 +1,6 @@
 from collections.abc import Callable
-from typing import TypeVar
+
+from typing_extensions import TypeVar
 
 import xdsl.dialects.arith as arith
 from xdsl.frontend.pyast.dialects.builtin import f16, f32, f64, i1, i32, i64, index

--- a/xdsl/frontend/pyast/dialects/builtin.py
+++ b/xdsl/frontend/pyast/dialects/builtin.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Any, Generic, Literal, TypeAlias, TypeVar
+from typing import Any, Generic, Literal, TypeAlias
+
+from typing_extensions import TypeVar
 
 import xdsl.dialects.builtin as builtin
 from xdsl.dialects.builtin import Signedness

--- a/xdsl/interpreter.py
+++ b/xdsl/interpreter.py
@@ -12,8 +12,9 @@ from typing import (
     NamedTuple,
     ParamSpec,
     TypeAlias,
-    TypeVar,
 )
+
+from typing_extensions import TypeVar
 
 from xdsl.dialects.builtin import ModuleOp, SymbolRefAttr
 from xdsl.ir import (

--- a/xdsl/interpreters/riscv.py
+++ b/xdsl/interpreters/riscv.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Iterator, Sequence
-from typing import Any, TypeAlias, TypeVar, cast
+from typing import Any, TypeAlias, cast
+
+from typing_extensions import TypeVar
 
 from xdsl.dialects import builtin, riscv
 from xdsl.dialects.builtin import (

--- a/xdsl/interpreters/shaped_array.py
+++ b/xdsl/interpreters/shaped_array.py
@@ -5,9 +5,9 @@ from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from itertools import accumulate, product
 from math import prod
-from typing import Generic, TypeVar
+from typing import Generic
 
-from typing_extensions import Self
+from typing_extensions import Self, TypeVar
 
 from xdsl.dialects.builtin import PackableType, ShapedType
 from xdsl.interpreters.utils.ptr import TypedPtr

--- a/xdsl/interpreters/utils/ptr.py
+++ b/xdsl/interpreters/utils/ptr.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 import itertools
 from collections.abc import Iterator, Sequence
 from dataclasses import KW_ONLY, dataclass, field
-from typing import Generic, Literal, TypeVar
+from typing import Generic, Literal
 
-from typing_extensions import Self
+from typing_extensions import Self, TypeVar
 
 from xdsl.dialects.builtin import (
     Float32Type,

--- a/xdsl/interpreters/utils/stream.py
+++ b/xdsl/interpreters/utils/stream.py
@@ -1,6 +1,8 @@
 import abc
 from dataclasses import dataclass, field
-from typing import Generic, TypeVar
+from typing import Generic
+
+from typing_extensions import TypeVar
 
 T = TypeVar("T")
 TCov = TypeVar("TCov", covariant=True)

--- a/xdsl/irdl/attributes.py
+++ b/xdsl/irdl/attributes.py
@@ -16,7 +16,6 @@ from typing import (
     Any,
     Generic,
     TypeAlias,
-    TypeVar,
     Union,
     cast,
     get_args,
@@ -24,6 +23,8 @@ from typing import (
     get_type_hints,
     overload,
 )
+
+from typing_extensions import TypeVar
 
 if TYPE_CHECKING:
     from typing_extensions import TypeForm

--- a/xdsl/irdl/constraints.py
+++ b/xdsl/irdl/constraints.py
@@ -9,11 +9,10 @@ from typing import (
     Generic,
     TypeAlias,
     TypeGuard,
-    TypeVar,
     cast,
 )
 
-from typing_extensions import assert_never
+from typing_extensions import TypeVar, assert_never
 
 from xdsl.ir import (
     Attribute,

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -9,7 +9,9 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from dataclasses import dataclass, field
-from typing import Literal, TypeVar
+from typing import Literal
+
+from typing_extensions import TypeVar
 
 from xdsl.dialects.builtin import UnitAttr
 from xdsl.ir import (

--- a/xdsl/irdl/operations.py
+++ b/xdsl/irdl/operations.py
@@ -14,14 +14,13 @@ from typing import (
     Generic,
     Literal,
     TypeAlias,
-    TypeVar,
     cast,
     get_args,
     get_origin,
     overload,
 )
 
-from typing_extensions import assert_never
+from typing_extensions import TypeVar, assert_never
 
 from xdsl.ir import (
     Attribute,

--- a/xdsl/parser/base_parser.py
+++ b/xdsl/parser/base_parser.py
@@ -4,7 +4,8 @@ that is inherited from the different parsers used in xDSL.
 """
 
 from dataclasses import dataclass
-from typing import TypeVar
+
+from typing_extensions import TypeVar
 
 from xdsl.utils.mlir_lexer import MLIRTokenKind, PunctuationSpelling, StringLiteral
 from xdsl.utils.str_enum import StrEnum

--- a/xdsl/parser/generic_parser.py
+++ b/xdsl/parser/generic_parser.py
@@ -7,7 +7,9 @@ from collections.abc import Callable, Iterable
 from contextlib import contextmanager
 from dataclasses import dataclass
 from enum import Enum
-from typing import Generic, NoReturn, TypeVar, overload
+from typing import Generic, NoReturn, overload
+
+from typing_extensions import TypeVar
 
 from xdsl.utils.exceptions import ParseError
 from xdsl.utils.lexer import Lexer, Position, Span, Token, TokenKindT

--- a/xdsl/passes.py
+++ b/xdsl/passes.py
@@ -7,11 +7,12 @@ from typing import (
     Any,
     ClassVar,
     NamedTuple,
-    TypeVar,
     Union,
     get_args,
     get_origin,
 )
+
+from typing_extensions import TypeVar
 
 from xdsl.context import Context
 from xdsl.dialects import builtin

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -6,7 +6,9 @@ from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass, field
 from functools import wraps
 from types import UnionType
-from typing import TypeVar, Union, final, get_args, get_origin
+from typing import Union, final, get_args, get_origin
+
+from typing_extensions import TypeVar
 
 from xdsl.builder import Builder, BuilderListener
 from xdsl.dialects.builtin import ArrayAttr, DictionaryAttr, ModuleOp

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -6,7 +6,9 @@ from collections.abc import Callable, Iterable, Mapping, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from itertools import chain
-from typing import Any, TypeVar, cast
+from typing import Any, cast
+
+from typing_extensions import TypeVar
 
 from xdsl.dialects.builtin import (
     AffineMapAttr,

--- a/xdsl/traits.py
+++ b/xdsl/traits.py
@@ -4,7 +4,9 @@ import abc
 from collections.abc import Iterator
 from dataclasses import dataclass, field
 from enum import Enum, auto
-from typing import TYPE_CHECKING, TypeVar, final
+from typing import TYPE_CHECKING, final
+
+from typing_extensions import TypeVar
 
 from xdsl.utils.exceptions import VerifyException
 

--- a/xdsl/transforms/common_subexpression_elimination.py
+++ b/xdsl/transforms/common_subexpression_elimination.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass, field
-from typing import TypeVar
+
+from typing_extensions import TypeVar
 
 from xdsl.context import Context
 from xdsl.dialects.builtin import ModuleOp, UnregisteredOp

--- a/xdsl/transforms/experimental/convert_stencil_to_ll_mlir.py
+++ b/xdsl/transforms/experimental/convert_stencil_to_ll_mlir.py
@@ -1,8 +1,10 @@
 from dataclasses import dataclass
 from itertools import product
 from math import prod
-from typing import TypeVar, cast
+from typing import cast
 from warnings import warn
+
+from typing_extensions import TypeVar
 
 from xdsl.context import Context
 from xdsl.dialects import arith, builtin, memref, scf

--- a/xdsl/transforms/experimental/dmp/stencil_global_to_local.py
+++ b/xdsl/transforms/experimental/dmp/stencil_global_to_local.py
@@ -2,7 +2,9 @@ from abc import ABC
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from math import prod
-from typing import ClassVar, TypeVar, cast
+from typing import ClassVar, cast
+
+from typing_extensions import TypeVar
 
 from xdsl.context import Context
 from xdsl.dialects import arith, builtin, func, memref, mpi, printf, scf, stencil

--- a/xdsl/transforms/lower_mpi.py
+++ b/xdsl/transforms/lower_mpi.py
@@ -2,7 +2,9 @@ from abc import ABC
 from collections.abc import Sequence
 from dataclasses import dataclass
 from math import prod
-from typing import TypeVar, cast
+from typing import cast
+
+from typing_extensions import TypeVar
 
 from xdsl.context import Context
 from xdsl.dialects import arith, builtin, func, llvm, memref, mpi

--- a/xdsl/transforms/stencil_bufferize.py
+++ b/xdsl/transforms/stencil_bufferize.py
@@ -1,7 +1,9 @@
 from collections.abc import Generator
 from dataclasses import dataclass
 from itertools import chain
-from typing import Any, TypeVar, cast
+from typing import Any, cast
+
+from typing_extensions import TypeVar
 
 from xdsl.context import Context
 from xdsl.dialects import builtin

--- a/xdsl/utils/base_printer.py
+++ b/xdsl/utils/base_printer.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from collections.abc import Callable, Iterable
 from contextlib import contextmanager
 from dataclasses import dataclass, field
-from typing import IO, Any, TypeVar
+from typing import IO, Any
+
+from typing_extensions import TypeVar
 
 
 @dataclass(eq=False, repr=False)

--- a/xdsl/utils/disjoint_set.py
+++ b/xdsl/utils/disjoint_set.py
@@ -5,7 +5,9 @@ See external [documentation](https://en.wikipedia.org/wiki/Disjoint-set_data_str
 """
 
 from collections.abc import Hashable, Sequence
-from typing import Generic, TypeVar
+from typing import Generic
+
+from typing_extensions import TypeVar
 
 
 class IntDisjointSet:

--- a/xdsl/utils/hints.py
+++ b/xdsl/utils/hints.py
@@ -8,12 +8,13 @@ from typing import (
     Generic,
     Literal,
     TypeGuard,
-    TypeVar,
     Union,
     cast,
     get_args,
     get_origin,
 )
+
+from typing_extensions import TypeVar
 
 from xdsl.ir import ParametrizedAttribute, SSAValue
 from xdsl.utils.exceptions import VerifyException

--- a/xdsl/utils/immutable_list.py
+++ b/xdsl/utils/immutable_list.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
-from typing import Any, SupportsIndex, TypeVar, cast, overload
+from typing import Any, SupportsIndex, cast, overload
+
+from typing_extensions import TypeVar
 
 _T = TypeVar("_T")
 _S = TypeVar("_S")

--- a/xdsl/utils/lexer.py
+++ b/xdsl/utils/lexer.py
@@ -4,7 +4,9 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from enum import Enum
 from io import StringIO
-from typing import Generic, TypeVar
+from typing import Generic
+
+from typing_extensions import TypeVar
 
 Position = int
 """

--- a/xdsl/utils/runtime_final.py
+++ b/xdsl/utils/runtime_final.py
@@ -1,4 +1,6 @@
-from typing import Any, TypeVar
+from typing import Any
+
+from typing_extensions import TypeVar
 
 
 def _init_subclass(cls: type, *args: Any, **kwargs: Any) -> None:

--- a/xdsl/utils/scoped_dict.py
+++ b/xdsl/utils/scoped_dict.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from typing import Generic, TypeVar, overload
+from typing import Generic, overload
+
+from typing_extensions import TypeVar
 
 _Key = TypeVar("_Key")
 _Value = TypeVar("_Value")


### PR DESCRIPTION
adding

```
"typing.TypeVar".msg = "Use typing_extensions.TypeVar instead."
```
to `pyproject.toml` seems to suffice to forbid the use of `typing.TypeVar`. This PR adds this line and replaces all remaining uses of `typing.TypeVar`.