### PR TITLE
core: Tighten typing of IRDLGenericAttrConstraint

### DIFF
--- a/xdsl/irdl/attributes.py
+++ b/xdsl/irdl/attributes.py
@@ -280,7 +280,7 @@ def irdl_attr_definition(cls: TypeAttributeInvT) -> TypeAttributeInvT:
 
 IRDLGenericAttrConstraint: TypeAlias = (
     GenericAttrConstraint[AttributeInvT]
-    | Attribute
+    | AttributeInvT
     | type[AttributeInvT]
     | "TypeForm[AttributeInvT]"
     | ConstraintVar


### PR DESCRIPTION
This means that, for example, `i64` is now an `IRDLGenericAttrConstraint[IntegerType]` instead of an `IRDLGenericAttrConstraint[Attribute]`.

I believe this was just an oversight in the original definition and hadn't been a problem yet.