### PR TITLE
dialects: (builtin) remove SymbolNameAttr

### DIFF
--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -265,17 +265,6 @@ class BytesAttr(Data[bytes], BuiltinAttribute):
 
 
 @irdl_attr_definition
-class SymbolNameAttr(ParametrizedAttribute, BuiltinAttribute):
-    name = "symbol_name"
-    data: ParameterDef[StringAttr]
-
-    def __init__(self, data: str | StringAttr) -> None:
-        if isinstance(data, str):
-            data = StringAttr(data)
-        super().__init__([data])
-
-
-@irdl_attr_definition
 class SymbolRefAttr(ParametrizedAttribute, BuiltinAttribute):
     name = "symbol_ref"
     root_reference: ParameterDef[StringAttr]
@@ -2634,7 +2623,6 @@ Builtin = Dialect(
         # Attributes
         StringAttr,
         SymbolRefAttr,
-        SymbolNameAttr,
         IntAttr,
         IntegerAttr,
         ArrayAttr,

--- a/xdsl/tools/xdsl_tblgen.py
+++ b/xdsl/tools/xdsl_tblgen.py
@@ -330,7 +330,7 @@ class TblgenLoader:
             case "StrAttr":
                 return "BaseAttr(StringAttr)"
             case "SymbolNameAttr":
-                return "BaseAttr(SymbolNameAttr)"
+                return "BaseAttr(StringAttr)"
             case "UnitAttr":
                 return "EqAttrConstraint(UnitAttr())"
             case _:


### PR DESCRIPTION
As far as I can tell this isn't actually part of MLIR's builtin dialect, and we don't use it anywhere.