### PR TITLE
misc: (Printer) remove uses of `str` while printing

### DIFF
--- a/tests/irdl/test_attribute_definition.py
+++ b/tests/irdl/test_attribute_definition.py
@@ -152,9 +152,8 @@ class IntListData(Data[tuple[int, ...]]):
 
     def print_parameter(self, printer: Printer) -> None:
         with printer.in_angle_brackets():
-            printer.print_string("[")
-            printer.print_list(self.data, lambda x: printer.print_string(str(x)))
-            printer.print_string("]")
+            with printer.in_square_brackets():
+                printer.print_list(self.data, printer.print_int)
 
 
 def test_non_class_data():

--- a/tests/test_pyrdl.py
+++ b/tests/test_pyrdl.py
@@ -51,7 +51,7 @@ class IntData(Data[int]):
 
     def print_parameter(self, printer: Printer):
         with printer.in_angle_brackets():
-            printer.print_string(str(self.data))
+            printer.print_int(self.data)
 
 
 @irdl_attr_definition

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -597,7 +597,7 @@ class IntegerType(
             printer.print_string("si")
         elif self.signedness.data == Signedness.UNSIGNED:
             printer.print_string("ui")
-        printer.print_string(str(self.width.data))
+        printer.print_int(self.width.data)
 
     def __repr__(self):
         width = self.width.data

--- a/xdsl/dialects/csl/csl_stencil.py
+++ b/xdsl/dialects/csl/csl_stencil.py
@@ -494,7 +494,7 @@ class AccessOp(IRDLOperation):
             index = 0
             for i in range(len(self.offset)):
                 if i in mapping:
-                    printer.print_string(str(offset[index]))
+                    printer.print_int(offset[index])
                     index += 1
                 else:
                     printer.print_string("_")

--- a/xdsl/dialects/experimental/dmp.py
+++ b/xdsl/dialects/experimental/dmp.py
@@ -184,13 +184,19 @@ class ExchangeDeclarationAttr(ParametrizedAttribute):
         )
 
     def print_parameters(self, printer: Printer) -> None:
-        printer.print_string("<at [")
-        printer.print_list(self.offset, lambda x: printer.print_string(str(x)))
-        printer.print_string("] size [")
-        printer.print_list(self.size, lambda x: printer.print_string(str(x)))
-        printer.print_string("] source offset [")
-        printer.print_list(self.source_offset, lambda x: printer.print_string(str(x)))
-        printer.print_string(f"] to {list(self.neighbor)}>")
+        with printer.in_angle_brackets():
+            printer.print_string("at ")
+            with printer.in_square_brackets():
+                printer.print_list(self.offset, printer.print_int)
+            printer.print_string(" size ")
+            with printer.in_square_brackets():
+                printer.print_list(self.size, printer.print_int)
+            printer.print_string(" source offset ")
+            with printer.in_square_brackets():
+                printer.print_list(self.source_offset, printer.print_int)
+            printer.print_string(" to ")
+            with printer.in_square_brackets():
+                printer.print_list(self.neighbor, printer.print_int)
 
     @classmethod
     def parse_parameters(cls, parser: AttrParser) -> list[Attribute]:

--- a/xdsl/dialects/hw.py
+++ b/xdsl/dialects/hw.py
@@ -323,7 +323,7 @@ class InnerSymPropertiesAttr(ParametrizedAttribute):
         printer.print_string("<@")
         printer.print_string(self.sym_name.data)
         printer.print_string(",")
-        printer.print_string(str(self.field_id.data))
+        printer.print_int(self.field_id.data)
         printer.print_string(",")
         printer.print_string(self.sym_visibility.data)
         printer.print_string(">")

