### PR TITLE
dialects: (builtin) move printing to BuiltinAttribute

### DIFF
--- a/tests/irdl/test_attribute_definition.py
+++ b/tests/irdl/test_attribute_definition.py
@@ -642,7 +642,7 @@ def test_informative_constraint():
     constr = MessageConstraint(NoneAttr(), "User-enlightening message.")
     with pytest.raises(
         VerifyException,
-        match="User-enlightening message.\nUnderlying verification failure: Expected attribute #none but got #builtin.int<1>",
+        match="User-enlightening message.\nUnderlying verification failure: Expected attribute none but got #builtin.int<1>",
     ):
         constr.verify(IntAttr(1), ConstraintContext())
     assert constr.can_infer(set())

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -140,12 +140,21 @@ class Attribute(ABC):
 class BuiltinAttribute(Attribute, ABC):
     """
     This class is used to mark builtin attributes.
-    Unlike other attributes in MLIR, printing and parsing of *Builtin*
-    attributes is handled directly by the parser.
+    Unlike other attributes in MLIR, parsing of *Builtin* attributes
+    is handled directly by the parser.
+    Printing of these attributes is handled by the `print_builtin` function, which must
+    be implemented by all *Builtin* attributes.
     Attributes outside of the `builtin` dialect should not inherit from `BuiltinAttribute`.
     """
 
-    pass
+    @abstractmethod
+    def print_builtin(self, printer: Printer) -> None:
+        """
+        Prints the attribute using the supplied printer.
+        `BuiltinAttribute`s need not follow the same rules as other attributes, for example
+        they do not need to be prefixed by `!` or `#` and do not need to print their name.
+        """
+        ...
 
 
 class TypeAttribute(Attribute):


### PR DESCRIPTION
As discussed on zulip, moves all the special casing in `Printer.print_attribute` to `BuilitinAttribute` and uses polymorphism instead. I've called the function `print_builtin` for now.

I feel this has uncovered some uncertainty in what the roles of `print_builtin`, `print_parameters`, and `parse_parameters` are for builtin attributes, but I don't think this PR adds any more confusion.