### PR TITLE
dialects: add missing `get_bases`

### DIFF
--- a/xdsl/dialects/bufferization.py
+++ b/xdsl/dialects/bufferization.py
@@ -86,6 +86,9 @@ class TensorFromMemRefConstraint(
             )
         return self.memref_constraint.verify(memref_type, constraint_context)
 
+    def get_bases(self) -> set[type[Attribute]] | None:
+        return {TensorType, UnrankedTensorType}
+
     def mapping_type_vars(
         self, type_var_mapping: dict[TypeVar, AttrConstraint]
     ) -> TensorFromMemRefConstraint:

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -1436,6 +1436,11 @@ class ContainerOf(
         else:
             self.elem_constr.verify(attr, constraint_context)
 
+    def get_bases(self) -> set[type[Attribute]] | None:
+        bases = self.elem_constr.get_bases()
+        if bases is not None:
+            return {*bases, TensorType, VectorType}
+
     def mapping_type_vars(
         self, type_var_mapping: dict[TypeVar, AttrConstraint]
     ) -> ContainerOf[AttributeCovT]:


### PR DESCRIPTION
Split off from #4510. Adds `get_bases` functions to some constraints that were missing it.