### PR TITLE
interpreter: (eqsat) Add pdl_interp implementations for eqsat

### DIFF
--- a/tests/interpreters/test_eqsat_pdl_interp_interpreter.py
+++ b/tests/interpreters/test_eqsat_pdl_interp_interpreter.py
@@ -7,6 +7,7 @@ from xdsl.dialects import eqsat, pdl, pdl_interp, test
 from xdsl.dialects.builtin import ModuleOp, i32, i64
 from xdsl.interpreter import Interpreter
 from xdsl.interpreters.eqsat_pdl_interp import EqsatPDLInterpFunctions
+from xdsl.ir import Operation
 from xdsl.utils.exceptions import InterpretationError
 from xdsl.utils.test_value import create_ssa_value
 
@@ -155,6 +156,174 @@ def test_run_getdefiningop():
 
     # Should not have set up any backtracking for regular operations
     assert len(interp_functions.backtrack_stack) == 0
+
+
+def test_run_createoperation_new_operation():
+    """Test that run_createoperation creates new operation and EClass when no existing match."""
+    interpreter = Interpreter(ModuleOp([]))
+    ctx = Context()
+    ctx.register_dialect("test", lambda: test.Test)
+    interp_functions = EqsatPDLInterpFunctions(ctx)
+    interpreter.register_implementations(interp_functions)
+
+    # Set up a mock rewriter
+    from xdsl.builder import ImplicitBuilder
+    from xdsl.ir import Block, Region
+    from xdsl.pattern_rewriter import PatternRewriter
+
+    testmodule = ModuleOp(Region([Block()]))
+    block = testmodule.body.first_block
+    with ImplicitBuilder(block):
+        root = test.TestOp()
+    rewriter = PatternRewriter(root)
+    interp_functions.rewriter = rewriter
+
+    # Create operands and types for the operation
+    operand = create_ssa_value(i32)
+    result_type = i32
+
+    # Create CreateOperationOp
+    create_op = pdl_interp.CreateOperationOp(
+        name="test.op",
+        input_operands=[operand],
+        input_attributes=[],
+        input_result_types=[create_ssa_value(pdl.TypeType())],
+    )
+
+    # Run the create operation
+    result = interp_functions.run_createoperation(
+        interpreter, create_op, (operand, result_type)
+    )
+
+    # Should return the created operation
+    assert len(result.values) == 1
+    created_op = result.values[0]
+    assert isinstance(created_op, Operation)
+    assert created_op.name == "test.op"
+
+    # Should add the operation to known_ops
+    assert created_op in interp_functions.known_ops
+    assert interp_functions.known_ops[created_op] is created_op
+
+    # Should create an EClass operation and add it to eclass_union_find
+    # The EClass should be created and inserted after the operation
+    assert len(interp_functions.eclass_union_find._values) == 1  # pyright: ignore[reportPrivateUsage]
+    eclass_op = interp_functions.eclass_union_find._values[0]  # pyright: ignore[reportPrivateUsage]
+    assert isinstance(eclass_op, eqsat.EClassOp)
+
+
+def test_run_createoperation_existing_operation_in_use():
+    """Test that run_createoperation returns existing operation when it's still in use."""
+    interpreter = Interpreter(ModuleOp([]))
+    ctx = Context()
+    ctx.register_dialect("test", lambda: test.Test)
+    interp_functions = EqsatPDLInterpFunctions(ctx)
+    interpreter.register_implementations(interp_functions)
+
+    # Set up a mock rewriter
+    from xdsl.builder import ImplicitBuilder
+    from xdsl.ir import Block, Region
+    from xdsl.pattern_rewriter import PatternRewriter
+
+    testmodule = ModuleOp(Region([Block()]))
+    block = testmodule.body.first_block
+    with ImplicitBuilder(block):
+        root = test.TestOp()
+    rewriter = PatternRewriter(root)
+    interp_functions.rewriter = rewriter
+
+    # Create an existing operation that's identical to what we'll create
+    operand = create_ssa_value(i32)
+    existing_op = test.TestOp((operand,), (i32,))
+
+    # Create a user for the existing operation to ensure it's "in use"
+    _user_op = test.TestOp((existing_op.results[0],), (i32,))
+
+    # Add the existing operation to known_ops
+    interp_functions.known_ops[existing_op] = existing_op
+
+    # Create CreateOperationOp that will create an identical operation
+    create_op = pdl_interp.CreateOperationOp(
+        name="test.op",
+        input_operands=[operand],
+        input_attributes=[],
+        input_result_types=[create_ssa_value(pdl.TypeType())],
+    )
+
+    # Track initial rewriter state
+    initial_has_done_action = rewriter.has_done_action
+
+    # Run the create operation
+    result = interp_functions.run_createoperation(
+        interpreter, create_op, (operand, i32)
+    )
+
+    # Should return the existing operation, not create a new one
+    assert len(result.values) == 1
+    returned_op = result.values[0]
+    assert returned_op is existing_op
+
+    # Should restore the rewriter's has_done_action state
+    assert rewriter.has_done_action == initial_has_done_action
+
+
+def test_run_createoperation_existing_operation_not_in_use():
+    """Test that run_createoperation creates new operation when existing has no uses."""
+    interpreter = Interpreter(ModuleOp([]))
+    ctx = Context()
+    ctx.register_dialect("test", lambda: test.Test)
+    interp_functions = EqsatPDLInterpFunctions(ctx)
+    interpreter.register_implementations(interp_functions)
+
+    # Set up a mock rewriter
+    from xdsl.builder import ImplicitBuilder
+    from xdsl.ir import Block, Region
+    from xdsl.pattern_rewriter import PatternRewriter
+
+    testmodule = ModuleOp(Region([Block()]))
+    block = testmodule.body.first_block
+    with ImplicitBuilder(block):
+        root = test.TestOp()
+    rewriter = PatternRewriter(root)
+    interp_functions.rewriter = rewriter
+
+    # Create an existing operation with no result uses
+    operand = create_ssa_value(i32)
+    existing_op = test.TestOp((operand,), (i32,))
+
+    # Verify the existing operation has no uses
+    assert len(existing_op.results) > 0, "Existing operation must have results"
+    assert len(existing_op.results[0].uses) == 0, (
+        "Existing operation result should have no uses"
+    )
+
+    # Add the existing operation to known_ops
+    interp_functions.known_ops[existing_op] = existing_op
+
+    # Create CreateOperationOp that will create an identical operation
+    create_op = pdl_interp.CreateOperationOp(
+        name="test.op",
+        input_operands=[operand],
+        input_attributes=[],
+        input_result_types=[create_ssa_value(pdl.TypeType())],
+    )
+
+    # Run the create operation
+    result = interp_functions.run_createoperation(
+        interpreter, create_op, (operand, i32)
+    )
+
+    # Should return a new operation (core behavior test)
+    assert len(result.values) == 1
+    created_op = result.values[0]
+    assert isinstance(created_op, Operation)
+    assert created_op.name == "test.op"
+
+    # The key test: should get a new operation, not the existing unused one
+    assert created_op is not existing_op
+
+    # Should create an EClass operation
+    assert interp_functions.eclass_union_find._values  # pyright: ignore[reportPrivateUsage]
 
 
 def test_run_finalize_empty_stack():

