### PR TITLE
backend: add RegisterType.allocatable_registers

### DIFF
--- a/xdsl/backend/register_type.py
+++ b/xdsl/backend/register_type.py
@@ -141,6 +141,13 @@ class RegisterType(ParametrizedAttribute, TypeAttribute, ABC):
         raise VerifyException(f"Invalid index {self.index.data} for register {name}.")
 
     @classmethod
+    def allocatable_registers(cls) -> Sequence[Self]:
+        """
+        Registers of this type that can be used for register allocation.
+        """
+        return ()
+
+    @classmethod
     @abstractmethod
     def index_by_name(cls) -> dict[str, int]:
         raise NotImplementedError()

--- a/xdsl/backend/riscv/register_stack.py
+++ b/xdsl/backend/riscv/register_stack.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 
 from xdsl.backend.register_stack import RegisterStack
-from xdsl.dialects.riscv import Registers
+from xdsl.dialects.riscv import FloatRegisterType, IntRegisterType, Registers
 
 
 @dataclass
@@ -20,10 +20,8 @@ class RiscvRegisterStack(RegisterStack):
     }
 
     DEFAULT_AVAILABLE_REGISTERS = (
-        *reversed(Registers.A),
-        *reversed(Registers.T),
-        *reversed(Registers.FA),
-        *reversed(Registers.FT),
+        *reversed(IntRegisterType.allocatable_registers()),
+        *reversed(FloatRegisterType.allocatable_registers()),
     )
 
     @classmethod

--- a/xdsl/backend/x86/register_stack.py
+++ b/xdsl/backend/x86/register_stack.py
@@ -17,7 +17,9 @@ class X86RegisterStack(RegisterStack):
         register.RSP,
     }
 
