### PR TITLE
interpreter: (eqsat) Add backtracking mechanism for `GetDefiningOp`

### DIFF
--- a/tests/interpreters/test_eqsat_pdl_interp_interpreter.py
+++ b/tests/interpreters/test_eqsat_pdl_interp_interpreter.py
@@ -219,6 +219,112 @@ def test_run_getdefiningop():
     assert len(interp_functions.backtrack_stack) == 0
 
 
+def test_run_getdefiningop_eclass_not_visited():
+    """Test that run_getdefiningop handles EClassOp when not visited."""
+    interpreter = Interpreter(ModuleOp([]))
+    interp_functions = EqsatPDLInterpFunctions(Context())
+    interpreter.register_implementations(interp_functions)
+
+    # Create test operations
+    c0 = create_ssa_value(i32)
+    test_op = test.TestOp((c0,), (i32,))
+    eclass_op = eqsat.EClassOp(test_op.results[0], res_type=i32)
+
+    # Create GetDefiningOpOp
+    gdo_op = pdl_interp.GetDefiningOpOp(create_ssa_value(pdl.OperationType()))
+
+    # Set up backtrack stack and visited state
+    from xdsl.interpreters.eqsat_pdl_interp import BacktrackPoint
+    from xdsl.ir import Block
+    from xdsl.utils.scoped_dict import ScopedDict
+
+    block = Block()
+    scope = ScopedDict[Any, Any]()
+    backtrack_point = BacktrackPoint(block, (), scope, gdo_op, 0, 0)
+    interp_functions.backtrack_stack.append(backtrack_point)
+    interp_functions.visited = False
+
+    # Test with EClassOp result
+    result = interpreter.run_op(gdo_op, (eclass_op.results[0],))
+
+    # Should use index from backtrack stack and set visited to True
+    assert interp_functions.visited
+    assert result == (test_op,)  # Should return the operand at index 0
+
+
+def test_run_getdefiningop_eclass_visited():
+    """Test that run_getdefiningop handles EClassOp when visited."""
+    interpreter = Interpreter(ModuleOp([]))
+    interp_functions = EqsatPDLInterpFunctions(Context())
+    interpreter.register_implementations(interp_functions)
+
+    # Create test operations with multiple operands
+    c0 = create_ssa_value(i32)
+    c1 = create_ssa_value(i32)
+    test_op1 = test.TestOp((c0,), (i32,))
+    test_op2 = test.TestOp((c1,), (i32,))
+    eclass_op = eqsat.EClassOp(test_op1.results[0], test_op2.results[0], res_type=i32)
+
+    # Create a block and add the GetDefiningOpOp to it
+    from xdsl.ir import Block
+
+    block = Block()
+    gdo_op = pdl_interp.GetDefiningOpOp(create_ssa_value(pdl.OperationType()))
+    block.add_op(gdo_op)
+
+    # Set visited to True and create a parent scope for the interpreter context
+    interp_functions.visited = True
+
+    # Create a child scope to give the current context a parent
+    from xdsl.utils.scoped_dict import ScopedDict
+
+    child_scope = ScopedDict(parent=interpreter._ctx)  # pyright: ignore[reportPrivateUsage]
+    interpreter._ctx = child_scope  # pyright: ignore[reportPrivateUsage]
+
+    # Test with EClassOp result
+    result = interpreter.run_op(gdo_op, (eclass_op.results[0],))
+
+    # Should create new backtrack point and use index 0
+    assert len(interp_functions.backtrack_stack) == 1
+    assert interp_functions.backtrack_stack[0].index == 0
+    assert interp_functions.backtrack_stack[0].max_index == 1  # len(operands) - 1
+    assert result == (test_op1,)  # Should return the operand at index 0
+
+
+def test_run_getdefiningop_eclass_error_multiple_gdo():
+    """Test that run_getdefiningop raises error for multiple get_defining_op in block."""
+    interpreter = Interpreter(ModuleOp([]))
+    interp_functions = EqsatPDLInterpFunctions(Context())
+    interpreter.register_implementations(interp_functions)
+
+    # Create test operations
+    c0 = create_ssa_value(i32)
+    test_op = test.TestOp((c0,), (i32,))
+    eclass_op = eqsat.EClassOp(test_op.results[0], res_type=i32)
+
+    # Create two different GetDefiningOpOp operations
+    gdo_op1 = pdl_interp.GetDefiningOpOp(create_ssa_value(pdl.OperationType()))
+    gdo_op2 = pdl_interp.GetDefiningOpOp(create_ssa_value(pdl.OperationType()))
+
+    # Set up backtrack stack with different gdo_op and visited=False
+    from xdsl.interpreters.eqsat_pdl_interp import BacktrackPoint
+    from xdsl.ir import Block
+    from xdsl.utils.scoped_dict import ScopedDict
+
+    block = Block()
+    scope = ScopedDict[Any, Any]()
+    backtrack_point = BacktrackPoint(block, (), scope, gdo_op1, 0, 1)  # Different op
+    interp_functions.backtrack_stack.append(backtrack_point)
+    interp_functions.visited = False
+
+    # Test should raise InterpretationError when using different gdo_op
+    with pytest.raises(
+        InterpretationError,
+        match="Case where a block contains multiple pdl_interp.get_defining_op is currently not supported",
+    ):
+        interpreter.run_op(gdo_op2, (eclass_op.results[0],))
+
+
 def test_run_finalize_empty_stack():
     """Test that run_finalize handles empty backtrack stack correctly."""
     interpreter = Interpreter(ModuleOp([]))

