### PR TITLE
core: Print metadata in file

### DIFF
--- a/tests/filecheck/parser-printer/metadata.mlir
+++ b/tests/filecheck/parser-printer/metadata.mlir
@@ -1,0 +1,45 @@
+// RUN: xdsl-opt %s | filecheck %s
+
+builtin.module {
+    func.func @constant_dense_resource() {
+        %0 = arith.constant dense_resource<dense_resource_test_5xf32> : tensor<5xf32>
+        return
+    }
+}
+
+{-#
+  dialect_resources: {
+    builtin: {
+      dense_resource_test_5xf32: "0x08000000041A503E183382BEFCEEBABE7A3AF0BE0E9DEE3E",
+      dense_resource_test_2x2xf32: "0x0800000054A3B53ED6C0B33E55D1A2BDE5D2BB3E"
+    }
+  }
+#-}
+
+// CHECK:       {-#
+// CHECK-NEXT:    dialect_resources: {
+// CHECK-NEXT:      builtin: {
+// CHECK-NEXT:        dense_resource_test_5xf32: "0x08000000041A503E183382BEFCEEBABE7A3AF0BE0E9DEE3E"
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  #-}
+
+// -----
+
+builtin.module {
+    func.func @constant_dense_resource() {
+        %0 = arith.constant dense_resource<non_matching_key> : tensor<5xf32>
+        return
+    }
+}
+
+{-#
+  dialect_resources: {
+    builtin: {
+      dense_resource_test_5xf32: "0x08000000041A503E183382BEFCEEBABE7A3AF0BE0E9DEE3E",
+      dense_resource_test_2x2xf32: "0x0800000054A3B53ED6C0B33E55D1A2BDE5D2BB3E"
+    }
+  }
+#-}
+
+// CHECK-NOT: {-#

--- a/tests/test_dialect_interfaces.py
+++ b/tests/test_dialect_interfaces.py
@@ -35,3 +35,8 @@ def test_op_asm_interface():
 
     with pytest.raises(KeyError):
         interf.parse_resource("non existent key", "0x0800000003")
+
+    interf.declare_resource("non_assigned_key")
+    assert interf.build_resources(["some_key", "non_assigned_key"]) == {
+        "some_key": "0x0800000001"
+    }

--- a/xdsl/dialect_interfaces.py
+++ b/xdsl/dialect_interfaces.py
@@ -1,3 +1,6 @@
+from collections.abc import Iterable
+
+
 class DialectInterface:
     """
     A base class for dialects' interfaces.
@@ -77,3 +80,14 @@ class OpAsmDialectInterface(DialectInterface):
         Get a value tied to a key.
         """
         return self._blob_storage.get(key)
+
+    def build_resources(self, keys: Iterable[str]) -> dict[str, str]:
+        """
+        Return dict of resources for a provided list of keys.
+        Filter out keys that haven't been assigned a value.
+        Usually used for printing, when provided with list of
+        keys referenced in the ir.
+        """
+        return {
+            key: self._blob_storage[key] for key in keys if self._blob_storage.get(key)
+        }

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -1434,7 +1434,9 @@ class DenseResourceAttr(BuiltinAttribute, TypedAttribute):
     type: ParameterDef[ShapedType]
 
     def print_without_type(self, printer: Printer):
-        printer.print_string(f"dense_resource<{self.resource_handle.data}>")
+        printer.print_string("dense_resource<")
+        printer.print_resource_handle("builtin", self.resource_handle.data)
+        printer.print_string(">")
 
     @staticmethod
     def from_params(handle: str | StringAttr, type: ShapedType) -> DenseResourceAttr:

--- a/xdsl/xdsl_opt_main.py
+++ b/xdsl/xdsl_opt_main.py
@@ -220,6 +220,7 @@ class xDSLOptMain(CommandLineTool):
                 print_debuginfo=self.args.print_debuginfo,
             )
             printer.print_op(prog)
+            printer.print_metadata(self.ctx.loaded_dialects)
             print("\n", file=output)
 
         def _output_riscv_asm(prog: ModuleOp, output: IO[str]):


### PR DESCRIPTION
Last part of [this](https://github.com/xdslproject/xdsl/pull/4502/files) pr.

We start printing the parsed metadata in a special subsection inside an mlir file.
