### PR TITLE
core: (Printer) remove variadic prints

### DIFF
--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -561,7 +561,12 @@ class PlusCustomFormatOp(IRDLOperation):
         return PlusCustomFormatOp.create(operands=[lhs, rhs], result_types=[type])
 
     def print(self, printer: Printer):
-        printer.print(" ", self.lhs, " + ", self.rhs, " : ", self.res.type)
+        printer.print_string(" ")
+        printer.print_ssa_value(self.lhs)
+        printer.print_string(" + ")
+        printer.print_ssa_value(self.rhs)
+        printer.print_string(" : ")
+        printer.print_attribute(self.res.type)
 
 
 def test_generic_format():
@@ -698,7 +703,8 @@ class CustomFormatAttr(ParametrizedAttribute):
 
     def print_parameters(self, printer: Printer) -> None:
         assert 0 <= self.attr.data <= 1
-        printer.print("<", "zero" if self.attr.data == 0 else "one", ">")
+        with printer.in_angle_brackets():
+            printer.print_string("zero" if self.attr.data == 0 else "one")
 
 
 @irdl_op_definition

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -2019,7 +2019,8 @@ class ModuleOp(IRDLOperation):
             printer.print(" {\n")
             printer.print("}")
         else:
-            printer.print(" ", self.body)
+            printer.print_string(" ")
+            printer.print_region(self.body)
 
 
 # FloatXXType shortcuts