--- a/tests/interpreters/test_eqsat_pdl_interp_interpreter.py
+++ b/tests/interpreters/test_eqsat_pdl_interp_interpreter.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 
 from xdsl.context import Context
@@ -192,3 +194,116 @@ def test_run_getresults_valuetype_no_results():
         (test_op,),
     )
     assert result == (None,)
+
+
+def test_run_getdefiningop():
+    """Test that run_getdefiningop handles regular operations correctly."""
+    interpreter = Interpreter(ModuleOp([]))
+    interp_functions = EqsatPDLInterpFunctions(Context())
+    interpreter.register_implementations(interp_functions)
+
+    # Create a test operation and its result
+    c0 = create_ssa_value(i32)
+    test_op = test.TestOp((c0,), (i32,))
+
+    # Test GetDefiningOpOp with regular operation result
+    result = interpreter.run_op(
+        pdl_interp.GetDefiningOpOp(create_ssa_value(pdl.OperationType())),
+        (test_op.results[0],),
+    )
+
+    # Should return the defining operation
+    assert result == (test_op,)
+
+    # Should not have set up any backtracking for regular operations
+    assert len(interp_functions.backtrack_stack) == 0
+
+
+def test_run_finalize_empty_stack():
+    """Test that run_finalize handles empty backtrack stack correctly."""
+    interpreter = Interpreter(ModuleOp([]))
+    interp_functions = EqsatPDLInterpFunctions(Context())
+    interpreter.register_implementations(interp_functions)
+
+    # Test finalize with empty backtrack stack - should return empty values
+    result = interpreter.run_op(pdl_interp.FinalizeOp(), ())
+    assert result == ()
+
+
+def test_backtrack_stack_manipulation():
+    """Test that backtrack stack operations work correctly."""
+    interp_functions = EqsatPDLInterpFunctions(Context())
+
+    # Verify initial state
+    assert len(interp_functions.backtrack_stack) == 0
+    assert interp_functions.visited
+
+    # Test adding to backtrack stack
+    from xdsl.interpreters.eqsat_pdl_interp import BacktrackPoint
+    from xdsl.ir import Block
+    from xdsl.utils.scoped_dict import ScopedDict
+
+    block = Block()
+    scope = ScopedDict[Any, Any]()
+    gdo_op = pdl_interp.GetDefiningOpOp(create_ssa_value(pdl.OperationType()))
+    backtrack_point = BacktrackPoint(block, (), scope, gdo_op, 0, 2)
+
+    interp_functions.backtrack_stack.append(backtrack_point)
+    assert len(interp_functions.backtrack_stack) == 1
+    assert interp_functions.backtrack_stack[0].index == 0
+    assert interp_functions.backtrack_stack[0].max_index == 2
+
+
+def test_run_finalize_with_backtrack_stack():
+    """Test that run_finalize handles non-empty backtrack stack correctly."""
+    interpreter = Interpreter(ModuleOp([]))
+    interp_functions = EqsatPDLInterpFunctions(Context())
+    interpreter.register_implementations(interp_functions)
+
+    # Import necessary classes
+    from xdsl.interpreter import Successor
+    from xdsl.interpreters.eqsat_pdl_interp import BacktrackPoint
+    from xdsl.ir import Block
+    from xdsl.utils.scoped_dict import ScopedDict
+
+    # Create a backtrack point that hasn't reached its max index
+    block = Block()
+    scope = ScopedDict[Any, Any]()
+    gdo_op = pdl_interp.GetDefiningOpOp(create_ssa_value(pdl.OperationType()))
+    backtrack_point = BacktrackPoint(
+        block, (), scope, gdo_op, 0, 2
+    )  # index < max_index
+
+    interp_functions.backtrack_stack.append(backtrack_point)
+
+    # Store original interpreter scope
+    original_scope = interpreter._ctx  # pyright: ignore[reportPrivateUsage]
+
+    # Test finalize with backtrack stack that can continue
+    result = interp_functions.run_finalize(interpreter, pdl_interp.FinalizeOp(), ())
+
+    # Should return a Successor to continue backtracking
+    assert isinstance(result.terminator_value, Successor)
+    assert result.terminator_value.block is block
+    assert result.terminator_value.args == ()
+    assert result.values == ()
+
+    # Should increment the index and set visited to False
+    assert interp_functions.backtrack_stack[0].index == 1
+    assert not interp_functions.visited
+
+    # Should restore the interpreter scope from the backtrack point
+    assert interpreter._ctx is scope  # pyright: ignore[reportPrivateUsage]
+    assert interpreter._ctx is not original_scope  # pyright: ignore[reportPrivateUsage]
+
+    # Test finalize when backtrack point reaches max index
+    interp_functions.backtrack_stack[0].index = 2  # Set to max_index
+    from xdsl.interpreter import ReturnedValues
+
+    result = interp_functions.run_finalize(interpreter, pdl_interp.FinalizeOp(), ())
+
+    # Should pop the backtrack point and return empty values
+    assert isinstance(result.terminator_value, ReturnedValues)
+    assert result.terminator_value.values == ()
+    assert result.values == ()
+    assert len(interp_functions.backtrack_stack) == 0

