### PR TITLE
dialects: (llvm) Add unreachable operation

### DIFF
--- a/tests/filecheck/dialects/llvm/example.mlir
+++ b/tests/filecheck/dialects/llvm/example.mlir
@@ -99,7 +99,7 @@ builtin.module {
 
 // CHECK-NEXT: %fval3 = llvm.fpext %fval : f32 to f64
 
-  "llvm.unreachable"() : () -> ()
+  llvm.unreachable {my_attr}
 
-// CHECK-NEXT: llvm.unreachable
+// CHECK-NEXT: llvm.unreachable {my_attr}
 }

--- a/tests/filecheck/dialects/llvm/example.mlir
+++ b/tests/filecheck/dialects/llvm/example.mlir
@@ -101,5 +101,5 @@ builtin.module {
 
   "llvm.unreachable"() : () -> ()
 
-// CHECK-NEXT: "llvm.unreachable"() : () -> ()
+// CHECK-NEXT: llvm.unreachable
 }

--- a/tests/filecheck/dialects/llvm/example.mlir
+++ b/tests/filecheck/dialects/llvm/example.mlir
@@ -99,7 +99,7 @@ builtin.module {
 
 // CHECK-NEXT: %fval3 = llvm.fpext %fval : f32 to f64
 
-	"llvm.unreachable"() : () -> ()
+  "llvm.unreachable"() : () -> ()
 
 // CHECK-NEXT: "llvm.unreachable"() : () -> ()
 }

--- a/tests/filecheck/dialects/llvm/example.mlir
+++ b/tests/filecheck/dialects/llvm/example.mlir
@@ -98,4 +98,8 @@ builtin.module {
   %fval3 = llvm.fpext %fval : f32 to f64
 
 // CHECK-NEXT: %fval3 = llvm.fpext %fval : f32 to f64
+
+	"llvm.unreachable"() : () -> ()
+
+// CHECK-NEXT: "llvm.unreachable"() : () -> ()
 }

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -1845,7 +1845,7 @@ class UnreachableOp(IRDLOperation):
     name = "llvm.unreachable"
 
     traits = traits_def(IsTerminator())
-
+    assembly_format = "attr-dict"
 
 LLVM = Dialect(
     "llvm",

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -1847,6 +1847,7 @@ class UnreachableOp(IRDLOperation):
     traits = traits_def(IsTerminator())
     assembly_format = "attr-dict"
 
+
 LLVM = Dialect(
     "llvm",
     [

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -1840,6 +1840,13 @@ class FPExtOp(GenericCastOp):
     name = "llvm.fpext"
 
 
+@irdl_op_definition
+class UnreachableOp(IRDLOperation):
+    name = "llvm.unreachable"
+
+    traits = traits_def(IsTerminator())
+
+
 LLVM = Dialect(
     "llvm",
     [
@@ -1883,6 +1890,7 @@ LLVM = Dialect(
         UDivOp,
         URemOp,
         UndefOp,
+        UnreachableOp,
         XOrOp,
         ZExtOp,
         ZeroOp,


### PR DESCRIPTION
The unreachable OP in the LLVM dialect, we need this for the Fortran work and this wasn't part of the xDSL LLVM dialect. A very simple operation in and of itself