@@ -2113,10 +2114,15 @@ class MemRefType(
         return [shape, type, layout, memory_space]
 
     def print_parameters(self, printer: Printer) -> None:
-        printer.print("<", self.shape, ", ", self.element_type)
-        if self.layout != NoneAttr() or self.memory_space != NoneAttr():
-            printer.print(", ", self.layout, ", ", self.memory_space)
-        printer.print(">")
+        with printer.in_angle_brackets():
+            printer.print(self.shape)
+            printer.print_string(", ")
+            printer.print_attribute(self.element_type)
+            if self.layout != NoneAttr() or self.memory_space != NoneAttr():
+                printer.print_string(", ")
+                printer.print(self.layout)
+                printer.print_string(", ")
+                printer.print(self.memory_space)
 
     def get_affine_map(self) -> AffineMap:
         """
@@ -2614,7 +2620,7 @@ class DenseIntOrFPElementsAttr(
         elif self.is_splat():
             self._print_one_elem(data[0], printer)
         elif len(self) > 100:
-            printer.print('"', "0x", self.data.data.hex().upper(), '"')
+            printer.print_string(f'"0x{self.data.data.hex().upper()}"')
         else:
             self._print_dense_list(data, shape, printer)
         printer.print_string(">")

--- a/xdsl/dialects/csl/csl.py
+++ b/xdsl/dialects/csl/csl.py
@@ -1020,7 +1020,8 @@ class LayoutOp(IRDLOperation):
         return cls(parser.parse_region())
 
     def print(self, printer: Printer):
-        printer.print(" ", self.body)
+        printer.print_string(" ")
+        printer.print_region(self.body)
 
 
 @irdl_op_definition

--- a/xdsl/dialects/experimental/air.py
+++ b/xdsl/dialects/experimental/air.py
@@ -836,9 +836,9 @@ class WaitAllOp(IRDLOperation):
         super().__init__(operands=[async_dependencies], result_types=[AsyncTokenAttr()])
 
     def print(self, printer: Printer):
-        printer.print(" async ")
+        printer.print_string(" async ")
         if self.async_dependencies:
-            printer.print(self.async_dependencies, printer.print_ssa_value, ",")
+            printer.print_list(self.async_dependencies, printer.print_ssa_value)
 
     @classmethod
     def parse(cls, parser: Parser) -> WaitAllOp:

--- a/xdsl/dialects/irdl/irdl.py
+++ b/xdsl/dialects/irdl/irdl.py
@@ -135,7 +135,7 @@ class DialectOp(IRDLOperation):
         return DialectOp(sym_name, region)
 
     def print(self, printer: Printer) -> None:
-        printer.print(" @", self.sym_name.data, " ")
+        printer.print(f" @{self.sym_name.data} ")
         if self.body.block.ops:
             printer.print_region(self.body)
 
@@ -165,7 +165,7 @@ class TypeOp(IRDLOperation):
         return TypeOp(sym_name, region)
 
     def print(self, printer: Printer) -> None:
-        printer.print(" @", self.sym_name.data, " ")
+        printer.print(f" @{self.sym_name.data} ")
         if self.body.block.ops:
             printer.print_region(self.body)
 
@@ -220,7 +220,7 @@ class AttributeOp(IRDLOperation):
         return AttributeOp(sym_name, region)
 
     def print(self, printer: Printer) -> None:
-        printer.print(" @", self.sym_name.data, " ")
+        printer.print(f" @{self.sym_name.data} ")
         if self.body.block.ops:
             printer.print_region(self.body)
 
@@ -305,7 +305,7 @@ class OperationOp(IRDLOperation):
         return OperationOp(sym_name, region)
 
     def print(self, printer: Printer) -> None:
-        printer.print(" @", self.sym_name.data, " ")
+        printer.print(f" @{self.sym_name.data} ")
         if self.body.block.ops:
             printer.print_region(self.body)
 
@@ -348,7 +348,8 @@ def _print_argument_with_var(
     printer.print_string(": ")
     variadicity = data[1].data
     if variadicity != VariadicityEnum.SINGLE:
-        printer.print(variadicity, " ")
+        printer.print_string(str(variadicity))
+        printer.print(" ")
     printer.print(data[2])
 
 

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -404,10 +404,13 @@ class ArithmeticBinOperation(IRDLOperation, ABC):
         return cls(operands[0], operands[1], attributes)
 
     def print(self, printer: Printer) -> None:
-        printer.print(" ", self.lhs, ", ", self.rhs)
+        printer.print_string(" ")
+        printer.print_ssa_value(self.lhs)
+        printer.print_string(", ")
+        printer.print_ssa_value(self.rhs)
         printer.print_op_attributes(self.attributes)
-        printer.print(" : ")
-        printer.print(self.lhs.type)
+        printer.print_string(" : ")
+        printer.print_attribute(self.lhs.type)
 
 
 class OverflowFlag(StrEnum):
@@ -477,12 +480,15 @@ class ArithmeticBinOpOverflow(IRDLOperation, ABC):
         return cls(operands[0], operands[1], attributes, overflowFlags)
 
     def print(self, printer: Printer) -> None:
-        printer.print(" ", self.lhs, ", ", self.rhs)
+        printer.print_string(" ")
+        printer.print_ssa_value(self.lhs)
+        printer.print_string(", ")
+        printer.print_ssa_value(self.rhs)
         if self.overflowFlags:
             self.overflowFlags.print(printer)
         printer.print_op_attributes(self.attributes)
-        printer.print(" : ")
-        printer.print(self.lhs.type)
+        printer.print_string(" : ")
+        printer.print_attribute(self.lhs.type)
 
 
 class ArithmeticBinOpExact(IRDLOperation, ABC):
@@ -536,10 +542,13 @@ class ArithmeticBinOpExact(IRDLOperation, ABC):
 
     def print(self, printer: Printer) -> None:
         self.print_exact(printer)
-        printer.print(" ", self.lhs, ", ", self.rhs)
+        printer.print_string(" ")
+        printer.print_ssa_value(self.lhs)
+        printer.print_string(", ")
+        printer.print_ssa_value(self.rhs)
         printer.print_op_attributes(self.attributes)
-        printer.print(" : ")
-        printer.print(self.lhs.type)
+        printer.print_string(" : ")
+        printer.print_attribute(self.lhs.type)
 
 
 class ArithmeticBinOpDisjoint(IRDLOperation, ABC):
@@ -602,10 +611,13 @@ class IntegerConversionOp(IRDLOperation, ABC):
         return cls(operands[0], res_type, attributes)
 
     def print(self, printer: Printer):
-        printer.print(" ", self.arg)
+        printer.print_string(" ")
+        printer.print_ssa_value(self.arg)
         printer.print_op_attributes(self.attributes)
-        printer.print(" : ")
-        printer.print(self.arg.type, " to ", self.res.type)
+        printer.print_string(" : ")
+        printer.print_attribute(self.arg.type)
+        printer.print_string(" to ")
+        printer.print_attribute(self.res.type)
 
 
 class IntegerConversionOpNNeg(IRDLOperation, ABC):
@@ -668,12 +680,15 @@ class IntegerConversionOpOverflow(IRDLOperation, ABC):
         return cls(operands[0], res_type, attributes, overflowFlags)
 
     def print(self, printer: Printer):
-        printer.print(" ", self.arg)
+        printer.print_string(" ")
+        printer.print_ssa_value(self.arg)
         if self.overflowFlags:
             self.overflowFlags.print(printer)
         printer.print_op_attributes(self.attributes)
-        printer.print(" : ")
-        printer.print(self.arg.type, " to ", self.res.type)
+        printer.print_string(" : ")
+        printer.print_attribute(self.arg.type)
+        printer.print_string(" to ")
+        printer.print_attribute(self.res.type)
 
 
 @irdl_op_definition
@@ -857,7 +872,10 @@ class ICmpOp(IRDLOperation):
     def print(self, printer: Printer):
         printer.print_string(' "')
         self.print_predicate(printer)
-        printer.print('" ', self.lhs, ", ", self.rhs)
+        printer.print_string('" ')
+        printer.print_ssa_value(self.lhs)
+        printer.print_string(", ")
+        printer.print_ssa_value(self.rhs)
         printer.print_op_attributes(self.attributes)
         printer.print_string(" : ")
         printer.print(self.lhs.type)
@@ -1585,7 +1603,8 @@ class ConstantOp(IRDLOperation):
             self.value.print_without_type(printer)
         else:
             printer.print(self.value)
-        printer.print(") : ", self.result.type)
+        printer.print_string(") : ")
+        printer.print_attribute(self.result.type)
 
 
 @irdl_attr_definition

--- a/xdsl/dialects/memref_stream.py
+++ b/xdsl/dialects/memref_stream.py
@@ -345,7 +345,7 @@ class StreamingRegionOp(IRDLOperation):
             if self.patterns.data:
                 printer.print_string("\npatterns = [")
                 with printer.indented():
-                    if len(self.patterns.data):
+                    if self.patterns.data:
                         printer.print_string("\n")
                         printer.print_list(
                             self.patterns.data,

--- a/xdsl/dialects/memref_stream.py
+++ b/xdsl/dialects/memref_stream.py
@@ -345,11 +345,13 @@ class StreamingRegionOp(IRDLOperation):
             if self.patterns.data:
                 printer.print_string("\npatterns = [")
                 with printer.indented():
-                    printer.print_list(
-                        self.patterns.data,
-                        lambda attr: printer.print("\n", attr),
-                        delimiter=",",
-                    )
+                    if len(self.patterns.data):
+                        printer.print_string("\n")
+                        printer.print_list(
+                            self.patterns.data,
+                            lambda attr: printer.print_attribute(attr),
+                            delimiter=",\n",
+                        )
                 printer.print_string("\n]")
             else:
                 printer.print_string("\npatterns = []")

--- a/xdsl/dialects/memref_stream.py
+++ b/xdsl/dialects/memref_stream.py
@@ -349,7 +349,7 @@ class StreamingRegionOp(IRDLOperation):
                         printer.print_string("\n")
                         printer.print_list(
                             self.patterns.data,
-                            lambda attr: printer.print_attribute(attr),
+                            printer.print_attribute,
                             delimiter=",\n",
                         )
                 printer.print_string("\n]")

--- a/xdsl/dialects/pdl.py
+++ b/xdsl/dialects/pdl.py
@@ -447,7 +447,8 @@ class OperationOp(IRDLOperation):
 
     def print(self, printer: Printer) -> None:
         if self.opName is not None:
-            printer.print(" ", self.opName)
+            printer.print_string(" ")
+            printer.print_attribute(self.opName)
 
         if len(self.operand_values) != 0:
             printer.print(" (")
@@ -455,7 +456,9 @@ class OperationOp(IRDLOperation):
             printer.print(")")
 
         def print_attribute_entry(entry: tuple[StringAttr, SSAValue]):
-            printer.print(entry[0], " = ", entry[1])
+            printer.print_attribute(entry[0])
+            printer.print_string(" = ")
+            printer.print_ssa_value(entry[1])
 
         if len(self.attributeValueNames) != 0:
             printer.print(" {")
@@ -589,8 +592,10 @@ class PatternOp(IRDLOperation):
 
     def print(self, printer: Printer) -> None:
         if self.sym_name is not None:
-            printer.print(" @", self.sym_name.data)
-        printer.print(" : benefit(", self.benefit.value.data, ") ", self.body)
+            printer.print_string(" @")
+            printer.print_string(self.sym_name.data)
+        printer.print_string(f" : benefit({self.benefit.value.data}) ")
+        printer.print_region(self.body)
 
 
 @irdl_op_definition
@@ -653,9 +658,10 @@ class RangeOp(IRDLOperation):
 
     def print(self, printer: Printer) -> None:
         if len(self.arguments) == 0:
-            printer.print(" : ", self.result.type)
+            printer.print_string(" : ")
+            printer.print_attribute(self.result.type)
             return
-        printer.print(" ")
+        printer.print_string(" ")
         print_operands_with_types(printer, self.arguments)
 
 
@@ -775,11 +781,13 @@ class ResultsOp(IRDLOperation):
 
     def print(self, printer: Printer) -> None:
         if self.index is None:
-            printer.print(" of ", self.parent_)
-            return
-        printer.print(
-            " ", self.index.value.data, " of ", self.parent_, " -> ", self.val.type
-        )
+            printer.print_string(" of ")
+            printer.print_ssa_value(self.parent_)
+        else:
+            printer.print_string(f" {self.index.value.data} of ")
+            printer.print_ssa_value(self.parent_)
+            printer.print_string(" -> ")
+            printer.print_attribute(self.val.type)
 
 
 @irdl_op_definition

--- a/xdsl/dialects/riscv_debug.py
+++ b/xdsl/dialects/riscv_debug.py
@@ -61,7 +61,8 @@ class PrintfOp(riscv.RISCVCustomFormatOperation, riscv.RISCVInstruction):
         return attributes
 
     def custom_print_attributes(self, printer: Printer) -> AbstractSet[str]:
-        printer.print(" ", self.format_str)
+        printer.print_string(" ")
+        printer.print_attribute(self.format_str)
         return {"format_str"}
 
     def assembly_line_args(self) -> tuple[riscv.AssemblyInstructionArg, ...]:

--- a/xdsl/dialects/riscv_scf.py
+++ b/xdsl/dialects/riscv_scf.py
@@ -298,18 +298,24 @@ class WhileOp(IRDLOperation):
                     f" got {block_arg.type}"
                 )
 
+    @staticmethod
+    def _print_pair(printer: Printer, pair: tuple[SSAValue, SSAValue]):
+        printer.print_ssa_value(pair[0])
+        printer.print_string(" = ")
+        printer.print_ssa_value(pair[1])
+
     def print(self, printer: Printer):
         printer.print_string(" (")
         block_args = self.before_region.block.args
         printer.print_list(
             zip(block_args, self.arguments, strict=True),
-            lambda pair: printer.print(pair[0], " = ", pair[1]),
+            lambda pair: self._print_pair(printer, pair),
         )
         printer.print_string(") : ")
         printer.print_operation_type(self)
         printer.print_string(" ")
         printer.print_region(self.before_region, print_entry_block_args=False)
-        printer.print(" do ")
+        printer.print_string(" do ")
         printer.print_region(self.after_region)
         if self.attributes:
             printer.print_op_attributes(self.attributes, print_keyword=True)
@@ -376,11 +382,15 @@ class ConditionOp(IRDLOperation):
         super().__init__(operands=[cond, output_ops])
 
     def print(self, printer: Printer):
-        printer.print("(", self.cond, " : ", self.cond.type, ") ")
+        printer.print_string("(")
+        printer.print_ssa_value(self.cond)
+        printer.print_string(" : ")
+        printer.print_attribute(self.cond.type)
+        printer.print_string(") ")
         if self.attributes:
             printer.print_op_attributes(self.attributes)
         if self.arguments:
-            printer.print(" ")
+            printer.print_string(" ")
             printer.print_list(self.arguments, printer.print_ssa_value)
             printer.print_string(" : ")
             printer.print_list(

--- a/xdsl/dialects/scf.py
+++ b/xdsl/dialects/scf.py
@@ -97,18 +97,24 @@ class WhileOp(IRDLOperation):
                     f"got {self.after_region.block.args[idx].type}"
                 )
 
+    @staticmethod
+    def _print_pair(printer: Printer, pair: tuple[SSAValue, SSAValue]):
+        printer.print_ssa_value(pair[0])
+        printer.print_string(" = ")
+        printer.print_ssa_value(pair[1])
+
     def print(self, printer: Printer):
         printer.print_string(" (")
         block_args = self.before_region.block.args
         printer.print_list(
             zip(block_args, self.arguments, strict=True),
-            lambda pair: printer.print(pair[0], " = ", pair[1]),
+            lambda pair: self._print_pair(printer, pair),
         )
         printer.print_string(") : ")
         printer.print_operation_type(self)
         printer.print_string(" ")
         printer.print_region(self.before_region, print_entry_block_args=False)
-        printer.print(" do ")
+        printer.print_string(" do ")
         printer.print_region(self.after_region)
         if self.attributes:
             printer.print_op_attributes(self.attributes, print_keyword=True)

--- a/xdsl/dialects/smt.py
+++ b/xdsl/dialects/smt.py
@@ -413,12 +413,13 @@ def _print_same_operand_type_variadic_to_bool_op(
     `%op1, %op2, ..., %opN attr-dict : T` where `T` is the type of all
     operands.
     """
-    printer.print(" ")
+    printer.print_string(" ")
     printer.print_list(operands, printer.print_ssa_value)
     if attr_dict:
         printer.print_string(" ")
         printer.print_attr_dict(attr_dict)
-    printer.print(" : ", operands[0].type)
+    printer.print_string(" : ")
+    printer.print_attribute(operands[0].type)
 
 
 class VariadicPredicateOp(IRDLOperation, ABC):

--- a/xdsl/dialects/snitch_stream.py
+++ b/xdsl/dialects/snitch_stream.py
@@ -279,11 +279,13 @@ class StreamingRegionOp(IRDLOperation):
             if self.stride_patterns.data:
                 printer.print_string("\npatterns = [")
                 with printer.indented():
-                    printer.print_list(
-                        self.stride_patterns.data,
-                        lambda attr: printer.print("\n", attr),
-                        delimiter=",",
-                    )
+                    if len(self.stride_patterns.data):
+                        printer.print_string("\n")
+                        printer.print_list(
+                            self.stride_patterns.data,
+                            lambda attr: printer.print_attribute(attr),
+                            delimiter=",\n",
+                        )
                 printer.print_string("\n]")
             else:
                 printer.print_string("\npatterns = []")

--- a/xdsl/dialects/snitch_stream.py
+++ b/xdsl/dialects/snitch_stream.py
@@ -283,7 +283,7 @@ class StreamingRegionOp(IRDLOperation):
                         printer.print_string("\n")
                         printer.print_list(
                             self.stride_patterns.data,
-                            lambda attr: printer.print_attribute(attr),
+                            printer.print_attribute,
                             delimiter=",\n",
                         )
                 printer.print_string("\n]")

--- a/xdsl/dialects/snitch_stream.py
+++ b/xdsl/dialects/snitch_stream.py
@@ -279,7 +279,7 @@ class StreamingRegionOp(IRDLOperation):
             if self.stride_patterns.data:
                 printer.print_string("\npatterns = [")
                 with printer.indented():
-                    if len(self.stride_patterns.data):
+                    if self.stride_patterns.data:
                         printer.print_string("\n")
                         printer.print_list(
                             self.stride_patterns.data,

--- a/xdsl/dialects/vector.py
+++ b/xdsl/dialects/vector.py
@@ -426,9 +426,14 @@ class ExtractOp(IRDLOperation):
 
     def print(self, printer: Printer) -> None:
         # Print the vector operand
-        printer.print(" ", self.vector, "[")
+        printer.print_string(" ")
+        printer.print_ssa_value(self.vector)
+        printer.print_string("[")
         printer.print_list(self.get_mixed_position(), printer.print)
-        printer.print("] : ", self.result.type, " from ", self.vector.type)
+        printer.print_string("] : ")
+        printer.print_attribute(self.result.type)
+        printer.print_string(" from ")
+        printer.print_attribute(self.vector.type)
 
 
 @irdl_op_definition
@@ -595,9 +600,16 @@ class InsertOp(IRDLOperation):
 
     def print(self, printer: Printer) -> None:
         # Print the vector operand
-        printer.print(" ", self.source, ", ", self.dest, "[")
+        printer.print_string(" ")
+        printer.print_ssa_value(self.source)
+        printer.print_string(", ")
+        printer.print_ssa_value(self.dest)
+        printer.print_string("[")
         printer.print_list(self.get_mixed_position(), printer.print)
-        printer.print("] : ", self.source.type, " into ", self.dest.type)
+        printer.print_string("] : ")
+        printer.print_attribute(self.source.type)
+        printer.print_string(" into ")
+        printer.print_attribute(self.dest.type)
 
 
 @irdl_op_definition


### PR DESCRIPTION
Removes all instances of using the variadic behaviour of `Printer.print`. All tests pass if `assert len(argv) == 1` is added to the top of this function.

I haven't added any sort of deprecation/change to `Printer.print` because I wasn't sure how and it didn't seem worth it if we were just going to deprecate the whole thing anyway.