### PR TITLE
core: Parameter to load dialect if needed

### DIFF
--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -265,13 +265,11 @@ def test_load_dialect_already_registered():
         ctx.load_dialect(testDialect)
 
 
-def test_load_if_needed():
+def test_get_dialect():
     ctx = Context()
     assert ctx.get_optional_dialect("test") is None
-    assert ctx.get_optional_dialect("test", load_if_needed=True) is None
     ctx.register_dialect("test", lambda: testDialect)
-    assert ctx.get_optional_dialect("test") is None
-    assert ctx.get_optional_dialect("test", load_if_needed=True) is testDialect
+    assert ctx.get_optional_dialect("test") is testDialect
 
 
 def test_get_optional_op_registered():

--- a/xdsl/context.py
+++ b/xdsl/context.py
@@ -287,21 +287,17 @@ class Context:
             raise UnregisteredConstructException(f"Dialect {name} is not registered")
         return dialect
 
-    def get_optional_dialect(
-        self, name: str, load_if_needed: bool = False
-    ) -> "Dialect | None":
+    def get_optional_dialect(self, name: str) -> "Dialect | None":
         """
-        Get a loaded dialect if it exists.
+        Get a dialect from its name if it exists.
+        If the dialect is not registered, return None.
+        """
+        if name in self._registered_dialects and name not in self._loaded_dialects:
+            self.load_registered_dialect(name)
 
-        `load_if_needed` parameter if set loads the corresponding registered
-        dialect if it wasn't loaded before.
-        With the parameter set function is equivalent to MLIR's `MLIRContext::getOrLoadDialect`.
-        """
-        if load_if_needed:
-            if name in self._registered_dialects and name not in self._loaded_dialects:
-                self.load_registered_dialect(name)
         if name in self._loaded_dialects:
             return self._loaded_dialects[name]
+
         return None
 
 


### PR DESCRIPTION
When parsing dialect resources we might [have resources](https://github.com/xdslproject/xdsl/pull/4502/files#diff-33d76e9b12c370dfd56375282fd868782518fe1914d9c02c9c300bc82d31ca1bR163) for a registered dialect which doesn't have any operations parsed. So it is not a loaded and we need to construct the object. 

I thought maybe it would be better to do this inside the `get_optional_dialect` function? 