### PR TITLE
frontend: (pyast) Add support for registering IntegerAttr types

### DIFF
--- a/tests/filecheck/frontend/refactor/builtin.py
+++ b/tests/filecheck/frontend/refactor/builtin.py
@@ -6,7 +6,7 @@ from xdsl.frontend.pyast.context import CodeContext
 from xdsl.frontend.pyast.program import FrontendProgram
 
 p = FrontendProgram()
-p.register_type(IntegerAttr[I64], i64)
+p.register_type(IntegerAttr[I64], i64, annotation_name="IntegerAttr[I64]")
 p.register_function(IntegerAttr.__add__, arith.AddiOp)
 with CodeContext(p):
     # CHECK:      builtin.module {

--- a/tests/filecheck/frontend/refactor/builtin.py
+++ b/tests/filecheck/frontend/refactor/builtin.py
@@ -5,21 +5,35 @@ from xdsl.dialects.builtin import I64, IntegerAttr, i64
 from xdsl.frontend.pyast.context import CodeContext
 from xdsl.frontend.pyast.program import FrontendProgram
 
-p = FrontendProgram()
-p.register_type(IntegerAttr[I64], i64, annotation_name="IntegerAttr[I64]")
-p.register_function(IntegerAttr.__add__, arith.AddiOp)
-with CodeContext(p):
+p1 = FrontendProgram()
+p1.register_type(IntegerAttr[I64], i64, annotation_name="IntegerAttr[I64]")
+with CodeContext(p1):
     # CHECK:      builtin.module {
-    # CHECK-NEXT:   func.func @test_addi_overload(%a : i64, %b : i64) -> i64 {
+    # CHECK-NEXT:   func.func @test_identity(%a : i64) -> i64 {
+    # CHECK-NEXT:     func.return %a : i64
+    # CHECK-NEXT:   }
+    # CHECK-NEXT: }
+    def test_identity(a: IntegerAttr[I64]) -> IntegerAttr[I64]:
+        return a
+
+
+p1.compile(desymref=True)
+print(p1.textual_format())
+
+
+p2 = FrontendProgram()
+p2.register_type(IntegerAttr[I64], i64, annotation_name="IntegerAttr[I64]")
+p2.register_function(IntegerAttr.__add__, arith.AddiOp)
+with CodeContext(p2):
+    # CHECK:      builtin.module {
+    # CHECK-NEXT:   func.func @test_addi(%a : i64, %b : i64) -> i64 {
     # CHECK-NEXT:     %0 = arith.addi %a, %b : i64
     # CHECK-NEXT:     func.return %0 : i64
     # CHECK-NEXT:   }
     # CHECK-NEXT: }
-    def test_addi_overload(
-        a: IntegerAttr[I64], b: IntegerAttr[I64]
-    ) -> IntegerAttr[I64]:
+    def test_addi(a: IntegerAttr[I64], b: IntegerAttr[I64]) -> IntegerAttr[I64]:
         return a + b
 
 
-p.compile(desymref=True)
-print(p.textual_format())
+p2.compile(desymref=True)
+print(p2.textual_format())

--- a/tests/filecheck/frontend/refactor/builtin.py
+++ b/tests/filecheck/frontend/refactor/builtin.py
@@ -6,7 +6,7 @@ from xdsl.frontend.pyast.context import CodeContext
 from xdsl.frontend.pyast.program import FrontendProgram
 
 p1 = FrontendProgram()
-p1.register_type(IntegerAttr[I64], i64, annotation_name="IntegerAttr[I64]")
+p1.register_type(IntegerAttr[I64], i64)
 with CodeContext(p1):
     # CHECK:      builtin.module {
     # CHECK-NEXT:   func.func @test_identity(%a : i64) -> i64 {
@@ -22,7 +22,7 @@ print(p1.textual_format())
 
 
 p2 = FrontendProgram()
-p2.register_type(IntegerAttr[I64], i64, annotation_name="IntegerAttr[I64]")
+p2.register_type(IntegerAttr[I64], i64)
 p2.register_function(IntegerAttr.__add__, arith.AddiOp)
 with CodeContext(p2):
     # CHECK:      builtin.module {

--- a/tests/filecheck/frontend/refactor/builtin.py
+++ b/tests/filecheck/frontend/refactor/builtin.py
@@ -1,6 +1,5 @@
 # RUN: python %s | filecheck %s
 
