### PR TITLE
misc: (Printer) remove print uses, 'easy cases'

### DIFF
--- a/xdsl/dialects/accfg.py
+++ b/xdsl/dialects/accfg.py
@@ -70,7 +70,7 @@ class EffectsAttr(Data[EffectsEnum]):
 
     def print_parameter(self, printer: Printer) -> None:
         with printer.in_angle_brackets():
-            printer.print(self.data.value)
+            printer.print_string(self.data.value)
 
 
 @irdl_attr_definition
@@ -280,7 +280,7 @@ class SetupOp(IRDLOperation):
             )
 
     def print(self, printer: Printer):
-        printer.print(" ")
+        printer.print_string(" ")
         printer.print_string_literal(self.accelerator.data)
 
         if self.in_state:
@@ -301,9 +301,9 @@ class SetupOp(IRDLOperation):
         printer.print_string(") ")
 
         if self.attributes:
-            printer.print("attrs ")
+            printer.print_string("attrs ")
             printer.print_attr_dict(self.attributes)
-            printer.print(" ")
+            printer.print_string(" ")
 
         printer.print_string(": ")
         printer.print_attribute(self.out_state.type)

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -883,14 +883,14 @@ class CmpiOp(ComparisonOperation):
         return cls(operand1, operand2, arg)
 
     def print(self, printer: Printer):
-        printer.print(" ")
+        printer.print_string(" ")
 
         printer.print_string(CMPI_COMPARISON_OPERATIONS[self.predicate.value.data])
-        printer.print(", ")
+        printer.print_string(", ")
         printer.print_operand(self.lhs)
-        printer.print(", ")
+        printer.print_string(", ")
         printer.print_operand(self.rhs)
-        printer.print(" : ")
+        printer.print_string(" : ")
         printer.print_attribute(self.lhs.type)
 
 
@@ -991,16 +991,16 @@ class CmpfOp(ComparisonOperation):
         return cls(operand1, operand2, arg, fastmath)
 
     def print(self, printer: Printer):
-        printer.print(" ")
+        printer.print_string(" ")
         printer.print_string(CMPF_COMPARISON_OPERATIONS[self.predicate.value.data])
-        printer.print(", ")
+        printer.print_string(", ")
         printer.print_operand(self.lhs)
-        printer.print(", ")
+        printer.print_string(", ")
         printer.print_operand(self.rhs)
         if self.fastmath != FastMathFlagsAttr("none"):
             printer.print_string(" fastmath")
             self.fastmath.print_parameter(printer)
-        printer.print(" : ")
+        printer.print_string(" : ")
         printer.print_attribute(self.lhs.type)
 
 

--- a/xdsl/dialects/func.py
+++ b/xdsl/dialects/func.py
@@ -189,7 +189,8 @@ class FuncOp(IRDLOperation):
     def print(self, printer: Printer):
         if self.sym_visibility:
             visibility = self.sym_visibility.data
-            printer.print(f" {visibility}")
+            printer.print_string(" ")
+            printer.print_string(visibility)
 
         print_func_op_like(
             printer,

--- a/xdsl/dialects/irdl/irdl.py
+++ b/xdsl/dialects/irdl/irdl.py
@@ -273,11 +273,10 @@ class ParametersOp(IRDLOperation):
         )
 
     def print(self, printer: Printer) -> None:
-        printer.print("(")
-        printer.print_list(
-            zip(self.names, self.args), lambda x: _print_argument(printer, x)
-        )
-        printer.print(")")
+        with printer.in_parens():
+            printer.print_list(
+                zip(self.names, self.args), lambda x: _print_argument(printer, x)
+            )
 
 
 @irdl_op_definition
@@ -349,8 +348,8 @@ def _print_argument_with_var(
     variadicity = data[1].data
     if variadicity != VariadicityEnum.SINGLE:
         printer.print_string(str(variadicity))
-        printer.print(" ")
-    printer.print(data[2])
+        printer.print_string(" ")
+    printer.print_ssa_value(data[2])
 
 
 @irdl_op_definition
@@ -391,13 +390,12 @@ class OperandsOp(IRDLOperation):
         )
 
     def print(self, printer: Printer) -> None:
-        printer.print("(")
-        printer.print_list(
-            zip(self.names, self.variadicity.value, self.args),
-            lambda x: _print_argument_with_var(printer, x),
-            ", ",
-        )
-        printer.print(")")
+        with printer.in_parens():
+            printer.print_list(
+                zip(self.names, self.variadicity.value, self.args),
+                lambda x: _print_argument_with_var(printer, x),
+                ", ",
+            )
 
 
 @irdl_op_definition
