### PR TITLE
core: Ensure parent OpTraits is not modified

### DIFF
--- a/tests/test_traits.py
+++ b/tests/test_traits.py
@@ -1001,3 +1001,29 @@ def test_modify_traits():
 
     with pytest.raises(VerifyException, match="Nope"):
         op.verify()
+
+
+def test_modify_parent_traits():
+    """
+    Test that adding traits do not modify parent traits when they are inherited.
+    """
+
+    class ParentOp(IRDLOperation, ABC):
+        name = "test.parent"
+
+        traits = traits_def(LargerOperandTrait())
+
+    @irdl_op_definition
+    class ModifiedOp(ParentOp):
+        name = "test.modified"
+
+    @irdl_op_definition
+    class NotModifiedOp(ParentOp):
+        name = "test.not_modified"
+
+    ModifiedOp.traits.add_trait(BitwidthSumLessThanTrait(64))
+
+    assert ModifiedOp.has_trait(LargerOperandTrait)
+    assert ModifiedOp.has_trait(BitwidthSumLessThanTrait(64))
+    assert NotModifiedOp.has_trait(LargerOperandTrait)
+    assert not NotModifiedOp.has_trait(BitwidthSumLessThanTrait(64))

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -795,6 +795,10 @@ class OpTraits(Iterable[OpTrait]):
     ) -> None:
         self._traits = traits
 
+    def copy(self) -> OpTraits:
+        """Returns a copy of this instance."""
+        return OpTraits(self._traits)
+
     @property
     def traits(self) -> frozenset[OpTrait]:
         """Returns a copy of this instance's traits."""

--- a/xdsl/irdl/operations.py
+++ b/xdsl/irdl/operations.py
@@ -2045,6 +2045,11 @@ def irdl_op_definition(cls: type[IRDLOperationInvT]) -> type[IRDLOperationInvT]:
         f"class {cls.__name__} should be a subclass of IRDLOperation"
     )
 
+    # This is required as traits are mutable, and thus we do not want to mutate
+    # the parent traits.
+    if (traits := getattr(cls, "traits", None)) is not None:
+        cls.traits = traits.copy()
+
     op_def = OpDef.from_pyrdl(cls)
     new_attrs = get_accessors_from_op_def(op_def, getattr(cls, "verify_", None))
 


### PR DESCRIPTION
Copy OpTraits when declaring a new operation.
This will ensure that modifying the traits of an operation will not modify the parent
traits of an operation.