### PR TITLE
dependencies: update dependency to LLVM 20.1.7

### DIFF
--- a/.github/workflows/ci-mlir.yml
+++ b/.github/workflows/ci-mlir.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     # https://github.com/xdslproject/llvm-docker/pkgs/container/llvm
-    container: ghcr.io/xdslproject/llvm:20.1.1
+    container: ghcr.io/xdslproject/llvm:20.1.7
     strategy:
       matrix:
         python-version: ['3.10', '3.11', '3.12']

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ pip install xdsl
 
 *Note:* This version of xDSL is validated against a specific MLIR version,
 interoperability with other versions may result in problems. The supported
-MLIR version is 20.1.1.
+MLIR version is 20.1.7.
 
 ### Subprojects With Extra Dependencies
 

--- a/docs/guides/mlir_interoperation.md
+++ b/docs/guides/mlir_interoperation.md
@@ -24,4 +24,4 @@ mlir-opt --convert-scf-to-cf --convert-cf-to-llvm --convert-func-to-llvm \
 
 The generated `tmp.ll` file contains LLVM IR, so it can be directly passed to
 the clang compiler. Notice that a `main` function is required for clang to
-build. The functionality is tested with the MLIR distributed with LLVM 20.1.1.
+build. The functionality is tested with the MLIR distributed with LLVM 20.1.7.


### PR DESCRIPTION
This also updates the docker image ƒrom a 10GB one to a 2GB one, so should make our MLIR CI time much faster.