@@ -438,13 +436,12 @@ class ResultsOp(IRDLOperation):
         )
 
     def print(self, printer: Printer) -> None:
-        printer.print("(")
-        printer.print_list(
-            zip(self.names, self.variadicity.value, self.args),
-            lambda x: _print_argument_with_var(printer, x),
-            ", ",
-        )
-        printer.print(")")
+        with printer.in_parens():
+            printer.print_list(
+                zip(self.names, self.variadicity.value, self.args),
+                lambda x: _print_argument_with_var(printer, x),
+                ", ",
+            )
 
 
 def _parse_attribute(parser: Parser) -> tuple[str, SSAValue]:
@@ -457,7 +454,7 @@ def _parse_attribute(parser: Parser) -> tuple[str, SSAValue]:
 
 def _print_attribute(printer: Printer, item: tuple[StringAttr, SSAValue]):
     printer.print_attribute(item[0])
-    printer.print(" = ")
+    printer.print_string(" = ")
     printer.print_operand(item[1])
 
 
@@ -542,11 +539,10 @@ class RegionsOp(IRDLOperation):
         )
 
     def print(self, printer: Printer) -> None:
-        printer.print("(")
-        printer.print_list(
-            zip(self.names, self.args), lambda x: _print_argument(printer, x)
-        )
-        printer.print(")")
+        with printer.in_parens():
+            printer.print_list(
+                zip(self.names, self.args), lambda x: _print_argument(printer, x)
+            )
 
 
 ################################################################################
@@ -574,7 +570,7 @@ class IsOp(IRDLOperation):
         return IsOp(expected)
 
     def print(self, printer: Printer) -> None:
-        printer.print(" ")
+        printer.print_string(" ")
         printer.print_attribute(self.expected)
 
 
@@ -617,10 +613,10 @@ class BaseOp(IRDLOperation):
 
     def print(self, printer: Printer) -> None:
         if self.base_ref is not None:
-            printer.print(" ")
+            printer.print_string(" ")
             printer.print_attribute(self.base_ref)
         elif self.base_name is not None:
-            printer.print(" ")
+            printer.print_string(" ")
             printer.print_attribute(self.base_name)
         printer.print_op_attributes(self.attributes)
 
@@ -661,11 +657,10 @@ class ParametricOp(IRDLOperation):
         return ParametricOp(base_type, args)
 
     def print(self, printer: Printer) -> None:
-        printer.print(" ")
+        printer.print_string(" ")
         printer.print_attribute(self.base_type)
-        printer.print("<")
-        printer.print_list(self.args, printer.print, ", ")
-        printer.print(">")
+        with printer.in_angle_brackets():
+            printer.print_list(self.args, printer.print_ssa_value)
 
 
 @irdl_op_definition
@@ -746,9 +741,8 @@ class AnyOfOp(IRDLOperation):
         return AnyOfOp(args)
 
     def print(self, printer: Printer) -> None:
-        printer.print("(")
-        printer.print_list(self.args, printer.print, ", ")
-        printer.print(")")
+        with printer.in_parens():
+            printer.print_list(self.args, printer.print_ssa_value)
 
 
 @irdl_op_definition
@@ -771,9 +765,8 @@ class AllOfOp(IRDLOperation):
         return AllOfOp(args)
 
     def print(self, printer: Printer) -> None:
