### PR TITLE
misc: remove TypeVar from list of allowed values in IRDLGenericAttrConstraint

### DIFF
--- a/xdsl/dialects/x86/ops.py
+++ b/xdsl/dialects/x86/ops.py
@@ -1150,7 +1150,7 @@ class S_PushOp(X86Instruction, X86CustomFormatOperation):
 
     rsp_in = operand_def(RSP)
     rsp_out = result_def(RSP)
-    source = operand_def(R1InvT)
+    source = operand_def(X86RegisterType)
 
     def __init__(
         self,
@@ -1187,7 +1187,7 @@ class D_PopOp(X86Instruction, X86CustomFormatOperation):
 
     rsp_in = operand_def(RSP)
     rsp_out = result_def(RSP)
-    destination = result_def(R1InvT)
+    destination = result_def(X86RegisterType)
 
     def __init__(
         self,
@@ -1279,7 +1279,7 @@ class S_IDivOp(X86Instruction, X86CustomFormatOperation):
 
     name = "x86.s.idiv"
 
-    source = operand_def(R1InvT)
+    source = operand_def(X86RegisterType)
     rdx_input = operand_def(RDX)
     rax_input = operand_def(RAX)
 
@@ -1743,7 +1743,7 @@ class M_PushOp(X86Instruction, X86CustomFormatOperation):
     rsp_in = operand_def(RSP)
     rsp_out = result_def(RSP)
 
-    memory = operand_def(R1InvT)
+    memory = operand_def(X86RegisterType)
     memory_offset = attr_def(IntegerAttr, default_value=IntegerAttr(0, 64))
 
     def __init__(
@@ -1907,7 +1907,7 @@ class M_IDivOp(X86Instruction, X86CustomFormatOperation):
 
     name = "x86.m.idiv"
 
-    memory = operand_def(R1InvT)
+    memory = operand_def(X86RegisterType)
     memory_offset = attr_def(IntegerAttr, default_value=IntegerAttr(0, 64))
     rdx_in = operand_def(RDX)
     rdx_out = result_def(RDX)
@@ -2225,8 +2225,8 @@ class SS_CmpOp(X86Instruction, X86CustomFormatOperation):
 
     name = "x86.ss.cmp"
 
-    source1 = operand_def(R1InvT)
-    source2 = operand_def(R2InvT)
+    source1 = operand_def(X86RegisterType)
+    source2 = operand_def(X86RegisterType)
 
     result = result_def(RFLAGSRegisterType)
 

--- a/xdsl/irdl/attributes.py
+++ b/xdsl/irdl/attributes.py
@@ -284,7 +284,6 @@ IRDLGenericAttrConstraint: TypeAlias = (
     | type[AttributeInvT]
     | "TypeForm[AttributeInvT]"
     | ConstraintVar
-    | TypeVar
 )
 """
 Attribute constraints represented using the IRDL python frontend. Attribute constraints
@@ -353,7 +352,7 @@ def irdl_to_attr_constraint(
 
 @overload
 def irdl_to_attr_constraint(
-    irdl: Attribute | TypeVar | ConstraintVar,
+    irdl: Attribute | ConstraintVar,
     *,
     allow_type_var: bool = False,
     type_var_mapping: dict[TypeVar, AttrConstraint] | None = None,


### PR DESCRIPTION
With TypeForm, we already handle the case where the TypeVar is a type, it turns out that there were a bunch of uses of this in a context where the TypeVar used was not a generic parameter of the operation, which feels like a bug to me.