### PR TITLE
core: (Printer) remove print_float_attr

### DIFF
--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -875,7 +875,7 @@ def test_float_attr():
 
         io_attr = StringIO()
         printer.stream = io_attr
-        printer.print_float_attr(FloatAttr(value, type))
+        FloatAttr(value, type).print_without_type(printer)
 
         assert io_float.getvalue() == io_attr.getvalue()
 

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -1085,7 +1085,7 @@ class FloatAttr(Generic[_FloatAttrType], BuiltinAttribute, TypedAttribute):
         return FloatAttr(parser.parse_float(), type)
 
     def print_without_type(self, printer: Printer):
-        return printer.print_float_attr(self)
+        return printer.print_float(self.value.data, self.type)
 
     def print_builtin(self, printer: Printer):
         self.print_without_type(printer)

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -18,7 +18,6 @@ from xdsl.dialects.builtin import (
     Float16Type,
     Float32Type,
     Float64Type,
-    FloatAttr,
     FunctionType,
     IntegerType,
     UnitAttr,
@@ -306,9 +305,6 @@ class Printer(BasePrinter):
                 case _:
                     self.print_string(chr(byte))
         self.print_string('"')
-
-    def print_float_attr(self, attribute: FloatAttr):
-        self.print_float(attribute.value.data, attribute.type)
 
     def print_complex_float(
         self, value: tuple[float, float], type: ComplexType[ComplexElementCovT]


### PR DESCRIPTION
Series of PRs to try to improve standardisation of `print_int` and `print_float`

This helper seems be used in one place, and it seems we don't want to add the corresponding `print_int_attr` helper, so this PR inlines it.