--- a/tests/interpreters/test_eqsat_pdl_interp_interpreter.py
+++ b/tests/interpreters/test_eqsat_pdl_interp_interpreter.py
@@ -1,7 +1,11 @@
+import pytest
+
 from xdsl.context import Context
-from xdsl.dialects import eqsat, test
-from xdsl.dialects.builtin import ModuleOp, i32
+from xdsl.dialects import eqsat, pdl, pdl_interp, test
+from xdsl.dialects.builtin import ModuleOp, i32, i64
+from xdsl.interpreter import Interpreter
 from xdsl.interpreters.eqsat_pdl_interp import EqsatPDLInterpFunctions
+from xdsl.utils.exceptions import InterpretationError
 from xdsl.utils.test_value import create_ssa_value
 
 
@@ -27,3 +31,102 @@ def test_populate_known_ops():
     # Assert that EClassOp is not in known_ops but is in eclass_union_find
     assert eclass_op not in interp_functions.known_ops
     assert eclass_op in interp_functions.eclass_union_find._index_by_value  # pyright: ignore[reportPrivateUsage]
+
+
+def test_run_getresult():
+    """Test that run_getresult handles EClass operations correctly."""
+    interpreter = Interpreter(ModuleOp([]))
+    interpreter.register_implementations(EqsatPDLInterpFunctions(Context()))
+
+    # Create a test operation with results
+    c0 = create_ssa_value(i32)
+    test_op = test.TestOp((c0,), (i32, i64))
+
+    # Create EClass operations that use both results
+    eclass_op1 = eqsat.EClassOp(test_op.results[0], res_type=i32)
+    eclass_op2 = eqsat.EClassOp(test_op.results[1], res_type=i64)
+
+    # Test GetResultOp for first result wrapped in EClass - should return EClass result
+    result = interpreter.run_op(
+        pdl_interp.GetResultOp(0, create_ssa_value(pdl.OperationType())), (test_op,)
+    )
+    assert result == (eclass_op1.results[0],)
+
+    # Test GetResultOp for second result wrapped in EClass - should return EClass result
+    result = interpreter.run_op(
+        pdl_interp.GetResultOp(1, create_ssa_value(pdl.OperationType())), (test_op,)
+    )
+    assert result == (eclass_op2.results[0],)
+
+
+def test_run_getresult_error_case():
+    """Test that run_getresult raises error when result is not used by EClass."""
+    interpreter = Interpreter(ModuleOp([]))
+    interpreter.register_implementations(EqsatPDLInterpFunctions(Context()))
+
+    # Create a test operation with result that is not used by EClass
+    c0 = create_ssa_value(i32)
+    test_op = test.TestOp((c0,), (i32,))
+
+    # Don't create any EClass operations, so result is not used by EClass
+
+    # Test GetResultOp should raise InterpretationError
+    with pytest.raises(
+        InterpretationError,
+        match="pdl_interp.get_result currently only supports operations with results that are used by a single EClassOp each.",
+    ):
+        interpreter.run_op(
+            pdl_interp.GetResultOp(0, create_ssa_value(pdl.OperationType())), (test_op,)
+        )
+
+
+def test_run_getresults():
+    """Test that run_getresults handles EClass operations correctly."""
+    interpreter = Interpreter(ModuleOp([]))
+    interpreter.register_implementations(EqsatPDLInterpFunctions(Context()))
+
+    # Create a test operation with multiple results
+    c0 = create_ssa_value(i32)
+    test_op = test.TestOp((c0,), (i32, i64))
+
+    # Create EClass operations that use all results
+    eclass_op1 = eqsat.EClassOp(test_op.results[0], res_type=i32)
+    eclass_op2 = eqsat.EClassOp(test_op.results[1], res_type=i64)
+
+    # Test GetResultsOp with all results wrapped in EClass
+    result = interpreter.run_op(
+        pdl_interp.GetResultsOp(
+            None,
+            create_ssa_value(pdl.OperationType()),
+            pdl.RangeType(pdl.ValueType()),
+        ),
+        (test_op,),
+    )
+    expected_results = [eclass_op1.results[0], eclass_op2.results[0]]
+    assert result == (expected_results,)
+
+
+def test_run_getresults_error_case():
+    """Test that run_getresults raises error when result is not used by EClass."""
+    interpreter = Interpreter(ModuleOp([]))
+    interpreter.register_implementations(EqsatPDLInterpFunctions(Context()))
+
+    # Create a test operation with results that are not used by EClass
+    c0 = create_ssa_value(i32)
+    test_op = test.TestOp((c0,), (i32, i64))
+
+    # Don't create any EClass operations, so results are not used by EClass
+
+    # Test GetResultsOp should raise InterpretationError
+    with pytest.raises(
+        InterpretationError,
+        match="pdl_interp.get_results currently only supports operations with results that are used by a single EClassOp each.",
+    ):
+        interpreter.run_op(
+            pdl_interp.GetResultsOp(
+                None,
+                create_ssa_value(pdl.OperationType()),
+                pdl.RangeType(pdl.ValueType()),
+            ),
+            (test_op,),
+        )