--- a/xdsl/dialects/irdl/irdl.py
+++ b/xdsl/dialects/irdl/irdl.py
@@ -355,7 +355,7 @@ def _print_argument_with_var(
     printer.print_string(": ")
     variadicity = data[1].data
     if variadicity != VariadicityEnum.SINGLE:
-        printer.print_string(str(variadicity))
+        printer.print_string(variadicity)
         printer.print_string(" ")
     printer.print_ssa_value(data[2])
 

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -203,11 +203,10 @@ class LLVMArrayType(ParametrizedAttribute, TypeAttribute):
     type: ParameterDef[Attribute]
 
     def print_parameters(self, printer: Printer) -> None:
-        printer.print_string("<")
-        printer.print_string(str(self.size.data))
-        printer.print_string(" x ")
-        printer.print_attribute(self.type)
-        printer.print_string(">")
+        with printer.in_angle_brackets():
+            printer.print_int(self.size.data)
+            printer.print_string(" x ")
+            printer.print_attribute(self.type)
 
     @classmethod
     def parse_parameters(cls, parser: AttrParser) -> list[Attribute]:

--- a/xdsl/dialects/pdl_interp.py
+++ b/xdsl/dialects/pdl_interp.py
@@ -299,7 +299,7 @@ class GetResultsOp(IRDLOperation):
     def print(self, printer: Printer):
         if self.index is not None:
             printer.print_string(" ", indent=0)
-            printer.print_string(str(self.index.value.data), indent=0)
+            self.index.print_without_type(printer)
         printer.print_string(" of ", indent=0)
         printer.print_operand(self.input_op)
         printer.print_string(" : ", indent=0)

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -1212,7 +1212,7 @@ class CsrReadWriteOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC):
 
     def custom_print_attributes(self, printer: Printer) -> AbstractSet[str]:
         printer.print_string(", ")
-        printer.print_string(str(self.csr.value.data))
+        self.csr.print_without_type(printer)
         if self.writeonly is not None:
             printer.print_string(', "w"')
         return {"csr", "writeonly"}
@@ -1285,7 +1285,7 @@ class CsrBitwiseOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC):
 
     def custom_print_attributes(self, printer: Printer) -> AbstractSet[str]:
         printer.print_string(", ")
-        printer.print_string(str(self.csr.value.data))
+        self.csr.print_without_type(printer)
         if self.readonly is not None:
             printer.print_string(', "r"')
         return {"csr", "readonly"}
@@ -1357,7 +1357,7 @@ class CsrReadWriteImmOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC
 
     def custom_print_attributes(self, printer: Printer) -> AbstractSet[str]:
         printer.print_string(" ")
-        printer.print_string(str(self.csr.value.data))
+        self.csr.print_without_type(printer)
         printer.print_string(", ")
         print_immediate_value(printer, self.immediate)
         if self.writeonly is not None:
@@ -1417,7 +1417,7 @@ class CsrBitwiseImmOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC):
 
     def custom_print_attributes(self, printer: Printer) -> AbstractSet[str]:
         printer.print_string(" ")
-        printer.print_string(str(self.csr.value.data))
+        self.csr.print_without_type(printer)
         printer.print_string(", ")
         print_immediate_value(printer, self.immediate)
         return {"csr", "immediate"}
@@ -4778,7 +4778,7 @@ def parse_immediate_value(
 def print_immediate_value(printer: Printer, immediate: IntegerAttr | LabelAttr):
     match immediate:
         case IntegerAttr():
-            printer.print_string(str(immediate.value.data))
+            immediate.print_without_type(printer)
         case LabelAttr():
             printer.print_string_literal(immediate.data)
 

--- a/xdsl/dialects/stencil.py
+++ b/xdsl/dialects/stencil.py
@@ -1054,7 +1054,7 @@ class AccessOp(IRDLOperation):
             index = 0
             for i in range(apply.get_rank()):
                 if i in mapping:
-                    printer.print_string(str(offset[index]))
+                    printer.print_int(offset[index])
                     index += 1
                 else:
                     printer.print_string("_")


### PR DESCRIPTION
I'm considering `printer.print_string(str(...))` to basically be an antipattern now that `printer.print_int` exists. The only two cases left are for printing `BoolAttr` (which seems to exist only in tests?)