### PR TITLE
Hendrik/dialect/emitc add lvalue type

### DIFF
--- a/tests/filecheck/dialects/emitc/emitc_types.mlir
+++ b/tests/filecheck/dialects/emitc/emitc_types.mlir
@@ -1,5 +1,9 @@
 // RUN: XDSL_ROUNDTRIP
 
+//===----------------------------------------------------------------------===//
+// ArrayType
+//===----------------------------------------------------------------------===//
+
 // CHECK: bf16_1D = !emitc.array<1xbf16>
 // CHECK-SAME: f32_2D = !emitc.array<4x2xf32>
 // CHECK-SAME: f64_1D = !emitc.array<5xf64>
@@ -15,4 +19,21 @@
   i1_3D = !emitc.array<3x4x5xi1>,
   i32_1D = !emitc.array<10xi32>,
   index_1D = !emitc.array<1xindex>
+}: ()->()
+
+//===----------------------------------------------------------------------===//
+// LValueType
+//===----------------------------------------------------------------------===//
+
+// CHECK: f64 = !emitc.lvalue<f64>
+// CHECK-SAME: i32 = !emitc.lvalue<i32>
+// CHECK-SAME: index = !emitc.lvalue<index>
+// CHECK-SAME: tensor_i32 = !emitc.lvalue<tensor<1xi32>>
+"test.op"() {
+  f64 = !emitc.lvalue<f64>,
+  i32 = !emitc.lvalue<i32>,
+  index = !emitc.lvalue<index>,
+  tensor_i32 = !emitc.lvalue<tensor<1xi32>>
+  // ptr_i32 = !emitc.lvalue<!emitc.ptr<i32>>,
+  // opaque_int = !emitc.lvalue<!emitc.opaque<"int">>
 }: ()->()

--- a/tests/filecheck/dialects/emitc/emitc_types_invalid.mlir
+++ b/tests/filecheck/dialects/emitc/emitc_types_invalid.mlir
@@ -69,3 +69,31 @@
 "test.op"() {
   illegal_array_unranked = !emitc.array<*xi32>
 }: ()->()
+
+// -----
+
+// CHECK: EmitC array element type '!emitc.lvalue<i32>' is not a supported EmitC type.
+"test.op"() {
+  lvalue_element_type = !emitc.array<4x!emitc.lvalue<i32>>
+}: ()->()
+
+// -----
+
+// CHECK: !emitc.lvalue cannot wrap !emitc.array type
+"test.op"() {
+  illegal_lvalue_type_1 = !emitc.lvalue<!emitc.array<1xi32>>
+}: ()->()
+
+// -----
+
+// CHECK: !emitc.lvalue must wrap supported emitc type, but got !emitc.lvalue<i32>
+"test.op"() {
+  illegal_lvalue_type_2 = !emitc.lvalue<!emitc.lvalue<i32>>
+}: ()->()
+
+// -----
+
+// CHECK: !emitc.lvalue must wrap supported emitc type, but got i17
+"test.op"() {
+  illegal_lvalue_type_3 = !emitc.lvalue<i17>
+}: ()->()

--- a/tests/filecheck/dialects/emitc/emitc_types_invalid.mlir
+++ b/tests/filecheck/dialects/emitc/emitc_types_invalid.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --split-input-file --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt %s --split-input-file --verify-diagnostics --parsing-diagnostics | filecheck %s
 
 // Check that the right diagnostics are emitted when verify EmitC types with invalid definition.
 
@@ -33,4 +33,39 @@
 // CHECK: EmitC array element type 'tensor<1x!emitc.array<1xf32>>' is not a supported EmitC type.
 "test.op"() {
   tensor_with_emitc_array = !emitc.array<1xtensor<1x!emitc.array<1xf32>>>
+}: ()->()
+
+// -----
+
+// CHECK: Expected shape type.
+"test.op"() {
+  missing_spec = !emitc.array<>
+}: ()->()
+
+// -----
+
+// CHECK: Expected 'x' in shape delimiter, got GREATER
+"test.op"() {
+  illegal_array_missing_x = !emitc.array<10>
+}: ()->()
+
+// -----
+
+// CHECK: Expected shape type.
+"test.op"() {
+  illegal_array_missing_type = !emitc.array<10x>
+}: ()->()
+
+// -----
+
+// CHECK: EmitC array dimensions must have non-negative size
+"test.op"() {
+  illegal_array_dynamic_shape = !emitc.array<10x?xi32>
+}: ()->()
+
+// -----
+
+// CHECK: '>' expected
+"test.op"() {
+  illegal_array_unranked = !emitc.array<*xi32>
 }: ()->()

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/emitc/emitc_types.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/emitc/emitc_types.mlir
@@ -1,5 +1,9 @@
 // RUN: mlir-opt %s --mlir-print-op-generic --allow-unregistered-dialect | xdsl-opt --print-op-generic | filecheck %s
 
+//===----------------------------------------------------------------------===//
+// ArrayType
+//===----------------------------------------------------------------------===//
+
 // CHECK: bf16_1D = !emitc.array<1xbf16>
 // CHECK-SAME: f32_2D = !emitc.array<4x2xf32>
 // CHECK-SAME: f64_1D = !emitc.array<5xf64>
