### PR TITLE
dialects:(omp) add ops for defining device data mapping

### DIFF
--- a/tests/filecheck/dialects/omp/ops.mlir
+++ b/tests/filecheck/dialects/omp/ops.mlir
@@ -136,6 +136,12 @@ builtin.module {
     }) : (memref<6xf32>, i64, i32, i1, memref<10xi8>, f64, i32) -> ()
     func.return
   }
+  func.func @omp_map_info_bounds(%lb : index, %ub : index, %ptr : memref<1xf32>, %ptr_ptr : memref<1xmemref<1xf32>>) {
+    %bounds = "omp.map.bounds"(%lb, %ub) <{operandSegmentSizes = array<i32: 1, 1, 0, 0, 0>}> : (index, index) -> !omp.map_bounds_ty
+    %ptr_info = "omp.map.info"(%ptr, %ptr_ptr, %bounds) <{operandSegmentSizes = array<i32: 1, 1, 0, 1>, var_type = memref<1xf32>, map_type = 1 : ui64, name = "ptr_info"}> : (memref<1xf32>, memref<1xmemref<1xf32>>, !omp.map_bounds_ty) -> memref<1xf32>
+    %ptr_ptr_info = "omp.map.info"(%ptr_ptr, %ptr_info, %bounds) <{operandSegmentSizes = array<i32: 1, 0, 1, 1>, map_capture_type = #omp<variable_capture_kind (ByCopy)>, var_type = memref<1xmemref<1xf32>>}> : (memref<1xmemref<1xf32>>, memref<1xf32>, !omp.map_bounds_ty) -> memref<1xmemref<1xf32>>
+    func.return
+  }
 }
 
 // CHECK:       builtin.module {
@@ -272,6 +278,12 @@ builtin.module {
 // CHECK-NEXT:      "omp.target"(%dep, %dev, %host, %if, %p1, %p2, %tlimit) <{operandSegmentSizes = array<i32: 0, 0, 1, 1, 0, 1, 1, 0, 0, 0, 2, 1>, in_reduction_syms = [@rsym1, @rsym2], private_syms = [@psym1, @psym2], nowait, bare, depend_kinds = [#omp<clause_task_depend (taskdependinout)>]}> ({
 // CHECK-NEXT:        "omp.terminator"() : () -> ()
 // CHECK-NEXT:      }) : (memref<6xf32>, i64, i32, i1, memref<10xi8>, f64, i32) -> ()
+// CHECK-NEXT:      func.return
+// CHECK-NEXT:    }
+// CHECK-NEXT:    func.func @omp_map_info_bounds(%lb : index, %ub : index, %ptr : memref<1xf32>, %ptr_ptr : memref<1xmemref<1xf32>>) {
+// CHECK-NEXT:      %bounds = "omp.map.bounds"(%lb, %ub) <{operandSegmentSizes = array<i32: 1, 1, 0, 0, 0>, stride_in_bytes = false}> : (index, index) -> !omp.map_bounds_ty
+// CHECK-NEXT:      %ptr_info = "omp.map.info"(%ptr, %ptr_ptr, %bounds) <{operandSegmentSizes = array<i32: 1, 1, 0, 1>, var_type = memref<1xf32>, map_type = 1 : ui64, name = "ptr_info"}> : (memref<1xf32>, memref<1xmemref<1xf32>>, !omp.map_bounds_ty) -> memref<1xf32>
+// CHECK-NEXT:      %ptr_ptr_info = "omp.map.info"(%ptr_ptr, %ptr_info, %bounds) <{operandSegmentSizes = array<i32: 1, 0, 1, 1>, map_capture_type = #omp<variable_capture_kind (ByCopy)>, var_type = memref<1xmemref<1xf32>>}> : (memref<1xmemref<1xf32>>, memref<1xf32>, !omp.map_bounds_ty) -> memref<1xmemref<1xf32>>
 // CHECK-NEXT:      func.return
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }

--- a/xdsl/dialects/omp.py
+++ b/xdsl/dialects/omp.py
@@ -1,12 +1,17 @@
-from enum import auto
+from enum import IntFlag, auto
 from typing import ClassVar, cast