--- a/tests/interpreters/test_eqsat_pdl_interp_interpreter.py
+++ b/tests/interpreters/test_eqsat_pdl_interp_interpreter.py
@@ -1,0 +1,29 @@
+from xdsl.context import Context
+from xdsl.dialects import eqsat, test
+from xdsl.dialects.builtin import ModuleOp, i32
+from xdsl.interpreters.eqsat_pdl_interp import EqsatPDLInterpFunctions
+from xdsl.utils.test_value import create_ssa_value
+
+
+def test_populate_known_ops():
+    """Test that populate_known_ops correctly categorizes operations."""
+    # Create test operations
+    regular_op = test.TestOp(result_types=[i32])
+    eclass_op = eqsat.EClassOp(create_ssa_value(i32), res_type=i32)
+
+    # Create module containing both types of operations
+    module = ModuleOp([regular_op, eclass_op])
+
+    # Create interpreter functions instance
+    interp_functions = EqsatPDLInterpFunctions(Context())
+
+    # Call the method under test
+    interp_functions.populate_known_ops(module)
+
+    # Assert that regular operations are in known_ops
+    assert regular_op in interp_functions.known_ops
+    assert interp_functions.known_ops[regular_op] is regular_op
+
+    # Assert that EClassOp is not in known_ops but is in eclass_union_find
+    assert eclass_op not in interp_functions.known_ops
+    assert eclass_op in interp_functions.eclass_union_find._index_by_value  # pyright: ignore[reportPrivateUsage]

