### PR TITLE
misc: remove ConstraintVar from list of allowed values in IRDLGenericAttrConstraint

### DIFF
--- a/xdsl/dialects/x86/ops.py
+++ b/xdsl/dialects/x86/ops.py
@@ -1150,7 +1150,7 @@ class S_PushOp(X86Instruction, X86CustomFormatOperation):
 
     rsp_in = operand_def(RSP)
     rsp_out = result_def(RSP)
-    source = operand_def(R1InvT)
+    source = operand_def(X86RegisterType)
 
     def __init__(
         self,
@@ -1187,7 +1187,7 @@ class D_PopOp(X86Instruction, X86CustomFormatOperation):
 
     rsp_in = operand_def(RSP)
     rsp_out = result_def(RSP)
-    destination = result_def(R1InvT)
+    destination = result_def(X86RegisterType)
 
     def __init__(
         self,
@@ -1279,7 +1279,7 @@ class S_IDivOp(X86Instruction, X86CustomFormatOperation):
 
     name = "x86.s.idiv"
 
-    source = operand_def(R1InvT)
+    source = operand_def(X86RegisterType)
     rdx_input = operand_def(RDX)
     rax_input = operand_def(RAX)
 
@@ -1743,7 +1743,7 @@ class M_PushOp(X86Instruction, X86CustomFormatOperation):
     rsp_in = operand_def(RSP)
     rsp_out = result_def(RSP)
 
-    memory = operand_def(R1InvT)
+    memory = operand_def(X86RegisterType)
     memory_offset = attr_def(IntegerAttr, default_value=IntegerAttr(0, 64))
 
     def __init__(
@@ -1907,7 +1907,7 @@ class M_IDivOp(X86Instruction, X86CustomFormatOperation):
 
     name = "x86.m.idiv"
 
-    memory = operand_def(R1InvT)
+    memory = operand_def(X86RegisterType)
     memory_offset = attr_def(IntegerAttr, default_value=IntegerAttr(0, 64))
     rdx_in = operand_def(RDX)
     rdx_out = result_def(RDX)
@@ -2225,8 +2225,8 @@ class SS_CmpOp(X86Instruction, X86CustomFormatOperation):
 
     name = "x86.ss.cmp"
 
-    source1 = operand_def(R1InvT)
-    source2 = operand_def(R2InvT)
+    source1 = operand_def(X86RegisterType)
+    source2 = operand_def(X86RegisterType)
 
     result = result_def(RFLAGSRegisterType)
 

--- a/xdsl/irdl/attributes.py
+++ b/xdsl/irdl/attributes.py
@@ -284,7 +284,6 @@ IRDLGenericAttrConstraint: TypeAlias = (
     | type[AttributeInvT]
     | "TypeForm[AttributeInvT]"
     | ConstraintVar
-    | TypeVar
 )
 """
 Attribute constraints represented using the IRDL python frontend. Attribute constraints
@@ -353,7 +352,7 @@ def irdl_to_attr_constraint(
 
 @overload
 def irdl_to_attr_constraint(
-    irdl: Attribute | TypeVar | ConstraintVar,
+    irdl: Attribute | ConstraintVar,
     *,
     allow_type_var: bool = False,
     type_var_mapping: dict[TypeVar, AttrConstraint] | None = None,

--- a/xdsl/irdl/attributes.py
+++ b/xdsl/irdl/attributes.py
@@ -21,7 +21,6 @@ from typing import (
     get_args,
     get_origin,
     get_type_hints,
-    overload,
 )
 
 from typing_extensions import TypeVar
@@ -283,7 +282,6 @@ IRDLGenericAttrConstraint: TypeAlias = (
     | AttributeInvT
     | type[AttributeInvT]
     | "TypeForm[AttributeInvT]"
-    | ConstraintVar
 )
 """
 Attribute constraints represented using the IRDL python frontend. Attribute constraints
@@ -292,7 +290,6 @@ can either be:
 - An instance of `Attribute` representing an equality constraint on an attribute.
 - A type representing a specific attribute class.
 - A TypeForm that can represent both unions and generic attributes.
-- A `ConstraintVar` representing a constraint variable.
 """
 
 IRDLAttrConstraint = IRDLGenericAttrConstraint[Attribute]
@@ -336,55 +333,35 @@ def irdl_list_to_attr_constraint(
     return constraints[0]
 
 
-@overload
 def irdl_to_attr_constraint(
-    irdl: (
-        GenericAttrConstraint[AttributeInvT]
-        | "TypeForm[AttributeInvT]"
-        | type[AttributeInvT]
-        | AttributeInvT
-    ),
+    irdl: IRDLGenericAttrConstraint[AttributeInvT],
     *,
     allow_type_var: bool = False,
     type_var_mapping: dict[TypeVar, AttrConstraint] | None = None,
-) -> GenericAttrConstraint[AttributeInvT]: ...
-
-
-@overload
-def irdl_to_attr_constraint(
-    irdl: Attribute | ConstraintVar,
-    *,
-    allow_type_var: bool = False,
-    type_var_mapping: dict[TypeVar, AttrConstraint] | None = None,
-) -> AttrConstraint: ...
-
-
-def irdl_to_attr_constraint(
-    irdl: IRDLAttrConstraint,
-    *,
-    allow_type_var: bool = False,
-    type_var_mapping: dict[TypeVar, AttrConstraint] | None = None,
-) -> AttrConstraint:
+) -> GenericAttrConstraint[AttributeInvT]:
     if isinstance(irdl, GenericAttrConstraint):
-        return cast(AttrConstraint, irdl)
+        return cast(GenericAttrConstraint[AttributeInvT], irdl)
 
     if isinstance(irdl, Attribute):
-        return EqAttrConstraint(irdl)
+        return cast(GenericAttrConstraint[AttributeInvT], EqAttrConstraint(irdl))
 
     # Annotated case
     # Each argument of the Annotated type corresponds to a constraint to satisfy.
     # If there is a `ConstraintVar` annotation, we add the entire constraint to
     # the constraint variable.
     if get_origin(irdl) == Annotated:
-        return irdl_list_to_attr_constraint(
-            get_args(irdl),
-            allow_type_var=allow_type_var,
+        return cast(
+            GenericAttrConstraint[AttributeInvT],
+            irdl_list_to_attr_constraint(
+                get_args(irdl),
+                allow_type_var=allow_type_var,
+            ),
         )
 
     # Attribute class case
     # This is an `AnyAttr`, which does not constrain the attribute.
     if irdl is Attribute:
-        return AnyAttr()
+        return cast(GenericAttrConstraint[AttributeInvT], AnyAttr())
 
     # Attribute class case
     # This is a coercion for an `BaseAttr`.
@@ -393,7 +370,7 @@ def irdl_to_attr_constraint(
         and not isinstance(irdl, GenericAlias)
         and issubclass(irdl, Attribute)
     ):
-        return BaseAttr(irdl)
+        return cast(GenericAttrConstraint[AttributeInvT], BaseAttr(irdl))
 
     # Type variable case
     # We take the type variable bound constraint.
@@ -404,7 +381,9 @@ def irdl_to_attr_constraint(
             raise ValueError("Type variables used in IRDL are expected to be bound.")
         # We do not allow nested type variables.
         constraint = irdl_to_attr_constraint(irdl.__bound__)
-        return TypeVarConstraint(irdl, constraint)
+        return cast(
+            GenericAttrConstraint[AttributeInvT], TypeVarConstraint(irdl, constraint)
+        )
 
     origin = get_origin(irdl)
 
@@ -415,7 +394,10 @@ def irdl_to_attr_constraint(
             raise Exception(f"GenericData args must have length 1, got {args}")
         origin = cast(type[GenericData[Any]], origin)
         args = cast(tuple[Attribute], args)
-        return AllOf((BaseAttr(origin), origin.generic_constraint_coercion(args)))
+        return cast(
+            GenericAttrConstraint[AttributeInvT],
+            AllOf((BaseAttr(origin), origin.generic_constraint_coercion(args))),
+        )
 
     # Generic ParametrizedAttributes case
     # We translate it to constraints over the attribute parameters.
@@ -449,7 +431,10 @@ def irdl_to_attr_constraint(
             )
             for _, param in origin_parameters
         ]
-        return ParamAttrConstraint(origin, origin_constraints)
+        return cast(
+            GenericAttrConstraint[AttributeInvT],
+            ParamAttrConstraint(origin, origin_constraints),
+        )
 
     # Union case
     # This is a coercion for an `AnyOf` constraint.
@@ -467,8 +452,8 @@ def irdl_to_attr_constraint(
                 )
             )
         if len(constraints) > 1:
-            return AnyOf(constraints)
-        return constraints[0]
+            return cast(GenericAttrConstraint[AttributeInvT], AnyOf(constraints))
+        return cast(GenericAttrConstraint[AttributeInvT], constraints[0])
 
     # Better error messages for missing GenericData in Data definitions
     if isclass(origin) and issubclass(origin, Data):


### PR DESCRIPTION
Note that this wasn't used anywhere, and as far as I can tell was always broken. ConstraintVars are used as one of the list of annotations, and are handled by `irdl_list_to_attr_constraint`, there's no need to pass them to `irdl_to_attr_constraint`.