--- a/xdsl/interpreters/eqsat_pdl_interp.py
+++ b/xdsl/interpreters/eqsat_pdl_interp.py
@@ -138,7 +138,7 @@ class EqsatPDLInterpFunctions(PDLInterpFunctions):
             if not self.visited:
                 if op != self.backtrack_stack[-1].gdo_op:
                     raise InterpretationError(
-                        "TODO: handle the case where a block contains multiple pdl_interp.get_defining_op."
+                        "Case where a block contains multiple pdl_interp.get_defining_op is currently not supported."
                     )
                 index = self.backtrack_stack[-1].index
                 self.visited = True

--- a/xdsl/interpreters/eqsat_pdl_interp.py
+++ b/xdsl/interpreters/eqsat_pdl_interp.py
@@ -24,23 +24,68 @@ from xdsl.utils.scoped_dict import ScopedDict
 
 @dataclass
 class BacktrackPoint:
+    """
+    Represents a point in pattern matching where backtracking may be needed.
+
+    When a GetDefiningOpOp encounters an EClassOp with multiple operands,
+    we need to try matching against each operand. This class captures the
+    interpreter state so we can backtrack and try the next operand if
+    the current match fails.
+    """
+
     block: Block
+    """The block to return to when backtracking."""
+
     block_args: tuple[SSAValue, ...]
