### PR TITLE
dialects: (func) Allow non-flat SymbolRefAttr in func.call

### DIFF
--- a/xdsl/dialects/func.py
+++ b/xdsl/dialects/func.py
@@ -5,7 +5,6 @@ from collections.abc import Sequence
 from xdsl.dialects.builtin import (
     ArrayAttr,
     DictionaryAttr,
-    FlatSymbolRefAttrConstr,
     FunctionType,
     StringAttr,
     SymbolRefAttr,
@@ -318,7 +317,7 @@ class FuncOp(IRDLOperation):
 class CallOp(IRDLOperation):
     name = "func.call"
     arguments = var_operand_def()
-    callee = prop_def(FlatSymbolRefAttrConstr)
+    callee = prop_def(SymbolRefAttr)
     res = var_result_def()
 
     traits = traits_def(


### PR DESCRIPTION
RFC

I would like `func.call` to loosen its verification tests to allow non-flat SymbolRefAttr in their callees. I found this code in xDSL:

```python
    nested.sym_name = StringAttr("nested")
    _call_op = func.CallOp(
        SymbolRefAttr("nested", ("nested_func",)),
        (),
        (i32,),
    )
```

But the verification is stricter and would cause this code to raise a verification error. 

One test needs to be changed, but I thought it would be good to get feedback from you before working on this.
