### PR TITLE
dialects: (riscv) remove uses of Printer.print

### DIFF
--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -409,7 +409,7 @@ class RISCVCustomFormatOperation(IRDLOperation, ABC):
 
     def print(self, printer: Printer) -> None:
         if self.operands:
-            printer.print(" ")
+            printer.print_string(" ")
             printer.print_list(self.operands, printer.print_operand)
         printed_attributes = self.custom_print_attributes(printer)
         unprinted_attributes = {
@@ -429,7 +429,7 @@ class RISCVCustomFormatOperation(IRDLOperation, ABC):
         return self.attributes.keys()
 
     def print_op_type(self, printer: Printer) -> None:
-        printer.print(" : ")
+        printer.print_string(" : ")
         printer.print_operation_type(self)
 
 
@@ -638,7 +638,7 @@ class RdRsRsFloatOperationWithFastMath(
 
     def custom_print_attributes(self, printer: Printer) -> AbstractSet[str]:
         if self.fastmath is not None and self.fastmath != FastMathFlagsAttr("none"):
-            printer.print(" fastmath")
+            printer.print_string(" fastmath")
             self.fastmath.print_parameter(printer)
         return {"fastmath"}
 
@@ -684,7 +684,7 @@ class RdImmIntegerOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC):
         return attributes
 
     def custom_print_attributes(self, printer: Printer) -> AbstractSet[str]:
-        printer.print(" ")
+        printer.print_string(" ")
         print_immediate_value(printer, self.immediate)
         return {"immediate"}
 
@@ -737,10 +737,10 @@ class RdImmJumpOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC):
         return attributes
 
     def custom_print_attributes(self, printer: Printer) -> AbstractSet[str]:
-        printer.print(" ")
+        printer.print_string(" ")
         print_immediate_value(printer, self.immediate)
         if self.rd is not None:
-            printer.print(", ")
+            printer.print_string(", ")
             printer.print_attribute(self.rd)
         return {"immediate", "rd"}
 
@@ -800,7 +800,7 @@ class RdRsImmIntegerOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC)
         return attributes
 
     def custom_print_attributes(self, printer: Printer) -> AbstractSet[str]:
-        printer.print(", ")
+        printer.print_string(", ")
         print_immediate_value(printer, self.immediate)
         return {"immediate"}
 
@@ -857,7 +857,7 @@ class RdRsImmShiftOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC):
         return attributes
 
     def custom_print_attributes(self, printer: Printer) -> AbstractSet[str]:
-        printer.print(", ")
+        printer.print_string(", ")
         print_immediate_value(printer, self.immediate)
         return {"immediate"}
 
@@ -920,10 +920,10 @@ class RdRsImmJumpOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC):
         return attributes
 
     def custom_print_attributes(self, printer: Printer) -> AbstractSet[str]:
-        printer.print(", ")
+        printer.print_string(", ")
         print_immediate_value(printer, self.immediate)
         if self.rd is not None:
-            printer.print(", ")
+            printer.print_string(", ")
             printer.print_attribute(self.rd)
         return {"immediate", "rd"}
 
@@ -1029,7 +1029,7 @@ class RsRsOffIntegerOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC)
         return attributes
 
     def custom_print_attributes(self, printer: Printer) -> AbstractSet[str]:
-        printer.print(", ")
+        printer.print_string(", ")
         print_immediate_value(printer, self.offset)
         return {"offset"}
 
@@ -1079,7 +1079,7 @@ class RsRsImmIntegerOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC)
         return attributes
 
     def custom_print_attributes(self, printer: Printer) -> AbstractSet[str]:
-        printer.print(", ")
+        printer.print_string(", ")
         print_immediate_value(printer, self.immediate)
         return {"immediate"}
 
@@ -1211,10 +1211,10 @@ class CsrReadWriteOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC):
         return attributes
 
     def custom_print_attributes(self, printer: Printer) -> AbstractSet[str]:
-        printer.print(", ")
-        printer.print(self.csr.value.data)
+        printer.print_string(", ")
+        printer.print_string(str(self.csr.value.data))
         if self.writeonly is not None:
-            printer.print(', "w"')
+            printer.print_string(', "w"')
         return {"csr", "writeonly"}
 
 
@@ -1284,10 +1284,10 @@ class CsrBitwiseOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC):
         return attributes
 
     def custom_print_attributes(self, printer: Printer) -> AbstractSet[str]:
-        printer.print(", ")
-        printer.print(self.csr.value.data)
+        printer.print_string(", ")
+        printer.print_string(str(self.csr.value.data))
         if self.readonly is not None:
-            printer.print(', "r"')
+            printer.print_string(', "r"')
         return {"csr", "readonly"}
 
 
