### PR TITLE
[WIP] core: Dialect resources and `DenseResourceAttr `

### DIFF
--- a/tests/filecheck/mlir-conversion/with-mlir/metadata.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/metadata.mlir
@@ -1,0 +1,15 @@
+
+builtin.module {
+    func.func @constant_dense_resource() {
+    }
+}
+
+{-#
+  dialect_resources: {
+    builtin: {
+      dense_resource_test_2xi32: "0x400000000100000002000000",
+      dense_resource_test_5xf32: "0x08000000041A503E183382BEFCEEBABE7A3AF0BE0E9DEE3E",
+      dense_resource_test_2x2xf32: "0x0800000054A3B53ED6C0B33E55D1A2BDE5D2BB3E"
+    }
+  }
+#-}

--- a/tests/filecheck/mlir-conversion/with-mlir/metadata.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/metadata.mlir
@@ -1,13 +1,14 @@
 
 builtin.module {
     func.func @constant_dense_resource() {
+        %0 = arith.constant dense_resource<dense_resource_test_5xf32> : tensor<5xf32>
+        return
     }
 }
 
 {-#
   dialect_resources: {
     builtin: {
-      dense_resource_test_2xi32: "0x400000000100000002000000",
       dense_resource_test_5xf32: "0x08000000041A503E183382BEFCEEBABE7A3AF0BE0E9DEE3E",
       dense_resource_test_2x2xf32: "0x0800000054A3B53ED6C0B33E55D1A2BDE5D2BB3E"
     }

--- a/tests/filecheck/parser-printer/invalid_metadata.mlir
+++ b/tests/filecheck/parser-printer/invalid_metadata.mlir
@@ -1,0 +1,80 @@
+// RUN: xdsl-opt %s --parsing-diagnostics --split-input-file | filecheck %s
+
+// CHECK: Expected a resource type key
+{-#
+
+// -----
+
+// CHECK: expected `:`
+{-#
+  key
+#-}
+
+// -----
+
+// CHECK: got an unexpected key in file metadata: some_key
+{-#
+  some_key: {}
+#-}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// `dialect_resources`
+//===----------------------------------------------------------------------===//
+
+// CHECK: '{' expected
+{-#
+  dialect_resources: "value"
+#-}
+
+// -----
+
+// CHECK: Expected a dialect name
+{-#
+  dialect_resources: {
+    10
+  }
+#-}
+
+// -----
+
+// CHECK: expected `:`
+{-#
+  dialect_resources: {
+    entry "value"
+  }
+#-}
+
+// -----
+
+// CHECK: dialect foobar is not registered
+{-#
+  dialect_resources: {
+    foobar: {
+      entry: "foo"
+    }
+  }
+#-}
+
+// -----
+
+// CHECK: string literal expected
+{-#
+  dialect_resources: {
+    test: {
+      invalid_blob: 10
+    }
+  }
+#-}
+
+// -----
+
+// CHECK: got an error when parsing a resource: Blob must be a hex string, got: abc
+{-#
+  dialect_resources: {
+    test: {
+      invalid_blob: "abc"
+    }
+  }
+#-}

--- a/tests/filecheck/parser-printer/metadata.mlir
+++ b/tests/filecheck/parser-printer/metadata.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s | mlir-opt | xdsl-opt | filecheck %s
+// RUN: xdsl-opt %s | filecheck %s
 
 builtin.module {
     func.func @constant_dense_resource() {

--- a/tests/test_dialect_interfaces.py
+++ b/tests/test_dialect_interfaces.py
@@ -5,13 +5,19 @@ from xdsl.dialect_interfaces import OpAsmDialectInterface
 
 def test_op_asm_interface():
     interf = OpAsmDialectInterface()
-    key = interf.parse_resource("some_key", "0x0800000001")
-    assert key == "some_key"
-    assert key in interf.blob_storage
 
-    key = interf.parse_resource("some_key", "0x0800000002")
+    key = interf.declare_resource("some_key")
+    assert key == "some_key"
+    interf.parse_resource(key, "0x0800000001")
+    assert interf.blob_storage[key] == "0x0800000001"
+
+    key = interf.declare_resource("some_key")
     assert key == "some_key_0"
-    assert key in interf.blob_storage
+    interf.parse_resource(key, "0x0800000002")
+    assert interf.blob_storage[key] == "0x0800000002"
 
     with pytest.raises(ValueError):
-        interf.parse_resource("other_key", "normal string")
+        interf.parse_resource("some_key", "normal string")
+
+    with pytest.raises(KeyError):
+        interf.parse_resource("non existent key", "0x0800000003")

--- a/tests/test_dialect_interfaces.py
+++ b/tests/test_dialect_interfaces.py
@@ -1,0 +1,17 @@
+import pytest
+
+from xdsl.dialect_interfaces import OpAsmDialectInterface
+
+
+def test_op_asm_interface():
+    interf = OpAsmDialectInterface()
+    key = interf.parse_resource("some_key", "0x0800000001")
+    assert key == "some_key"
+    assert key in interf.blob_storage
+
+    key = interf.parse_resource("some_key", "0x0800000002")
+    assert key == "some_key_0"
+    assert key in interf.blob_storage
+
+    with pytest.raises(ValueError):
+        interf.parse_resource("other_key", "normal string")

--- a/xdsl/context.py
+++ b/xdsl/context.py
@@ -287,7 +287,13 @@ class Context:
             raise UnregisteredConstructException(f"Dialect {name} is not registered")
         return dialect
 
-    def get_optional_dialect(self, name: str) -> "Dialect | None":
+    def get_optional_dialect(
+        self, name: str, load_if_needed: bool = False
+    ) -> "Dialect | None":
+        if load_if_needed:
+            if name in self._registered_dialects and name not in self._loaded_dialects:
+                self.load_registered_dialect(name)
+
         if name in self._loaded_dialects:
             return self._loaded_dialects[name]
         return None

--- a/xdsl/dialect_interfaces.py
+++ b/xdsl/dialect_interfaces.py
@@ -6,18 +6,31 @@ class OpAsmDialectInterface(DialectInterface):
     blob_storage: dict[str, str] = {}
 
     ## Aliases - yet to be implemented
+
     ## Resources
-    def parse_resource(self, key: str, val: str) -> str:
-        # deduplicate the key
+    def declare_resource(self, key: str) -> str:
+        """
+        Declare a resource in the storage.
+        Does key deduplication, returns the key that is actually used in the storage.
+        """
+        # This deduplication is mainly needed when we create resources
+        # programmatically and derive keys from value types.
+        # In case of parsing we think that all equal keys point to the same resource.
         if key in self.blob_storage:
             counter = 0
             while key + f"_{counter}" in self.blob_storage:
                 counter += 1
             key = key + f"_{counter}"
 
+        self.blob_storage[key] = ""
+
+        return key
+
+    def parse_resource(self, key: str, val: str):
         if not val.startswith("0x"):
             raise ValueError(f"Blob must be a hex string, got: {val}")
 
-        self.blob_storage[key] = val
+        if key not in self.blob_storage:
+            raise KeyError(f"Resource with key {key} wasn't declared")
 
-        return key
+        self.blob_storage[key] = val

--- a/xdsl/dialect_interfaces.py
+++ b/xdsl/dialect_interfaces.py
@@ -1,0 +1,23 @@
+class DialectInterface:
+    pass
+
+
+class OpAsmDialectInterface(DialectInterface):
+    blob_storage: dict[str, str] = {}
+
+    ## Aliases - yet to be implemented
+    ## Resources
+    def parse_resource(self, key: str, val: str) -> str:
+        # deduplicate the key
+        if key in self.blob_storage:
+            counter = 0
+            while key + f"_{counter}" in self.blob_storage:
+                counter += 1
+            key = key + f"_{counter}"
+
+        if not val.startswith("0x"):
+            raise ValueError(f"Blob must be a hex string, got: {val}")
+
+        self.blob_storage[key] = val
+
+        return key

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -9,6 +9,7 @@ from xdsl.dialects.builtin import (
     AnyFloatConstr,
     ContainerOf,
     DenseIntOrFPElementsAttr,
+    DenseResourceAttr,
     FixedBitwidthType,
     Float16Type,
     Float32Type,
@@ -135,7 +136,8 @@ class ConstantOp(IRDLOperation):
         TypedAttributeConstraint(
             IntegerAttr.constr(type=SignlessIntegerConstraint | IndexTypeConstr)
             | BaseAttr[FloatAttr[AnyFloat]](FloatAttr)
-            | BaseAttr(DenseIntOrFPElementsAttr),
+            | BaseAttr(DenseIntOrFPElementsAttr)
+            | BaseAttr(DenseResourceAttr),
             _T,
         )
     )
@@ -146,7 +148,10 @@ class ConstantOp(IRDLOperation):
 
     def __init__(
         self,
-        value: IntegerAttr | FloatAttr[AnyFloat] | DenseIntOrFPElementsAttr,
+        value: IntegerAttr
+        | FloatAttr[AnyFloat]
+        | DenseIntOrFPElementsAttr
+        | DenseResourceAttr,
         value_type: Attribute | None = None,
     ):
         if value_type is None:

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -21,6 +21,7 @@ from typing import (
 from immutabledict import immutabledict
 from typing_extensions import Self, TypeVar, deprecated
 
+from xdsl.dialect_interfaces import OpAsmDialectInterface
 from xdsl.ir import (
     Attribute,
     AttributeCovT,
@@ -2671,4 +2672,5 @@ Builtin = Dialect(
         MemRefType,
         UnrankedMemRefType,
     ],
+    [OpAsmDialectInterface()],
 )

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -1433,16 +1433,17 @@ class VectorBaseTypeAndRankConstraint(AttrConstraint):
 
 
 @irdl_attr_definition
-class DenseResourceAttr(ParametrizedAttribute, BuiltinAttribute):
+class DenseResourceAttr(BuiltinAttribute, TypedAttribute):
     name = "dense_resource"
 
     resource_handle: ParameterDef[StringAttr]
+    type: ParameterDef[ShapedType]
 
-    # Should be a ShapedType, but this is not defined yet in xDSL
-    type: ParameterDef[Attribute]
+    def print_without_type(self, printer: Printer):
+        printer.print_string(f"dense_resource<{self.resource_handle.data}>")
 
     @staticmethod
-    def from_params(handle: str | StringAttr, type: Attribute) -> DenseResourceAttr:
+    def from_params(handle: str | StringAttr, type: ShapedType) -> DenseResourceAttr:
         if isinstance(handle, str):
             handle = StringAttr(handle)
         return DenseResourceAttr([handle, type])

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -1440,7 +1440,9 @@ class DenseResourceAttr(BuiltinAttribute, TypedAttribute):
     type: ParameterDef[ShapedType]
 
     def print_without_type(self, printer: Printer):
-        printer.print_string(f"dense_resource<{self.resource_handle.data}>")
+        printer.print_string("dense_resource<")
+        printer.print_resource_handle("builtin", self.resource_handle.data)
+        printer.print_string(">")
 
     @staticmethod
     def from_params(handle: str | StringAttr, type: ShapedType) -> DenseResourceAttr:

--- a/xdsl/dialects/test.py
+++ b/xdsl/dialects/test.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 
+from xdsl.dialect_interfaces import OpAsmDialectInterface
 from xdsl.ir import (
     Attribute,
     Block,
@@ -268,4 +269,5 @@ Test = Dialect(
     [
         TestType,
     ],
+    [OpAsmDialectInterface()],
 )

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -29,6 +29,7 @@ from typing import (
 
 from typing_extensions import Self, TypeVar
 
+from xdsl.dialect_interfaces import DialectInterface
 from xdsl.traits import IsTerminator, NoTerminator, OpTrait, OpTraitInvT
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.mlir_lexer import MLIRLexer
@@ -57,6 +58,9 @@ class Dialect:
     _attributes: list[type[Attribute]] = field(
         default_factory=list[type["Attribute"]], init=True, repr=True
     )
+    _interfaces: list[DialectInterface] = field(
+        default_factory=list[DialectInterface], init=True, repr=True
+    )
 
     @property
     def operations(self) -> Iterator[type[Operation]]:
@@ -78,6 +82,15 @@ class Dialect:
             return (first, second)
         except ValueError as e:
             raise ValueError(f"Invalid operation or attribute name {name}.") from e
+
+    def get_interface(self, inter: type[DialectInterface]) -> DialectInterface | None:
+        for i in self._interfaces:
+            if isinstance(i, inter):
+                return i
+        return None
+
+    def has_interface(self, inter: type[DialectInterface]) -> bool:
+        return self.get_interface(inter) is not None
 
 
 A = TypeVar("A", bound="Attribute")

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -44,6 +44,7 @@ if TYPE_CHECKING:
     from xdsl.printer import Printer
 
 OpT = TypeVar("OpT", bound="Operation")
+DialectInterfT = TypeVar("DialectInterfT", bound=DialectInterface)
 
 
 @dataclass
@@ -83,13 +84,13 @@ class Dialect:
         except ValueError as e:
             raise ValueError(f"Invalid operation or attribute name {name}.") from e
 
-    def get_interface(self, inter: type[DialectInterface]) -> DialectInterface | None:
+    def get_interface(self, inter: type[DialectInterfT]) -> DialectInterfT | None:
         for i in self._interfaces:
             if isinstance(i, inter):
                 return i
         return None
 
-    def has_interface(self, inter: type[DialectInterface]) -> bool:
+    def has_interface(self, inter: type[DialectInterfT]) -> bool:
         return self.get_interface(inter) is not None
 
 

--- a/xdsl/parser/attribute_parser.py
+++ b/xdsl/parser/attribute_parser.py
@@ -873,7 +873,7 @@ class AttrParser(BaseParser):
         resource_interface = self.ctx.get_dialect("builtin").get_interface(
             OpAsmDialectInterface
         )
-        if not isinstance(resource_interface, OpAsmDialectInterface):
+        if not resource_interface:
             self.raise_error("builtin dialect should have an OpAsmDialectInterface")
 
         resource_handle = self._parse_dialect_resource_handle(

--- a/xdsl/parser/core.py
+++ b/xdsl/parser/core.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from typing import Literal, overload
 
 from xdsl.context import Context
+from xdsl.dialect_interfaces import OpAsmDialectInterface
 from xdsl.dialects.builtin import DictionaryAttr, ModuleOp
 from xdsl.ir import (
     Attribute,
@@ -127,6 +128,9 @@ class Parser(AttrParser):
                 ):
                     self._parse_alias_def()
                     continue
+                if self._current_token.kind in (MLIRTokenKind.FILE_METADATA_BEGIN,):
+                    self._parse_file_metadata_dictionary()
+                    continue
                 if (parsed_op := self.parse_optional_operation()) is not None:
                     parsed_ops.append(parsed_op)
                     continue
@@ -148,6 +152,64 @@ class Parser(AttrParser):
             self.raise_error(f"values used but not defined: [{value_names}]")
 
         return module_op
+
+    def _parse_dialect_resources(self):
+        def parse_element() -> None:
+            dialect_name = self._parse_token(
+                MLIRTokenKind.BARE_IDENT, "Expected a dialect name"
+            )
+            self._parse_token(MLIRTokenKind.COLON, "expected `:`")
+
+            dialect = self.ctx.get_optional_dialect(
+                dialect_name.text, load_if_needed=True
+            )
+            if dialect is None:
+                self.raise_error(f"dialect {dialect_name.text} is not registered")
+
+            interface = dialect.get_interface(OpAsmDialectInterface)
+            if not interface or type(interface) is not OpAsmDialectInterface:
+                self.raise_error(
+                    f"dialect {dialect} doesn't have an OpAsmDialectInterface interface"
+                )
+
+            def parse_resource() -> None:
+                key = self._parse_token(
+                    MLIRTokenKind.BARE_IDENT, "Expected a resource key"
+                )
+                self._parse_token(MLIRTokenKind.COLON, "expected `:`")
+                value = self.parse_str_literal()
+
+                try:
+                    interface.parse_resource(key.text, value)
+                except Exception as e:
+                    self.raise_error(f"got an error when parsing a resource: {e}")
+
+            self.parse_comma_separated_list(self.Delimiter.BRACES, parse_resource)
+
+        self.parse_comma_separated_list(self.Delimiter.BRACES, parse_element)
+
+    def _parse_external_resources(self) -> None:
+        raise NotImplementedError("Currently only dialect resources are supported")
+
+    def _parse_file_metadata_dictionary(self):
+        def parse_element() -> None:
+            resource_type = self._parse_token(
+                MLIRTokenKind.BARE_IDENT, "Expected a resource type key"
+            )
+
+            self._parse_token(MLIRTokenKind.COLON, "expected `:`")
+
+            match resource_type.text:
+                case "dialect_resources":
+                    self._parse_dialect_resources()
+                case "external_resources":
+                    self._parse_external_resources()
+                case _:
+                    self.raise_error(
+                        f"got an unexpected key in file metadata: {resource_type.text}"
+                    )
+
+        self.parse_comma_separated_list(self.Delimiter.METADATA_TOKEN, parse_element)
 
     def _parse_alias_def(self):
         """

--- a/xdsl/parser/core.py
+++ b/xdsl/parser/core.py
@@ -167,7 +167,7 @@ class Parser(AttrParser):
                 self.raise_error(f"dialect {dialect_name.text} is not registered")
 
             interface = dialect.get_interface(OpAsmDialectInterface)
-            if not interface or type(interface) is not OpAsmDialectInterface:
+            if not interface:
                 self.raise_error(
                     f"dialect {dialect} doesn't have an OpAsmDialectInterface interface"
                 )

--- a/xdsl/parser/core.py
+++ b/xdsl/parser/core.py
@@ -173,14 +173,12 @@ class Parser(AttrParser):
                 )
 
             def parse_resource() -> None:
-                key = self._parse_token(
-                    MLIRTokenKind.BARE_IDENT, "Expected a resource key"
-                )
+                key = self._parse_dialect_resource_handle(dialect_name.text, interface)
                 self._parse_token(MLIRTokenKind.COLON, "expected `:`")
                 value = self.parse_str_literal()
 
                 try:
-                    interface.parse_resource(key.text, value)
+                    interface.parse_resource(key, value)
                 except Exception as e:
                     self.raise_error(f"got an error when parsing a resource: {e}")
 

--- a/xdsl/parser/generic_parser.py
+++ b/xdsl/parser/generic_parser.py
@@ -190,6 +190,7 @@ class GenericParser(Generic[TokenKindT]):
         ANGLE = ("<", ">")
         SQUARE = ("[", "]")
         BRACES = ("{", "}")
+        METADATA_TOKEN = ("{-#", "#-}")
         NONE = None
 
     def parse_comma_separated_list(

--- a/xdsl/xdsl_opt_main.py
+++ b/xdsl/xdsl_opt_main.py
@@ -8,6 +8,7 @@ from itertools import accumulate
 from typing import IO, Any
 
 from xdsl.context import Context
+from xdsl.dialect_interfaces import OpAsmDialectInterface
 from xdsl.dialects.builtin import ModuleOp
 from xdsl.passes import ModulePass, PipelinePass
 from xdsl.printer import Printer
@@ -220,6 +221,14 @@ class xDSLOptMain(CommandLineTool):
                 print_debuginfo=self.args.print_debuginfo,
             )
             printer.print_op(prog)
+
+            interfaces = [
+                (d.name, d.get_interface(OpAsmDialectInterface))
+                for d in self.ctx.loaded_dialects
+            ]
+            resource_interfaces = {n: interf for n, interf in interfaces if interf}
+            printer.print_file_metadata(resource_interfaces)
+
             print("\n", file=output)
 
         def _output_riscv_asm(prog: ModuleOp, output: IO[str]):


### PR DESCRIPTION
`torch-mlir` uses dialect resources to store network weights so it seems like a good idea to support this mechanism in xdsl.

Dialect resources are stored in file metadata - `{-# ... #-}` section - in the code data is stored using a dialect interface.

The mechanism is quite general in MLIR, in this case the resources are only referenced through `DenseResourceAttr `.