### PR TITLE
Add python 3.13 to mlir ci

### DIFF
--- a/.github/workflows/ci-mlir.yml
+++ b/.github/workflows/ci-mlir.yml
@@ -18,7 +18,7 @@ jobs:
     container: ghcr.io/xdslproject/llvm:20.1.1
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
 
     env:
       LLVM_SYMBOLIZER_PATH: /usr/lib/llvm-11/bin/llvm-symbolizer


### PR DESCRIPTION
Seems to me this was just missed at some point?