### PR TITLE
core: (Printer) add delimited

### DIFF
--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -1030,6 +1030,35 @@ def test_get_printed_name():
     assert f"%{picked_name}" == printed.getvalue()
 
 
+def test_delimiters():
+    printer = Printer()
+
+    printer.stream = StringIO()
+    with printer.in_angle_brackets():
+        printer.print_string("testing")
+    assert "<testing>" == printer.stream.getvalue()
+
+    printer.stream = StringIO()
+    with printer.in_square_brackets():
+        printer.print_string("testing")
+    assert "[testing]" == printer.stream.getvalue()
+
+    printer.stream = StringIO()
+    with printer.in_braces():
+        printer.print_string("testing")
+    assert "{testing}" == printer.stream.getvalue()
+
+    printer.stream = StringIO()
+    with printer.in_parens():
+        printer.print_string("testing")
+    assert "(testing)" == printer.stream.getvalue()
+
+    printer.stream = StringIO()
+    with printer.delimited("test<", ">"):
+        printer.print_string("testing")
+    assert "test<testing>" == printer.stream.getvalue()
+
+
 def assert_print_op(
     operation: Operation,
     expected: str,

--- a/xdsl/dialects/stim/stim_printer_parser.py
+++ b/xdsl/dialects/stim/stim_printer_parser.py
@@ -4,7 +4,6 @@ Full documentation can be found here: https://github.com/quantumlib/Stim/blob/ma
 """
 
 import abc
-from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import cast
 
@@ -15,23 +14,12 @@ from xdsl.utils.base_printer import BasePrinter
 
 @dataclass(eq=False, repr=False)
 class StimPrinter(BasePrinter):
-    @contextmanager
-    def in_braces(self):
-        self.print_string("{")
-        yield
-        self.print_string("}")
-
-    @contextmanager
-    def in_parens(self):
-        self.print_string("(")
-        yield
-        self.print_string(") ")
-
     def print_attribute(self, attribute: Attribute) -> None:
         if isinstance(attribute, ArrayAttr):
             attribute = cast(ArrayAttr[Attribute], attribute)
             with self.in_parens():
                 self.print_list(attribute, self.print_attribute)
+            self.print_string(" ")
             return
         if isinstance(attribute, FloatData):
             self.print_string(f"{attribute.data}")

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import json
 import math
 from collections.abc import Callable, Iterable, Mapping, Sequence
-from contextlib import contextmanager
 from dataclasses import dataclass, field
 from itertools import chain
 from typing import Any, cast
@@ -118,14 +117,6 @@ class Printer(BasePrinter):
     @property
     def block_names(self):
         return self._block_names[-1]
-
-    @contextmanager
-    def in_angle_brackets(self):
-        self.print_string("<")
-        try:
-            yield
-        finally:
-            self.print_string(">")
 
     def print(self, *argv: Any) -> None:
         for arg in argv:

--- a/xdsl/utils/base_printer.py
+++ b/xdsl/utils/base_printer.py
@@ -68,6 +68,26 @@ class BasePrinter:
                 self.print_string(delimiter)
             print_fn(elem)
 
+    @contextmanager
+    def delimited(self, start: str, end: str):
+        self.print_string(start)
+        try:
+            yield
+        finally:
+            self.print_string(end)
+
+    def in_angle_brackets(self):
+        return self.delimited("<", ">")
+
+    def in_braces(self):
+        return self.delimited("{", "}")
+
+    def in_parens(self):
+        return self.delimited("(", ")")
+
+    def in_square_brackets(self):
+        return self.delimited("[", "]")
+
     def _print_new_line(
         self, indent: int | None = None, print_message: bool = True
     ) -> None:


### PR DESCRIPTION
It's always annoyed me that there is `in_angle_brackets` but not the other corresponding helpers. I started trying to remedy this and created a huge diff by moving `Delimiter`, so have stacked this on #4546 

I think this will help with moving various `print` constructions to `print_string`.