--- a/xdsl/interpreters/eqsat_pdl_interp.py
+++ b/xdsl/interpreters/eqsat_pdl_interp.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from xdsl.dialects import eqsat
+from xdsl.dialects.builtin import ModuleOp
+from xdsl.interpreter import (
+    register_impls,
+)
+from xdsl.interpreters.pdl_interp import PDLInterpFunctions
+from xdsl.transforms.common_subexpression_elimination import KnownOps
+from xdsl.utils.disjoint_set import DisjointSet
+
+
+@register_impls
+@dataclass
+class EqsatPDLInterpFunctions(PDLInterpFunctions):
+    known_ops: KnownOps = field(default_factory=KnownOps)
+    eclass_union_find: DisjointSet[eqsat.EClassOp] = field(
+        default_factory=lambda: DisjointSet[eqsat.EClassOp]()
+    )
+
+    def populate_known_ops(self, module: ModuleOp) -> None:
+        """
+        Populates the known_ops dictionary by traversing the module.
+
+        Args:
+            module: The module to traverse
+        """
+        # Walk through all operations in the module
+        for op in module.walk():
+            # Skip EClassOp instances
+            if not isinstance(op, eqsat.EClassOp):
+                self.known_ops[op] = op
+            else:
+                self.eclass_union_find.add(op)

--- a/xdsl/interpreters/eqsat_pdl_interp.py
+++ b/xdsl/interpreters/eqsat_pdl_interp.py
@@ -16,6 +16,7 @@ from xdsl.interpreter import (
 )
 from xdsl.interpreters.pdl_interp import PDLInterpFunctions
 from xdsl.ir import Attribute, Block, Operation, OpResult, SSAValue