+    """Block arguments to restore when backtracking."""
+
     scope: ScopedDict[SSAValue, Any]
+    """Variable scope to restore when backtracking."""
+
     gdo_op: pdl_interp.GetDefiningOpOp
+    """The GetDefiningOpOp that created this backtrack point."""
+
     index: int
+    """Current operand index being tried in the EClassOp."""
+
     max_index: int
+    """Last valid operand index in the EClassOp (len(operands) - 1)."""
 
 
 @register_impls
 @dataclass
 class EqsatPDLInterpFunctions(PDLInterpFunctions):
+    """Interpreter functions for PDL patterns operating on e-graphs."""
+
     backtrack_stack: list[BacktrackPoint] = field(default_factory=list[BacktrackPoint])
+    """Stack of backtrack points for exploring multiple matching paths in e-classes."""
+
     visited: bool = True
+    """Signals whether the GetDefiningOp (GDO) in the block that run_finalize jumps to has been encountered.
+
+    This is to handle when a block contains GDOs before the GDO we're backtracking to.
+    If this is the case, run_finalize jumps to the block but will encounter the wrong GDOs first.
+    e.g.:
+    ```
+    BB0:
+        %0 = pdl_interp.get_defining_op ...
+        %1 = pdl_interp.get_defining_op ...
+    BB1:
+        pdl_interp.finalize # backtrack to BB0 at this point
+    ```
+    Backtracking works by jumping to the start of the block containing the GDO (`BB0`).
+    When we need to backtrack to the second GDO (`%1`), `visited` is still `False` when encountering the first GDO (`%0`).
+    This allows us to know that we have to skip the first GDO and continue with the second one.
+    """
+
     known_ops: KnownOps = field(default_factory=KnownOps)
+    """Used for hashconsing operations. When new operations are created, if they are identical to an existing operation,
+    the existing operation is reused instead of creating a new one."""
+
     eclass_union_find: DisjointSet[eqsat.EClassOp] = field(
         default_factory=lambda: DisjointSet[eqsat.EClassOp]()
     )
