### PR TITLE
misc: resolve licence mismatch in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "xdsl"
 description = "xDSL"
 readme = "README.md"
 requires-python = ">=3.10"
-license = { text = "MIT License" }
+license = { text = "Apache License v2.0 with LLVM Exceptions" }
 authors = [{ name = "Mathieu Fehr", email = "mathieu.fehr@ed.ac.uk" }]
 classifiers = ["Programming Language :: Python :: 3"]
 dependencies = [


### PR DESCRIPTION
The `LICENSE` file is "Apache License v2.0 with LLVM Exceptions", but the `pyproject.toml` licence text is MIT. This PR updates `pyproject.toml` to have the correct licence.