@@ -15,4 +19,21 @@
   i1_3D = !emitc.array<3x4x5xi1>,
   i32_1D = !emitc.array<10xi32>,
   index_1D = !emitc.array<1xindex>
+}: ()->()
+
+//===----------------------------------------------------------------------===//
+// LValueType
+//===----------------------------------------------------------------------===//
+
+// CHECK: f64 = !emitc.lvalue<f64>
+// CHECK-SAME: i32 = !emitc.lvalue<i32>
+// CHECK-SAME: index = !emitc.lvalue<index>
+// CHECK-SAME: tensor_i32 = !emitc.lvalue<tensor<1xi32>>
+"test.op"() {
+  f64 = !emitc.lvalue<f64>,
+  i32 = !emitc.lvalue<i32>,
+  index = !emitc.lvalue<index>,
+  tensor_i32 = !emitc.lvalue<tensor<1xi32>>
+  // ptr_i32 = !emitc.lvalue<!emitc.ptr<i32>>,
+  // opaque_int = !emitc.lvalue<!emitc.opaque<"int">>
 }: ()->()

--- a/xdsl/dialects/emitc.py
+++ b/xdsl/dialects/emitc.py
@@ -8,6 +8,7 @@ See external [documentation](https://mlir.llvm.org/docs/Dialects/EmitC/).
 """
 
 from collections.abc import Iterable
+from typing import cast
 
 from xdsl.dialects.builtin import (
     ArrayAttr,
@@ -20,6 +21,7 @@ from xdsl.dialects.builtin import (
     IntAttr,
     IntegerType,
     ShapedType,
+    TensorType,
 )
 from xdsl.ir import (
     Attribute,
@@ -111,6 +113,40 @@ class EmitC_ArrayType(
         )
 
 
+@irdl_attr_definition
+class EmitC_LValueType(ParametrizedAttribute, TypeAttribute):
+    """
+    EmitC lvalue type.
+    Values of this type can be assigned to and their address can be taken.
+    See [tablegen definition](https://github.com/llvm/llvm-project/blob/main/mlir/include/mlir/Dialect/EmitC/IR/EmitCTypes.td#L87)
+    """
+
+    name = "emitc.lvalue"
+    value_type: ParameterDef[TypeAttribute]
+
+    def __init__(self, value_type: TypeAttribute):
+        super().__init__([value_type])
+
+    def verify(self) -> None:
+        """
+        Verify the LValueType.
+        See [MLIR implementation](https://github.com/llvm/llvm-project/blob/main/mlir/lib/Dialect/EmitC/IR/EmitC.cpp#L1095)
+        """
+        # Check that the wrapped type is valid. This especially forbids nested lvalue types.
+        if not is_supported_emitc_type(self.value_type):
+            raise VerifyException(
+                f"!emitc.lvalue must wrap supported emitc type, but got {self.value_type}"
+            )
+        if isinstance(self.value_type, EmitC_ArrayType):
+            raise VerifyException("!emitc.lvalue cannot wrap !emitc.array type")
+
+    @classmethod
+    def parse_parameter(cls, parser: AttrParser):
+        with parser.in_angle_brackets():
+            type = parser.parse_type()
+            return type
+
+
 _SUPPORTED_BITWIDTHS = (1, 8, 16, 32, 64)
 
 
@@ -150,10 +186,43 @@ def is_integer_index_or_opaque_type(
     return _is_supported_integer_type(type_attr) or isa(type_attr, IndexType)
 
 
+def is_supported_emitc_type(type_attr: Attribute) -> bool:
+    """
+    Check if a type is supported by EmitC.
+    See [MLIR implementation](https://github.com/llvm/llvm-project/blob/main/mlir/lib/Dialect/EmitC/IR/EmitC.cpp#L62).
+    """
+    match type_attr:
+        case IntegerType():
+            return _is_supported_integer_type(type_attr)
+        case IndexType():
+            return True
+        case EmitC_ArrayType():
+            elem_type = cast(Attribute, type_attr.get_element_type())
+            return not isa(elem_type, EmitC_ArrayType) and is_supported_emitc_type(
+                elem_type
+            )
+        case Float16Type() | BFloat16Type() | Float32Type() | Float64Type():
+            return True
+        case TensorType():
+            elem_type = cast(Attribute, type_attr.get_element_type())
+            if isinstance(elem_type, EmitC_ArrayType):
+                return False
+            return is_supported_emitc_type(elem_type)
+        # TODO: Tuple type is not implemented yet, but it should be a valid emitc type.
+        # case TupleType():
+        #     return all(
+        #         not isinstance(t, EmitC_ArrayType) and is_supported_emitc_type(t)
+        #         for t in type_attr.types
+        #     )
+        case _:
+            return False
+
+
 EmitC = Dialect(
     "emitc",
     [],
     [
         EmitC_ArrayType,
+        EmitC_LValueType,
     ],
 )


### PR DESCRIPTION
Tests are taken over from the [MLIR repo](https://github.com/llvm/llvm-project/tree/main/mlir/test/Dialect/EmitC)

Based on #4511 (does github not support stacked pull requests for forks?)