### PR TITLE
core: allow multiple levels of Generics in operation definitions

### DIFF
--- a/tests/irdl/test_operation_definition.py
+++ b/tests/irdl/test_operation_definition.py
@@ -804,6 +804,53 @@ def test_generic_op():
         op_result_fail.verify()
 
 
+class Generic2Op(Generic[_Operand], GenericOp[StringAttr, _Operand, FooType]): ...
+
+
+@irdl_op_definition
+class StringFoo2Op(Generic2Op[FooType]):
+    name = "test.string_specialized_2"
+
+
+def test_generic2_op():
+    """Test generic operation with two levels of specialization."""
+    FooOperand = create_ssa_value(TestType("foo"))
+    BarOperand = create_ssa_value(TestType("bar"))
+    FooResultType = TestType("foo")
+    BarResultType = TestType("bar")
+
+    op = StringFoo2Op(
+        attributes={"attr": StringAttr("test")},
+        operands=[FooOperand],
+        result_types=[FooResultType],
+    )
+    op.verify()
+
+    op_attr_fail = StringFoo2Op(
+        attributes={"attr": IntAttr(1)},
+        operands=[FooOperand],
+        result_types=[FooResultType],
+    )
+    with pytest.raises(DiagnosticException):
+        op_attr_fail.verify()
+
+    op_operand_fail = StringFoo2Op(
+        attributes={"attr": StringAttr("test")},
+        operands=[BarOperand],
+        result_types=[FooResultType],
+    )
+    with pytest.raises(DiagnosticException):
+        op_operand_fail.verify()
+
+    op_result_fail = StringFoo2Op(
+        attributes={"attr": StringAttr("test")},
+        operands=[FooOperand],
+        result_types=[BarResultType],
+    )
+    with pytest.raises(DiagnosticException):
+        op_result_fail.verify()
+
+
 class OtherParentOp(IRDLOperation):
     other_attr = attr_def(Attribute)
 

--- a/tests/utils/test_hints.py
+++ b/tests/utils/test_hints.py
@@ -1,0 +1,72 @@
+import re
+from typing import Generic
+
+import pytest
+from typing_extensions import TypeVar
+
+from xdsl.utils.hints import get_type_var_mapping
+
+T0 = TypeVar("T0")
+T1 = TypeVar("T1")
+T2 = TypeVar("T2")
+
+
+class A(Generic[T1, T2]): ...
+
+
+class B(Generic[T1], A[T1, int]): ...
+
+
+class C(B[str]): ...
+
+
+class D(Generic[T0], A[T0, T0]): ...
+
+
+class D2(A[T0, T0]): ...
+
+
+class E(Generic[T2]): ...
+
+
+class F(C, E[str]): ...
+
+
+def test_get_type_var_mapping():
+    assert get_type_var_mapping(A) == ((T1, T2), {})
+    assert get_type_var_mapping(B) == ((T1,), {T2: int})
+    assert get_type_var_mapping(C) == (
+        (),
+        {
+            T1: str,
+            T2: int,
+        },
+    )
+    assert get_type_var_mapping(D) == (
+        (T0,),
+        {
+            T1: T0,
+            T2: T0,
+        },
+    )
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "Invalid definition D2, generic classes must subclass `Generic`."
+        ),
+    ):
+        assert get_type_var_mapping(D2) == (
+            (T0,),
+            {
+                T1: T0,
+                T2: T0,
+            },
+        )
+    assert get_type_var_mapping(E) == ((T2,), {})
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "Error extracting assignments of TypeVars of F, inconsistent assignments to ~T2 in superclasses: str, int."
+        ),
+    ):
+        assert get_type_var_mapping(F) == ()

