### PR TITLE
dialects: (builtin) tighten `get_{int/float}_values` typing

### DIFF
--- a/xdsl/backend/riscv/lowering/convert_memref_to_riscv.py
+++ b/xdsl/backend/riscv/lowering/convert_memref_to_riscv.py
@@ -274,13 +274,19 @@ class ConvertMemRefGlobalOp(RewritePattern):
                     raise DiagnosticException(
                         f"Unsupported memref element type for riscv lowering: {element_type}"
                     )
-                ints = initial_value.get_int_values()
+                ints = cast(
+                    DenseIntOrFPElementsAttr[IntegerType], initial_value
+                ).get_int_values()
                 ptr = TypedPtr.new_int32(ints).raw
             case Float32Type():
-                floats = initial_value.get_float_values()
+                floats = cast(
+                    DenseIntOrFPElementsAttr[Float32Type], initial_value
+                ).get_float_values()
                 ptr = TypedPtr.new_float32(floats).raw
             case Float64Type():
-                floats = initial_value.get_float_values()
+                floats = cast(
+                    DenseIntOrFPElementsAttr[Float64Type], initial_value
+                ).get_float_values()
                 ptr = TypedPtr.new_float64(floats).raw
             case _:
                 raise DiagnosticException(

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -2592,33 +2592,32 @@ class DenseIntOrFPElementsAttr(
         """
         return self.get_element_type().iter_unpack(self.data.data)
 
-    def get_int_values(self) -> Sequence[int]:
+    def get_int_values(
+        self: DenseIntOrFPElementsAttr[IntegerType | IndexType],
+    ) -> Sequence[int]:
         """
         Return all the values of the elements in this DenseIntOrFPElementsAttr,
         checking that the elements are integers.
         """
         el_type = self.get_element_type()
-        assert isinstance(el_type, IntegerType | IndexType), el_type
         return el_type.unpack(self.data.data, len(self))
 
-    def get_float_values(self) -> Sequence[float]:
+    def get_float_values(self: DenseIntOrFPElementsAttr[AnyFloat]) -> Sequence[float]:
         """
         Return all the values of the elements in this DenseIntOrFPElementsAttr,
         checking that the elements are floats.
         """
         el_type = self.get_element_type()
-        assert isinstance(el_type, AnyFloat), el_type
         return el_type.unpack(self.data.data, len(self))
 
     def get_complex_values(
-        self,
+        self: DenseIntOrFPElementsAttr[ComplexType],
     ) -> Sequence[tuple[int, int]] | Sequence[tuple[float, float]]:
         """
         Return all the values of the elements in this DenseIntOrFPElementsAttr,
         checking that the elements are complex.
         """
         el_type = self.get_element_type()
-        assert isinstance(el_type, ComplexType), el_type
         return el_type.unpack(self.data.data, len(self))
 
     def get_values(


### PR DESCRIPTION
Removes some asserts and strictens the typing on these functions.