### PR TITLE
core: use attribute definition in irdl_to_attr_constraint

### DIFF
--- a/xdsl/irdl/attributes.py
+++ b/xdsl/irdl/attributes.py
@@ -435,7 +435,10 @@ def irdl_to_attr_constraint(
 
         type_var_mapping = dict(zip(generic_args, args))
 
-        origin_parameters = irdl_param_attr_get_param_type_hints(origin)
+        # Map the constraints in the attribute definition
+        attr_def = origin.get_irdl_definition()
+        origin_parameters = attr_def.parameters
+
         origin_constraints = [
             irdl_to_attr_constraint(param, allow_type_var=True).mapping_type_vars(
                 type_var_mapping

--- a/xdsl/transforms/experimental/convert_stencil_to_ll_mlir.py
+++ b/xdsl/transforms/experimental/convert_stencil_to_ll_mlir.py
@@ -51,6 +51,7 @@ from xdsl.pattern_rewriter import (
     PatternRewriteWalker,
     RewritePattern,
     TypeConversionPattern,
+    attr_constr_rewrite_pattern,
     attr_type_rewrite_pattern,
     op_type_rewrite_pattern,
 )
@@ -658,7 +659,7 @@ def return_target_analysis(module: builtin.ModuleOp):
 
 
 class StencilTypeConversion(TypeConversionPattern):
-    @attr_type_rewrite_pattern
+    @attr_constr_rewrite_pattern(StencilTypeConstr)
     def convert_type(self, typ: StencilType[Attribute]) -> MemRefType[Attribute]:
         return StencilToMemRefType(typ)
 


### PR DESCRIPTION
This avoids us re-parsing it every time.