-from xdsl.dialects import arith
 from xdsl.dialects.builtin import I64, IntegerAttr, i64
 from xdsl.frontend.pyast.context import CodeContext
 from xdsl.frontend.pyast.program import FrontendProgram
@@ -19,21 +18,3 @@ with CodeContext(p1):
 
 p1.compile(desymref=True)
 print(p1.textual_format())
-
-
-p2 = FrontendProgram()
-p2.register_type(IntegerAttr[I64], i64)
-p2.register_function(IntegerAttr.__add__, arith.AddiOp)
-with CodeContext(p2):
-    # CHECK:      builtin.module {
-    # CHECK-NEXT:   func.func @test_addi(%a : i64, %b : i64) -> i64 {
-    # CHECK-NEXT:     %0 = arith.addi %a, %b : i64
-    # CHECK-NEXT:     func.return %0 : i64
-    # CHECK-NEXT:   }
-    # CHECK-NEXT: }
-    def test_addi(a: IntegerAttr[I64], b: IntegerAttr[I64]) -> IntegerAttr[I64]:
-        return a + b
-
-
-p2.compile(desymref=True)
-print(p2.textual_format())

--- a/tests/filecheck/frontend/refactor/builtin.py
+++ b/tests/filecheck/frontend/refactor/builtin.py
@@ -1,0 +1,25 @@
+# RUN: python %s | filecheck %s
+
+from xdsl.dialects import arith
+from xdsl.dialects.builtin import I64, IntegerAttr, i64
+from xdsl.frontend.pyast.context import CodeContext
+from xdsl.frontend.pyast.program import FrontendProgram
+
+p = FrontendProgram()
+p.register_type(IntegerAttr[I64], i64)
+p.register_function(IntegerAttr.__add__, arith.AddiOp)
+with CodeContext(p):
+    # CHECK:      builtin.module {
+    # CHECK-NEXT:   func.func @test_addi_overload(%a : i64, %b : i64) -> i64 {
+    # CHECK-NEXT:     %0 = arith.addi %a, %b : i64
+    # CHECK-NEXT:     func.return %0 : i64
+    # CHECK-NEXT:   }
+    # CHECK-NEXT: }
+    def test_addi_overload(
+        a: IntegerAttr[I64], b: IntegerAttr[I64]
+    ) -> IntegerAttr[I64]:
+        return a + b
+
+
+p.compile(desymref=True)
+print(p.textual_format())

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -889,9 +889,9 @@ class IntegerAttr(
 
     def __add__(self, other: Self) -> Self:
         """Add two integers."""
-        assert self.type == other.type
-        result = int.__add__(self.value.data, other.value.data)
-        return type(self)(result, self.type, truncate_bits=True)
+        return type(self)(
+            self.value.data + other.value.data, self.type, truncate_bits=True
+        )
 
 
 BoolAttr: TypeAlias = IntegerAttr[Annotated[IntegerType, IntegerType(1)]]

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -887,6 +887,12 @@ class IntegerAttr(
         """
         return tuple(IntegerAttr(value, type) for value in type.unpack(buffer, num))
 
+    def __add__(self, other: Self) -> Self:
+        """Add two integers."""
+        assert self.type == other.type
+        result = int.__add__(self.value.data, other.value.data)
+        return type(self)(result, self.type, truncate_bits=True)
+
 
 BoolAttr: TypeAlias = IntegerAttr[Annotated[IntegerType, IntegerType(1)]]
 

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -887,12 +887,6 @@ class IntegerAttr(
         """
         return tuple(IntegerAttr(value, type) for value in type.unpack(buffer, num))
 
-    def __add__(self, other: Self) -> Self:
-        """Add two integers."""
-        return type(self)(
-            self.value.data + other.value.data, self.type, truncate_bits=True
-        )
-
 
 BoolAttr: TypeAlias = IntegerAttr[Annotated[IntegerType, IntegerType(1)]]
 

--- a/xdsl/frontend/pyast/code_generation.py
+++ b/xdsl/frontend/pyast/code_generation.py
@@ -502,7 +502,7 @@ class CodeGenerationVisitor(ast.NodeVisitor):
                     "Function arguments must be type hinted",
                 )
             xdsl_type = self.type_converter.type_registry.resolve_attribute(
-                ast.unparse(arg.annotation)
+                ast.unparse(arg.annotation), self.type_converter.globals
             )
             if xdsl_type is None:
                 if not isinstance(arg.annotation, ast.Name):
@@ -518,7 +518,7 @@ class CodeGenerationVisitor(ast.NodeVisitor):
         return_types: list[Attribute] = []
         if node.returns is not None:
             xdsl_type = self.type_converter.type_registry.resolve_attribute(
-                ast.unparse(node.returns)
+                ast.unparse(node.returns), self.type_converter.globals
             )
             if xdsl_type is None:
                 if not isinstance(node.returns, ast.Name):

--- a/xdsl/frontend/pyast/code_generation.py
+++ b/xdsl/frontend/pyast/code_generation.py
@@ -517,17 +517,17 @@ class CodeGenerationVisitor(ast.NodeVisitor):
 
         return_types: list[Attribute] = []
         if node.returns is not None:
-            if not isinstance(node.returns, ast.Name):
-                raise CodeGenerationException(
-                    self.file,
-                    node.lineno,
-                    node.col_offset,
-                    f"Unsupported function return type: '{ast.unparse(node.returns)}'",
-                )
             xdsl_type = self.type_converter.type_registry.resolve_attribute(
-                node.returns.id
+                ast.unparse(node.returns)
             )
             if xdsl_type is None:
+                if not isinstance(node.returns, ast.Name):
+                    raise CodeGenerationException(
+                        self.file,
+                        node.lineno,
+                        node.col_offset,
+                        f"Unsupported function return type: '{ast.unparse(node.returns)}'",
+                    )
                 xdsl_type = self.type_converter.convert_type_hint(node.returns)
             return_types.append(xdsl_type)
 

--- a/xdsl/frontend/pyast/program.py
+++ b/xdsl/frontend/pyast/program.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass, field
 from io import StringIO
 from typing import Any
 
+from typing_extensions import TypeForm
+
 from xdsl.dialects.builtin import ModuleOp
 from xdsl.frontend.pyast.code_generation import CodeGeneration
 from xdsl.frontend.pyast.exception import FrontendProgramException
@@ -12,10 +14,9 @@ from xdsl.frontend.pyast.python_code_check import FunctionMap
 from xdsl.frontend.pyast.type_conversion import (
     FunctionRegistry,
     TypeConverter,
-    TypeName,
     TypeRegistry,
 )
-from xdsl.ir import Operation, TypeAttribute
+from xdsl.ir import Attribute, Operation, TypeAttribute
 from xdsl.printer import Printer
 
 
@@ -38,9 +39,6 @@ class FrontendProgram:
     xdsl_program: ModuleOp | None = field(default=None)
     """Generated xDSL program when AST is compiled."""
 
-    type_names: dict[TypeName, type] = field(default_factory=dict[TypeName, type])
-    """Mappings from source type names to source types."""
-
     type_registry: TypeRegistry = field(default_factory=TypeRegistry)
     """Mappings between source code and IR type."""
 
@@ -50,30 +48,17 @@ class FrontendProgram:
     file: str | None = field(default=None)
     """Path to the file that contains the program."""
 
-    def register_type(self, source_type: type, ir_type: TypeAttribute) -> None:
+    def register_type(
+        self, source_type: type | TypeForm[Attribute], ir_type: TypeAttribute
+    ) -> None:
         """Associate a type in the source code with its type in the IR."""
-        if (type_name := source_type.__qualname__) in self.type_names:
-            raise FrontendProgramException(
-                f"Cannot re-register type name '{type_name}'"
-            )
-        # Qualified names not being registered implies matching objects aren't
-        assert source_type not in self.type_registry
-        if not self.type_registry.valid_insert(source_type, ir_type):
-            raise FrontendProgramException(
-                f"Cannot register multiple source types for IR type '{ir_type.__name__}'"
-            )
-        self.type_names[type_name] = source_type
-        self.type_registry[source_type] = ir_type
+        self.type_registry.insert(source_type, ir_type)
 
     def register_function(
         self, function: Callable[..., Any], ir_op: type[Operation]
     ) -> None:
         """Associate a method on an object in the source code with its IR implementation."""
-        if function in self.function_registry:
-            raise FrontendProgramException(
-                f"Cannot re-register function '{function.__qualname__}'"
-            )
-        self.function_registry[function] = ir_op
+        self.function_registry.insert(function, ir_op)
 
     def _check_can_compile(self):
         if self.stmts is None or self.globals is None:
@@ -95,7 +80,6 @@ Cannot compile program without the code context. Try to use:
 
         type_converter = TypeConverter(
             globals=self.globals,
-            type_names=self.type_names,
             type_registry=self.type_registry,
             function_registry=self.function_registry,
         )

--- a/xdsl/frontend/pyast/program.py
+++ b/xdsl/frontend/pyast/program.py
@@ -49,10 +49,13 @@ class FrontendProgram:
     """Path to the file that contains the program."""
 
     def register_type(
-        self, source_type: type | TypeForm[Attribute], ir_type: TypeAttribute
+        self,
+        source_type: type | TypeForm[Attribute],
+        ir_type: TypeAttribute,
+        annotation_name: str | None = None,
     ) -> None:
         """Associate a type in the source code with its type in the IR."""
-        self.type_registry.insert(source_type, ir_type)
+        self.type_registry.insert(source_type, ir_type, annotation_name)
 
     def register_function(
         self, function: Callable[..., Any], ir_op: type[Operation]

--- a/xdsl/frontend/pyast/program.py
+++ b/xdsl/frontend/pyast/program.py
@@ -52,10 +52,9 @@ class FrontendProgram:
         self,
         source_type: type | TypeForm[Attribute],
         ir_type: TypeAttribute,
-        annotation_name: str | None = None,
     ) -> None:
         """Associate a type in the source code with its type in the IR."""
-        self.type_registry.insert(source_type, ir_type, annotation_name)
+        self.type_registry.insert(source_type, ir_type)
 
     def register_function(
         self, function: Callable[..., Any], ir_op: type[Operation]

--- a/xdsl/frontend/pyast/type_conversion.py
+++ b/xdsl/frontend/pyast/type_conversion.py
@@ -86,13 +86,24 @@ class TypeRegistry:
         self._mapping: dict[type | TypeForm[Attribute], TypeAttribute] = {}
         self._type_names: dict[str, type | TypeForm[Attribute]] = {}
 
+    def _get_annotation_name(
+        self, annotation: type | TypeForm[Attribute], annotation_name: str | None = None
+    ) -> str:
+        """Get the name of an annotation."""
+        if annotation_name is not None:
+            return annotation_name
+        return annotation.__qualname__
+
     def insert(
-        self, annotation: type | TypeForm[Attribute], attribute: TypeAttribute
+        self,
+        annotation: type | TypeForm[Attribute],
+        attribute: TypeAttribute,
+        annotation_name: str | None = None,
     ) -> None:
         """Insert a relation between a Python type annotation and an IR type attribute."""
         # Enforce type is not generic/final if not subclass attribute
         # Resolve attributes
-        annotation_name = annotation.__qualname__
+        annotation_name = self._get_annotation_name(annotation, annotation_name)
         if annotation_name in self._type_names:
             raise FrontendProgramException(
                 f"Cannot re-register type name '{annotation_name}'"

--- a/xdsl/frontend/pyast/type_conversion.py
+++ b/xdsl/frontend/pyast/type_conversion.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field
 from typing import (
     Any,
     _GenericAlias,  # pyright: ignore[reportUnknownVariableType, reportAttributeAccessIssue]
+    cast,
 )
 
 from typing_extensions import TypeForm
@@ -122,7 +123,9 @@ class TypeRegistry:
         self, annotation_name: str, globals: dict[str, Any]
     ) -> TypeAttribute | None:
         """Get an IR type attribute from a string annotation."""
-        annotation = eval(annotation_name, globals=globals)
+        annotation = cast(
+            type | TypeForm[Attribute], eval(annotation_name, globals=globals)
+        )
         return self._mapping.get(annotation, None)
 
 


### PR DESCRIPTION
Add support for registering `IntegerAttr` types to express fixed bit-width integers in emitted MLIR, for example the following code should be valid:

```python
p = FrontendProgram()
p.register_type(IntegerAttr[I64], i64)
with CodeContext(p):
    def test_identity(a: IntegerAttr[I64]) -> IntegerAttr[I64]:
        return a
```

Peeled from #4617 to avoid complications with registering and defining functions on `IntegerAttr`s