### PR TITLE
frontend: (pyast) add support for calling functions with variable arguments

### DIFF
--- a/tests/filecheck/frontend/programs/call.py
+++ b/tests/filecheck/frontend/programs/call.py
@@ -1,0 +1,26 @@
+# RUN: python %s | filecheck %s
+
+from xdsl.dialects import arith, builtin
+from xdsl.frontend.pyast.context import CodeContext
+from xdsl.frontend.pyast.program import FrontendProgram
+
+
+def add_bigint(operand1: int, operand2: int) -> int: ...
+
+
+p1 = FrontendProgram()
+p1.register_type(int, builtin.i32)
+p1.register_function(add_bigint, arith.AddiOp)
+with CodeContext(p1):
+    # CHECK:      builtin.module {
+    # CHECK-NEXT:   func.func @foo(%x : i32, %y : i32) -> i32 {
+    # CHECK-NEXT:     %0 = arith.addi %x, %y : i32
+    # CHECK-NEXT:     func.return %0 : i32
+    # CHECK-NEXT:   }
+    # CHECK-NEXT: }
+    def foo(x: int, y: int) -> int:
+        return add_bigint(x, operand2=y)
+
+
+p1.compile()
+print(p1.textual_format())

--- a/tests/filecheck/frontend/programs/call.py
+++ b/tests/filecheck/frontend/programs/call.py
@@ -33,7 +33,7 @@ try:
     with CodeContext(p):
         # CHECK-NEXT: Function arguments must be declared variables.
         def test_args():
-            return add_i32(1, 2)
+            return add_i32(1, 2)  # pyright: ignore[reportArgumentType]
 
     p.compile(desymref=False)
     print(p.textual_format())
@@ -44,7 +44,7 @@ try:
     with CodeContext(p):
         # CHECK-NEXT: Function arguments must be declared variables.
         def test_args():
-            return add_i32(operand1=1, operand2=2)
+            return add_i32(operand1=1, operand2=2)  # pyright: ignore[reportArgumentType]
 
     p.compile(desymref=False)
     print(p.textual_format())

--- a/tests/filecheck/frontend/programs/call.py
+++ b/tests/filecheck/frontend/programs/call.py
@@ -1,16 +1,18 @@
 # RUN: python %s | filecheck %s
 
+from ctypes import c_int32
+
 from xdsl.dialects import arith, builtin
 from xdsl.frontend.pyast.context import CodeContext
 from xdsl.frontend.pyast.program import FrontendProgram
 
 
-def add_bigint(operand1: int, operand2: int) -> int: ...
+def add_i32(operand1: c_int32, operand2: c_int32) -> c_int32: ...
 
 
 p1 = FrontendProgram()
-p1.register_type(int, builtin.i32)
-p1.register_function(add_bigint, arith.AddiOp)
+p1.register_type(c_int32, builtin.i32)
+p1.register_function(add_i32, arith.AddiOp)
 with CodeContext(p1):
     # CHECK:      builtin.module {
     # CHECK-NEXT:   func.func @foo(%x : i32, %y : i32) -> i32 {
@@ -18,8 +20,8 @@ with CodeContext(p1):
     # CHECK-NEXT:     func.return %0 : i32
     # CHECK-NEXT:   }
     # CHECK-NEXT: }
-    def foo(x: int, y: int) -> int:
-        return add_bigint(x, operand2=y)
+    def foo(x: c_int32, y: c_int32) -> c_int32:
+        return add_i32(x, operand2=y)
 
 
 p1.compile()

--- a/tests/filecheck/frontend/programs/call.py
+++ b/tests/filecheck/frontend/programs/call.py
@@ -4,25 +4,75 @@ from ctypes import c_int32
 
 from xdsl.dialects import arith, builtin
 from xdsl.frontend.pyast.context import CodeContext
+from xdsl.frontend.pyast.exception import CodeGenerationException
 from xdsl.frontend.pyast.program import FrontendProgram
 
 
 def add_i32(operand1: c_int32, operand2: c_int32) -> c_int32: ...
 
 
-p1 = FrontendProgram()
-p1.register_type(c_int32, builtin.i32)
-p1.register_function(add_i32, arith.AddiOp)
-with CodeContext(p1):
+p = FrontendProgram()
+p.register_type(c_int32, builtin.i32)
+p.register_function(add_i32, arith.AddiOp)
+with CodeContext(p):
     # CHECK:      builtin.module {
-    # CHECK-NEXT:   func.func @foo(%x : i32, %y : i32) -> i32 {
+    # CHECK-NEXT:   func.func @test_add(%x : i32, %y : i32) -> i32 {
     # CHECK-NEXT:     %0 = arith.addi %x, %y : i32
     # CHECK-NEXT:     func.return %0 : i32
     # CHECK-NEXT:   }
     # CHECK-NEXT: }
-    def foo(x: c_int32, y: c_int32) -> c_int32:
+    def test_add(x: c_int32, y: c_int32) -> c_int32:
         return add_i32(x, operand2=y)
 
 
