### PR TITLE
dialects: (emitc) Add additional invalid emitc array type checks

### DIFF
--- a/tests/filecheck/dialects/emitc/emitc_types_invalid.mlir
+++ b/tests/filecheck/dialects/emitc/emitc_types_invalid.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --split-input-file --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt %s --split-input-file --verify-diagnostics --parsing-diagnostics | filecheck %s
 
 // Check that the right diagnostics are emitted when verify EmitC types with invalid definition.
 
@@ -33,4 +33,39 @@
 // CHECK: EmitC array element type 'tensor<1x!emitc.array<1xf32>>' is not a supported EmitC type.
 "test.op"() {
   tensor_with_emitc_array = !emitc.array<1xtensor<1x!emitc.array<1xf32>>>
+}: ()->()
+
+// -----
+
+// CHECK: Expected shape type.
+"test.op"() {
+  missing_spec = !emitc.array<>
+}: ()->()
+
+// -----
+
+// CHECK: Expected 'x' in shape delimiter, got GREATER
+"test.op"() {
+  illegal_array_missing_x = !emitc.array<10>
+}: ()->()
+
+// -----
+
+// CHECK: Expected shape type.
+"test.op"() {
+  illegal_array_missing_type = !emitc.array<10x>
+}: ()->()
+
+// -----
+
+// CHECK: EmitC array dimensions must have non-negative size
+"test.op"() {
+  illegal_array_dynamic_shape = !emitc.array<10x?xi32>
+}: ()->()
+
+// -----
+
+// CHECK: '>' expected
+"test.op"() {
+  illegal_array_unranked = !emitc.array<*xi32>
 }: ()->()


### PR DESCRIPTION
The tests are taken from
https://github.com/llvm/llvm-project/blob/main/mlir/test/Dialect/EmitC/invalid_types.mlir#L17
