### PR TITLE
core: (AnyOf) verify without backtracking

### DIFF
--- a/tests/filecheck/dialects/arith/arith_invalid.mlir
+++ b/tests/filecheck/dialects/arith/arith_invalid.mlir
@@ -19,9 +19,9 @@
 // -----
 
 %c = arith.constant 1 : si32
-// CHECK:  Unexpected attribute 1 : si32
+// CHECK: Expected attribute #builtin.signedness<signless> but got #builtin.signedness<signed>
 
 // -----
 
 %c = arith.constant 1 : ui32
-// CHECK:  Unexpected attribute 1 : ui32
+// CHECK: Expected attribute #builtin.signedness<signless> but got #builtin.signedness<unsigned>

--- a/xdsl/irdl/constraints.py
+++ b/xdsl/irdl/constraints.py
@@ -439,6 +439,11 @@ class AnyOf(Generic[AttributeCovT], GenericAttrConstraint[AttributeCovT]):
     attr_constrs: tuple[GenericAttrConstraint[AttributeCovT], ...]
     """The list of constraints that are checked."""
 
+    _eq_constrs: set[Attribute] = field(hash=False, repr=False)
+    _based_constrs: dict[type[Attribute], GenericAttrConstraint[AttributeCovT]] = field(
+        hash=False, repr=False
+    )
+
     def __init__(
         self,
         attr_constrs: Sequence[
@@ -450,6 +455,9 @@ class AnyOf(Generic[AttributeCovT], GenericAttrConstraint[AttributeCovT]):
         constrs: tuple[GenericAttrConstraint[AttributeCovT], ...] = tuple(
             irdl_to_attr_constraint(constr) for constr in attr_constrs
         )
+
+        eq_constrs = set[Attribute]()
+        based_constrs = dict[type[Attribute], GenericAttrConstraint[AttributeCovT]]()
 
         bases = set[Attribute]()
         eq_bases = set[Attribute]()
@@ -467,6 +475,7 @@ class AnyOf(Generic[AttributeCovT], GenericAttrConstraint[AttributeCovT]):
                 )
 
             if isinstance(c, EqAttrConstraint):
+                eq_constrs.add(c.attr)
                 eq_bases |= b
             else:
                 if not b.isdisjoint(eq_bases):
@@ -474,6 +483,8 @@ class AnyOf(Generic[AttributeCovT], GenericAttrConstraint[AttributeCovT]):
                         f"Non-equality constraint {c} shares a base with a constraint "
                         f"in {set(constrs[0:i])} in `AnyOf` constraint."
                     )
+                for base in b:
+                    based_constrs[base] = c
                 bases |= b
 
         object.__setattr__(
@@ -481,21 +492,24 @@ class AnyOf(Generic[AttributeCovT], GenericAttrConstraint[AttributeCovT]):
             "attr_constrs",
             constrs,
         )
+        object.__setattr__(
+            self,
+            "_eq_constrs",
+            eq_constrs,
+        )
+        object.__setattr__(
+            self,
+            "_based_constrs",
+            based_constrs,
+        )
 
     def verify(self, attr: Attribute, constraint_context: ConstraintContext) -> None:
-        constraint_context = constraint_context or ConstraintContext()
-        for attr_constr in self.attr_constrs:
-            # Copy the constraint to ensure that if the constraint fails, the
-            # constraint context is not modified.
-            constraint_context_copy = constraint_context.copy()
-            try:
-                attr_constr.verify(attr, constraint_context_copy)
-                # If the constraint succeeds, we update back the constraint variables
-                constraint_context.update(constraint_context_copy)
-                return
-            except VerifyException:
-                pass
-        raise VerifyException(f"Unexpected attribute {attr}")
+        if attr in self._eq_constrs:
+            return
+        constr = self._based_constrs.get(attr.__class__)
+        if constr is None:
+            raise VerifyException(f"Unexpected attribute {attr}")
+        constr.verify(attr, constraint_context)
 
     def __or__(
         self, value: GenericAttrConstraint[_AttributeCovT], /


### PR DESCRIPTION
Thought I'd make a draft PR to further motivate the disjointness changes. Could probably be cleaned up a bit, but this is at least a proof of concept. 

Would it be possible to try some of the verification benchmarks on this? Would like to know if this actually improves anything/makes stuff worse/whether it's better to just iterate through tuples rather than making dictionaries and sets etc.