### PR TITLE
dialects: (builtin) simplify and fix array printing

### DIFF
--- a/tests/filecheck/dialects/builtin/attrs.mlir
+++ b/tests/filecheck/dialects/builtin/attrs.mlir
@@ -17,7 +17,7 @@
     %x6 = "arith.constant"() {"value" = 0 : i64, "test" = false} : () -> i64
     // CHECK:  test = array<i32: 2, 3, 4>
     %x7 = "arith.constant"() {"value" = 0 : i64, "test" = array<i32: 2, 3, 4>} : () -> i64
-    // CHECK:  test = array<f32: 2.0999999046325684, 3.200000047683716, 4.300000190734863>
+    // CHECK:  test = array<f32: 2.100000e+00, 3.200000e+00, 4.300000e+00>
     %x8 = "arith.constant"() {"value" = 0 : i64, "test" = array<f32: 2.1, 3.2, 4.3>} : () -> i64
     // CHECK:  test = #builtin.signedness<signless>
     %x9 = "arith.constant"() {"value" = 0 : i64, "test" = #builtin.signedness<signless>} : () -> i64

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -761,7 +761,7 @@ def test_densearray_attr():
     """Test that a DenseArrayAttr can be parsed and then printed."""
 
     prog = """
-"func.func"() <{sym_name = "test", function_type = i64, sym_visibility = "private", unit_attr}> {bool_attrs = array<i1: false, true>, int_attr = array<i32: 19, 23, 55>, float_attr = array<f32: 0.3400000035762787>} : () -> ()
+"func.func"() <{sym_name = "test", function_type = i64, sym_visibility = "private", unit_attr}> {bool_attrs = array<i1: false, true>, int_attr = array<i32: 19, 23, 55>, float_attr = array<f32: 3.400000e-01>} : () -> ()
     """
 
     ctx = Context()

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -1588,15 +1588,13 @@ class DenseArrayBase(
                 return
             data = self.iter_values()
             printer.print_string(": ")
-            # There is a bug in MLIR which will segfault when parsing DenseArrayBase type i1 as 0 or 1,
-            # therefore we need to print these as false and true
-            if self.elt_type == i1:
+            elt_type: IntegerType | AnyFloat = self.elt_type
+            if isinstance(elt_type, IntegerType):
                 printer.print_list(
-                    data,
-                    lambda x: printer.print_string("true" if x else "false"),
+                    data, lambda x: printer.print_int(cast(int, x), elt_type)
                 )
             else:
-                printer.print_list(data, lambda x: printer.print_string(str(x)))
+                printer.print_list(data, lambda x: printer.print_float(x, elt_type))
 
     def verify(self):
         data_len = len(self.data.data)


### PR DESCRIPTION
Removes the old `str` based printing and uses the new helpers instead. My understanding is that this is the "correct" way to print floats.