+from xdsl.rewriter import InsertPoint
 from xdsl.transforms.common_subexpression_elimination import KnownOps
 from xdsl.utils.disjoint_set import DisjointSet
 from xdsl.utils.exceptions import InterpretationError
@@ -152,6 +153,46 @@ class EqsatPDLInterpFunctions(PDLInterpFunctions):
             ).values
 
         return (defining_op,)
+
+    @impl(pdl_interp.CreateOperationOp)
+    def run_createoperation(
+        self,
+        interpreter: Interpreter,
+        op: pdl_interp.CreateOperationOp,
+        args: tuple[Any, ...],
+    ) -> tuple[Any, ...]:
+        has_done_action_checkpoint = self.rewriter.has_done_action
+        (new_op,) = PDLInterpFunctions.run_create_operation(
+            self, interpreter, op, args
+        ).values
+
+        assert isinstance(new_op, Operation)
+
+        # Check if an identical operation already exists in our known_ops map
+        if existing_op := self.known_ops.get(new_op):
+            # CSE can have removed the existing operation, here we check if it is still in use:
+            if existing_op.results and existing_op.results[0].uses:
+                self.rewriter.erase_op(new_op)
+                self.rewriter.has_done_action = has_done_action_checkpoint
+                return (existing_op,)
+            else:
+                # if CSE has removed the existing operation, we can remove it from our known_ops map:
+                self.known_ops.pop(existing_op)
+
+        # No existing eclass for this operation yet
+
+        eclass_op = eqsat.EClassOp(
+            new_op.results[0],
+        )
+        self.rewriter.insert_op(
+            eclass_op,
+            InsertPoint.after(new_op),
+        )
+
+        self.known_ops[new_op] = new_op
+        self.eclass_union_find.add(eclass_op)
+
+        return (new_op,)
 
     @impl_terminator(pdl_interp.FinalizeOp)
     def run_finalize(

--- a/xdsl/interpreters/eqsat_pdl_interp.py
+++ b/xdsl/interpreters/eqsat_pdl_interp.py
@@ -53,15 +53,19 @@ class EqsatPDLInterpFunctions(PDLInterpFunctions):
             PDLInterpFunctions.run_get_result(self, interpreter, op, args).values[0],
         )
 
