### PR TITLE
core: constrain Data bound to be Hashable

### DIFF
--- a/tests/irdl/test_attribute_definition.py
+++ b/tests/irdl/test_attribute_definition.py
@@ -716,11 +716,11 @@ class DataListAttr(AttrConstraint):
 
 
 @irdl_attr_definition
-class ListData(GenericData[list[AttributeInvT]]):
+class ListData(Generic[AttributeInvT], GenericData[tuple[AttributeInvT, ...]]):
     name = "test.list"
 
     @classmethod
-    def parse_parameter(cls, parser: AttrParser) -> list[AttributeInvT]:
+    def parse_parameter(cls, parser: AttrParser) -> tuple[AttributeInvT, ...]:
         raise NotImplementedError()
 
     def print_parameter(self, printer: Printer) -> None:
@@ -736,7 +736,7 @@ class ListData(GenericData[list[AttributeInvT]]):
 
     @staticmethod
     def from_list(data: list[AttributeInvT]) -> ListData[AttributeInvT]:
-        return ListData(data)
+        return ListData(tuple(data))
 
 
 AnyListData: TypeAlias = ListData[Attribute]
@@ -747,7 +747,7 @@ class Test_generic_data_verifier:
         """
         Test that a GenericData can be created.
         """
-        attr = ListData([BoolData(True), ListData([BoolData(False)])])
+        attr = ListData((BoolData(True), ListData((BoolData(False),))))
         stream = StringIO()
         p = Printer(stream=stream)
         p.print_attribute(attr)
@@ -768,7 +768,7 @@ def test_generic_data_wrapper_verifier():
     """
     Test that a GenericData used in constraints pass the verifier when correct.
     """
-    attr = ListDataWrapper((ListData([BoolData(True), BoolData(False)]),))
+    attr = ListDataWrapper((ListData((BoolData(True), BoolData(False))),))
     stream = StringIO()
     p = Printer(stream=stream)
     p.print_attribute(attr)
@@ -784,7 +784,7 @@ def test_generic_data_wrapper_verifier_failure():
     the verifier when constraints are not satisfied.
     """
     with pytest.raises(VerifyException) as e:
-        ListDataWrapper((ListData([BoolData(True), ListData([BoolData(False)])]),))
+        ListDataWrapper((ListData((BoolData(True), ListData((BoolData(False),)))),))
     assert (
         e.value.args[0]
         == "#test.list<[#test.bool<False>]> should be of base attribute test.bool"
@@ -807,7 +807,7 @@ def test_generic_data_no_generics_wrapper_verifier():
     Test that GenericType can be used in constraints without a parameter.
     """
     attr = ListDataNoGenericsWrapper(
-        (ListData([BoolData(True), ListData([BoolData(False)])]),)
+        (ListData((BoolData(True), ListData((BoolData(False),)))),)
     )
     stream = StringIO()
     p = Printer(stream=stream)

--- a/xdsl/irdl/attributes.py
+++ b/xdsl/irdl/attributes.py
@@ -6,7 +6,7 @@
 #
 
 from abc import ABC, abstractmethod
-from collections.abc import Sequence
+from collections.abc import Hashable, Sequence
 from dataclasses import dataclass
 from inspect import isclass
 from types import FunctionType, GenericAlias, UnionType
@@ -61,7 +61,7 @@ from .constraints import (  # noqa: TID251
 )
 from .error import IRDLAnnotations  # noqa: TID251
 
-_DataElement = TypeVar("_DataElement", covariant=True)
+_DataElement = TypeVar("_DataElement", bound=Hashable, covariant=True)
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
This is a proxy for immutability, and guarantees that equality works.