-        printer.print("(")
-        printer.print_list(self.args, printer.print, ", ")
-        printer.print(")")
+        with printer.in_parens():
+            printer.print_list(self.args, printer.print)
 
 
 IRDL = Dialect(

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -563,7 +563,7 @@ class ExpandShapeOp(AlterShapeOperation):
         printer.print_list(t, lambda x: printer.print_string(str(x)))
         printer.print_string("]")
         if self.attributes:
-            printer.print(" ")
+            printer.print_string(" ")
             printer.print_attr_dict(self.attributes)
         printer.print_string(" : ")
         printer.print_attribute(self.src.type)

--- a/xdsl/dialects/pdl.py
+++ b/xdsl/dialects/pdl.py
@@ -202,11 +202,10 @@ class ApplyNativeConstraintOp(IRDLOperation):
         return ApplyNativeConstraintOp(name, operands)
 
     def print(self, printer: Printer) -> None:
-        printer.print(" ")
+        printer.print_string(" ")
         printer.print_string_literal(self.constraint_name.data)
-        printer.print("(")
-        print_operands_with_types(printer, self.operands)
-        printer.print(")")
+        with printer.in_parens():
+            print_operands_with_types(printer, self.operands)
 
 
 @irdl_op_definition
@@ -248,13 +247,12 @@ class ApplyNativeRewriteOp(IRDLOperation):
         return ApplyNativeRewriteOp(name, operands, result_types)
 
     def print(self, printer: Printer) -> None:
-        printer.print(" ")
+        printer.print_string(" ")
         printer.print_string_literal(self.constraint_name.data)
-        printer.print("(")
-        print_operands_with_types(printer, self.operands)
-        printer.print(")")
+        with printer.in_parens():
+            print_operands_with_types(printer, self.operands)
         if len(self.results) != 0:
-            printer.print(" : ")
+            printer.print_string(" : ")
             printer.print_list(self.result_types, printer.print)
 
 
@@ -451,9 +449,9 @@ class OperationOp(IRDLOperation):
             printer.print_attribute(self.opName)
 
         if len(self.operand_values) != 0:
-            printer.print(" (")
-            print_operands_with_types(printer, self.operand_values)
-            printer.print(")")
+            printer.print_string(" ")
+            with printer.in_parens():
+                print_operands_with_types(printer, self.operand_values)
 
         def print_attribute_entry(entry: tuple[StringAttr, SSAValue]):
             printer.print_attribute(entry[0])
@@ -461,17 +459,17 @@ class OperationOp(IRDLOperation):
             printer.print_ssa_value(entry[1])
 
         if len(self.attributeValueNames) != 0:
-            printer.print(" {")
-            printer.print_list(
-                zip(self.attributeValueNames, self.attribute_values),
-                print_attribute_entry,
-            )
-            printer.print("}")
+            printer.print_string(" ")
+            with printer.in_braces():
+                printer.print_list(
+                    zip(self.attributeValueNames, self.attribute_values),
+                    print_attribute_entry,
+                )
 
         if len(self.type_values) != 0:
-            printer.print(" -> (")
-            print_operands_with_types(printer, self.type_values)
-            printer.print(")")
+            printer.print_string(" -> ")
+            with printer.in_parens():
+                print_operands_with_types(printer, self.type_values)
 
 
 def _visit_pdl_ops(op: Operation, visited: set[Operation]):

--- a/xdsl/dialects/riscv_func.py
+++ b/xdsl/dialects/riscv_func.py
@@ -209,7 +209,8 @@ class FuncOp(IRDLOperation, AssemblyPrintable):
     def print(self, printer: Printer):
         if self.sym_visibility:
             visibility = self.sym_visibility.data
-            printer.print(f" {visibility}")
+            printer.print_string(" ")
+            printer.print_string(visibility)
 
         print_func_op_like(
             printer,

--- a/xdsl/dialects/utils/format.py
+++ b/xdsl/dialects/utils/format.py
@@ -194,21 +194,21 @@ def print_func_op_like(
 ):
     printer.print(f" @{sym_name.data}")
     if body.blocks:
-        printer.print("(")
-        if arg_attrs is not None:
-            printer.print_list(
-                zip(body.blocks[0].args, arg_attrs),
-                lambda arg_with_attrs: print_func_argument(
-                    printer, arg_with_attrs[0], arg_with_attrs[1]
-                ),
-            )
-        else:
-            printer.print_list(body.blocks[0].args, printer.print_block_argument)
-        printer.print(")")
+        with printer.in_parens():
+            if arg_attrs is not None:
+                printer.print_list(
+                    zip(body.blocks[0].args, arg_attrs),
+                    lambda arg_with_attrs: print_func_argument(
+                        printer, arg_with_attrs[0], arg_with_attrs[1]
+                    ),
+                )
+            else:
+                printer.print_list(body.blocks[0].args, printer.print_block_argument)
+
         if function_type.outputs:
-            printer.print(" -> ")
+            printer.print_string(" -> ")
             if len(function_type.outputs) > 1 or res_attrs is not None:
-                printer.print("(")
+                printer.print_string("(")
             if res_attrs is not None:
                 printer.print_list(
                     zip(function_type.outputs, res_attrs),
@@ -219,7 +219,7 @@ def print_func_op_like(
             else:
                 printer.print_list(function_type.outputs, printer.print_attribute)
             if len(function_type.outputs) > 1 or res_attrs is not None:
-                printer.print(")")
+                printer.print_string(")")
     else:
         printer.print_attribute(function_type)
     printer.print_op_attributes(


### PR DESCRIPTION
Removes a bunch of uses of `Printer.print`. This isn't complete but I thought doing this in batches would help the reviewing process.

Only non trivial thing I've done here is use some `printer.in_parens()` when possible.