### PR TITLE
core: (Parser) move Delimiter to separate module

### DIFF
--- a/tests/test_dialect_utils.py
+++ b/tests/test_dialect_utils.py
@@ -17,6 +17,7 @@ from xdsl.dialects.utils.dynamic_index_list import verify_dynamic_index_list
 from xdsl.ir import Dialect, SSAValue
 from xdsl.parser import Parser, UnresolvedOperand
 from xdsl.printer import Printer
+from xdsl.utils.delimiter import Delimiter
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.test_value import create_ssa_value
 
@@ -131,7 +132,7 @@ def test_print_dynamic_index_list():
         DYNAMIC_INDEX,
         [],
         [1, 2, 3],
-        delimiter=Parser.Delimiter.PAREN,
+        delimiter=Delimiter.PAREN,
     )
     assert stream.getvalue() == "(1, 2, 3)"
 
@@ -145,15 +146,13 @@ def test_print_dynamic_index_list():
 @pytest.mark.parametrize(
     "delimiter,expected",
     [
-        (Parser.Delimiter.SQUARE, "[1, 2, 3]"),
-        (Parser.Delimiter.PAREN, "(1, 2, 3)"),
-        (Parser.Delimiter.ANGLE, "<1, 2, 3>"),
-        (Parser.Delimiter.BRACES, "{1, 2, 3}"),
+        (Delimiter.SQUARE, "[1, 2, 3]"),
+        (Delimiter.PAREN, "(1, 2, 3)"),
+        (Delimiter.ANGLE, "<1, 2, 3>"),
+        (Delimiter.BRACES, "{1, 2, 3}"),
     ],
 )
-def test_print_dynamic_index_list_delimiters(
-    delimiter: Parser.Delimiter, expected: str
-):
+def test_print_dynamic_index_list_delimiters(delimiter: Delimiter, expected: str):
     stream = StringIO()
     printer = Printer(stream)
     print_dynamic_index_list(printer, DYNAMIC_INDEX, [], [1, 2, 3], delimiter=delimiter)
@@ -218,7 +217,7 @@ def test_parse_dynamic_index_list_with_custom_delimiter():
     parser.ssa_values["0"] = (test_values[0],)
     parser.ssa_values["1"] = (test_values[1],)
     values, indices = parse_dynamic_index_list_with_types(
-        parser, dynamic_index=dynamic_index, delimiter=Parser.Delimiter.PAREN
+        parser, dynamic_index=dynamic_index, delimiter=Delimiter.PAREN
     )
     assert len(values) == 2
     assert values[0] is test_values[0]

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -31,6 +31,7 @@ from xdsl.irdl import (
 )
 from xdsl.parser import Parser
 from xdsl.printer import Printer
+from xdsl.utils.delimiter import Delimiter
 from xdsl.utils.exceptions import ParseError
 from xdsl.utils.mlir_lexer import MLIRTokenKind, PunctuationSpelling
 from xdsl.utils.str_enum import StrEnum
@@ -439,15 +440,15 @@ def test_parse_block_name():
 @pytest.mark.parametrize(
     "delimiter,open_bracket,close_bracket",
     [
-        (Parser.Delimiter.NONE, "", ""),
-        (Parser.Delimiter.PAREN, "(", ")"),
-        (Parser.Delimiter.SQUARE, "[", "]"),
-        (Parser.Delimiter.BRACES, "{", "}"),
-        (Parser.Delimiter.ANGLE, "<", ">"),
+        (Delimiter.NONE, "", ""),
+        (Delimiter.PAREN, "(", ")"),
+        (Delimiter.SQUARE, "[", "]"),
+        (Delimiter.BRACES, "{", "}"),
+        (Delimiter.ANGLE, "<", ">"),
     ],
 )
 def test_parse_comma_separated_list(
-    delimiter: Parser.Delimiter, open_bracket: str, close_bracket: str
+    delimiter: Delimiter, open_bracket: str, close_bracket: str
 ):
     input = open_bracket + "2, 4, 5" + close_bracket
 