--- a/xdsl/utils/hints.py
+++ b/xdsl/utils/hints.py
@@ -149,48 +149,53 @@ def get_type_var_from_generic_class(cls: type[Any]) -> tuple[TypeVar, ...]:
 
 def get_type_var_mapping(
     cls: type[Any],
-) -> tuple[type[Any], dict[TypeVar, Any]]:
+) -> tuple[tuple[TypeVar, ...], dict[TypeVar, Any]]:
     """
-    Given a class that specializes a generic class, return the generic class and
-    the mapping from the generic class type variables to the specialized arguments.
+    Given a Generic class, return the TypeVars used to specialize it, and the mapping
+    from the generic class type variables to the specialized arguments.
     """
 
     if not issubclass(cls, Generic):
         raise ValueError(f"{cls} does not specialize a generic class.")
 
-    # Get the generic parent
     orig_bases: Iterable[Any] = getattr(cls, "__orig_bases__")
-    orig_bases = [
-        orig_base
-        for orig_base in orig_bases
-        if (origin := get_origin(orig_base)) is not Generic and origin is not None
-    ]
-    # Do not handle more than one generic parent in the mro.
-    # It is possible to handle more than one generic parent, but
-    # the mapping of type variables will be more complex, especially for
-    # generic parents inheriting from other generic parents.
-    if len(orig_bases) != 1:
-        raise ValueError(
-            "Class cannot have more than one generic class in its mro. This "
-            "restriction may be lifted in the future.",
-            orig_bases,
-        )
+    mapping: dict[TypeVar, Any] = {}
+    args: tuple[TypeVar, ...] = ()
 
-    # Get the generic operation, and its specialized type parameters.
-    generic_parent: type[Any] = get_origin(orig_bases[0])
-    specialized_args = get_args(orig_bases[0])
+    for base in orig_bases:
+        base_origin = get_origin(base)
+        if base_origin is Generic:
+            args = get_args(base)
+            continue
+        base_cls = base if base_origin is None else base_origin
+        if not issubclass(base_cls, Generic):
+            continue
+        base_type_vars, base_mapping = get_type_var_mapping(cast(type[Any], base_cls))
+        base_args = get_args(base)
 
-    # Get the `TypeVar` used in the generic parent
-    generic_args = get_type_var_from_generic_class(generic_parent)
+        for k, v in zip(base_type_vars, base_args, strict=True):
+            if isinstance(v, TypeVar) and v not in args:
+                # Pyright complains if there is a Generic parent that doesn't include
+                # all the TypeVars used in later classes, so this is a valid check.
+                raise ValueError(
+                    f"Invalid definition {cls.__qualname__}, generic classes must subclass `Generic`."
+                )
+            if k is not v:
+                # Don't assign forwarded TypeVars
+                base_mapping[k] = v
 
-    if len(generic_args) != len(specialized_args):
-        raise ValueError(
-            f"Generic class {generic_parent} class has {len(generic_args)} "
-            f"parameters, but {cls} specialize {len(specialized_args)} of them."
-        )
+        for k, v in base_mapping.items():
+            if k in mapping:
+                if v is not mapping[k]:
+                    raise ValueError(
+                        "Error extracting assignments of TypeVars of "
+                        f"{cls.__qualname__}, inconsistent assignments to {k} in "
+                        f"superclasses: {v.__qualname__}, {mapping[k].__qualname__}."
+                    )
+                continue
+            mapping[k] = v
 
-    type_var_mapping = dict(zip(generic_args, specialized_args))
-    return generic_parent, type_var_mapping
+    return args, mapping
 
 
 def type_repr(obj: Any) -> str:


### PR DESCRIPTION
The current implementation of checking for generic mappings only looks at one level of superclasses, and not recursively. This leads to a silent failure when doing multiple levels of subclassing like in the riscv dialect, where we progressively specialise the operation. The default constraint of the bound of the TypeVar is used instead of the specialised type variable, for which we don't have any tests so we didn't see it before. This PR adds a test to make sure that the constraints are more specific, as well as more tests for getting the type var mapping. As a bonus we can now handle multiple generic parents.