### PR TITLE
testing: remove TestSSAValue deprecated two months ago

### DIFF
--- a/xdsl/utils/test_value.py
+++ b/xdsl/utils/test_value.py
@@ -1,5 +1,3 @@
-from typing_extensions import deprecated
-
 from xdsl.dialects.test import TestOp
 from xdsl.ir import AttributeCovT, OpResult
 
@@ -7,8 +5,3 @@ from xdsl.ir import AttributeCovT, OpResult
 def create_ssa_value(t: AttributeCovT) -> OpResult[AttributeCovT]:
     op = TestOp(result_types=(t,))
     return op.results[0]  # pyright: ignore[reportReturnType]
-
-
-@deprecated("Please use `create_ssa_value` instead")
-def TestSSAValue(t: AttributeCovT) -> OpResult[AttributeCovT]:
-    return create_ssa_value(t)


### PR DESCRIPTION
Deprecated April 14th so seems like fair game.