@@ -456,7 +457,7 @@ def test_parse_comma_separated_list(
     assert res == [2, 4, 5]
 
     parser = Parser(Context(), input)
-    if delimiter is Parser.Delimiter.NONE:
+    if delimiter is Delimiter.NONE:
         res = parser.parse_optional_undelimited_comma_separated_list(
             parser.parse_optional_integer, parser.parse_integer
         )
@@ -470,14 +471,14 @@ def test_parse_comma_separated_list(
 @pytest.mark.parametrize(
     "delimiter,open_bracket,close_bracket",
     [
-        (Parser.Delimiter.PAREN, "(", ")"),
-        (Parser.Delimiter.SQUARE, "[", "]"),
-        (Parser.Delimiter.BRACES, "{", "}"),
-        (Parser.Delimiter.ANGLE, "<", ">"),
+        (Delimiter.PAREN, "(", ")"),
+        (Delimiter.SQUARE, "[", "]"),
+        (Delimiter.BRACES, "{", "}"),
+        (Delimiter.ANGLE, "<", ">"),
     ],
 )
 def test_parse_comma_separated_list_empty(
-    delimiter: Parser.Delimiter, open_bracket: str, close_bracket: str
+    delimiter: Delimiter, open_bracket: str, close_bracket: str
 ):
     input = open_bracket + close_bracket
     parser = Parser(Context(), input)
@@ -489,7 +490,7 @@ def test_parse_comma_separated_list_none_delimiter_empty():
     parser = Parser(Context(), "o")
     with pytest.raises(ParseError):
         parser.parse_comma_separated_list(
-            Parser.Delimiter.NONE, parser.parse_integer, " in test"
+            Delimiter.NONE, parser.parse_integer, " in test"
         )
 
 
@@ -497,7 +498,7 @@ def test_parse_comma_separated_list_none_delimiter_two_no_comma():
     """Test that a list without commas will only parse the first element."""
     parser = Parser(Context(), "1 2")
     res = parser.parse_comma_separated_list(
-        Parser.Delimiter.NONE, parser.parse_integer, " in test"
+        Delimiter.NONE, parser.parse_integer, " in test"
     )
     assert res == [1]
     assert parser.parse_optional_integer() is not None
@@ -513,13 +514,13 @@ def test_parse_comma_separated_list_none_delimiter_two_no_comma():
 @pytest.mark.parametrize(
     "delimiter",
     [
-        (Parser.Delimiter.PAREN),
-        (Parser.Delimiter.SQUARE),
-        (Parser.Delimiter.BRACES),
-        (Parser.Delimiter.ANGLE),
+        (Delimiter.PAREN),
+        (Delimiter.SQUARE),
+        (Delimiter.BRACES),
+        (Delimiter.ANGLE),
     ],
 )
-def test_parse_optional_comma_separated_list(delimiter: Parser.Delimiter):
+def test_parse_optional_comma_separated_list(delimiter: Delimiter):
     parser = Parser(Context(), "o")
     res = parser.parse_optional_comma_separated_list(delimiter, parser.parse_integer)
     assert res is None
@@ -536,14 +537,14 @@ def test_parse_optional_undelimited_comma_separated_list_empty():
 @pytest.mark.parametrize(
     "delimiter,open_bracket,close_bracket",
     [
-        (Parser.Delimiter.PAREN, "(", ")"),
-        (Parser.Delimiter.SQUARE, "[", "]"),
-        (Parser.Delimiter.BRACES, "{", "}"),
-        (Parser.Delimiter.ANGLE, "<", ">"),
+        (Delimiter.PAREN, "(", ")"),
+        (Delimiter.SQUARE, "[", "]"),
+        (Delimiter.BRACES, "{", "}"),
+        (Delimiter.ANGLE, "<", ">"),
     ],
 )
 def test_parse_comma_separated_list_error_element(
-    delimiter: Parser.Delimiter, open_bracket: str, close_bracket: str
+    delimiter: Delimiter, open_bracket: str, close_bracket: str
 ):
     input = open_bracket + "o" + close_bracket
     parser = Parser(Context(), input)
@@ -560,14 +561,14 @@ def test_parse_comma_separated_list_error_element(
 @pytest.mark.parametrize(
     "delimiter,open_bracket,close_bracket",
     [
-        (Parser.Delimiter.PAREN, "(", ")"),
-        (Parser.Delimiter.SQUARE, "[", "]"),
-        (Parser.Delimiter.BRACES, "{", "}"),
-        (Parser.Delimiter.ANGLE, "<", ">"),
+        (Delimiter.PAREN, "(", ")"),
+        (Delimiter.SQUARE, "[", "]"),
+        (Delimiter.BRACES, "{", "}"),
+        (Delimiter.ANGLE, "<", ">"),
     ],
 )
 def test_parse_comma_separated_list_error_delimiters(
-    delimiter: Parser.Delimiter, open_bracket: str, close_bracket: str
+    delimiter: Delimiter, open_bracket: str, close_bracket: str
 ):
     input = open_bracket + "2, 4 5"
     parser = Parser(Context(), input)

--- a/xdsl/dialects/accfg.py
+++ b/xdsl/dialects/accfg.py
@@ -39,6 +39,7 @@ from xdsl.irdl import (
 from xdsl.parser import AttrParser, Parser
 from xdsl.printer import Printer
 from xdsl.traits import SymbolOpInterface
+from xdsl.utils.delimiter import Delimiter
 
 
 class EffectsEnum(Enum):
@@ -330,7 +331,7 @@ class SetupOp(IRDLOperation):
             return name, val
 
         args: Sequence[tuple[str, SSAValue]] = parser.parse_comma_separated_list(
-            Parser.Delimiter.PAREN, parse_itm
+            Delimiter.PAREN, parse_itm
         )
 
         attributes = {}

--- a/xdsl/dialects/affine.py
+++ b/xdsl/dialects/affine.py
@@ -41,6 +41,7 @@ from xdsl.traits import (
     RecursivelySpeculatable,
     RecursiveMemoryEffect,
 )
+from xdsl.utils.delimiter import Delimiter
 from xdsl.utils.exceptions import VerifyException
 
 
@@ -79,12 +80,12 @@ class ApplyOp(IRDLOperation):
         if not isinstance(m, AffineMapAttr):
             parser.raise_error("Expected affine map attr", at_position=pos)
         dims = parser.parse_optional_comma_separated_list(
-            parser.Delimiter.PAREN, lambda: parser.parse_operand()
+            Delimiter.PAREN, lambda: parser.parse_operand()
         )
         if dims is None:
             dims = []
         syms = parser.parse_optional_comma_separated_list(
-            parser.Delimiter.SQUARE, lambda: parser.parse_operand()
+            Delimiter.SQUARE, lambda: parser.parse_operand()
         )
         if syms is None:
             syms = []

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -87,6 +87,7 @@ from xdsl.utils.comparisons import (
     unsigned_upper_bound,
     unsigned_value_range,
 )
+from xdsl.utils.delimiter import Delimiter
 from xdsl.utils.exceptions import DiagnosticException, VerifyException
 from xdsl.utils.hints import isa
 
@@ -152,7 +153,7 @@ class ArrayAttr(
     def parse_parameter(cls, parser: AttrParser) -> tuple[AttributeCovT, ...]:
         with parser.in_angle_brackets():
             data = parser.parse_comma_separated_list(
-                parser.Delimiter.SQUARE, parser.parse_attribute
+                Delimiter.SQUARE, parser.parse_attribute
             )
             # the type system can't ensure that the elements are of type _ArrayAttrT
             result = cast(tuple[AttributeCovT, ...], tuple(data))
@@ -1786,12 +1787,12 @@ class UnrealizedConversionCastOp(IRDLOperation):
     def parse(cls, parser: Parser) -> Self:
         if parser.parse_optional_characters("to") is None:
             args = parser.parse_comma_separated_list(
-                parser.Delimiter.NONE,
+                Delimiter.NONE,
                 parser.parse_unresolved_operand,
             )
             parser.parse_punctuation(":")
             input_types = parser.parse_comma_separated_list(
-                parser.Delimiter.NONE,
+                Delimiter.NONE,
                 parser.parse_type,
             )
             parser.parse_characters("to")
@@ -1799,7 +1800,7 @@ class UnrealizedConversionCastOp(IRDLOperation):
         else:
             inputs = list[SSAValue]()
         output_types = parser.parse_comma_separated_list(
-            parser.Delimiter.NONE,
+            Delimiter.NONE,
             parser.parse_type,
         )
         attributes = parser.parse_optional_attr_dict()

--- a/xdsl/dialects/cf.py
+++ b/xdsl/dialects/cf.py
@@ -36,6 +36,7 @@ from xdsl.parser import Parser
 from xdsl.pattern_rewriter import RewritePattern
 from xdsl.printer import Printer
 from xdsl.traits import HasCanonicalizationPatternsTrait, IsTerminator, Pure
+from xdsl.utils.delimiter import Delimiter
 from xdsl.utils.exceptions import VerifyException
 
 
@@ -331,12 +332,10 @@ class SwitchOp(IRDLOperation):
         block = parser.parse_successor()
         if parser.parse_optional_punctuation("("):
             unresolved = parser.parse_comma_separated_list(
-                Parser.Delimiter.NONE, parser.parse_unresolved_operand
+                Delimiter.NONE, parser.parse_unresolved_operand
             )
             parser.parse_punctuation(":")
-            types = parser.parse_comma_separated_list(
-                Parser.Delimiter.NONE, parser.parse_type
-            )
+            types = parser.parse_comma_separated_list(Delimiter.NONE, parser.parse_type)
             parser.parse_punctuation(")")
             operands = parser.resolve_operands(unresolved, types, parser.pos)
             return (block, operands)
@@ -364,7 +363,7 @@ class SwitchOp(IRDLOperation):
         case_operands: tuple[tuple[SSAValue, ...], ...] = ()
         if parser.parse_optional_punctuation(","):
             cases = parser.parse_comma_separated_list(
-                Parser.Delimiter.NONE, lambda: cls._parse_case(parser)
+                Delimiter.NONE, lambda: cls._parse_case(parser)
             )
             assert isinstance(flag_type, IntegerType | IndexType)
             data = tuple(x for (x, _, _) in cases)

--- a/xdsl/dialects/comb.py
+++ b/xdsl/dialects/comb.py
@@ -34,6 +34,7 @@ from xdsl.irdl import (
 )
 from xdsl.parser import Parser
 from xdsl.printer import Printer
+from xdsl.utils.delimiter import Delimiter
 from xdsl.utils.exceptions import VerifyException
 
 ICMP_COMPARISON_OPERATIONS = [
@@ -132,7 +133,7 @@ class VariadicCombOperation(IRDLOperation, ABC):
     @classmethod
     def parse(cls, parser: Parser):
         inputs = parser.parse_comma_separated_list(
-            parser.Delimiter.NONE, parser.parse_unresolved_operand
+            Delimiter.NONE, parser.parse_unresolved_operand
         )
         parser.parse_punctuation(":")
         result_type = parser.parse_type()
@@ -506,11 +507,11 @@ class ConcatOp(IRDLOperation):
     @classmethod
     def parse(cls, parser: Parser):
         inputs = parser.parse_comma_separated_list(
-            parser.Delimiter.NONE, parser.parse_unresolved_operand
+            Delimiter.NONE, parser.parse_unresolved_operand
         )
         parser.parse_punctuation(":")
         input_types = parser.parse_comma_separated_list(
-            parser.Delimiter.NONE, parser.parse_type
+            Delimiter.NONE, parser.parse_type
         )
         sum_of_width = _get_sum_of_int_width(input_types)
         if sum_of_width is None:

--- a/xdsl/dialects/csl/csl_stencil.py
+++ b/xdsl/dialects/csl/csl_stencil.py
@@ -54,6 +54,7 @@ from xdsl.traits import (
     Pure,
     RecursiveMemoryEffect,
 )
+from xdsl.utils.delimiter import Delimiter
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.hints import isa
 
@@ -108,9 +109,7 @@ class ExchangeDeclarationAttr(ParametrizedAttribute):
     def parse_parameters(cls, parser: AttrParser) -> list[Attribute]:
         parser.parse_characters("<")
         parser.parse_characters("to")
-        to = parser.parse_comma_separated_list(
-            parser.Delimiter.SQUARE, parser.parse_integer
-        )
+        to = parser.parse_comma_separated_list(Delimiter.SQUARE, parser.parse_integer)
         parser.parse_characters(">")
 
         return [builtin.DenseArrayBase.from_list(builtin.i64, to)]
@@ -299,7 +298,7 @@ class ApplyOp(IRDLOperation):
             value = parser.resolve_operand(value, type)
             return value
 
-        ops = parser.parse_comma_separated_list(parser.Delimiter.PAREN, parse_args)
+        ops = parser.parse_comma_separated_list(Delimiter.PAREN, parse_args)
 
         if parser.parse_optional_punctuation("->"):
             parser.parse_punctuation("(")
@@ -310,9 +309,7 @@ class ApplyOp(IRDLOperation):
         else:
             parser.parse_keyword("outs")
             parser.parse_punctuation("(")
-            destinations = parser.parse_comma_separated_list(
-                parser.Delimiter.NONE, parse_args
-            )
+            destinations = parser.parse_comma_separated_list(Delimiter.NONE, parse_args)
             result_types = []
         parser.parse_punctuation(")")
 

--- a/xdsl/dialects/experimental/air.py
+++ b/xdsl/dialects/experimental/air.py
@@ -56,6 +56,7 @@ from xdsl.traits import (
     IsTerminator,
     SingleBlockImplicitTerminator,
 )
+from xdsl.utils.delimiter import Delimiter
 
 
 @irdl_attr_definition
@@ -314,13 +315,13 @@ class ExecuteOp(IRDLOperation):
     @classmethod
     def parse(cls, parser: Parser) -> ExecuteOp:
         async_dependencies = parser.parse_optional_comma_separated_list(
-            parser.Delimiter.SQUARE, parser.parse_operand
+            Delimiter.SQUARE, parser.parse_operand
         )
 
         result_types: list[Attribute] | None = []
         if parser.parse_optional_characters("->"):
             result_types = parser.parse_optional_comma_separated_list(
-                parser.Delimiter.PAREN, parser.parse_type
+                Delimiter.PAREN, parser.parse_type
             )
 
         body = parser.parse_region()
@@ -452,7 +453,7 @@ class HerdOp(IRDLOperation):
     def parse(cls, parser: Parser) -> HerdOp:
         sym_name = parser.parse_optional_symbol_name()
         async_dependencies = parser.parse_optional_comma_separated_list(
-            parser.Delimiter.SQUARE, parser.parse_operand
+            Delimiter.SQUARE, parser.parse_operand
         )
         parser.parse_keyword("tile")
         arg_list = parser.parse_op_args_list()
@@ -550,7 +551,7 @@ class LaunchOp(IRDLOperation):
         sym_name = parser.parse_optional_symbol_name()
 
         async_dependencies = parser.parse_optional_comma_separated_list(
-            parser.Delimiter.SQUARE, parser.parse_operand
+            Delimiter.SQUARE, parser.parse_operand
         )
 
         block_args_lst: list[Parser.Argument] = []
@@ -844,7 +845,7 @@ class WaitAllOp(IRDLOperation):
     def parse(cls, parser: Parser) -> WaitAllOp:
         parser.parse_keyword("async")
         async_dependencies = parser.parse_optional_comma_separated_list(
-            parser.Delimiter.SQUARE, parser.parse_operand
+            Delimiter.SQUARE, parser.parse_operand
         )
 
         return WaitAllOp(async_dependencies)

--- a/xdsl/dialects/experimental/dmp.py
+++ b/xdsl/dialects/experimental/dmp.py
@@ -41,6 +41,7 @@ from xdsl.traits import (
     MemoryEffect,
     MemoryEffectKind,
 )
+from xdsl.utils.delimiter import Delimiter
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.hints import isa
 
@@ -197,21 +198,17 @@ class ExchangeDeclarationAttr(ParametrizedAttribute):
         parser.parse_characters("<")
         parser.parse_characters("at")
         offset = parser.parse_comma_separated_list(
-            parser.Delimiter.SQUARE, parser.parse_integer
+            Delimiter.SQUARE, parser.parse_integer
         )
         parser.parse_characters("size")
-        size = parser.parse_comma_separated_list(
-            parser.Delimiter.SQUARE, parser.parse_integer
-        )
+        size = parser.parse_comma_separated_list(Delimiter.SQUARE, parser.parse_integer)
         parser.parse_characters("source")
         parser.parse_characters("offset")
         source_offset = parser.parse_comma_separated_list(
-            parser.Delimiter.SQUARE, parser.parse_integer
+            Delimiter.SQUARE, parser.parse_integer
         )
         parser.parse_characters("to")
-        to = parser.parse_comma_separated_list(
-            parser.Delimiter.SQUARE, parser.parse_integer
-        )
+        to = parser.parse_comma_separated_list(Delimiter.SQUARE, parser.parse_integer)
         parser.parse_characters(">")
 
         return [

--- a/xdsl/dialects/hw.py
+++ b/xdsl/dialects/hw.py
@@ -57,6 +57,7 @@ from xdsl.traits import (
     SymbolOpInterface,
     SymbolTable,
 )
+from xdsl.utils.delimiter import Delimiter
 from xdsl.utils.exceptions import VerifyException
 
 
@@ -415,7 +416,7 @@ class InnerSymAttr(
             return [ArrayAttr([InnerSymPropertiesAttr(sym_name, 0, "public")])]
 
         data = parser.parse_comma_separated_list(
-            parser.Delimiter.SQUARE,
+            Delimiter.SQUARE,
             lambda: InnerSymPropertiesAttr.parse_parameters(parser),
         )
         return [ArrayAttr(InnerSymPropertiesAttr(*tup) for tup in data)]
@@ -532,9 +533,7 @@ class ModuleType(ParametrizedAttribute, TypeAttribute):
             return ModulePort([StringAttr(name), typ, DirectionAttr(direction)])
 
         return [
-            ArrayAttr(
-                parser.parse_comma_separated_list(parser.Delimiter.ANGLE, parse_port)
-            )
+            ArrayAttr(parser.parse_comma_separated_list(Delimiter.ANGLE, parse_port))
         ]
 
     def print_parameters(self, printer: Printer):
@@ -714,12 +713,10 @@ class ParsedModuleHeader(NamedTuple):
         sym_visibility = parser.parse_optional_visibility_keyword()
         name = parser.parse_symbol_name()
         parameters = parser.parse_optional_comma_separated_list(
-            parser.Delimiter.ANGLE,
+            Delimiter.ANGLE,
             lambda: ParamDeclAttr(ParamDeclAttr.parse_free_standing_parameters(parser)),
         )
-        args = parser.parse_comma_separated_list(
-            parser.Delimiter.PAREN, parse_module_arg
-        )
+        args = parser.parse_comma_separated_list(Delimiter.PAREN, parse_module_arg)
 
         return cls(
             visibility=sym_visibility,
@@ -1156,11 +1153,11 @@ class InstanceOp(IRDLOperation):
             return (port_name, port_type)
 
         input_ports = parser.parse_comma_separated_list(
-            Parser.Delimiter.PAREN, parse_input_port, "input port list expected"
+            Delimiter.PAREN, parse_input_port, "input port list expected"
         )
         parser.parse_punctuation("->")
         output_ports = parser.parse_comma_separated_list(
-            Parser.Delimiter.PAREN, parse_output_port, "output port list expected"
+            Delimiter.PAREN, parse_output_port, "output port list expected"
         )
         attributes_attr = parser.parse_optional_attr_dict_with_reserved_attr_names(
             (
@@ -1277,7 +1274,7 @@ class OutputOp(IRDLOperation):
 
         parser.parse_punctuation(":")
         types = parser.parse_comma_separated_list(
-            parser.Delimiter.NONE, parser.parse_attribute
+            Delimiter.NONE, parser.parse_attribute
         )
         operands = parser.resolve_operands(operands, types, parser.pos)
         return cls(operands)

--- a/xdsl/dialects/irdl/irdl.py
+++ b/xdsl/dialects/irdl/irdl.py
@@ -46,6 +46,7 @@ from xdsl.traits import (
     SymbolOpInterface,
     SymbolTable,
 )
+from xdsl.utils.delimiter import Delimiter
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.str_enum import StrEnum
 
@@ -86,7 +87,7 @@ class VariadicityArrayAttr(ParametrizedAttribute, SpacedOpaqueSyntaxAttribute):
     @classmethod
     def parse_parameters(cls, parser: AttrParser) -> tuple[ArrayAttr[VariadicityAttr]]:
         data = parser.parse_comma_separated_list(
-            AttrParser.Delimiter.SQUARE, lambda: VariadicityAttr.parse_parameter(parser)
+            Delimiter.SQUARE, lambda: VariadicityAttr.parse_parameter(parser)
         )
         return (ArrayAttr(VariadicityAttr(x) for x in data),)
 
@@ -265,7 +266,7 @@ class ParametersOp(IRDLOperation):
     @classmethod
     def parse(cls, parser: Parser) -> ParametersOp:
         args = parser.parse_comma_separated_list(
-            parser.Delimiter.PAREN, lambda: _parse_argument(parser)
+            Delimiter.PAREN, lambda: _parse_argument(parser)
         )
         return ParametersOp(
             tuple(x[1] for x in args),
@@ -381,7 +382,7 @@ class OperandsOp(IRDLOperation):
     @classmethod
     def parse(cls, parser: Parser) -> OperandsOp:
         args = parser.parse_comma_separated_list(
-            parser.Delimiter.PAREN, lambda: _parse_argument_with_var(parser)
+            Delimiter.PAREN, lambda: _parse_argument_with_var(parser)
         )
         return OperandsOp(
             tuple(x[2] for x in args),
@@ -428,7 +429,7 @@ class ResultsOp(IRDLOperation):
     @classmethod
     def parse(cls, parser: Parser) -> ResultsOp:
         args = parser.parse_comma_separated_list(
-            parser.Delimiter.PAREN, lambda: _parse_argument_with_var(parser)
+            Delimiter.PAREN, lambda: _parse_argument_with_var(parser)
         )
         return ResultsOp(
             tuple(x[2] for x in args),
@@ -489,7 +490,7 @@ class AttributesOp(IRDLOperation):
     @classmethod
     def parse(cls, parser: Parser) -> AttributesOp:
         tuples = parser.parse_optional_comma_separated_list(
-            parser.Delimiter.BRACES, lambda: _parse_attribute(parser)
+            Delimiter.BRACES, lambda: _parse_attribute(parser)
         )
         if tuples is None:
             return AttributesOp.get(dict())
@@ -533,7 +534,7 @@ class RegionsOp(IRDLOperation):
     @classmethod
     def parse(cls, parser: Parser) -> RegionsOp:
         args = parser.parse_comma_separated_list(
-            parser.Delimiter.PAREN, lambda: _parse_argument(parser)
+            Delimiter.PAREN, lambda: _parse_argument(parser)
         )
         return RegionsOp(
             tuple(x[1] for x in args),
@@ -654,9 +655,7 @@ class ParametricOp(IRDLOperation):
         base_type = parser.parse_attribute()
         if not isinstance(base_type, SymbolRefAttr):
             parser.raise_error("expected symbol reference")
-        args = parser.parse_comma_separated_list(
-            parser.Delimiter.ANGLE, parser.parse_operand
-        )
+        args = parser.parse_comma_separated_list(Delimiter.ANGLE, parser.parse_operand)
         return ParametricOp(base_type, args)
 
     def print(self, printer: Printer) -> None:
@@ -739,9 +738,7 @@ class AnyOfOp(IRDLOperation):
 
     @classmethod
     def parse(cls, parser: Parser) -> AnyOfOp:
-        args = parser.parse_comma_separated_list(
-            parser.Delimiter.PAREN, parser.parse_operand
-        )
+        args = parser.parse_comma_separated_list(Delimiter.PAREN, parser.parse_operand)
         return AnyOfOp(args)
 
     def print(self, printer: Printer) -> None:
@@ -764,9 +761,7 @@ class AllOfOp(IRDLOperation):
 
     @classmethod
     def parse(cls, parser: Parser) -> AllOfOp:
-        args = parser.parse_comma_separated_list(
-            parser.Delimiter.PAREN, parser.parse_operand
-        )
+        args = parser.parse_comma_separated_list(Delimiter.PAREN, parser.parse_operand)
         return AllOfOp(args)
 
     def print(self, printer: Printer) -> None:

--- a/xdsl/dialects/linalg.py
+++ b/xdsl/dialects/linalg.py
@@ -58,6 +58,7 @@ from xdsl.irdl import (
 from xdsl.parser import AttrParser, Parser
 from xdsl.printer import Printer
 from xdsl.traits import HasParent, IsTerminator
+from xdsl.utils.delimiter import Delimiter
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.hints import isa
 from xdsl.utils.str_enum import StrEnum
@@ -327,11 +328,11 @@ class GenericOp(IRDLOperation):
         if parser.parse_optional_characters("ins"):
             parser.parse_punctuation("(")
             unresolved_ins = parser.parse_comma_separated_list(
-                Parser.Delimiter.NONE, parser.parse_unresolved_operand
+                Delimiter.NONE, parser.parse_unresolved_operand
             )
             parser.parse_punctuation(":")
             ins_types = parser.parse_comma_separated_list(
-                Parser.Delimiter.NONE, parser.parse_type
+                Delimiter.NONE, parser.parse_type
             )
             parser.parse_punctuation(")")
             ins = parser.resolve_operands(unresolved_ins, ins_types, pos)
@@ -342,11 +343,11 @@ class GenericOp(IRDLOperation):
         if parser.parse_optional_characters("outs"):
             parser.parse_punctuation("(")
             unresolved_outs = parser.parse_comma_separated_list(
-                Parser.Delimiter.NONE, parser.parse_unresolved_operand
+                Delimiter.NONE, parser.parse_unresolved_operand
             )
             parser.parse_punctuation(":")
             outs_types = parser.parse_comma_separated_list(
-                Parser.Delimiter.NONE, parser.parse_type
+                Delimiter.NONE, parser.parse_type
             )
             parser.parse_punctuation(")")
             outs = parser.resolve_operands(unresolved_outs, outs_types, pos)
@@ -365,7 +366,7 @@ class GenericOp(IRDLOperation):
 
         if parser.parse_optional_punctuation("->"):
             res_types = parser.parse_comma_separated_list(
-                parser.Delimiter.NONE, parser.parse_attribute
+                Delimiter.NONE, parser.parse_attribute
             )
         else:
             res_types = ()
@@ -459,11 +460,11 @@ class NamedOpBase(IRDLOperation, ABC):
         if parser.parse_optional_characters("ins"):
             parser.parse_punctuation("(")
             unresolved_ins = parser.parse_comma_separated_list(
-                Parser.Delimiter.NONE, parser.parse_unresolved_operand
+                Delimiter.NONE, parser.parse_unresolved_operand
             )
             parser.parse_punctuation(":")
             ins_types = parser.parse_comma_separated_list(
-                Parser.Delimiter.NONE, parser.parse_type
+                Delimiter.NONE, parser.parse_type
             )
             parser.parse_punctuation(")")
             ins = parser.resolve_operands(unresolved_ins, ins_types, pos)
@@ -474,11 +475,11 @@ class NamedOpBase(IRDLOperation, ABC):
         if parser.parse_optional_characters("outs"):
             parser.parse_punctuation("(")
             unresolved_outs = parser.parse_comma_separated_list(
-                Parser.Delimiter.NONE, parser.parse_unresolved_operand
+                Delimiter.NONE, parser.parse_unresolved_operand
             )
             parser.parse_punctuation(":")
             outs_types = parser.parse_comma_separated_list(
-                Parser.Delimiter.NONE, parser.parse_type
+                Delimiter.NONE, parser.parse_type
             )
             parser.parse_punctuation(")")
             outs = parser.resolve_operands(unresolved_outs, outs_types, pos)
@@ -496,7 +497,7 @@ class NamedOpBase(IRDLOperation, ABC):
 
         if parser.parse_optional_punctuation("->"):
             res_types = parser.parse_optional_comma_separated_list(
-                parser.Delimiter.PAREN, parser.parse_attribute
+                Delimiter.PAREN, parser.parse_attribute
             )
             if res_types is None:
                 res_types = [[parser.parse_attribute()]]
@@ -962,7 +963,7 @@ class TransposeOp(IRDLOperation):
         parser.parse_keyword("permutation")
         parser.parse_punctuation("=")
         permutation = parser.parse_comma_separated_list(
-            parser.Delimiter.SQUARE, parser.parse_integer
+            Delimiter.SQUARE, parser.parse_integer
         )
         transpose = cls(
             input,
@@ -1333,7 +1334,7 @@ class BroadcastOp(IRDLOperation):
         parser.parse_keyword("dimensions")
         parser.parse_punctuation("=")
         dimensions = parser.parse_comma_separated_list(
-            parser.Delimiter.SQUARE, parser.parse_integer
+            Delimiter.SQUARE, parser.parse_integer
         )
         broadcast = cls(
             input,

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -67,6 +67,7 @@ from xdsl.traits import (
     SameOperandsAndResultType,
     SymbolOpInterface,
 )
+from xdsl.utils.delimiter import Delimiter
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.hints import isa
 from xdsl.utils.str_enum import StrEnum
@@ -141,7 +142,7 @@ class LLVMStructType(ParametrizedAttribute, TypeAttribute):
             parser.parse_characters(",", " after type")
 
         params = parser.parse_comma_separated_list(
-            parser.Delimiter.PAREN, lambda: parse_llvm_type(parser)
+            Delimiter.PAREN, lambda: parse_llvm_type(parser)
         )
         parser.parse_characters(">", " to close LLVM struct parameters")
         return [StringAttr(struct_name), ArrayAttr(params)]
@@ -303,7 +304,7 @@ class LLVMFunctionType(ParametrizedAttribute, TypeAttribute):
             return parse_llvm_type(parser)
 
         inputs = parser.parse_comma_separated_list(
-            Parser.Delimiter.PAREN, _parse_attr_or_variadic
+            Delimiter.PAREN, _parse_attr_or_variadic
         )
         is_varargs: NoneAttr | UnitAttr = NoneAttr()
         if inputs and inputs[-1] is Ellipsis:

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -66,6 +66,7 @@ from xdsl.traits import (
     SymbolOpInterface,
 )
 from xdsl.utils.bitwise_casts import is_power_of_two
+from xdsl.utils.delimiter import Delimiter
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.hints import isa
 
@@ -236,10 +237,10 @@ class AllocOp(IRDLOperation):
         #  %alloc = memref.alloc(%a)[%s] {alignment = 64 : i64} : memref<3x2xf32>
 
         unresolved_dynamic_sizes = parser.parse_comma_separated_list(
-            parser.Delimiter.PAREN, parser.parse_unresolved_operand
+            Delimiter.PAREN, parser.parse_unresolved_operand
         )
         unresolved_symbol_operands = parser.parse_optional_comma_separated_list(
-            parser.Delimiter.SQUARE, parser.parse_unresolved_operand
+            Delimiter.SQUARE, parser.parse_unresolved_operand
         )
         if unresolved_symbol_operands is None:
             unresolved_symbol_operands = []

--- a/xdsl/dialects/memref_stream.py
+++ b/xdsl/dialects/memref_stream.py
@@ -61,6 +61,7 @@ from xdsl.traits import (
     IsTerminator,
     NoTerminator,
 )
+from xdsl.utils.delimiter import Delimiter
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.hints import isa
 from xdsl.utils.str_enum import StrEnum
@@ -212,7 +213,7 @@ class StridePattern(ParametrizedAttribute):
             ub = ArrayAttr(
                 IntegerAttr(i, index)
                 for i in parser.parse_comma_separated_list(
-                    parser.Delimiter.SQUARE, parser.parse_integer
+                    Delimiter.SQUARE, parser.parse_integer
                 )
             )
             parser.parse_punctuation(",")
@@ -397,11 +398,11 @@ class StreamingRegionOp(IRDLOperation):
         if parser.parse_optional_characters("ins"):
             parser.parse_punctuation("(")
             unresolved_ins = parser.parse_comma_separated_list(
-                Parser.Delimiter.NONE, parser.parse_unresolved_operand
+                Delimiter.NONE, parser.parse_unresolved_operand
             )
             parser.parse_punctuation(":")
             ins_types = parser.parse_comma_separated_list(
-                Parser.Delimiter.NONE, parser.parse_type
+                Delimiter.NONE, parser.parse_type
             )
             parser.parse_punctuation(")")
             ins = parser.resolve_operands(unresolved_ins, ins_types, pos)
@@ -412,11 +413,11 @@ class StreamingRegionOp(IRDLOperation):
         if parser.parse_optional_characters("outs"):
             parser.parse_punctuation("(")
             unresolved_outs = parser.parse_comma_separated_list(
-                Parser.Delimiter.NONE, parser.parse_unresolved_operand
+                Delimiter.NONE, parser.parse_unresolved_operand
             )
             parser.parse_punctuation(":")
             outs_types = parser.parse_comma_separated_list(
-                Parser.Delimiter.NONE, parser.parse_type
+                Delimiter.NONE, parser.parse_type
             )
             parser.parse_punctuation(")")
             outs = parser.resolve_operands(unresolved_outs, outs_types, pos)
@@ -683,7 +684,7 @@ class GenericOp(IRDLOperation):
 
         parser.parse_punctuation("(")
         optional_inits = parser.parse_comma_separated_list(
-            Parser.Delimiter.NONE, lambda: cls._parse_init(parser)
+            Delimiter.NONE, lambda: cls._parse_init(parser)
         )
         parser.parse_punctuation(")")
         enumerated_inits = tuple(
@@ -776,11 +777,11 @@ class GenericOp(IRDLOperation):
         if parser.parse_optional_characters("ins"):
             parser.parse_punctuation("(")
             unresolved_ins = parser.parse_comma_separated_list(
-                Parser.Delimiter.NONE, parser.parse_unresolved_operand
+                Delimiter.NONE, parser.parse_unresolved_operand
             )
             parser.parse_punctuation(":")
             ins_types = parser.parse_comma_separated_list(
-                Parser.Delimiter.NONE, parser.parse_type
+                Delimiter.NONE, parser.parse_type
             )
             parser.parse_punctuation(")")
             ins = parser.resolve_operands(unresolved_ins, ins_types, pos)
@@ -791,11 +792,11 @@ class GenericOp(IRDLOperation):
         if parser.parse_optional_characters("outs"):
             parser.parse_punctuation("(")
             unresolved_outs = parser.parse_comma_separated_list(
-                Parser.Delimiter.NONE, parser.parse_unresolved_operand
+                Delimiter.NONE, parser.parse_unresolved_operand
             )
             parser.parse_punctuation(":")
             outs_types = parser.parse_comma_separated_list(
-                Parser.Delimiter.NONE, parser.parse_type
+                Delimiter.NONE, parser.parse_type
             )
             parser.parse_punctuation(")")
             outs = parser.resolve_operands(unresolved_outs, outs_types, pos)

--- a/xdsl/dialects/pdl.py
+++ b/xdsl/dialects/pdl.py
@@ -45,6 +45,7 @@ from xdsl.irdl import (
 from xdsl.parser import AttrParser, Parser
 from xdsl.printer import Printer
 from xdsl.traits import HasParent, IsTerminator, NoTerminator, OptionalSymbolOpInterface
+from xdsl.utils.delimiter import Delimiter
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.hints import isa
 
@@ -56,13 +57,9 @@ def parse_operands_with_types(parser: Parser) -> list[SSAValue]:
     At least one operand is expected.
     """
     pos = parser.pos
-    operands = parser.parse_comma_separated_list(
-        Parser.Delimiter.NONE, parser.parse_operand
-    )
+    operands = parser.parse_comma_separated_list(Delimiter.NONE, parser.parse_operand)
     parser.parse_punctuation(":")
-    types = parser.parse_comma_separated_list(
-        Parser.Delimiter.NONE, parser.parse_attribute
-    )
+    types = parser.parse_comma_separated_list(Delimiter.NONE, parser.parse_attribute)
     end_pos = parser.pos
     if len(operands) != len(types):
         parser.raise_error(
@@ -243,7 +240,7 @@ class ApplyNativeRewriteOp(IRDLOperation):
         result_types = []
         if parser.parse_optional_punctuation(":") is not None:
             result_types = parser.parse_comma_separated_list(
-                Parser.Delimiter.NONE, parser.parse_attribute
+                Delimiter.NONE, parser.parse_attribute
             )
         return ApplyNativeRewriteOp(name, operands, result_types)
 
@@ -430,7 +427,7 @@ class OperationOp(IRDLOperation):
             return (name, type)
 
         attributes = parser.parse_optional_comma_separated_list(
-            Parser.Delimiter.BRACES, parse_attribute_entry
+            Delimiter.BRACES, parse_attribute_entry
         )
         if attributes is None:
             attributes = []

--- a/xdsl/dialects/pdl_interp.py
+++ b/xdsl/dialects/pdl_interp.py
@@ -63,6 +63,7 @@ from xdsl.traits import (
     IsTerminator,
     SymbolOpInterface,
 )
+from xdsl.utils.delimiter import Delimiter
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.hints import isa
 
@@ -611,12 +612,12 @@ class CreateOperationOp(IRDLOperation):
         values: list[SSAValue] = []
         if parser.parse_optional_punctuation("("):
             values = parser.parse_comma_separated_list(
-                delimiter=Parser.Delimiter.NONE,
+                delimiter=Delimiter.NONE,
                 parse=lambda: parser.parse_operand(),
             )
             parser.parse_punctuation(":")
             parser.parse_comma_separated_list(
-                delimiter=Parser.Delimiter.NONE,
+                delimiter=Delimiter.NONE,
                 parse=lambda: parser.parse_type(),
             )
             parser.parse_punctuation(")")
@@ -631,7 +632,7 @@ class CreateOperationOp(IRDLOperation):
         input_attribute_names = None
         input_attributes = None
         attributes = parser.parse_optional_comma_separated_list(
-            delimiter=Parser.Delimiter.BRACES,
+            delimiter=Delimiter.BRACES,
             parse=lambda: CreateOperationOp._parse_attr(parser),
         )
         if attributes is not None:

--- a/xdsl/dialects/riscv_cf.py
+++ b/xdsl/dialects/riscv_cf.py
@@ -27,6 +27,7 @@ from xdsl.pattern_rewriter import RewritePattern
 from xdsl.printer import Printer
 from xdsl.traits import HasCanonicalizationPatternsTrait, IsTerminator
 from xdsl.utils.comparisons import to_signed, to_unsigned
+from xdsl.utils.delimiter import Delimiter
 from xdsl.utils.exceptions import VerifyException
 
 
@@ -172,12 +173,12 @@ class ConditionalBranchOperation(RISCVInstruction, ABC):
         parser.parse_punctuation(",")
         then_block = parser.parse_successor()
         then_args = parser.parse_comma_separated_list(
-            parser.Delimiter.PAREN, lambda: _parse_type_pair(parser)
+            Delimiter.PAREN, lambda: _parse_type_pair(parser)
         )
         parser.parse_punctuation(",")
         else_block = parser.parse_successor()
         else_args = parser.parse_comma_separated_list(
-            parser.Delimiter.PAREN, lambda: _parse_type_pair(parser)
+            Delimiter.PAREN, lambda: _parse_type_pair(parser)
         )
         attrs = parser.parse_optional_attr_dict_with_keyword()
         op = cls(rs1, rs2, then_args, else_args, then_block, else_block)
@@ -372,7 +373,7 @@ class BranchOp(riscv.RISCVAsmOperation):
     def parse(cls, parser: Parser) -> Self:
         successor = parser.parse_successor()
         block_arguments = parser.parse_comma_separated_list(
-            parser.Delimiter.PAREN, lambda: _parse_type_pair(parser)
+            Delimiter.PAREN, lambda: _parse_type_pair(parser)
         )
         attrs = parser.parse_optional_attr_dict_with_keyword()
         op = cls(block_arguments, successor)
@@ -451,7 +452,7 @@ class JOp(RISCVInstruction):
     def parse(cls, parser: Parser) -> Self:
         successor = parser.parse_successor()
         block_arguments = parser.parse_comma_separated_list(
-            parser.Delimiter.PAREN, lambda: _parse_type_pair(parser)
+            Delimiter.PAREN, lambda: _parse_type_pair(parser)
         )
         attrs = parser.parse_optional_attr_dict_with_keyword()
         op = cls(block_arguments, successor)

--- a/xdsl/dialects/riscv_scf.py
+++ b/xdsl/dialects/riscv_scf.py
@@ -42,6 +42,7 @@ from xdsl.traits import (
     SingleBlockImplicitTerminator,
     ensure_terminator,
 )
+from xdsl.utils.delimiter import Delimiter
 from xdsl.utils.exceptions import VerifyException
 
 
@@ -323,7 +324,7 @@ class WhileOp(IRDLOperation):
             return arg, operand
 
         tuples = parser.parse_comma_separated_list(
-            parser.Delimiter.PAREN,
+            Delimiter.PAREN,
             parse_assignment,
         )
 
@@ -405,9 +406,7 @@ class ConditionOp(IRDLOperation):
         )
         if unresolved_arguments is not None:
             parser.parse_punctuation(":")
-            types = parser.parse_comma_separated_list(
-                parser.Delimiter.NONE, parser.parse_type
-            )
+            types = parser.parse_comma_separated_list(Delimiter.NONE, parser.parse_type)
             arguments = parser.resolve_operands(unresolved_arguments, types, pos)
         else:
             arguments: Sequence[SSAValue] = ()

--- a/xdsl/dialects/riscv_snitch.py
+++ b/xdsl/dialects/riscv_snitch.py
@@ -69,6 +69,7 @@ from xdsl.traits import (
     SingleBlockImplicitTerminator,
     ensure_terminator,
 )
+from xdsl.utils.delimiter import Delimiter
 from xdsl.utils.exceptions import VerifyException
 
 # region Snitch Extensions
@@ -318,13 +319,13 @@ class FRepOperation(RISCVInstruction):
         iter_arg_types: list[Attribute] = []
         if parser.parse_optional_characters("iter_args"):
             for iter_arg, iter_arg_operand in parser.parse_comma_separated_list(
-                Parser.Delimiter.PAREN, lambda: parse_assignment(parser)
+                Delimiter.PAREN, lambda: parse_assignment(parser)
             ):
                 unresolved_iter_args.append(iter_arg)
                 iter_arg_unresolved_operands.append(iter_arg_operand)
             parser.parse_characters("->")
             iter_arg_types = parser.parse_comma_separated_list(
-                Parser.Delimiter.PAREN, parser.parse_attribute
+                Delimiter.PAREN, parser.parse_attribute
             )
 
         iter_arg_operands = parser.resolve_operands(

--- a/xdsl/dialects/scf.py
+++ b/xdsl/dialects/scf.py
@@ -54,6 +54,7 @@ from xdsl.traits import (
     SingleBlockImplicitTerminator,
     ensure_terminator,
 )
+from xdsl.utils.delimiter import Delimiter
 from xdsl.utils.exceptions import VerifyException
 
 
@@ -122,7 +123,7 @@ class WhileOp(IRDLOperation):
             return arg, operand
 
         tuples = parser.parse_comma_separated_list(
-            parser.Delimiter.PAREN,
+            Delimiter.PAREN,
             parse_assignment,
         )
 
@@ -231,7 +232,7 @@ class IfOp(IRDLOperation):
         return_types = []
         if parser.parse_optional_punctuation("->"):
             return_types = parser.parse_comma_separated_list(
-                parser.Delimiter.PAREN, parser.parse_type
+                Delimiter.PAREN, parser.parse_type
             )
         else:
             return_types = []

--- a/xdsl/dialects/smt.py
+++ b/xdsl/dialects/smt.py
@@ -42,6 +42,7 @@ from xdsl.irdl import (
 from xdsl.parser import AttrParser, Parser
 from xdsl.printer import Printer
 from xdsl.traits import ConstantLike, HasParent, IsTerminator, Pure
+from xdsl.utils.delimiter import Delimiter
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.hints import isa
 
@@ -120,7 +121,7 @@ class FuncType(ParametrizedAttribute, TypeAttribute):
     def parse_parameters(cls, parser: AttrParser) -> Sequence[Attribute]:
         with parser.in_angle_brackets():
             domain_types = parser.parse_comma_separated_list(
-                parser.Delimiter.PAREN, parser.parse_type
+                Delimiter.PAREN, parser.parse_type
             )
             range_type = parser.parse_type()
 
@@ -394,7 +395,7 @@ def _parse_same_operand_type_variadic_to_bool_op(
     """
     operand_pos = parser.pos
     operands = parser.parse_comma_separated_list(
-        parser.Delimiter.NONE, parser.parse_unresolved_operand, "operand list"
+        Delimiter.NONE, parser.parse_unresolved_operand, "operand list"
     )
     attr_dict = parser.parse_optional_attr_dict()
     parser.parse_punctuation(":")

--- a/xdsl/dialects/snitch_stream.py
+++ b/xdsl/dialects/snitch_stream.py
@@ -51,6 +51,7 @@ from xdsl.irdl import (
 from xdsl.parser import AttrParser, Parser
 from xdsl.printer import Printer
 from xdsl.traits import NoTerminator
+from xdsl.utils.delimiter import Delimiter
 from xdsl.utils.exceptions import VerifyException
 
 
@@ -96,7 +97,7 @@ class StridePattern(ParametrizedAttribute):
             ub = ArrayAttr(
                 IntAttr(i)
                 for i in parser.parse_comma_separated_list(
-                    parser.Delimiter.SQUARE, parser.parse_integer
+                    Delimiter.SQUARE, parser.parse_integer
                 )
             )
             parser.parse_punctuation(",")
@@ -105,7 +106,7 @@ class StridePattern(ParametrizedAttribute):
             strides = ArrayAttr(
                 IntAttr(i)
                 for i in parser.parse_comma_separated_list(
-                    parser.Delimiter.SQUARE, parser.parse_integer
+                    Delimiter.SQUARE, parser.parse_integer
                 )
             )
             if parser.parse_optional_punctuation(","):
@@ -331,11 +332,11 @@ class StreamingRegionOp(IRDLOperation):
         if parser.parse_optional_characters("ins"):
             parser.parse_punctuation("(")
             unresolved_ins = parser.parse_comma_separated_list(
-                Parser.Delimiter.NONE, parser.parse_unresolved_operand
+                Delimiter.NONE, parser.parse_unresolved_operand
             )
             parser.parse_punctuation(":")
             ins_types = parser.parse_comma_separated_list(
-                Parser.Delimiter.NONE, parser.parse_type
+                Delimiter.NONE, parser.parse_type
             )
             parser.parse_punctuation(")")
             ins = parser.resolve_operands(unresolved_ins, ins_types, pos)
@@ -346,11 +347,11 @@ class StreamingRegionOp(IRDLOperation):
         if parser.parse_optional_characters("outs"):
             parser.parse_punctuation("(")
             unresolved_outs = parser.parse_comma_separated_list(
-                Parser.Delimiter.NONE, parser.parse_unresolved_operand
+                Delimiter.NONE, parser.parse_unresolved_operand
             )
             parser.parse_punctuation(":")
             outs_types = parser.parse_comma_separated_list(
-                Parser.Delimiter.NONE, parser.parse_type
+                Delimiter.NONE, parser.parse_type
             )
             parser.parse_punctuation(")")
             outs = parser.resolve_operands(unresolved_outs, outs_types, pos)

--- a/xdsl/dialects/stablehlo.py
+++ b/xdsl/dialects/stablehlo.py
@@ -55,6 +55,7 @@ from xdsl.irdl import (
 from xdsl.parser import AttrParser
 from xdsl.printer import Printer
 from xdsl.traits import IsTerminator
+from xdsl.utils.delimiter import Delimiter
 from xdsl.utils.exceptions import VerifyException
 
 IntegerTensorType: TypeAlias = TensorType[IntegerType]
@@ -309,7 +310,7 @@ class DotAttr(ParametrizedAttribute):
         parser.parse_characters(name)
         parser.parse_punctuation("=")
         value = parser.parse_comma_separated_list(
-            AttrParser.Delimiter.SQUARE,
+            Delimiter.SQUARE,
             lambda: IntegerAttr(parser.parse_integer(), i64),
         )
         return ArrayAttr(value)

--- a/xdsl/dialects/stencil.py
+++ b/xdsl/dialects/stencil.py
@@ -71,6 +71,7 @@ from xdsl.traits import (
     Pure,
     RecursiveMemoryEffect,
 )
+from xdsl.utils.delimiter import Delimiter
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.hints import isa
 
@@ -100,7 +101,7 @@ class IndexAttr(ParametrizedAttribute, Iterable[int]):
         e.g.: `[1, 2, 3]`
         """
         ints = parser.parse_comma_separated_list(
-            parser.Delimiter.SQUARE, lambda: parser.parse_integer(allow_boolean=False)
+            Delimiter.SQUARE, lambda: parser.parse_integer(allow_boolean=False)
         )
         return ArrayAttr(IntAttr(i) for i in ints)
 
@@ -545,7 +546,7 @@ class ApplyOp(IRDLOperation):
             return parser.resolve_operand(op, type)
 
         assign_args = parser.parse_comma_separated_list(
-            parser.Delimiter.PAREN, parse_assign_args
+            Delimiter.PAREN, parse_assign_args
         )
         args: tuple[Parser.Argument, ...]
         operands: tuple[SSAValue, ...]
@@ -561,7 +562,7 @@ class ApplyOp(IRDLOperation):
             parser.parse_keyword("outs")
             parser.parse_punctuation("(")
             destinations = parser.parse_comma_separated_list(
-                parser.Delimiter.NONE, parse_operand
+                Delimiter.NONE, parse_operand
             )
             result_types = []
         parser.parse_punctuation(")")

--- a/xdsl/dialects/stim/ops.py
+++ b/xdsl/dialects/stim/ops.py
@@ -16,6 +16,7 @@ from xdsl.irdl import (
 )
 from xdsl.parser import AttrParser
 from xdsl.printer import Printer
+from xdsl.utils.delimiter import Delimiter
 
 
 @irdl_attr_definition
@@ -91,7 +92,7 @@ class QubitMappingAttr(StimPrintable, ParametrizedAttribute):
     ) -> tuple[ArrayAttr[FloatData | IntAttr], QubitAttr]:
         parser.parse_punctuation("<")
         coords = parser.parse_comma_separated_list(
-            delimiter=parser.Delimiter.PAREN,
+            delimiter=Delimiter.PAREN,
             parse=lambda: IntAttr(x)
             if type(x := parser.parse_number(allow_boolean=False)) is int
             else FloatData(x),

--- a/xdsl/dialects/tensor.py
+++ b/xdsl/dialects/tensor.py
@@ -35,6 +35,7 @@ from xdsl.irdl import (
 from xdsl.parser import Parser
 from xdsl.printer import Printer
 from xdsl.traits import NoMemoryEffect
+from xdsl.utils.delimiter import Delimiter
 from xdsl.utils.exceptions import VerifyException
 
 
@@ -165,7 +166,7 @@ class EmptyOp(IRDLOperation):
             dynamic_sizes = ()
         else:
             unresolved_dynamic_sizes = parser.parse_comma_separated_list(
-                Parser.Delimiter.NONE, parser.parse_unresolved_operand
+                Delimiter.NONE, parser.parse_unresolved_operand
             )
             unresolved_types = (IndexType(),) * len(unresolved_dynamic_sizes)
             parser.parse_punctuation(")")
@@ -242,7 +243,7 @@ class ReshapeOp(IRDLOperation):
         parser.parse_punctuation(")")
         parser.parse_punctuation(":")
         parser.parse_punctuation("(")
-        parser.parse_comma_separated_list(Parser.Delimiter.NONE, parser.parse_type)
+        parser.parse_comma_separated_list(Delimiter.NONE, parser.parse_type)
         parser.parse_punctuation(")")
         parser.parse_optional_punctuation("->")
         result_type = parser.parse_attribute()
@@ -464,7 +465,7 @@ class ExtractOp(IRDLOperation):
     def parse(cls, parser: Parser) -> Self:
         tensor = parser.parse_operand()
         indices = parser.parse_comma_separated_list(
-            delimiter=parser.Delimiter.SQUARE, parse=parser.parse_operand
+            delimiter=Delimiter.SQUARE, parse=parser.parse_operand
         )
         parser.parse_punctuation(":")
         source_tensor_type = parser.parse_type()
@@ -509,7 +510,7 @@ class InsertOp(IRDLOperation):
         parser.parse_characters("into")
         dest = parser.parse_operand()
         indices = parser.parse_comma_separated_list(
-            delimiter=parser.Delimiter.SQUARE, parse=parser.parse_operand
+            delimiter=Delimiter.SQUARE, parse=parser.parse_operand
         )
         parser.parse_punctuation(":")
         parser.parse_type()

--- a/xdsl/dialects/utils/dynamic_index_list.py
+++ b/xdsl/dialects/utils/dynamic_index_list.py
@@ -15,6 +15,7 @@ from collections.abc import Iterable, Sequence
 from xdsl.ir import Attribute, SSAValue
 from xdsl.parser import Parser, UnresolvedOperand
 from xdsl.printer import Printer
+from xdsl.utils.delimiter import Delimiter
 from xdsl.utils.exceptions import VerifyException
 
 
@@ -91,7 +92,7 @@ def print_dynamic_index_list(
     integers: Iterable[int],
     value_types: Sequence[Attribute] = (),
     *,
-    delimiter: Parser.Delimiter = Parser.Delimiter.SQUARE,
+    delimiter: Delimiter = Delimiter.SQUARE,
 ):
     """
     Prints a list with either
@@ -152,7 +153,7 @@ def parse_dynamic_index_list_with_types(
     parser: Parser,
     dynamic_index: int,
     *,
-    delimiter: Parser.Delimiter = Parser.Delimiter.SQUARE,
+    delimiter: Delimiter = Delimiter.SQUARE,
 ) -> tuple[Sequence[SSAValue], Sequence[int]]:
     """
     Parses an in index list, composed of a mix of indices and ssa values with types:
@@ -181,7 +182,7 @@ def parse_dynamic_index_list_without_types(
     parser: Parser,
     dynamic_index: int,
     *,
-    delimiter: Parser.Delimiter = Parser.Delimiter.SQUARE,
+    delimiter: Delimiter = Delimiter.SQUARE,
 ) -> tuple[Sequence[UnresolvedOperand], Sequence[int]]:
     """
     Parses an in index list, composed of a mix of indices and ssa values without types:

--- a/xdsl/dialects/utils/format.py
+++ b/xdsl/dialects/utils/format.py
@@ -19,6 +19,7 @@ from xdsl.ir import (
 from xdsl.irdl import IRDLOperation, var_operand_def
 from xdsl.parser import Parser, UnresolvedOperand
 from xdsl.printer import Printer
+from xdsl.utils.delimiter import Delimiter
 
 
 class AbstractYieldOperation(Generic[AttributeInvT], IRDLOperation):
@@ -147,13 +148,13 @@ def parse_for_op_like(
     iter_arg_types: list[Attribute] = []
     if parser.parse_optional_characters("iter_args"):
         for iter_arg, iter_arg_operand in parser.parse_comma_separated_list(
-            Parser.Delimiter.PAREN, lambda: parse_assignment(parser)
+            Delimiter.PAREN, lambda: parse_assignment(parser)
         ):
             unresolved_iter_args.append(iter_arg)
             iter_arg_unresolved_operands.append(iter_arg_operand)
         parser.parse_characters("->")
         iter_arg_types = parser.parse_comma_separated_list(
-            Parser.Delimiter.PAREN, parser.parse_attribute
+            Delimiter.PAREN, parser.parse_attribute
         )
 
     iter_arg_operands = parser.resolve_operands(
@@ -268,7 +269,7 @@ def parse_func_op_like(
 
     # Parse function arguments
     args = parser.parse_comma_separated_list(
-        parser.Delimiter.PAREN,
+        Delimiter.PAREN,
         parse_fun_input,
     )
 
@@ -302,7 +303,7 @@ def parse_func_op_like(
     res_attrs_raw: list[dict[str, Attribute]] | None = []
     if parser.parse_optional_punctuation("->"):
         return_attributes = parser.parse_optional_comma_separated_list(
-            parser.Delimiter.PAREN, parse_fun_output
+            Delimiter.PAREN, parse_fun_output
         )
         if return_attributes is None:
             # output attributes are supported only if return results are enclosed in brackets (...)

--- a/xdsl/dialects/vector.py
+++ b/xdsl/dialects/vector.py
@@ -51,6 +51,7 @@ from xdsl.irdl import (
 from xdsl.parser import Parser, UnresolvedOperand
 from xdsl.printer import Printer
 from xdsl.traits import Pure
+from xdsl.utils.delimiter import Delimiter
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.hints import isa
 from xdsl.utils.lexer import Position
@@ -407,7 +408,7 @@ class ExtractOp(IRDLOperation):
 
         # Parse the positions
         positions = parser.parse_comma_separated_list(
-            Parser.Delimiter.SQUARE, parse_int_or_value
+            Delimiter.SQUARE, parse_int_or_value
         )
 
         # parse the attribute dictionary
@@ -575,7 +576,7 @@ class InsertOp(IRDLOperation):
 
         # Parse the positions
         positions = parser.parse_comma_separated_list(
-            Parser.Delimiter.SQUARE, parse_int_or_value
+            Delimiter.SQUARE, parse_int_or_value
         )
 
         # parse the attribute dictionary
@@ -879,7 +880,7 @@ class TransferReadOp(VectorTransferOperation):
     def parse(cls, parser: Parser) -> TransferReadOp:
         source = parser.parse_unresolved_operand()
         indices = parser.parse_comma_separated_list(
-            Parser.Delimiter.SQUARE, parser.parse_operand
+            Delimiter.SQUARE, parser.parse_operand
         )
         parser.parse_punctuation(",")
         padding = parser.parse_operand()
@@ -986,7 +987,7 @@ class TransferWriteOp(VectorTransferOperation):
         parser.parse_punctuation(",")
         source = parser.parse_unresolved_operand()
         indices = parser.parse_comma_separated_list(
-            Parser.Delimiter.SQUARE, parser.parse_operand
+            Delimiter.SQUARE, parser.parse_operand
         )
         if parser.parse_optional_punctuation(","):
             mask_start_pos = parser.pos

--- a/xdsl/dialects/x86/ops.py
+++ b/xdsl/dialects/x86/ops.py
@@ -69,6 +69,7 @@ from xdsl.irdl import (
 from xdsl.parser import Parser, UnresolvedOperand
 from xdsl.printer import Printer
 from xdsl.traits import IsTerminator
+from xdsl.utils.delimiter import Delimiter
 from xdsl.utils.exceptions import VerifyException
 
 from .assembly import (
@@ -950,12 +951,12 @@ class ConditionalJumpOperation(X86Instruction, X86CustomFormatOperation, ABC):
         parser.parse_punctuation(",")
         then_block = parser.parse_successor()
         then_args = parser.parse_comma_separated_list(
-            parser.Delimiter.PAREN, lambda: parse_type_pair(parser)
+            Delimiter.PAREN, lambda: parse_type_pair(parser)
         )
         parser.parse_punctuation(",")
         else_block = parser.parse_successor()
         else_args = parser.parse_comma_separated_list(
-            parser.Delimiter.PAREN, lambda: parse_type_pair(parser)
+            Delimiter.PAREN, lambda: parse_type_pair(parser)
         )
         attrs = parser.parse_optional_attr_dict_with_keyword()
         op = cls(rflags, then_args, else_args, then_block, else_block)
@@ -2200,7 +2201,7 @@ class C_JmpOp(X86Instruction, X86CustomFormatOperation):
     def parse(cls, parser: Parser) -> Self:
         successor = parser.parse_successor()
         block_values = parser.parse_comma_separated_list(
-            parser.Delimiter.PAREN, lambda: parse_type_pair(parser)
+            Delimiter.PAREN, lambda: parse_type_pair(parser)
         )
         attrs = parser.parse_optional_attr_dict_with_keyword()
         op = cls(block_values, successor)

--- a/xdsl/parser/affine_parser.py
+++ b/xdsl/parser/affine_parser.py
@@ -7,6 +7,7 @@ from xdsl.ir.affine import (
     AffineMap,
     AffineSet,
 )
+from xdsl.utils.delimiter import Delimiter
 from xdsl.utils.exceptions import ParseError
 from xdsl.utils.mlir_lexer import MLIRToken, MLIRTokenKind
 
@@ -127,7 +128,7 @@ class AffineParser(BaseParser):
         def parse_expr() -> AffineExpr:
             return self._parse_affine_expr(dims, syms)
 
-        return self.parse_comma_separated_list(self.Delimiter.PAREN, parse_expr)
+        return self.parse_comma_separated_list(Delimiter.PAREN, parse_expr)
 
     # TODO: Extend to semi-affine maps; see https://github.com/xdslproject/xdsl/issues/1087
     def _parse_affine_constraint(
@@ -167,7 +168,7 @@ class AffineParser(BaseParser):
         def parse_constraint() -> AffineConstraintExpr:
             return self._parse_affine_constraint(dims, syms)
 
-        return self.parse_comma_separated_list(self.Delimiter.PAREN, parse_constraint)
+        return self.parse_comma_separated_list(Delimiter.PAREN, parse_constraint)
 
     def _parse_affine_space(self) -> tuple[list[str], list[str]]:
         """
@@ -182,12 +183,12 @@ class AffineParser(BaseParser):
             ).text
 
         # Parse dimensions
-        dims = self.parse_comma_separated_list(self.Delimiter.PAREN, parse_id)
+        dims = self.parse_comma_separated_list(Delimiter.PAREN, parse_id)
         # Parse optional symbols
         if self._current_token.kind != MLIRTokenKind.L_SQUARE:
             syms = []
         else:
-            syms = self.parse_comma_separated_list(self.Delimiter.SQUARE, parse_id)
+            syms = self.parse_comma_separated_list(Delimiter.SQUARE, parse_id)
         # TODO: Do not allow duplicate ids.
         return dims, syms
 

--- a/xdsl/parser/attribute_parser.py
+++ b/xdsl/parser/attribute_parser.py
@@ -65,6 +65,7 @@ from xdsl.utils.bitwise_casts import (
     convert_u32_to_f32,
     convert_u64_to_f64,
 )
+from xdsl.utils.delimiter import Delimiter
 from xdsl.utils.exceptions import ParseError, VerifyException
 from xdsl.utils.lexer import Position, Span
 from xdsl.utils.mlir_lexer import MLIRTokenKind, StringLiteral
@@ -211,7 +212,7 @@ class AttrParser(BaseParser):
 
     def parse_optional_dictionary_attr_dict(self) -> dict[str, Attribute]:
         attrs = self.parse_optional_comma_separated_list(
-            self.Delimiter.BRACES, self._parse_attribute_entry
+            Delimiter.BRACES, self._parse_attribute_entry
         )
         if attrs is None:
             return dict()
@@ -681,7 +682,7 @@ class AttrParser(BaseParser):
         # Parse stride list
         self._parse_token(MLIRTokenKind.LESS, "Expected `<` after `strided`")
         strides = self.parse_comma_separated_list(
-            self.Delimiter.SQUARE,
+            Delimiter.SQUARE,
             lambda: self._parse_int_or_question(" in stride list"),
             " in stride list",
         )
@@ -867,7 +868,7 @@ class AttrParser(BaseParser):
 
     def _parse_builtin_opaque_attr(self):
         str_lit_list = self.parse_comma_separated_list(
-            self.Delimiter.ANGLE, self.parse_str_literal
+            Delimiter.ANGLE, self.parse_str_literal
         )
 
         if len(str_lit_list) != 2:
@@ -961,13 +962,13 @@ class AttrParser(BaseParser):
 
         if isinstance(element_type, IntegerType):
             values = self.parse_comma_separated_list(
-                self.Delimiter.NONE,
+                Delimiter.NONE,
                 lambda: self._parse_typed_integer(element_type, allow_boolean=True),
             )
             res = DenseArrayBase.create_dense_int(element_type, values)
         else:
             values = self.parse_comma_separated_list(
-                self.Delimiter.NONE,
+                Delimiter.NONE,
                 lambda: self.parse_float(),
             )
             res = DenseArrayBase.create_dense_float(element_type, values)
@@ -1174,7 +1175,7 @@ class AttrParser(BaseParser):
         the data, and [2, 3] for the shape.
         """
         res = self.parse_optional_comma_separated_list(
-            self.Delimiter.SQUARE, self._parse_tensor_literal
+            Delimiter.SQUARE, self._parse_tensor_literal
         )
         if res is not None:
             if len(res) == 0:
@@ -1358,7 +1359,7 @@ class AttrParser(BaseParser):
             array-attr ::= `[` (attribute (`,` attribute)*)? `]`
         """
         attrs = self.parse_optional_comma_separated_list(
-            self.Delimiter.SQUARE, self.parse_attribute
+            Delimiter.SQUARE, self.parse_attribute
         )
         if attrs is None:
             return None
@@ -1385,13 +1386,13 @@ class AttrParser(BaseParser):
             return None
 
         # Parse the arguments
-        args = self.parse_comma_separated_list(self.Delimiter.PAREN, self.parse_type)
+        args = self.parse_comma_separated_list(Delimiter.PAREN, self.parse_type)
 
         self.parse_punctuation("->")
 
         # Parse the returns
         returns = self.parse_optional_comma_separated_list(
-            self.Delimiter.PAREN, self.parse_type
+            Delimiter.PAREN, self.parse_type
         )
         if returns is None:
             returns = [self.parse_type()]
@@ -1401,7 +1402,7 @@ class AttrParser(BaseParser):
         self, skip_white_space: bool = True
     ) -> list[Attribute]:
         res = self.parse_optional_comma_separated_list(
-            self.Delimiter.ANGLE, self.parse_attribute
+            Delimiter.ANGLE, self.parse_attribute
         )
         if res is None:
             return []

--- a/xdsl/parser/core.py
+++ b/xdsl/parser/core.py
@@ -18,6 +18,7 @@ from xdsl.ir import (
     SSAValue,
 )
 from xdsl.irdl import IRDLOperation
+from xdsl.utils.delimiter import Delimiter
 from xdsl.utils.exceptions import MultipleSpansParseError
 from xdsl.utils.lexer import Input, Span
 from xdsl.utils.mlir_lexer import MLIRLexer, MLIRTokenKind
@@ -210,7 +211,7 @@ class Parser(AttrParser):
             block_arg = block.insert_arg(arg_type, len(block.args))
             self._register_ssa_definition(arg_name.text[1:], (block_arg,), arg_name)
 
-        self.parse_comma_separated_list(self.Delimiter.PAREN, parse_argument)
+        self.parse_comma_separated_list(Delimiter.PAREN, parse_argument)
         return block
 
     def _parse_block_body(self, block: Block):
@@ -611,7 +612,7 @@ class Parser(AttrParser):
         """
         if self._current_token.kind == MLIRTokenKind.L_PAREN:
             return self.parse_comma_separated_list(
-                self.Delimiter.PAREN, self.parse_region, " in operation region list"
+                Delimiter.PAREN, self.parse_region, " in operation region list"
             )
         return []
 
@@ -779,7 +780,7 @@ class Parser(AttrParser):
         """
         if self._current_token.kind == MLIRTokenKind.PERCENT_IDENT:
             res = self.parse_comma_separated_list(
-                self.Delimiter.NONE, self._parse_op_result, " in operation result list"
+                Delimiter.NONE, self._parse_op_result, " in operation result list"
             )
             self.parse_punctuation("=", " after operation result list")
             return res
@@ -798,7 +799,7 @@ class Parser(AttrParser):
             return dict()
 
         entries = self.parse_comma_separated_list(
-            self.Delimiter.BRACES, self._parse_attribute_entry
+            Delimiter.BRACES, self._parse_attribute_entry
         )
         self.parse_punctuation(">")
 
@@ -934,7 +935,7 @@ class Parser(AttrParser):
             successor      ::= caret-id
         """
         return self.parse_comma_separated_list(
-            self.Delimiter.SQUARE,
+            Delimiter.SQUARE,
             lambda: self.expect(self.parse_successor, "block-id expected"),
         )
 
@@ -945,7 +946,7 @@ class Parser(AttrParser):
            value-use-list ::= `%` suffix-id (`,` `%` suffix-id)*
         """
         return self.parse_comma_separated_list(
-            self.Delimiter.PAREN,
+            Delimiter.PAREN,
             self.parse_unresolved_operand,
             " in operation argument list",
         )
@@ -979,12 +980,12 @@ class Parser(AttrParser):
             )
 
         self.parse_comma_separated_list(
-            self.Delimiter.BRACES, lambda: self._parse_resource(dialect.name, interface)
+            Delimiter.BRACES, lambda: self._parse_resource(dialect.name, interface)
         )
 
     def _parse_dialect_resources(self) -> None:
         self.parse_comma_separated_list(
-            self.Delimiter.BRACES, self._parse_single_dialect_resources
+            Delimiter.BRACES, self._parse_single_dialect_resources
         )
 
     def _parse_external_resources(self) -> None:
@@ -1013,5 +1014,5 @@ class Parser(AttrParser):
         Returns None since results are stored in the context object.
         """
         self.parse_comma_separated_list(
-            self.Delimiter.METADATA_TOKEN, self._parse_metadata_element
+            Delimiter.METADATA_TOKEN, self._parse_metadata_element
         )

--- a/xdsl/parser/generic_parser.py
+++ b/xdsl/parser/generic_parser.py
@@ -6,11 +6,11 @@ that is inherited from the different parsers used in xDSL.
 from collections.abc import Callable, Iterable
 from contextlib import contextmanager
 from dataclasses import dataclass
-from enum import Enum
 from typing import Generic, NoReturn, overload
 
 from typing_extensions import TypeVar
 
+from xdsl.utils.delimiter import Delimiter
 from xdsl.utils.exceptions import ParseError
 from xdsl.utils.lexer import Lexer, Position, Span, Token, TokenKindT
 
@@ -181,18 +181,6 @@ class GenericParser(Generic[TokenKindT]):
             self.raise_error(error_message)
         return res
 
-    class Delimiter(Enum):
-        """
-        Supported delimiters when parsing lists.
-        """
-
-        PAREN = ("(", ")")
-        ANGLE = ("<", ">")
-        SQUARE = ("[", "]")
-        BRACES = ("{", "}")
-        METADATA_TOKEN = ("{-#", "#-}")
-        NONE = None
-
     def parse_comma_separated_list(
         self, delimiter: Delimiter, parse: Callable[[], _AnyInvT], context_msg: str = ""
     ) -> list[_AnyInvT]:
@@ -237,7 +225,7 @@ class GenericParser(Generic[TokenKindT]):
         `parse_optional_undelimited_comma_separated_list` instead.
         """
 
-        if delimiter == self.Delimiter.NONE:
+        if delimiter == Delimiter.NONE:
             raise ValueError(
                 "Cannot use `Delimiter.NONE` with "
                 "`parse_optional_comma_separated_list`. Use "

--- a/xdsl/utils/delimiter.py
+++ b/xdsl/utils/delimiter.py
@@ -1,0 +1,14 @@
+from enum import Enum
+
+
+class Delimiter(Enum):
+    """
+    Supported delimiters for parsing and printing.
+    """
+
+    PAREN = ("(", ")")
+    ANGLE = ("<", ">")
+    SQUARE = ("[", "]")
+    BRACES = ("{", "}")
+    METADATA_TOKEN = ("{-#", "#-}")
+    NONE = None


### PR DESCRIPTION
I wish to use `Delimiter` in the printer in the next PR, and moving this class out of `Parser` creates an insane diff so I thought I'd factor this change out.

`utils` was the first place that came to mind but I'm happy to accept different suggestions.