-p1.compile()
-print(p1.textual_format())
+p.compile()
+print(p.textual_format())
+
+
+try:
+    with CodeContext(p):
+        # CHECK-NEXT: Function arguments must be declared variables.
+        def test_args():
+            return add_i32(1, 2)
+
+    p.compile(desymref=False)
+    print(p.textual_format())
+except CodeGenerationException as e:
+    print(e.msg)
+
+try:
+    with CodeContext(p):
+        # CHECK-NEXT: Function arguments must be declared variables.
+        def test_args():
+            return add_i32(operand1=1, operand2=2)
+
+    p.compile(desymref=False)
+    print(p.textual_format())
+except CodeGenerationException as e:
+    print(e.msg)
+
+
+def func():
+    pass
+
+
+with CodeContext(p):
+
+    def test_func():
+        return func()  # noqa: F821
+
+
+try:
+    # CHECK-NEXT: Function 'func' is not registered.
+    p.compile(desymref=False)
+    print(p.textual_format())
+except CodeGenerationException as e:
+    print(e.msg)
+
+try:
+    # CHECK-NEXT: Function 'func' is not defined in scope.
+    del func
+    p.compile(desymref=False)
+    print(p.textual_format())
+except CodeGenerationException as e:
+    print(e.msg)

--- a/xdsl/frontend/pyast/code_generation.py
+++ b/xdsl/frontend/pyast/code_generation.py
@@ -200,11 +200,8 @@ class CodeGenerationVisitor(ast.NodeVisitor):
         # Resolve function
         assert isinstance(node.func, ast.Name)
         func_name = node.func.id
-        for key, value in self.type_converter.globals.items():
-            if key == func_name:
-                source_func = value
-                break
-        else:
+        source_func = self.type_converter.globals.get(func_name, None)
+        if source_func is None:
             raise CodeGenerationException(
                 self.file,
                 node.lineno,
@@ -229,7 +226,7 @@ class CodeGenerationVisitor(ast.NodeVisitor):
                     self.file,
                     node.lineno,
                     node.col_offset,
-                    "Function arguments must be a declared variable.",
+                    "Function arguments must be declared variables.",
                 )
             args.append(arg_op := symref.FetchOp(arg.id, self.symbol_table[arg.id]))
             self.inserter.insert_op(arg_op)

--- a/xdsl/frontend/pyast/code_generation.py
+++ b/xdsl/frontend/pyast/code_generation.py
@@ -167,9 +167,9 @@ class CodeGenerationVisitor(ast.NodeVisitor):
         if source_type is not None:  # NOTE: To support old codebase
             method_name = python_AST_operator_to_python_overload[op_name]
             function_name = f"{source_type.__qualname__}.{method_name}"
-            op = self.type_converter.function_registry.resolve_operation(
+            op = self.type_converter.function_registry.resolve_method(
                 module_name=source_type.__module__,
-                function_name=function_name,
+                method_name=function_name,
                 args=(lhs, rhs),
             )
             if op is not None:
@@ -195,6 +195,65 @@ class CodeGenerationVisitor(ast.NodeVisitor):
                 f"is not supported by type '{frontend_type.__qualname__}' "
                 f"which does not overload '{overload_name}'.",
             )
+
+    def visit_Call(self, node: ast.Call):
+        # Resolve function
+        assert isinstance(node.func, ast.Name)
+        func_name = node.func.id
+        for key, value in self.type_converter.globals.items():
+            if key == func_name:
+                source_func = value
+                break
+        else:
+            raise CodeGenerationException(
+                self.file,
+                node.lineno,
+                node.col_offset,
+                f"Function '{func_name}' is not defined in scope.",
+            )
+        ir_op = self.type_converter.function_registry.get_operation_type(source_func)
+        if ir_op is None:
+            raise CodeGenerationException(
+                self.file,
+                node.lineno,
+                node.col_offset,
+                f"Function '{func_name}' is not registered.",
+            )
+
+        # Resolve arguments
+        assert self.symbol_table is not None
+        args: list[symref.FetchOp] = []
+        for arg in node.args:
+            if not isinstance(arg, ast.Name) or arg.id not in self.symbol_table:
+                raise CodeGenerationException(
+                    self.file,
+                    node.lineno,
+                    node.col_offset,
+                    "Function arguments must be a declared variable.",
+                )
+            args.append(arg_op := symref.FetchOp(arg.id, self.symbol_table[arg.id]))
+            self.inserter.insert_op(arg_op)
+
+        # Resolve keyword arguments
+        kwargs: dict[str, symref.FetchOp] = {}
+        for keyword in node.keywords:
+            if (
+                not isinstance(keyword.value, ast.Name)
+                or keyword.value.id not in self.symbol_table
+            ):
+                raise CodeGenerationException(
+                    self.file,
+                    node.lineno,
+                    node.col_offset,
+                    "Function arguments must be declared variables.",
+                )
+            assert keyword.arg is not None
+            kwargs[keyword.arg] = symref.FetchOp(
+                keyword.value.id, self.symbol_table[keyword.value.id]
+            )
+            self.inserter.insert_op(kwargs[keyword.arg])
+
+        self.inserter.insert_op(ir_op(*args, **kwargs))
 
     def visit_Compare(self, node: ast.Compare):
         # Allow a single comparison only.
