### PR TITLE
core: (constraints) ensure `AnyOf` cases are disjoint

### DIFF
--- a/tests/irdl/test_attr_constraint.py
+++ b/tests/irdl/test_attr_constraint.py
@@ -31,6 +31,7 @@ from xdsl.irdl import (
     eq,
     irdl_attr_definition,
 )
+from xdsl.utils.exceptions import PyRDLError
 
 
 def test_failing_inference():
@@ -78,6 +79,16 @@ class AttrC(Base):
         super().__init__(())
 
 
+@irdl_attr_definition
+class AttrD(Base):
+    name = "test.attr_d"
+
+    param: ParameterDef[AttrA | AttrC]
+
+    def __init__(self, param: AttrA | AttrC):
+        super().__init__((param,))
+
+
 @pytest.mark.parametrize(
     "constraint, expected",
     [
@@ -85,12 +96,14 @@ class AttrC(Base):
         (EqAttrConstraint(AttrB(AttrA())), {AttrB}),
         (BaseAttr(Base), None),
         (BaseAttr(AttrA), {AttrA}),
-        (EqAttrConstraint(AttrB(AttrA())) | AnyAttr(), None),
         (EqAttrConstraint(AttrB(AttrA())) | BaseAttr(AttrA), {AttrA, AttrB}),
-        (EqAttrConstraint(AttrB(AttrA())) | BaseAttr(AttrB), {AttrB}),
+        (
+            EqAttrConstraint(AttrD(AttrA())) | EqAttrConstraint(AttrD(AttrC())),
+            {AttrD},
+        ),
         (AllOf((AnyAttr(), BaseAttr(Base))), None),
         (AllOf((AnyAttr(), BaseAttr(AttrA))), {AttrA}),
-        (ParamAttrConstraint(AttrA, [BaseAttr(AttrB)]), {AttrA}),
+        (ParamAttrConstraint(AttrB, [BaseAttr(AttrA)]), {AttrB}),
         (ParamAttrConstraint(Base, [BaseAttr(AttrA)]), None),
         (VarConstraint("T", BaseAttr(Base)), None),
         (VarConstraint("T", BaseAttr(AttrA)), {AttrA}),
@@ -256,9 +269,9 @@ def test_memref_to_tensor(
             ParamAttrConstraint(AttrB, (BaseAttr(AttrA),)),
         ),
         (
-            ParamAttrConstraint(AttrB, (BaseAttr(AttrA),))
-            | ParamAttrConstraint(AttrB, (BaseAttr(AttrC),)),
-            ParamAttrConstraint(AttrB, (BaseAttr(AttrA) | BaseAttr(AttrC),)),
+            ParamAttrConstraint(AttrD, (BaseAttr(AttrA),))
+            | ParamAttrConstraint(AttrD, (BaseAttr(AttrC),)),
+            ParamAttrConstraint(AttrD, (BaseAttr(AttrA) | BaseAttr(AttrC),)),
         ),
         (
             ParamAttrConstraint(AttrB, (BaseAttr(AttrA),))
@@ -274,3 +287,64 @@ def test_memref_to_tensor(
 )
 def test_constraint_simplification(lhs: AttrConstraint, rhs: AttrConstraint):
     assert lhs == rhs
+
+
+@pytest.mark.parametrize(
+    "c1, c2, msg",
+    [
+        (
+            AnyAttr(),
+            BaseAttr(AttrA),
+            re.escape(
+                "Constraint AnyAttr() cannot appear in an `AnyOf` constraint as its bases aren't known"
+            ),
+        ),
+        (
+            BaseAttr(AttrA) | BaseAttr(AttrB),
+            BaseAttr(AttrA),
+            re.escape(
+                "Constraint BaseAttr(AttrA) shares a base with a non-equality constraint in {AnyOf(attr_constrs=(BaseAttr(AttrA), BaseAttr(AttrB)))} in `AnyOf` constraint."
+            ),
+        ),
+        (
+            BaseAttr(AttrA),
+            EqAttrConstraint(AttrA()),
+            re.escape(
+                "Constraint EqAttrConstraint(attr=AttrA()) shares a base with a non-equality constraint in {BaseAttr(AttrA)} in `AnyOf` constraint."
+            ),
+        ),
+        (
+            EqAttrConstraint(AttrA()),
+            BaseAttr(AttrA),
+            re.escape(
+                "Non-equality constraint BaseAttr(AttrA) shares a base with a constraint in {EqAttrConstraint(attr=AttrA())} in `AnyOf` constraint."
+            ),
+        ),
+    ],
+)
+def test_any_of_overlapping(c1: AttrConstraint, c2: AttrConstraint, msg: str):
+    with pytest.raises(PyRDLError, match=msg):
+        AnyOf((c1, c2))
+
+
+@pytest.mark.parametrize(
+    "constrs",
+    [
+        (
+            BaseAttr(AttrC),
+            BaseAttr(AttrA),
+        ),
+        (
+            EqAttrConstraint(AttrD(AttrA())),
+            EqAttrConstraint(AttrD(AttrC())),
+        ),
+        (
+            EqAttrConstraint(AttrD(AttrA())),
+            BaseAttr(AttrA),
+            BaseAttr(AttrC),
+            EqAttrConstraint(AttrD(AttrC())),
+        ),
+    ],
+)
+def test_any_of_non_overlapping(constrs: tuple[AttrConstraint, ...]):
+    AnyOf(constrs)

--- a/tests/irdl/test_attribute_definition.py
+++ b/tests/irdl/test_attribute_definition.py
@@ -1055,6 +1055,11 @@ class B(Data[int]):
     name = "test.b"
 
 
+@irdl_attr_definition
+class C(Data[int]):
+    name = "test.c"
+
+
 _A = TypeVar("_A", bound=Attribute)
 
 
@@ -1092,14 +1097,14 @@ def test_message_constraint():
 def test_anyof_constraint():
     anyof_constraint = AnyOf((TypeVarConstraint(_A, BaseAttr(A)), BaseAttr(B)))
 
-    assert anyof_constraint.mapping_type_vars({_A: BaseAttr(B)}) == AnyOf(
-        (BaseAttr(B), BaseAttr(B))
+    assert anyof_constraint.mapping_type_vars({_A: BaseAttr(C)}) == AnyOf(
+        (BaseAttr(C), BaseAttr(B))
     )
 
 
 def test_allof_constraint():
     allof_constraint = AllOf((TypeVarConstraint(_A, BaseAttr(A)), BaseAttr(B)))
 
-    assert allof_constraint.mapping_type_vars({_A: BaseAttr(B)}) == AllOf(
-        (BaseAttr(B), BaseAttr(B))
+    assert allof_constraint.mapping_type_vars({_A: BaseAttr(C)}) == AllOf(
+        (BaseAttr(C), BaseAttr(B))
     )

--- a/tests/irdl/test_operation_definition.py
+++ b/tests/irdl/test_operation_definition.py
@@ -748,8 +748,8 @@ BarType = Annotated[TestType, TestType("bar")]
 
 
 _Attr = TypeVar("_Attr", bound=StringAttr | IntAttr)
-_Operand = TypeVar("_Operand", bound=FooType | BarType)
-_Result = TypeVar("_Result", bound=FooType | BarType)
+_Operand = TypeVar("_Operand", bound=TestType)
+_Result = TypeVar("_Result", bound=TestType)
 
 
 class GenericOp(Generic[_Attr, _Operand, _Result], IRDLOperation):

--- a/tests/test_pyrdl.py
+++ b/tests/test_pyrdl.py
@@ -56,6 +56,22 @@ class IntData(Data[int]):
 
 
 @irdl_attr_definition
+class FloatData(Data[float]):
+    """An attribute holding a float value."""
+
+    name = "test.float"
+
+    @classmethod
+    def parse_parameter(cls, parser: AttrParser) -> float:
+        with parser.in_angle_brackets():
+            return parser.parse_float()
+
+    def print_parameter(self, printer: Printer):
+        with printer.in_angle_brackets():
+            printer.print_string(str(self.data))
+
+
+@irdl_attr_definition
 class DoubleParamAttr(ParametrizedAttribute):
     """An attribute with two unbounded attribute parameters."""
 
@@ -177,11 +193,11 @@ def test_anyof_verify():
     Check that an AnyOf constraint verifies if one of the constraints
     verify.
     """
-    constraint = LessThan(0) | GreaterThan(10)
-    constraint.verify(IntData(-1), ConstraintContext())
+    constraint = BaseAttr(BoolData) | BaseAttr(IntData)
+    constraint.verify(IntData(1), ConstraintContext())
     constraint.verify(IntData(-10), ConstraintContext())
-    constraint.verify(IntData(11), ConstraintContext())
-    constraint.verify(IntData(100), ConstraintContext())
+    constraint.verify(BoolData(True), ConstraintContext())
+    constraint.verify(BoolData(False), ConstraintContext())
 
 
 def test_anyof_verify_fail():
@@ -189,16 +205,14 @@ def test_anyof_verify_fail():
     Check that an AnyOf constraint fails to verify if none of the constraints
     verify.
     """
-    constraint = LessThan(0) | GreaterThan(10)
+    constraint = BaseAttr(BoolData) | BaseAttr(IntData)
 
-    zero = IntData(0)
-    ten = IntData(10)
+    f = FloatData(10.0)
 
-    with pytest.raises(VerifyException, match=f"Unexpected attribute {zero}"):
-        constraint.verify(zero, ConstraintContext())
-
-    with pytest.raises(VerifyException, match=f"Unexpected attribute {ten}"):
-        constraint.verify(ten, ConstraintContext())
+    with pytest.raises(
+        VerifyException, match=r"Unexpected attribute #test.float<10.0>"
+    ):
+        constraint.verify(f, ConstraintContext())
 
 
 def test_allof_verify():


### PR DESCRIPTION
I had a go at enforcing that the sets of bases are disjoint in `AnyOf` constraints. This is all the things that need to be changed. I think the only possible meaningful one is the `StencilType` change.

My hope is that this will allow:
- simplifying the verify method for `AnyOf`, as instead of the context copying stuff, we can just ensure that we are going down the correct branch first. An alternative to performing the check manually is to try to enforce that all constraints should check their base is correct before setting any variables (which most do).
- allow variables to be set by `AnyOf`. Extracting variables from anyof should be safe once branches are disjoint. This will allow us to get rid of `TypedAttributeConstraint`