-    DEFAULT_AVAILABLE_REGISTERS = (*reversed(register.YMM),)
+    DEFAULT_AVAILABLE_REGISTERS = (
+        *reversed(register.AVX2RegisterType.allocatable_registers()),
+    )
 
     def push(self, reg: RegisterType) -> None:
         if (

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -166,6 +166,15 @@ class IntRegisterType(RISCVRegisterType):
     def infinite_register_prefix(cls):
         return "j_"
 
+    # This class variable is created and exclusively accessed in `abi_name_by_index`.
+    # _ALLOCATABLE_REGISTERS: ClassVar[tuple[IntRegisterType, ...]]
+
+    @classmethod
+    def allocatable_registers(cls):
+        if not hasattr(cls, "_ALLOCATABLE_REGISTERS"):
+            cls._ALLOCATABLE_REGISTERS = (*Registers.T, *Registers.A)
+        return cls._ALLOCATABLE_REGISTERS
+
 
 _RV32F_ABI_INDEX_BY_NAME = {
     "ft0": 0,
@@ -224,6 +233,15 @@ class FloatRegisterType(RISCVRegisterType):
     @classmethod
     def infinite_register_prefix(cls):
         return "fj_"
+
+    # This class variable is created and exclusively accessed in `abi_name_by_index`.
+    # _ALLOCATABLE_REGISTERS: ClassVar[tuple[FloatRegisterType, ...]]
+
+    @classmethod
+    def allocatable_registers(cls):
+        if not hasattr(cls, "_ALLOCATABLE_REGISTERS"):
+            cls._ALLOCATABLE_REGISTERS = (*Registers.FT, *Registers.FA)
+        return cls._ALLOCATABLE_REGISTERS
 
 
 RDInvT = TypeVar("RDInvT", bound=RISCVRegisterType)

--- a/xdsl/dialects/x86/register.py
+++ b/xdsl/dialects/x86/register.py
@@ -166,22 +166,25 @@ See external # [documentation](https://wiki.osdev.org/X86-64_Instruction_Encodin
 """
 
 UNALLOCATED_SSE = SSERegisterType.unallocated()
-XMM0 = SSERegisterType.from_name("xmm0")
-XMM1 = SSERegisterType.from_name("xmm1")
-XMM2 = SSERegisterType.from_name("xmm2")
-XMM3 = SSERegisterType.from_name("xmm3")
-XMM4 = SSERegisterType.from_name("xmm4")
-XMM5 = SSERegisterType.from_name("xmm5")
-XMM6 = SSERegisterType.from_name("xmm6")
-XMM7 = SSERegisterType.from_name("xmm7")
-XMM8 = SSERegisterType.from_name("xmm8")
-XMM9 = SSERegisterType.from_name("xmm9")
-XMM10 = SSERegisterType.from_name("xmm10")
-XMM11 = SSERegisterType.from_name("xmm11")
-XMM12 = SSERegisterType.from_name("xmm12")
-XMM13 = SSERegisterType.from_name("xmm13")
-XMM14 = SSERegisterType.from_name("xmm14")
-XMM15 = SSERegisterType.from_name("xmm15")
+XMM = tuple(SSERegisterType.from_name(f"xmm{i}") for i in range(16))
+(
+    XMM0,
+    XMM1,
+    XMM2,
+    XMM3,
+    XMM4,
+    XMM5,
+    XMM6,
+    XMM7,
+    XMM8,
+    XMM9,
+    XMM10,
+    XMM11,
+    XMM12,
+    XMM13,
+    XMM14,
+    XMM15,
+) = XMM
 
 
 @irdl_attr_definition
@@ -199,6 +202,10 @@ class AVX2RegisterType(X86VectorRegisterType):
     @classmethod
     def infinite_register_prefix(cls):
         return "inf_avx2_"
+
+    @classmethod
+    def allocatable_registers(cls):
+        return YMM
 
 
 AVX2_INDEX_BY_NAME = {
@@ -305,35 +312,38 @@ See external # [documentation](https://wiki.osdev.org/X86-64_Instruction_Encodin
 """
 
 UNALLOCATED_AVX512 = AVX512RegisterType.unallocated()
-ZMM0 = AVX512RegisterType.from_name("zmm0")
-ZMM1 = AVX512RegisterType.from_name("zmm1")
-ZMM2 = AVX512RegisterType.from_name("zmm2")
-ZMM3 = AVX512RegisterType.from_name("zmm3")
-ZMM4 = AVX512RegisterType.from_name("zmm4")
-ZMM5 = AVX512RegisterType.from_name("zmm5")
-ZMM6 = AVX512RegisterType.from_name("zmm6")
-ZMM7 = AVX512RegisterType.from_name("zmm7")
-ZMM8 = AVX512RegisterType.from_name("zmm8")
-ZMM9 = AVX512RegisterType.from_name("zmm9")
-ZMM10 = AVX512RegisterType.from_name("zmm10")
-ZMM11 = AVX512RegisterType.from_name("zmm11")
-ZMM12 = AVX512RegisterType.from_name("zmm12")
-ZMM13 = AVX512RegisterType.from_name("zmm13")
-ZMM14 = AVX512RegisterType.from_name("zmm14")
-ZMM15 = AVX512RegisterType.from_name("zmm15")
-ZMM16 = AVX512RegisterType.from_name("zmm16")
-ZMM17 = AVX512RegisterType.from_name("zmm17")
-ZMM18 = AVX512RegisterType.from_name("zmm18")
-ZMM19 = AVX512RegisterType.from_name("zmm19")
-ZMM20 = AVX512RegisterType.from_name("zmm20")
-ZMM21 = AVX512RegisterType.from_name("zmm21")
-ZMM22 = AVX512RegisterType.from_name("zmm22")
-ZMM23 = AVX512RegisterType.from_name("zmm23")
-ZMM24 = AVX512RegisterType.from_name("zmm24")
-ZMM25 = AVX512RegisterType.from_name("zmm25")
-ZMM26 = AVX512RegisterType.from_name("zmm26")
-ZMM27 = AVX512RegisterType.from_name("zmm27")
-ZMM28 = AVX512RegisterType.from_name("zmm28")
-ZMM29 = AVX512RegisterType.from_name("zmm29")
-ZMM30 = AVX512RegisterType.from_name("zmm30")
-ZMM31 = AVX512RegisterType.from_name("zmm31")
+ZMM = tuple(AVX512RegisterType.from_name(f"zmm{i}") for i in range(32))
+(
+    ZMM0,
+    ZMM1,
+    ZMM2,
+    ZMM3,
+    ZMM4,
+    ZMM5,
+    ZMM6,
+    ZMM7,
+    ZMM8,
+    ZMM9,
+    ZMM10,
+    ZMM11,
+    ZMM12,
+    ZMM13,
+    ZMM14,
+    ZMM15,
+    ZMM16,
+    ZMM17,
+    ZMM18,
+    ZMM19,
+    ZMM20,
+    ZMM21,
+    ZMM22,
+    ZMM23,
+    ZMM24,
+    ZMM25,
+    ZMM26,
+    ZMM27,
+    ZMM28,
+    ZMM29,
+    ZMM30,
+    ZMM31,
+) = ZMM


### PR DESCRIPTION
When trying to write the documentation for register allocation, I realised that the logic in our code was slightly backwards. Which registers are available for allocation is more a function of the register itself, meaning whether the register is general-purpose or has a special meaning in the ABI, just like the mapping of the register names which is on the register type already. In upcoming PRs I'll make the shift in how the queue is used more towards this perspective, this PR is just to move a bit of logic to the register type while preserving current behaviour.