@@ -1356,12 +1356,12 @@ class CsrReadWriteImmOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC
         return attributes
 
     def custom_print_attributes(self, printer: Printer) -> AbstractSet[str]:
-        printer.print(" ")
-        printer.print(self.csr.value.data)
-        printer.print(", ")
+        printer.print_string(" ")
+        printer.print_string(str(self.csr.value.data))
+        printer.print_string(", ")
         print_immediate_value(printer, self.immediate)
         if self.writeonly is not None:
-            printer.print(', "w"')
+            printer.print_string(', "w"')
         return {"csr", "immediate", "writeonly"}
 
 
@@ -1416,9 +1416,9 @@ class CsrBitwiseImmOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC):
         return attributes
 
     def custom_print_attributes(self, printer: Printer) -> AbstractSet[str]:
-        printer.print(" ")
-        printer.print(self.csr.value.data)
-        printer.print(", ")
+        printer.print_string(" ")
+        printer.print_string(str(self.csr.value.data))
+        printer.print_string(", ")
         print_immediate_value(printer, self.immediate)
         return {"csr", "immediate"}
 
@@ -3393,7 +3393,7 @@ class LiOp(RISCVCustomFormatOperation, RISCVInstruction, ABC):
         return attributes
 
     def custom_print_attributes(self, printer: Printer) -> AbstractSet[str]:
-        printer.print(" ")
+        printer.print_string(" ")
         print_immediate_value(printer, self.immediate)
         return {"immediate", "fastmath"}
 
@@ -3406,7 +3406,7 @@ class LiOp(RISCVCustomFormatOperation, RISCVInstruction, ABC):
         return (), (res_type,)
 
     def print_op_type(self, printer: Printer) -> None:
-        printer.print(" : ")
+        printer.print_string(" : ")
         printer.print_attribute(self.rd.type)
 
 
@@ -3466,7 +3466,7 @@ class LabelOp(RISCVCustomFormatOperation, RISCVAsmOperation):
         return attributes
 
     def custom_print_attributes(self, printer: Printer) -> AbstractSet[str]:
-        printer.print(" ")
+        printer.print_string(" ")
         printer.print_string_literal(self.label.data)
         return {"label"}
 
@@ -3532,10 +3532,10 @@ class DirectiveOp(RISCVCustomFormatOperation, RISCVAsmOperation):
         return attributes
 
     def custom_print_attributes(self, printer: Printer) -> AbstractSet[str]:
-        printer.print(" ")
+        printer.print_string(" ")
         printer.print_string_literal(self.directive.data)
         if self.value is not None:
-            printer.print(" ")
+            printer.print_string(" ")
             printer.print_string_literal(self.value.data)
         return {"directive", "value"}
 
@@ -3785,7 +3785,7 @@ class GetAnyRegisterOperation(
         return (), (res_type,)
 
     def print_op_type(self, printer: Printer) -> None:
-        printer.print(" : ")
+        printer.print_string(" : ")
         printer.print_attribute(self.res.type)
 
 
@@ -3892,7 +3892,7 @@ class RdRsRsFloatFloatIntegerOperationWithFastMath(
 
     def custom_print_attributes(self, printer: Printer) -> AbstractSet[str]:
         if self.fastmath != FastMathFlagsAttr("none"):
-            printer.print(" fastmath")
+            printer.print_string(" fastmath")
             self.fastmath.print_parameter(printer)
         return {"fastmath"}
 
@@ -3940,7 +3940,7 @@ class RsRsImmFloatOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC):
         return attributes
 
     def custom_print_attributes(self, printer: Printer) -> AbstractSet[str]:
-        printer.print(", ")
+        printer.print_string(", ")
         print_immediate_value(printer, self.immediate)
         return {"immediate"}
 
@@ -3990,7 +3990,7 @@ class RdRsImmFloatOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC):
         return attributes
 
     def custom_print_attributes(self, printer: Printer) -> AbstractSet[str]:
-        printer.print(", ")
+        printer.print_string(", ")
         print_immediate_value(printer, self.immediate)
         return {"immediate"}
 
@@ -4778,7 +4778,7 @@ def parse_immediate_value(
 def print_immediate_value(printer: Printer, immediate: IntegerAttr | LabelAttr):
     match immediate:
         case IntegerAttr():
-            printer.print(immediate.value.data)
+            printer.print_string(str(immediate.value.data))
         case LabelAttr():
             printer.print_string_literal(immediate.data)
 


### PR DESCRIPTION
This is all the cases for riscv. 

I'm unhappy with the `printer.print_string(str(an_integer))` and in these cases where we have an IntegerAttr we can actually do:
```
integer_attr.print_without_type(printer)
```
but I think this would print `true` and `false` in `i1` cases which may not be what you always want? In any case what is here preserves the current behaviour, but I just wanted to point out that I'm uneasy about printing integers.