### PR TITLE
dialects: (builtin) undeprecate DenseIntOrFPElementsAttr.from_list

### DIFF
--- a/tests/dialects/test_builtin.py
+++ b/tests/dialects/test_builtin.py
@@ -379,20 +379,6 @@ def test_DenseIntOrFPElementsAttr_fp_type_conversion():
     assert isinstance(value2, float)
     assert value2 == 5.0
 
-    t1 = FloatAttr(4.0, f32)
-    t2 = FloatAttr(5.0, f32)
-
-    check2 = DenseIntOrFPElementsAttr.create_dense_float(TensorType(f32, [2]), [t1, t2])
-
-    value3 = check2.get_attrs()[0].value.data
-    value4 = check2.get_attrs()[1].value.data
-
-    # Ensure type conversion happened properly during attribute construction.
-    assert isinstance(value3, float)
-    assert value3 == 4.0
-    assert isinstance(value4, float)
-    assert value4 == 5.0
-
 
 def test_DenseIntOrFPElementsAttr_splat():
     attr_int = DenseIntOrFPElementsAttr.create_dense_int(TensorType(i64, [3]), 4)

--- a/xdsl/transforms/csl_stencil_set_global_coeffs.py
+++ b/xdsl/transforms/csl_stencil_set_global_coeffs.py
@@ -5,7 +5,6 @@ from xdsl.dialects import arith, memref, stencil
 from xdsl.dialects.builtin import (
     DenseIntOrFPElementsAttr,
     Float32Type,
-    FloatAttr,
     IntegerAttr,
     ModuleOp,
 )
@@ -69,13 +68,13 @@ def get_coeff_api_ops(op: csl_stencil.ApplyOp, wrapper: csl_wrapper.ModuleOp):
     neighbours = pattern - 1
     is_wse2 = wrapper.target.data == "wse2"
     if is_wse2:
-        empty: list[FloatAttr] = [FloatAttr(f, elem_t) for f in [0] + neighbours * [1]]
+        empty = [0] + neighbours * [1.0]
         shape = (pattern,)
     else:
-        empty: list[FloatAttr] = [FloatAttr(f, elem_t) for f in neighbours * [1]]
+        empty = neighbours * [1.0]
         shape = (pattern - 1,)
 
-    cmap: dict[csl.Direction, list[FloatAttr]] = {
+    cmap: dict[csl.Direction, list[float]] = {
         csl.Direction.NORTH: empty,
         csl.Direction.SOUTH: empty.copy(),
         csl.Direction.EAST: empty.copy(),
@@ -86,7 +85,7 @@ def get_coeff_api_ops(op: csl_stencil.ApplyOp, wrapper: csl_wrapper.ModuleOp):
         direction, distance = get_dir_and_distance(c.offset)
         if not is_wse2:
             distance -= 1
-        cmap[direction][distance] = c.coeff
+        cmap[direction][distance] = c.coeff.value.data
 
     memref_t = memref.MemRefType(elem_t, shape)
     ptr_t = csl.PtrType.get(memref_t, is_single=True, is_const=True)


### PR DESCRIPTION
Trying to mimic the interface for `DenseArrayBase` proposed by @superlopuh . Everything seems to work straight away except:
- There was one case where FloatAttrs were actually used in csl
- I can't quite seem to get the typing for ComplexTypes right. It currently accepts a `ComplexType[AnyFloat] | ComplexType[IntegerType]` instead of `ComplexType`. I can fix this by adding another overload to ComplexType.pack, but this overload doesn't seem sound to me.

If we want to go ahead with this then my suggestion is that we leave deprecation of create_dense_* to a second PR.

cc @erick-xanadu for complex stuff.