+    """Union-find structure tracking which e-classes are equivalent and should be merged."""
 
     def populate_known_ops(self, module: ModuleOp) -> None:
         """
@@ -135,8 +180,9 @@ class EqsatPDLInterpFunctions(PDLInterpFunctions):
             ],
         )
         if isinstance(eclass_op := defining_op, eqsat.EClassOp):
-            if not self.visited:
+            if not self.visited:  # we come directly from run_finalize
                 if op != self.backtrack_stack[-1].gdo_op:
+                    # we first encounter a GDO that is not the one we are backtracking to:
                     raise InterpretationError(
                         "Case where a block contains multiple pdl_interp.get_defining_op is currently not supported."
                     )

--- a/xdsl/interpreters/eqsat_pdl_interp.py
+++ b/xdsl/interpreters/eqsat_pdl_interp.py
@@ -1,26 +1,42 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, cast
 
 from xdsl.dialects import eqsat, pdl_interp
 from xdsl.dialects.builtin import ModuleOp
 from xdsl.dialects.pdl import ValueType
 from xdsl.interpreter import (
     Interpreter,
+    ReturnedValues,
+    Successor,
     impl,
+    impl_terminator,
     register_impls,
 )
 from xdsl.interpreters.pdl_interp import PDLInterpFunctions
-from xdsl.ir import Operation, OpResult
+from xdsl.ir import Block, Operation, OpResult, SSAValue
 from xdsl.transforms.common_subexpression_elimination import KnownOps
 from xdsl.utils.disjoint_set import DisjointSet
 from xdsl.utils.exceptions import InterpretationError
+from xdsl.utils.scoped_dict import ScopedDict
+
+
+@dataclass
+class BacktrackPoint:
+    block: Block
+    block_args: tuple[SSAValue, ...]
+    scope: ScopedDict[SSAValue, Any]
+    gdo_op: pdl_interp.GetDefiningOpOp
+    index: int
+    max_index: int
 
 
 @register_impls
 @dataclass
 class EqsatPDLInterpFunctions(PDLInterpFunctions):
+    backtrack_stack: list[BacktrackPoint] = field(default_factory=list[BacktrackPoint])
+    visited: bool = True
     known_ops: KnownOps = field(default_factory=KnownOps)
     eclass_union_find: DisjointSet[eqsat.EClassOp] = field(
         default_factory=lambda: DisjointSet[eqsat.EClassOp]()
@@ -104,3 +120,56 @@ class EqsatPDLInterpFunctions(PDLInterpFunctions):
                         )
             results.append(result)
         return (results,)
+
+    @impl(pdl_interp.GetDefiningOpOp)
+    def run_getdefiningop(
+        self,
+        interpreter: Interpreter,
+        op: pdl_interp.GetDefiningOpOp,
+        args: tuple[Any, ...],
+    ) -> tuple[Any, ...]:
+        defining_op = cast(
+            None | Operation,
+            PDLInterpFunctions.run_get_defining_op(self, interpreter, op, args).values[
+                0
+            ],
+        )
+        if isinstance(eclass_op := defining_op, eqsat.EClassOp):
+            if not self.visited:
+                if op != self.backtrack_stack[-1].gdo_op:
+                    raise InterpretationError(
+                        "TODO: handle the case where a block contains multiple pdl_interp.get_defining_op."
+                    )
+                index = self.backtrack_stack[-1].index
+                self.visited = True
+            else:
+                block = op.parent_block()
+                assert block
+                block_args = interpreter.get_values(block.args)
+                scope = interpreter._ctx.parent  # pyright: ignore[reportPrivateUsage]
+                assert scope
+                index = 0
+                self.backtrack_stack.append(
+                    BacktrackPoint(
+                        block, block_args, scope, op, index, len(eclass_op.operands) - 1
+                    )
+                )
+            return PDLInterpFunctions.run_get_defining_op(
+                self, interpreter, op, (eclass_op.operands[index],)
+            ).values
+
+        return (defining_op,)
+
+    @impl_terminator(pdl_interp.FinalizeOp)
+    def run_finalize(
+        self, interpreter: Interpreter, _: pdl_interp.FinalizeOp, args: tuple[Any, ...]
+    ):
+        for backtrack_point in reversed(self.backtrack_stack):
+            if backtrack_point.index >= backtrack_point.max_index:
+                self.backtrack_stack.pop()
+            else:
+                backtrack_point.index += 1
+                interpreter._ctx = backtrack_point.scope  # pyright: ignore[reportPrivateUsage]
+                self.visited = False
+                return Successor(backtrack_point.block, backtrack_point.block_args), ()
+        return ReturnedValues(()), ()

--- a/xdsl/interpreters/eqsat_pdl_interp.py
+++ b/xdsl/interpreters/eqsat_pdl_interp.py
@@ -206,9 +206,8 @@ class EqsatPDLInterpFunctions(PDLInterpFunctions):
                         block, block_args, scope, op, index, len(eclass_op.operands) - 1
                     )
                 )
-            return PDLInterpFunctions.run_get_defining_op(
-                self, interpreter, op, (eclass_op.operands[index],)
-            ).values
+            defining_op = eclass_op.operands[index].owner
+            assert isinstance(defining_op, Operation)
 
         return (defining_op,)
 


### PR DESCRIPTION
~Draft until https://github.com/xdslproject/xdsl/pull/4515 gets merged~

So backtracking is currently fully handled by the interpreter. I like the idea of trying to move logic into the IR itself but I think this is still a good place to start from?
