### PR TITLE
core: add PyRDLTypeError for irdl_to_attr_constraint

### DIFF
--- a/tests/irdl/test_attribute_definition.py
+++ b/tests/irdl/test_attribute_definition.py
@@ -58,7 +58,11 @@ from xdsl.irdl import (
 )
 from xdsl.parser import AttrParser, Parser
 from xdsl.printer import Printer
-from xdsl.utils.exceptions import PyRDLAttrDefinitionError, VerifyException
+from xdsl.utils.exceptions import (
+    PyRDLAttrDefinitionError,
+    PyRDLTypeError,
+    VerifyException,
+)
 from xdsl.utils.hints import isa
 
 
@@ -686,7 +690,7 @@ def test_data_with_generic_missing_generic_data_failure():
     without implementing GenericData.
     """
     with pytest.raises(
-        ValueError,
+        PyRDLTypeError,
         match=(
             "Generic `Data` type 'test.missing_genericdata' cannot be converted to an "
             "attribute constraint. Consider making it inherit from `GenericData` "

--- a/tests/test_pyrdl.py
+++ b/tests/test_pyrdl.py
@@ -18,10 +18,11 @@ from xdsl.irdl import (
     VarConstraint,
     eq,
     irdl_attr_definition,
+    irdl_to_attr_constraint,
 )
 from xdsl.parser import AttrParser
 from xdsl.printer import Printer
-from xdsl.utils.exceptions import VerifyException
+from xdsl.utils.exceptions import PyRDLTypeError, VerifyException
 
 
 @irdl_attr_definition
@@ -327,3 +328,10 @@ def test_constraint_vars_fail_underlying_constraint():
 
     with pytest.raises(VerifyException):
         constraint.verify(IntData(1), ConstraintContext())
+
+
+def test_irdl_to_attr_constraint():
+    with pytest.raises(
+        PyRDLTypeError, match="Unexpected irdl constraint: <class 'int'>"
+    ):
+        irdl_to_attr_constraint(int)  # pyright: ignore[reportArgumentType]

--- a/xdsl/irdl/attributes.py
+++ b/xdsl/irdl/attributes.py
@@ -39,7 +39,7 @@ from xdsl.ir import (
     ParametrizedAttribute,
     TypedAttribute,
 )
-from xdsl.utils.exceptions import PyRDLAttrDefinitionError
+from xdsl.utils.exceptions import PyRDLAttrDefinitionError, PyRDLTypeError
 from xdsl.utils.hints import (
     PropertyType,
     get_type_var_from_generic_class,
@@ -376,9 +376,11 @@ def irdl_to_attr_constraint(
     # We take the type variable bound constraint.
     if isinstance(irdl, TypeVar):
         if not allow_type_var:
-            raise ValueError("TypeVar in unexpected context.")
+            raise PyRDLTypeError("TypeVar in unexpected context.")
         if irdl.__bound__ is None:
-            raise ValueError("Type variables used in IRDL are expected to be bound.")
+            raise PyRDLTypeError(
+                "Type variables used in IRDL are expected to be bound."
+            )
         # We do not allow nested type variables.
         constraint = irdl_to_attr_constraint(irdl.__bound__)
         return cast(
@@ -391,7 +393,7 @@ def irdl_to_attr_constraint(
     if isclass(origin) and issubclass(origin, GenericData):
         args = get_args(irdl)
         if len(args) != 1:
-            raise Exception(f"GenericData args must have length 1, got {args}")
+            raise PyRDLTypeError(f"GenericData args must have length 1, got {args}")
         constr = irdl_to_attr_constraint(args[0])
 
         return cast(GenericAttrConstraint[AttributeInvT], origin.constr(constr))
@@ -411,7 +413,7 @@ def irdl_to_attr_constraint(
 
         # Check that we have the right number of parameters
         if len(args) != len(generic_args):
-            raise Exception(
+            raise PyRDLTypeError(
                 f"{origin.name} expects {len(generic_args)}"
                 f" parameters, got {len(args)}."
             )
@@ -454,13 +456,13 @@ def irdl_to_attr_constraint(
 
     # Better error messages for missing GenericData in Data definitions
     if isclass(origin) and issubclass(origin, Data):
-        raise ValueError(
+        raise PyRDLTypeError(
             f"Generic `Data` type '{origin.name}' cannot be converted to "
             "an attribute constraint. Consider making it inherit from "
             "`GenericData` instead of `Data`."
         )
 
-    raise ValueError(f"Unexpected irdl constraint: {irdl}")
+    raise PyRDLTypeError(f"Unexpected irdl constraint: {irdl}")
 
 
 def base(irdl: type[AttributeInvT]) -> GenericAttrConstraint[AttributeInvT]:

--- a/xdsl/utils/exceptions.py
+++ b/xdsl/utils/exceptions.py
@@ -48,25 +48,25 @@ class PassFailedException(DiagnosticException):
 
 class PyRDLError(Exception):
     """
-    An error in our Python to IRDL conversion.
+    An error in our IRDL eDSL.
     """
 
 
 class PyRDLOpDefinitionError(PyRDLError):
     """
-    An error in our Python to IRDL Operation definition conversion.
+    An error in the Operation definition eDSL.
     """
 
 
 class PyRDLAttrDefinitionError(PyRDLError):
     """
-    An error in our Python to IRDL Attribute definitnion conversion.
+    An error in the Attribute definition eDSL.
     """
 
 
 class PyRDLTypeError(TypeError, PyRDLError):
     """
-    An error in our Python to IRDL conversion indicating an error in types.
+    A type error in our IRDL eDSL.
     """
 
 

--- a/xdsl/utils/exceptions.py
+++ b/xdsl/utils/exceptions.py
@@ -47,15 +47,27 @@ class PassFailedException(DiagnosticException):
 
 
 class PyRDLError(Exception):
-    pass
+    """
+    An error in our Python to IRDL conversion.
+    """
 
 
-class PyRDLOpDefinitionError(Exception):
-    pass
+class PyRDLOpDefinitionError(PyRDLError):
+    """
+    An error in our Python to IRDL Operation definition conversion.
+    """
 
 
-class PyRDLAttrDefinitionError(Exception):
-    pass
+class PyRDLAttrDefinitionError(PyRDLError):
+    """
+    An error in our Python to IRDL Attribute definitnion conversion.
+    """
+
+
+class PyRDLTypeError(TypeError, PyRDLError):
+    """
+    An error in our Python to IRDL conversion indicating an error in types.
+    """
 
 
 class InvalidIRException(Exception):


### PR DESCRIPTION
Makes our exceptions a little more precise. Also adds doc strings for existing PyRDL errors.