### PR TITLE
transformations: shift right by zero canonicalization for RISCV dialect

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -45,7 +45,7 @@ The first step is finding a missing optimisation pattern.
 You're welcome to come up with your own, or do one of the following:
 
 - `x + x * n -> x * (n + 1)` (where `n` is an immediate)
-- `x >> 0 -> x`
+- `x | x -> x` 
 - `x * 1 -> x`
 - `n * x -> x * n` (where `n` is an immediate)
 

--- a/tests/filecheck/backend/riscv/canonicalize.mlir
+++ b/tests/filecheck/backend/riscv/canonicalize.mlir
@@ -129,6 +129,9 @@ builtin.module {
   %shift_left_zero_r0 = riscv.slli %i2, 0 : (!riscv.reg) -> !riscv.reg<a0>
   "test.op"(%shift_left_zero_r0) : (!riscv.reg<a0>) -> ()
 
+  %shift_right_zero_r0 = riscv.srli %i2, 0 : (!riscv.reg) -> !riscv.reg<a0>
+  "test.op"(%shift_right_zero_r0) : (!riscv.reg<a0>) -> ()
+
   // scfgw immediates
   riscv_snitch.scfgw %i1, %c1 : (!riscv.reg<a1>, !riscv.reg) -> ()
 }
@@ -256,6 +259,9 @@ builtin.module {
 
 // CHECK-NEXT:   %shift_left_zero_r0 = riscv.mv %i2 : (!riscv.reg) -> !riscv.reg<a0>
 // CHECK-NEXT:   "test.op"(%shift_left_zero_r0) : (!riscv.reg<a0>) -> ()
+
+// CHECK-NEXT:   %shift_right_zero_r0 = riscv.mv %i2 : (!riscv.reg) -> !riscv.reg<a0>
+// CHECK-NEXT:   "test.op"(%shift_right_zero_r0) : (!riscv.reg<a0>) -> ()
 
 // CHECK-NEXT:   riscv_snitch.scfgwi %i1, 1 : (!riscv.reg<a1>) -> ()
 

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -1556,12 +1556,14 @@ class SlliOp(RdRsImmShiftOperation):
 
     traits = traits_def(SlliOpHasCanonicalizationPatternsTrait())
 
+
 class SrliOpHasCanonicalizationPatternsTrait(HasCanonicalizationPatternsTrait):
     @classmethod
     def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
         from xdsl.transforms.canonicalization_patterns.riscv import ShiftRightbyZero
 
         return (ShiftRightbyZero(),)
+
 
 @irdl_op_definition
 class SrliOp(RdRsImmShiftOperation):

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -1556,6 +1556,12 @@ class SlliOp(RdRsImmShiftOperation):
 
     traits = traits_def(SlliOpHasCanonicalizationPatternsTrait())
 
+class SrliOpHasCanonicalizationPatternsTrait(HasCanonicalizationPatternsTrait):
+    @classmethod
+    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+        from xdsl.transforms.canonicalization_patterns.riscv import ShiftRightbyZero
+
+        return (ShiftRightbyZero(),)
 
 @irdl_op_definition
 class SrliOp(RdRsImmShiftOperation):
@@ -1569,6 +1575,8 @@ class SrliOp(RdRsImmShiftOperation):
     """
 
     name = "riscv.srli"
+
+    traits = traits_def(SrliOpHasCanonicalizationPatternsTrait())
 
 
 @irdl_op_definition

--- a/xdsl/transforms/canonicalization_patterns/riscv.py
+++ b/xdsl/transforms/canonicalization_patterns/riscv.py
@@ -231,6 +231,7 @@ class ShiftRightbyZero(RewritePattern):
         if isinstance(op.immediate, IntegerAttr) and op.immediate.value.data == 0:
             rewriter.replace_matched_op(riscv.MVOp(op.rs1, rd=op.rd.type))
 
+
 class LoadWordWithKnownOffset(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: riscv.LwOp, rewriter: PatternRewriter) -> None:

--- a/xdsl/transforms/canonicalization_patterns/riscv.py
+++ b/xdsl/transforms/canonicalization_patterns/riscv.py
@@ -220,6 +220,17 @@ class ShiftLeftbyZero(RewritePattern):
             rewriter.replace_matched_op(riscv.MVOp(op.rs1, rd=op.rd.type))
 
 
+class ShiftRightbyZero(RewritePattern):
+    """
+    x >> 0 -> x
+    """
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: riscv.SrliOp, rewriter: PatternRewriter) -> None:
+        # check if the shift amount is zero
+        if isinstance(op.immediate, IntegerAttr) and op.immediate.value.data == 0:
+            rewriter.replace_matched_op(riscv.MVOp(op.rs1, rd=op.rd.type))
+
 class LoadWordWithKnownOffset(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: riscv.LwOp, rewriter: PatternRewriter) -> None:


### PR DESCRIPTION
Implemented the `x >> 0 -> x` canonicalization as per [GETTING_STARTED](https://github.com/xdslproject/xdsl/blob/main/GETTING_STARTED.md) guide.