-        if (
-            result
-            and len(result.uses) == 1
-            and isinstance(
-                eclass_op := next(iter(result.uses)).operation, eqsat.EClassOp
-            )
+        if result is None:
+            return (None,)
+
+        if len(result.uses) == 1 and isinstance(
+            eclass_op := next(iter(result.uses)).operation, eqsat.EClassOp
         ):
             assert len(eclass_op.results) == 1
             result = eclass_op.results[0]
+        else:
+            raise InterpretationError(
+                "pdl_interp.get_result currently only supports operations with results"
+                " that are used by a single EClassOp each."
+            )
 
         return (result,)
 

--- a/xdsl/interpreters/eqsat_pdl_interp.py
+++ b/xdsl/interpreters/eqsat_pdl_interp.py
@@ -8,19 +8,35 @@ from xdsl.dialects.builtin import ModuleOp
 from xdsl.dialects.pdl import ValueType
 from xdsl.interpreter import (
     Interpreter,
+    ReturnedValues,
+    Successor,
     impl,
+    impl_terminator,
     register_impls,
 )
 from xdsl.interpreters.pdl_interp import PDLInterpFunctions
-from xdsl.ir import Attribute, Operation, OpResult
+from xdsl.ir import Attribute, Block, Operation, OpResult, SSAValue
 from xdsl.transforms.common_subexpression_elimination import KnownOps
 from xdsl.utils.disjoint_set import DisjointSet
 from xdsl.utils.exceptions import InterpretationError
+from xdsl.utils.scoped_dict import ScopedDict
+
+
+@dataclass
+class BacktrackPoint:
+    block: Block
+    block_args: tuple[SSAValue, ...]
+    scope: ScopedDict[SSAValue, Any]
+    gdo_op: pdl_interp.GetDefiningOpOp
+    index: int
+    max_index: int
 
 
 @register_impls
 @dataclass
 class EqsatPDLInterpFunctions(PDLInterpFunctions):
+    backtrack_stack: list[BacktrackPoint] = field(default_factory=list[BacktrackPoint])
+    visited: bool = True
     known_ops: KnownOps = field(default_factory=KnownOps)
     eclass_union_find: DisjointSet[eqsat.EClassOp] = field(
         default_factory=lambda: DisjointSet[eqsat.EClassOp]()
@@ -97,3 +113,56 @@ class EqsatPDLInterpFunctions(PDLInterpFunctions):
                     " that are used by a single EClassOp each."
                 )
         return (results,)
+
+    @impl(pdl_interp.GetDefiningOpOp)
+    def run_getdefiningop(
+        self,
+        interpreter: Interpreter,
+        op: pdl_interp.GetDefiningOpOp,
+        args: tuple[Any, ...],
+    ) -> tuple[Any, ...]:
+        defining_op = cast(
+            None | Operation,
+            PDLInterpFunctions.run_get_defining_op(self, interpreter, op, args).values[
+                0
+            ],
+        )
+        if isinstance(eclass_op := defining_op, eqsat.EClassOp):
+            if not self.visited:
+                if op != self.backtrack_stack[-1].gdo_op:
+                    raise InterpretationError(
+                        "TODO: handle the case where a block contains multiple pdl_interp.get_defining_op."
+                    )
+                index = self.backtrack_stack[-1].index
+                self.visited = True
+            else:
+                block = op.parent_block()
+                assert block
+                block_args = interpreter.get_values(block.args)
+                scope = interpreter._ctx.parent  # pyright: ignore[reportPrivateUsage]
+                assert scope
+                index = 0
+                self.backtrack_stack.append(
+                    BacktrackPoint(
+                        block, block_args, scope, op, index, len(eclass_op.operands) - 1
+                    )
+                )
+            return PDLInterpFunctions.run_get_defining_op(
+                self, interpreter, op, (eclass_op.operands[index],)
+            ).values
+
+        return (defining_op,)
+
+    @impl_terminator(pdl_interp.FinalizeOp)
+    def run_finalize(
+        self, interpreter: Interpreter, _: pdl_interp.FinalizeOp, args: tuple[Any, ...]
+    ):
+        for backtrack_point in reversed(self.backtrack_stack):
+            if backtrack_point.index >= backtrack_point.max_index:
+                self.backtrack_stack.pop()
+            else:
+                backtrack_point.index += 1
+                interpreter._ctx = backtrack_point.scope  # pyright: ignore[reportPrivateUsage]
+                self.visited = False
+                return Successor(backtrack_point.block, backtrack_point.block_args), ()
+        return ReturnedValues(()), ()

--- a/xdsl/interpreters/eqsat_pdl_interp.py
+++ b/xdsl/interpreters/eqsat_pdl_interp.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, cast
 
+from ordered_set import OrderedSet
+
 from xdsl.dialects import eqsat, pdl_interp
 from xdsl.dialects.builtin import ModuleOp
 from xdsl.dialects.pdl import ValueType
@@ -15,7 +17,7 @@ from xdsl.interpreter import (
     register_impls,
 )
 from xdsl.interpreters.pdl_interp import PDLInterpFunctions
-from xdsl.ir import Attribute, Block, Operation, OpResult, SSAValue
+from xdsl.ir import Attribute, Block, Operation, OpResult, SSAValue, Use
 from xdsl.rewriter import InsertPoint
 from xdsl.transforms.common_subexpression_elimination import KnownOps
 from xdsl.utils.disjoint_set import DisjointSet
@@ -33,15 +35,28 @@ class BacktrackPoint:
     max_index: int
 
 
+@dataclass
+class MergeTodo:
+    to_keep: eqsat.EClassOp
+    to_replace: eqsat.EClassOp
+
+
 @register_impls
 @dataclass
 class EqsatPDLInterpFunctions(PDLInterpFunctions):
     backtrack_stack: list[BacktrackPoint] = field(default_factory=list[BacktrackPoint])
     visited: bool = True
     known_ops: KnownOps = field(default_factory=KnownOps)
+    known_ops_restore_list: list[Operation] = field(default_factory=list[Operation])
     eclass_union_find: DisjointSet[eqsat.EClassOp] = field(
         default_factory=lambda: DisjointSet[eqsat.EClassOp]()
     )
+    merge_list: list[MergeTodo] = field(default_factory=list[MergeTodo])
+
+    def modification_handler(self, op: Operation):
+        if op in self.known_ops:
+            removed = self.known_ops.pop(op)
+            self.known_ops_restore_list.append(removed)
 
     def populate_known_ops(self, module: ModuleOp) -> None:
         """
@@ -154,6 +169,60 @@ class EqsatPDLInterpFunctions(PDLInterpFunctions):
 
         return (defining_op,)
 
+    @impl(pdl_interp.ReplaceOp)
+    def run_replace(
+        self,
+        interpreter: Interpreter,
+        op: pdl_interp.ReplaceOp,
+        args: tuple[Any, ...],
+    ) -> tuple[Any, ...]:
+        assert args
+        input_op = args[0]
+        assert isinstance(input_op, Operation)
+        assert len(input_op.results) == 1, (
+            "ReplaceOp currently only supports replacing operations that have a single result"
+        )
+
+        it = iter(input_op.results[0].uses)
+        original_eclass = next(it).operation
+        if not isinstance(original_eclass, eqsat.EClassOp):
+            raise InterpretationError(
+                "Replaced operation result must be used by an EClassOp"
+            )
+
+        repl_values = (
+            (args[1],) if isinstance(op.repl_values.types[0], ValueType) else args[1]
+        )
+        assert len(repl_values) == 1, (
+            "pdl_interp.replace currently only a supports replacing with a single e-class result."
+        )
+        repl_value: SSAValue = repl_values[0]
+        repl_eclass = repl_value.owner
+        if not isinstance(repl_eclass, eqsat.EClassOp):
+            raise InterpretationError(
+                "Replacement value must be the result of an EClassOp"
+            )
+
+        repl_eclass = self.eclass_union_find.find(repl_eclass)
+        original_eclass = self.eclass_union_find.find(original_eclass)
+
+        if repl_eclass == original_eclass:
+            return ()
+
+        self.eclass_union_find.union(
+            original_eclass,
+            repl_eclass,
+        )
+        if self.eclass_union_find.find(original_eclass) == repl_eclass:
+            # In the union-find the canonical representative of the original_eclass
+            # is now the repl_eclass, so we have to keep the repl_eclass:
+            self.merge_list.append(MergeTodo(repl_eclass, original_eclass))
+        else:
+            # otherwise we keep the original_eclass:
+            self.merge_list.append(MergeTodo(original_eclass, repl_eclass))
+
+        return ()
+
     @impl(pdl_interp.CreateOperationOp)
     def run_createoperation(
         self,
@@ -207,3 +276,26 @@ class EqsatPDLInterpFunctions(PDLInterpFunctions):
                 self.visited = False
                 return Successor(backtrack_point.block, backtrack_point.block_args), ()
         return ReturnedValues(()), ()
+
+    def apply_matches(self):
+        todo = OrderedSet(
+            (self.eclass_union_find.find(todo.to_keep), todo.to_replace)
+            for todo in self.merge_list
+        )
+        self.merge_list.clear()
+        for to_keep, to_replace in todo:
+            operands = to_keep._operands  # pyright: ignore[reportPrivateUsage]
+            startlen = len(operands)
+            for i, val in enumerate(to_replace.operands):
+                val.add_use(Use(to_keep, startlen + i))
+                new_operands = operands + to_replace._operands  # pyright: ignore[reportPrivateUsage]
+                to_keep._operands = new_operands  # pyright: ignore[reportPrivateUsage]
+
+            self.rewriter.replace_op(
+                to_replace, new_ops=[], new_results=to_keep.results
+            )
+
+        while self.known_ops_restore_list:
+            op = self.known_ops_restore_list.pop()
+            assert op not in self.known_ops
+            self.known_ops[op] = op

--- a/xdsl/interpreters/eqsat_pdl_interp.py
+++ b/xdsl/interpreters/eqsat_pdl_interp.py
@@ -1,15 +1,21 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import Any, cast
 
-from xdsl.dialects import eqsat
+from xdsl.dialects import eqsat, pdl_interp
 from xdsl.dialects.builtin import ModuleOp
+from xdsl.dialects.pdl import ValueType
 from xdsl.interpreter import (
+    Interpreter,
+    impl,
     register_impls,
 )
 from xdsl.interpreters.pdl_interp import PDLInterpFunctions
+from xdsl.ir import Attribute, Operation, OpResult
 from xdsl.transforms.common_subexpression_elimination import KnownOps
 from xdsl.utils.disjoint_set import DisjointSet
+from xdsl.utils.exceptions import InterpretationError
 
 
 @register_impls
@@ -34,3 +40,56 @@ class EqsatPDLInterpFunctions(PDLInterpFunctions):
                 self.known_ops[op] = op
             else:
                 self.eclass_union_find.add(op)
+
+    @impl(pdl_interp.GetResultOp)
+    def run_getresult(
+        self,
+        interpreter: Interpreter,
+        op: pdl_interp.GetResultOp,
+        args: tuple[Any, ...],
+    ) -> tuple[Any, ...]:
+        result = cast(
+            None | OpResult[Attribute],
+            PDLInterpFunctions.run_get_result(self, interpreter, op, args).values[0],
+        )
+
+        if (
+            result
+            and len(result.uses) == 1
+            and isinstance(
+                eclass_op := next(iter(result.uses)).operation, eqsat.EClassOp
+            )
+        ):
+            assert len(eclass_op.results) == 1
+            result = eclass_op.results[0]
+
+        return (result,)
+
+    @impl(pdl_interp.GetResultsOp)
+    def run_getresults(
+        self,
+        interpreter: Interpreter,
+        op: pdl_interp.GetResultsOp,
+        args: tuple[Any, ...],
+    ) -> tuple[Any, ...]:
+        assert isinstance(args[0], Operation)
+        src_op = args[0]
+        assert op.index is None, (
+            "pdl_interp.get_results with index is not yet supported."
+        )
+        if isinstance(op.result_types[0], ValueType) and len(src_op.results) != 1:
+            return (None,)
+
+        results: list[OpResult] = []
+        for result in src_op.results:
+            if len(result.uses) == 1 and isinstance(
+                eclass_op := next(iter(result.uses)).operation, eqsat.EClassOp
+            ):
+                assert len(eclass_op.results) == 1
+                results.append(eclass_op.results[0])
+            else:
+                raise InterpretationError(
+                    "pdl_interp.get_results currently only supports operations with results"
+                    " that are used by a single EClassOp each."
+                )
+        return (results,)


### PR DESCRIPTION
`apply_matches` roughly follows `rebuild` and and the hashcons restoration from`repair` from the algorithm in the egg paper:
<img width="1003" alt="image" src="https://github.com/user-attachments/assets/ec1ce248-cb7b-4eac-944d-5c961387f8b2" />