+
+from typing_extensions import TypeVar
 
 from xdsl.dialects.builtin import (
     ArrayAttr,
+    BoolAttr,
     DenseIntOrFPElementsAttr,
     IndexType,
     IntegerAttr,
     IntegerType,
+    Signedness,
+    StringAttr,
     SymbolRefAttr,
     UnitAttr,
     i1,
@@ -18,8 +23,10 @@ from xdsl.ir import (
     Attribute,
     Dialect,
     EnumAttribute,
+    ParametrizedAttribute,
     SpacedOpaqueSyntaxAttribute,
     StrEnum,
+    TypeAttribute,
 )
 from xdsl.irdl import (
     AnyAttr,
@@ -32,16 +39,65 @@ from xdsl.irdl import (
     base,
     irdl_attr_definition,
     irdl_op_definition,
+    operand_def,
     opt_operand_def,
     opt_prop_def,
+    prop_def,
     region_def,
+    result_def,
     traits_def,
     var_operand_def,
 )
 from xdsl.parser import AttrParser
 from xdsl.printer import Printer
-from xdsl.traits import IsolatedFromAbove, IsTerminator, NoTerminator
+from xdsl.traits import IsolatedFromAbove, IsTerminator, NoMemoryEffect, NoTerminator
 from xdsl.utils.exceptions import VerifyException
+
+
+class OpenMPOffloadMappingFlags(IntFlag):
+    """
+    Copied from [OMPConstants.h](https://github.com/llvm/llvm-project/blob/daa2a587cc01c5656deecda7f768fed0afc1e515/llvm/include/llvm/Frontend/OpenMP/OMPConstants.h#L198)
+
+    To be used as `map_type` value of `omp.map.info`
+    """
+
+    # No flags
+    NONE = 0x0
+    # Allocate memory on the device and move data from host to device.
+    TO = 0x01
+    # Allocate memory on the device and move data from device to host.
+    FROM = 0x02
+    # Always perform the requested mapping action on the element, even if it was already mapped before.
+    ALWAYS = 0x04
+    # Delete the element from the device environment, ignoring the current reference count associated with the element.
+    DELETE = 0x08
+    # The element being mapped is a pointer-pointee pair; both the pointer and the pointee should be mapped.
+    PTR_AND_OBJ = 0x10
+    # This flags signals that the base address of an entry should be passed to the target kernel as an argument.
+    TARGET_PARAM = 0x20
+    # Signal that the runtime library has to return the device pointer in the current position for the data being mapped.
+    # Used when we have the use_device_ptr or use_device_addr clause.
+    RETURN_PARAM = 0x40
+    # This flag signals that the reference being passed is a pointer to private data.
+    PRIVATE = 0x80
+    # Pass the element to the device by value.
+    LITERAL = 0x100
+    # Implicit map
+    IMPLICIT = 0x200
+    # Close is a hint to the runtime to allocate memory close to the target device.
+    CLOSE = 0x400
+    # 0x800 is reserved for compatibility with XLC. Produce a runtime error if the data is not already allocated.
+    PRESENT = 0x1000
+    # Increment and decrement a separate reference counter so that the data cannot be unmapped within the associated region.
+    # Thus, this flag is intended to be used on 'target' and 'target data' directives because they are inherently structured.
+    # It is not intended to be used on 'target enter data' and 'target exit data' directives because they are inherently dynamic.
+    # This is an OpenMP extension for the sake of OpenACC support.
+    OMPX_HOLD = 0x2000
+    # Signal that the runtime library should use args as an array of descriptor_dim pointers and use args_size as dims. Used when
+    # we have non-contiguous list items in target update directive
+    NON_CONTIG = 0x100000000000
+    # The 16 MSBs of the flags indicate whether the entry is member of some struct/class.
+    MEMBER_OF = 0xFFFF000000000000
 
 
 class ScheduleKind(StrEnum):
@@ -69,6 +125,31 @@ class DependKind(StrEnum):
     taskdependinoutset = auto()
 
 
+class VariableCaptureKind(StrEnum):
+    This = "This"
+    ByRef = "ByRef"
+    ByCopy = "ByCopy"
+    VLAType = "VLAType"
+
+
+_ui64 = IntegerType(64, Signedness.UNSIGNED)
+
+OmpEnumType = TypeVar("OmpEnumType", bound=StrEnum)
+
+
+def _print_omp_enum(e: EnumAttribute[OmpEnumType], printer: Printer):
+    with printer.in_parens():
+        printer.print_string(e.data)
+
+
+def _parse_omp_enum(e: type[EnumAttribute[OmpEnumType]], parser: AttrParser):
+    parser.in_angle_brackets()
+    parser.parse_punctuation("(")
+    res = parser.parse_str_enum(e.enum_type)
+    parser.parse_punctuation(")")
+    return cast(OmpEnumType, res)
+
+
 @irdl_attr_definition
 class ScheduleKindAttr(EnumAttribute[ScheduleKind], SpacedOpaqueSyntaxAttribute):
     name = "omp.schedulekind"
@@ -86,19 +167,35 @@ class DependKindAttr(EnumAttribute[DependKind], SpacedOpaqueSyntaxAttribute):
     name = "omp.clause_task_depend"
 
     def print_parameter(self, printer: Printer) -> None:
-        printer.print_string("(" + self.data + ")")
+        _print_omp_enum(self, printer)
 
     @classmethod
     def parse_parameter(cls, parser: AttrParser) -> DependKind:
-        parser.parse_punctuation("(")
-        res = parser.parse_str_enum(cls.enum_type)
-        parser.parse_punctuation(")")
-        return cast(DependKind, res)
+        return _parse_omp_enum(cls, parser)
 
 
 @irdl_attr_definition
 class OrderKindAttr(EnumAttribute[OrderKind], SpacedOpaqueSyntaxAttribute):
     name = "omp.orderkind"
+
+
+@irdl_attr_definition
+class VariableCaptureKindAttr(
+    EnumAttribute[VariableCaptureKind], SpacedOpaqueSyntaxAttribute
+):
+    name = "omp.variable_capture_kind"
+
+    def print_parameter(self, printer: Printer) -> None:
+        _print_omp_enum(self, printer)
+
+    @classmethod
+    def parse_parameter(cls, parser: AttrParser) -> VariableCaptureKind:
+        return _parse_omp_enum(cls, parser)
+
+
+@irdl_attr_definition
+class MapBoundsType(ParametrizedAttribute, TypeAttribute):
+    name = "omp.map_bounds_ty"
 
 
 @irdl_op_definition
@@ -243,6 +340,63 @@ class TargetOp(IRDLOperation):
     traits = traits_def(IsolatedFromAbove())
 
 
+@irdl_op_definition
+class MapBoundsOp(IRDLOperation):
+    """
+    Implementation of upstream omp.map.bounds
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/OpenMPDialect/ODS/#ompmapbounds-ompmapboundsop).
+    """
+
+    name = "omp.map.bounds"
+
+    lower_bound = opt_operand_def(IntegerType | IndexType)
+    upper_bound = opt_operand_def(IntegerType | IndexType)
+    extent = opt_operand_def(IntegerType | IndexType)
+    stride = opt_operand_def(IntegerType | IndexType)
+    start_idx = opt_operand_def(IntegerType | IndexType)
+
+    stride_in_bytes = prop_def(BoolAttr, default_value=BoolAttr.from_bool(False))
+
+    res = result_def(MapBoundsType)
+
+    irdl_options = [AttrSizedOperandSegments(as_property=True)]
+    traits = traits_def(NoMemoryEffect())
+
+
+@irdl_op_definition
+class MapInfoOp(IRDLOperation):
+    """
+    Implementation of upstream omp.map.info
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/OpenMPDialect/ODS/#ompmapinfo-ompmapinfoop).
+    """
+
+    name = "omp.map.info"
+
+    var_ptr = operand_def()  # TODO: OpenMP_PointerLikeTypeInterface
+    var_ptr_ptr = opt_operand_def()  # TODO: OpenMP_PointerLikeTypeInterface
+    members = var_operand_def()  # TODO: OpenMP_PointerLikeTypeInterface
+    bounds = var_operand_def(MapBoundsType)
+
+    var_type = prop_def(TypeAttribute)
+    map_type = opt_prop_def(IntegerAttr[_ui64])
+    map_capture_type = opt_prop_def(VariableCaptureKindAttr)
+    members_index = opt_prop_def(ArrayAttr[i64])
+    var_name = opt_prop_def(StringAttr, prop_name="name")
+    partial_map = opt_prop_def(BoolAttr, default_value=BoolAttr.from_bool(False))
+
+    omp_ptr = result_def()  # TODO: OpenMP_PointerLikeTypeInterface
+
+    irdl_options = [AttrSizedOperandSegments(as_property=True)]
+
+    def verify_(self) -> None:
+        for mem in self.members:
+            if not isinstance(mem.owner, MapInfoOp):
+                raise VerifyException(
+                    f"All `members` must be results of another {self.name}"
+                )
+        return super().verify_()
+
+
 OMP = Dialect(
     "omp",
     [
@@ -252,6 +406,8 @@ OMP = Dialect(
         LoopNestOp,
         YieldOp,
         TargetOp,
+        MapBoundsOp,
+        MapInfoOp,
     ],
     [
         OrderKindAttr,
@@ -259,5 +415,7 @@ OMP = Dialect(
         ScheduleKindAttr,
         ScheduleModifierAttr,
         DependKindAttr,
+        MapBoundsType,
+        VariableCaptureKindAttr,
     ],
 )


### PR DESCRIPTION
`omp.map.bounds` and `omp.map.info`.

Also adds `OpenMPOffloadMappingFlags`, which defines what each bit in `map_type` does.

