### PR TITLE
misc: remove some duplicate declarations

### DIFF
--- a/xdsl/dialects/irdl/pyrdl_to_irdl.py
+++ b/xdsl/dialects/irdl/pyrdl_to_irdl.py
@@ -58,45 +58,45 @@ def op_def_to_irdl(op: type[IRDLOperation]) -> OperationOp:
 
     # Operands
     operand_values: list[SSAValue] = []
-    variadicities: list[VariadicityAttr] = []
-    names: list[StringAttr] = []
+    operand_variadicities: list[VariadicityAttr] = []
+    operand_names: list[StringAttr] = []
     for operand in op_def.operands:
         operand_values.append(range_to_irdl(builder, operand[1].constr))
         if isinstance(operand[1], OptionalDef):
-            variadicities.append(VariadicityAttr.OPTIONAL)
+            operand_variadicities.append(VariadicityAttr.OPTIONAL)
         elif isinstance(operand[1], VariadicDef):
-            variadicities.append(VariadicityAttr.VARIADIC)
+            operand_variadicities.append(VariadicityAttr.VARIADIC)
         else:
-            variadicities.append(VariadicityAttr.SINGLE)
-        names.append(StringAttr(depython_name(operand[0])))
+            operand_variadicities.append(VariadicityAttr.SINGLE)
+        operand_names.append(StringAttr(depython_name(operand[0])))
     if operand_values:
         builder.insert(
             OperandsOp(
                 operand_values,
-                VariadicityArrayAttr(ArrayAttr(variadicities)),
-                ArrayAttr(names),
+                VariadicityArrayAttr(ArrayAttr(operand_variadicities)),
+                ArrayAttr(operand_names),
             )
         )
 
     # Results
     result_values: list[SSAValue] = []
-    variadicities: list[VariadicityAttr] = []
-    names: list[StringAttr] = []
+    result_variadicities: list[VariadicityAttr] = []
+    result_names: list[StringAttr] = []
     for result in op_def.results:
         result_values.append(range_to_irdl(builder, result[1].constr))
         if isinstance(result[1], OptionalDef):
-            variadicities.append(VariadicityAttr.OPTIONAL)
+            result_variadicities.append(VariadicityAttr.OPTIONAL)
         elif isinstance(result[1], VariadicDef):
-            variadicities.append(VariadicityAttr.VARIADIC)
+            result_variadicities.append(VariadicityAttr.VARIADIC)
         else:
-            variadicities.append(VariadicityAttr.SINGLE)
-        names.append(StringAttr(depython_name(result[0])))
+            result_variadicities.append(VariadicityAttr.SINGLE)
+        result_names.append(StringAttr(depython_name(result[0])))
     if result_values:
         builder.insert(
             ResultsOp(
                 result_values,
-                VariadicityArrayAttr(ArrayAttr(variadicities)),
-                ArrayAttr(names),
+                VariadicityArrayAttr(ArrayAttr(result_variadicities)),
+                ArrayAttr(result_names),
             )
         )
 

--- a/xdsl/transforms/lower_csl_stencil.py
+++ b/xdsl/transforms/lower_csl_stencil.py
@@ -368,14 +368,15 @@ class FullStencilAccessImmediateReductionOptimization(RewritePattern):
         direction_count = arith.ConstantOp.from_int_and_width(4, 16)
         pattern = wrapper.get_program_param("pattern")
         chunk_size = wrapper.get_program_param("chunk_size")
+        new_ops: list[Operation]
         if wrapper.target.data != "wse2":
             assert isinstance(pattern.type, IntegerType)
             one = arith.ConstantOp.from_int_and_width(1, pattern.type)
             pattern_m_one = arith.SubiOp(pattern, one)
-            new_ops: list[Operation] = [one, pattern_m_one]
+            new_ops = [one, pattern_m_one]
             neighbors = pattern_m_one
         else:
-            new_ops: list[Operation] = []
+            new_ops = []
             neighbors = pattern
         acc_dsd = csl.GetMemDsdOp.build(
             operands=[alloc, [direction_count, neighbors, chunk_size]],


### PR DESCRIPTION
Tiny cleanup PR, Pyright in Zed was complaining about this for some reason, technically each variable can only be declared once in a scope.