### PR TITLE
dialects: (fir) Update to bring inline with operations in Flang 20.1.1

### DIFF
--- a/xdsl/dialects/experimental/hlfir.py
+++ b/xdsl/dialects/experimental/hlfir.py
@@ -42,11 +42,11 @@ from xdsl.irdl import (
     opt_prop_def,
     prop_def,
     region_def,
-    var_region_def,
     result_def,
-    var_result_def,
-    var_operand_def,
     traits_def,
+    var_operand_def,
+    var_region_def,
+    var_result_def,
 )
 from xdsl.parser import AttrParser
 from xdsl.printer import Printer

--- a/xdsl/dialects/experimental/hlfir.py
+++ b/xdsl/dialects/experimental/hlfir.py
@@ -44,11 +44,15 @@ from xdsl.irdl import (
     opt_prop_def,
     prop_def,
     region_def,
+    var_region_def,
     result_def,
+    var_result_def,
     var_operand_def,
+    traits_def,
 )
 from xdsl.parser import AttrParser
 from xdsl.printer import Printer
+from xdsl.traits import IsTerminator
 
 
 @irdl_attr_definition
@@ -62,7 +66,7 @@ class ExprType(ParametrizedAttribute, TypeAttribute):
 
     name = "hlfir.expr"
     shape: ParameterDef[ArrayAttr[IntegerAttr | DeferredAttr | NoneType]]
-    elementType: ParameterDef[IntegerType | AnyFloat | ReferenceType]
+    elementType: ParameterDef[Attribute]
 
     def print_parameters(self, printer: Printer) -> None:
         printer.print("<")
@@ -494,7 +498,7 @@ class AssociateOp(IRDLOperation):
     typeparams = var_operand_def()
     uniq_name = opt_prop_def(StringAttr)
     fortran_attrs = opt_prop_def(FortranVariableFlagsAttr)
-    result = result_def()
+    result = var_result_def()
 
     irdl_options = [AttrSizedOperandSegments(as_property=True)]
 
@@ -588,6 +592,7 @@ class ElementalOp(IRDLOperation):
     mold = opt_operand_def()
     typeparams = var_operand_def()
     unordered = opt_prop_def(UnitAttr)
+    regs = var_region_def()
     result = result_def()
 
     irdl_options = [AttrSizedOperandSegments(as_property=True)]
@@ -603,6 +608,8 @@ class YieldElementOp(IRDLOperation):
 
     name = "hlfir.yield_element"
     element_value = operand_def()
+
+    traits = traits_def(IsTerminator())
 
 
 @irdl_op_definition
@@ -696,7 +703,7 @@ class CopyInOp(IRDLOperation):
     name = "hlfir.copy_in"
     var = operand_def()
     var_is_present = opt_operand_def()
-    result = result_def()
+    result = var_result_def()
 
 
 @irdl_op_definition
@@ -806,6 +813,8 @@ class RegionYieldOp(IRDLOperation):
     name = "hlfir.yield"
     entity = operand_def()
     cleanup = region_def()
+
+    traits = traits_def(IsTerminator())
 
 
 @irdl_op_definition

--- a/xdsl/dialects/experimental/hlfir.py
+++ b/xdsl/dialects/experimental/hlfir.py
@@ -150,6 +150,7 @@ class DeclareOp(IRDLOperation):
     memref = operand_def()
     shape = opt_operand_def()
     typeparams = var_operand_def()
+    dummy_scope = opt_operand_def()
     uniq_name = opt_prop_def(StringAttr)
     fortran_attrs = opt_prop_def(FortranVariableFlagsAttr)
     result = result_def()

--- a/xdsl/dialects/experimental/hlfir.py
+++ b/xdsl/dialects/experimental/hlfir.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 from xdsl.dialects.arith import FastMathFlagsAttr
 from xdsl.dialects.builtin import (
-    AnyFloat,
     ArrayAttr,
     Attribute,
     BoolAttr,
@@ -30,7 +29,6 @@ from xdsl.dialects.experimental.fir import (
     DeferredAttr,
     FortranVariableFlagsAttr,
     NoneType,
-    ReferenceType,
 )
 from xdsl.ir import Dialect, TypeAttribute
 from xdsl.irdl import (


### PR DESCRIPTION
Additional of the DummyScopeType and Operation, along with a missing optional operand elsewhere that brings HLFIR and FIR inline with the version used in Flang 20.1.1 that we are now working with.

These are experimental dialects, hence no tests 
