### PR TITLE
core: deprecate attr_constr_coercion

### DIFF
--- a/docs/marimo/irdl.py
+++ b/docs/marimo/irdl.py
@@ -170,7 +170,7 @@ def _(mo):
         r"""
     #### Attribute Constraint Coercion
 
-    To simplify the definitions of constraints, constraint constructors expecting an attribute constraints will coerce `Attribute` to an equality attribute constraint, and will coerce an `Attribute` type to a base attribute constraint. this is done using the `attr_constr_coercion` function:
+    To simplify the definitions of constraints, constraint constructors expecting an attribute constraints will coerce `Attribute` to an equality attribute constraint, and will coerce an `Attribute` type to a base attribute constraint. this is done using the `irdl_to_attr_constraint` function:
     """
     )
     return
@@ -178,12 +178,12 @@ def _(mo):
 
 @app.cell
 def _(BaseAttr, EqAttrConstraint, StringAttr, i32):
-    from xdsl.irdl import AnyOf, attr_constr_coercion
+    from xdsl.irdl import AnyOf, irdl_to_attr_constraint
 
-    assert attr_constr_coercion(i32) == EqAttrConstraint(i32)
-    assert attr_constr_coercion(StringAttr) == BaseAttr(StringAttr)
+    assert irdl_to_attr_constraint(i32) == EqAttrConstraint(i32)
+    assert irdl_to_attr_constraint(StringAttr) == BaseAttr(StringAttr)
     assert AnyOf([i32, StringAttr]) == AnyOf([EqAttrConstraint(i32), BaseAttr(StringAttr)])
-    return AnyOf, attr_constr_coercion
+    return AnyOf, irdl_to_attr_constraint
 
 
 @app.cell(hide_code=True)
@@ -327,7 +327,7 @@ def _(mo):
 
 
 @app.cell
-def _(ConstraintContext, IntAttr, VerifyException, attr_constr_coercion):
+def _(ConstraintContext, IntAttr, VerifyException, irdl_to_attr_constraint):
     from dataclasses import dataclass
 
     from xdsl.dialects.builtin import ArrayAttr
@@ -343,7 +343,7 @@ def _(ConstraintContext, IntAttr, VerifyException, attr_constr_coercion):
 
         # The custom init applies the attribute constraint coercion
         def __init__(self, constr: Attribute | type[Attribute] | AttrConstraint):
-            object.__setattr__(self, "elem_constr", attr_constr_coercion(constr))
+            object.__setattr__(self, "elem_constr", irdl_to_attr_constraint(constr))
 
         # Check that an attribute satisfies the constraints
         def verify(self, attr: Attribute, constraint_context: ConstraintContext) -> None:

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -61,7 +61,6 @@ from xdsl.irdl import (
     ParamAttrConstraint,
     ParameterDef,
     RangeOf,
-    attr_constr_coercion,
     base,
     irdl_attr_definition,
     irdl_op_definition,
@@ -1338,7 +1337,7 @@ class ContainerOf(
             AttributeCovT | type[AttributeCovT] | GenericAttrConstraint[AttributeCovT]
         ),
     ) -> None:
-        object.__setattr__(self, "elem_constr", attr_constr_coercion(elem_constr))
+        object.__setattr__(self, "elem_constr", irdl_to_attr_constraint(elem_constr))
 
     def verify(self, attr: Attribute, constraint_context: ConstraintContext) -> None:
         if isinstance(attr, VectorType) or isinstance(attr, TensorType):

--- a/xdsl/irdl/attributes.py
+++ b/xdsl/irdl/attributes.py
@@ -26,6 +26,8 @@ from typing import (
 
 from typing_extensions import TypeVar
 
+from xdsl.ir import AttributeCovT
+
 if TYPE_CHECKING:
     from typing_extensions import TypeForm
 
@@ -55,7 +57,10 @@ from .constraints import (  # noqa: TID251
     ConstraintVar,
     EqAttrConstraint,
     GenericAttrConstraint,
+    GenericRangeConstraint,
     ParamAttrConstraint,
+    RangeOf,
+    SingleOf,
     TypeVarConstraint,
     VarConstraint,
 )
@@ -487,3 +492,22 @@ def eq(irdl: AttributeInvT) -> GenericAttrConstraint[AttributeInvT]:
     Converts an attribute instance into the equivalent constraint.
     """
     return irdl_to_attr_constraint(irdl)
+
+
+def range_constr_coercion(
+    attr: (
+        AttributeCovT
+        | type[AttributeCovT]
+        | GenericAttrConstraint[AttributeCovT]
+        | GenericRangeConstraint[AttributeCovT]
+    ),
+) -> GenericRangeConstraint[AttributeCovT]:
+    if isinstance(attr, GenericRangeConstraint):
+        return attr
+    return RangeOf(irdl_to_attr_constraint(attr))
+
+
+def single_range_constr_coercion(
+    attr: AttributeCovT | type[AttributeCovT] | GenericAttrConstraint[AttributeCovT],
+) -> GenericRangeConstraint[AttributeCovT]:
+    return SingleOf(irdl_to_attr_constraint(attr))

--- a/xdsl/irdl/constraints.py
+++ b/xdsl/irdl/constraints.py
@@ -4,7 +4,6 @@ from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from collections.abc import Set as AbstractSet
 from dataclasses import KW_ONLY, dataclass, field
-from inspect import isclass
 from typing import (
     TYPE_CHECKING,
     Generic,
@@ -13,7 +12,7 @@ from typing import (
     cast,
 )
 
-from typing_extensions import TypeVar, assert_never
+from typing_extensions import TypeVar, deprecated
 
 from xdsl.ir import (
     Attribute,
@@ -392,6 +391,7 @@ class BaseAttr(Generic[AttributeCovT], GenericAttrConstraint[AttributeCovT]):
         return self
 
 
+@deprecated("Please use `irdl_to_attr_constraint` instead")
 def attr_constr_coercion(
     attr: AttributeCovT | type[AttributeCovT] | GenericAttrConstraint[AttributeCovT],
 ) -> GenericAttrConstraint[AttributeCovT]:
@@ -399,13 +399,9 @@ def attr_constr_coercion(
     Attributes are coerced into EqAttrConstraints,
     and Attribute types are coerced into BaseAttr.
     """
-    if isinstance(attr, GenericAttrConstraint):
-        return attr
-    if isinstance(attr, Attribute):
-        return EqAttrConstraint(attr)
-    if isclass(attr):
-        return BaseAttr(attr)
-    assert_never(attr)
+    from xdsl.irdl import irdl_to_attr_constraint
+
+    return irdl_to_attr_constraint(attr)
 
 
 @dataclass(frozen=True)
@@ -438,8 +434,10 @@ class AnyOf(Generic[AttributeCovT], GenericAttrConstraint[AttributeCovT]):
             AttributeCovT | type[AttributeCovT] | GenericAttrConstraint[AttributeCovT]
         ],
     ):
