### PR TITLE
dialects: (builtin) remove duplicate FlatSymbolRefAttrConstr

### DIFF
--- a/tests/filecheck/dialects/func/func_invalid.mlir
+++ b/tests/filecheck/dialects/func/func_invalid.mlir
@@ -36,7 +36,7 @@ builtin.module {
 
 "func.call"() { "callee" = @call::@invalid } : () -> ()
 
-// CHECK:       Operation does not verify: Unexpected nested symbols in FlatSymbolRefAttr
+// CHECK:       Operation does not verify: Expected SymbolRefAttr with no nested symbols.
 // CHECK-NEXT:  Underlying verification failure: expected empty array, but got ["invalid"]
 
 // -----

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -333,7 +333,7 @@ class EmptyArrayAttrConstraint(AttrConstraint):
 
 FlatSymbolRefAttrConstr = MessageConstraint(
     ParamAttrConstraint(SymbolRefAttr, [AnyAttr(), EmptyArrayAttrConstraint()]),
-    "Unexpected nested symbols in FlatSymbolRefAttr.",
+    "Expected SymbolRefAttr with no nested symbols.",
 )
 """Constrain SymbolRef to be FlatSymbolRef"""
 


### PR DESCRIPTION
This slightly modifies the logic but I expect to an acceptable degree, adding the explanatory message for both nested symbols and things that are not symbols at all.