@@ -258,9 +317,9 @@ class CodeGenerationVisitor(ast.NodeVisitor):
         if source_type is not None:  # NOTE: To support old codebase
             method_name = python_AST_cmpop_to_python_overload[op_name]
             function_name = f"{source_type.__qualname__}.{method_name}"
-            op = self.type_converter.function_registry.resolve_operation(
+            op = self.type_converter.function_registry.resolve_method(
                 module_name=source_type.__module__,
-                function_name=function_name,
+                method_name=function_name,
                 args=(lhs, rhs),
             )
             if op is not None:

--- a/xdsl/frontend/pyast/code_generation.py
+++ b/xdsl/frontend/pyast/code_generation.py
@@ -167,7 +167,7 @@ class CodeGenerationVisitor(ast.NodeVisitor):
         if source_type is not None:  # NOTE: To support old codebase
             method_name = python_AST_operator_to_python_overload[op_name]
             function_name = f"{source_type.__qualname__}.{method_name}"
-            op = self.type_converter.function_registry.resolve_method(
+            op = self.type_converter.function_registry.resolve_operation(
                 module_name=source_type.__module__,
                 method_name=function_name,
                 args=(lhs, rhs),
@@ -317,7 +317,7 @@ class CodeGenerationVisitor(ast.NodeVisitor):
         if source_type is not None:  # NOTE: To support old codebase
             method_name = python_AST_cmpop_to_python_overload[op_name]
             function_name = f"{source_type.__qualname__}.{method_name}"
-            op = self.type_converter.function_registry.resolve_method(
+            op = self.type_converter.function_registry.resolve_operation(
                 module_name=source_type.__module__,
                 method_name=function_name,
                 args=(lhs, rhs),

--- a/xdsl/frontend/pyast/type_conversion.py
+++ b/xdsl/frontend/pyast/type_conversion.py
@@ -43,7 +43,7 @@ class FunctionRegistry:
         """Get the IR operation type from a Python callable"""
         return self._mapping.get(callable, None)
 
-    def resolve_method(
+    def resolve_operation(
         self,
         module_name: str,
         method_name: str,

--- a/xdsl/frontend/pyast/type_conversion.py
+++ b/xdsl/frontend/pyast/type_conversion.py
@@ -43,23 +43,23 @@ class FunctionRegistry:
         """Get the IR operation type from a Python callable"""
         return self._mapping.get(callable, None)
 
-    def resolve_operation(
+    def resolve_method(
         self,
         module_name: str,
-        function_name: str,
+        method_name: str,
         args: tuple[SSAValue[Attribute], ...] = tuple(),
         kwargs: dict[str, SSAValue[Attribute]] = dict(),
     ) -> Operation | None:
-        """Get a concrete IR operation from a function name and its arguments."""
-        # Start at the module, and walk till a function leaf is found
-        function = importlib.import_module(module_name)
-        for attr in function_name.split("."):
-            function = getattr(function, attr, None)
-        assert function is not None, (
-            f"'{module_name}.{function_name}' must exist to be passed as argument during registration"
+        """Get a concrete IR operation from a method name and its arguments."""
+        # Start at the module, and walk till a method leaf is found
+        method = importlib.import_module(module_name)
+        for attr in method_name.split("."):
+            method = getattr(method, attr, None)
+        assert method is not None, (
+            f"'{module_name}.{method_name}' must exist to be passed as argument during registration"
         )
-        assert callable(function), "Guaranteed by type signature of registration method"
-        if (operation_type := self.get_operation_type(function)) is not None:
+        assert callable(method), "Guaranteed by type signature of registration method"
+        if (operation_type := self.get_operation_type(method)) is not None:
             return operation_type(*args, **kwargs)
         return None
 


### PR DESCRIPTION
Add support for calling functions with positional and keyword arguments defined as symref variables. This supports code generation for cases like this:

```python
from ctypes import c_int32

from xdsl.dialects import arith, builtin
from xdsl.frontend.pyast.context import CodeContext
from xdsl.frontend.pyast.program import FrontendProgram

def add_i32(operand1: c_int32, operand2: c_int32) -> c_int32: ...

p1 = FrontendProgram()
p1.register_type(c_int32, builtin.i32)
p1.register_function(add_i32, arith.AddiOp)
with CodeContext(p1):
    def foo(x: c_int32, y: c_int32) -> c_int32:
        return add_i32(x, operand2=y)

p1.compile()
print(p1.textual_format())
```

into

```mlir
builtin.module {
  func.func @foo(%x : i32, %y : i32) -> i32 {
    %0 = arith.addi %x, %y : i32
    func.return %0 : i32
  }
}
```

which then unblocks porting existing tests away from the custom PyAST dialects