+        from xdsl.irdl import irdl_to_attr_constraint
+
         constrs: tuple[GenericAttrConstraint[AttributeCovT], ...] = tuple(
-            attr_constr_coercion(constr) for constr in attr_constrs
+            irdl_to_attr_constraint(constr) for constr in attr_constrs
         )
         object.__setattr__(
             self,
@@ -662,7 +660,9 @@ class MessageConstraint(GenericAttrConstraint[AttributeCovT]):
         ),
         message: str,
     ):
-        object.__setattr__(self, "constr", attr_constr_coercion(constr))
+        from xdsl.irdl import irdl_to_attr_constraint
+
+        object.__setattr__(self, "constr", irdl_to_attr_constraint(constr))
         object.__setattr__(self, "message", message)
 
     def verify(
@@ -1028,22 +1028,3 @@ class SingleOf(GenericRangeConstraint[AttributeCovT]):
         self, type_var_mapping: dict[TypeVar, AttrConstraint]
     ) -> SingleOf[AttributeCovT]:
         return SingleOf(self.constr.mapping_type_vars(type_var_mapping))
-
-
-def range_constr_coercion(
-    attr: (
-        AttributeCovT
-        | type[AttributeCovT]
-        | GenericAttrConstraint[AttributeCovT]
-        | GenericRangeConstraint[AttributeCovT]
-    ),
-) -> GenericRangeConstraint[AttributeCovT]:
-    if isinstance(attr, GenericRangeConstraint):
-        return attr
-    return RangeOf(attr_constr_coercion(attr), length=AnyInt())
-
-
-def single_range_constr_coercion(
-    attr: AttributeCovT | type[AttributeCovT] | GenericAttrConstraint[AttributeCovT],
-) -> GenericRangeConstraint[AttributeCovT]:
-    return SingleOf(attr_constr_coercion(attr))

--- a/xdsl/irdl/operations.py
+++ b/xdsl/irdl/operations.py
@@ -49,6 +49,8 @@ from .attributes import (  # noqa: TID251
     IRDLGenericAttrConstraint,
     irdl_list_to_attr_constraint,
     irdl_to_attr_constraint,
+    range_constr_coercion,
+    single_range_constr_coercion,
 )
 from .constraints import (  # noqa: TID251
     AnyAttr,
@@ -58,9 +60,6 @@ from .constraints import (  # noqa: TID251
     GenericRangeConstraint,
     RangeConstraint,
     RangeOf,
-    attr_constr_coercion,
-    range_constr_coercion,
-    single_range_constr_coercion,
 )
 from .error import IRDLAnnotations  # noqa: TID251
 
@@ -1036,12 +1035,12 @@ class OpDef:
 
                             if option.as_property:
                                 prop_def = PropertyDef(
-                                    attr_constr_coercion(DenseArrayBase)
+                                    irdl_to_attr_constraint(DenseArrayBase)
                                 )
                                 op_def.properties[option.attribute_name] = prop_def
                             else:
                                 attr_def = AttributeDef(
-                                    attr_constr_coercion(DenseArrayBase)
+                                    irdl_to_attr_constraint(DenseArrayBase)
                                 )
                                 op_def.attributes[option.attribute_name] = attr_def
                     continue


### PR DESCRIPTION
It doesn't seem worth it to me to have both this and `irdl_to_attr_constraint`. Thoughts? Also moved `range_constr_coercion` and `single_range_constr_coercion` to the other file so that they don't need the local imports, though perhaps a better idea would be to move `irdl_to_attr_constraint`?