### PR TITLE
dialect: Add PositiveIntConstr Constraint to tensor dialect

### DIFF
--- a/tests/filecheck/dialects/tensor/invalid_ops.mlir
+++ b/tests/filecheck/dialects/tensor/invalid_ops.mlir
@@ -86,6 +86,6 @@ builtin.module {
 // -----
 
 // CHECK: The following constraints were not satisfied:
-// CHECK-NEXT: Expected positive integer, got -2.
+// CHECK-NEXT: expected integer >= 0, got -2
 // CHECK-NEXT: All inner arrays must be contiguous: [[-2 : i64, 3 : i64], [0 : i64, 1 : i64]]
 %res_collapse2 = tensor.collapse_shape %t0 [ [-2, 3], [0, 1] ] : tensor<4x1xf32> into tensor<4x1xf32>

--- a/tests/filecheck/dialects/tensor/invalid_ops.mlir
+++ b/tests/filecheck/dialects/tensor/invalid_ops.mlir
@@ -82,3 +82,10 @@ builtin.module {
 
 // CHECK: All inner arrays must be contiguous: [[2 : i64, 3 : i64], [0 : i64, 1 : i64]]
 %res_collapse2 = tensor.collapse_shape %t0 [ [2, 3], [0, 1] ] : tensor<4x1xf32> into tensor<4x1xf32>
+
+// -----
+
+// CHECK: The following constraints were not satisfied:
+// CHECK-NEXT: Expected positive integer, got -2.
+// CHECK-NEXT: All inner arrays must be contiguous: [[-2 : i64, 3 : i64], [0 : i64, 1 : i64]]
+%res_collapse2 = tensor.collapse_shape %t0 [ [-2, 3], [0, 1] ] : tensor<4x1xf32> into tensor<4x1xf32>

--- a/xdsl/dialects/tensor.py
+++ b/xdsl/dialects/tensor.py
@@ -48,7 +48,8 @@ class ContiguousArrayOfIntArray(AttrConstraint):
     """
     Enforce an ArrayAttr of ArrayAttr[IntegerAttr] to contain contiguous integer values across all inner arrays.
     For example: [[0, 1], [2, 3]] is valid, but [[3, 4], [0, 1]] is not.
-    An empty inner array is considered contiguous.
+    An empty inner array is considered contiguous. Incidentally, this also
+    verifies that all integers across all inner arrays are unique.
     """
 
     def verify(
@@ -70,6 +71,25 @@ class ContiguousArrayOfIntArray(AttrConstraint):
         self, type_var_mapping: dict[TypeVar, AttrConstraint]
     ) -> ContiguousArrayOfIntArray:
         # No type variables to map in this constraint
+        return self
+
+
+class PositiveIntConstr(AttrConstraint):
+    """
+    Enforce that an IntegerAttr is positive (> 0).
+    """
+
+    def verify(self, attr: Attribute, constraint_context: ConstraintContext) -> None:
+        if not isinstance(attr, IntegerAttr):
+            raise VerifyException(
+                f"Expected {IntegerAttr.name} attribute, but got {attr.name}."
+            )
+        if attr.value.data < 0:
+            raise VerifyException(f"Expected positive integer, got {attr.value.data}.")
+
+    def mapping_type_vars(
+        self, type_var_mapping: dict[TypeVar, AttrConstraint]
+    ) -> PositiveIntConstr:
         return self
 
 
@@ -216,7 +236,7 @@ class EmptyOp(IRDLOperation):
 
 
 ReassociationAttr = Annotated[
-    ArrayAttr[ArrayAttr[IntegerAttr[I64]]],
+    ArrayAttr[ArrayAttr[Annotated[IntegerAttr[I64], PositiveIntConstr()]]],
     ContiguousArrayOfIntArray(),
 ]
 

--- a/xdsl/dialects/tensor.py
+++ b/xdsl/dialects/tensor.py
@@ -15,6 +15,7 @@ from xdsl.dialects.builtin import (
     ArrayAttr,
     DenseArrayBase,
     IndexType,
+    IntAttrConstraint,
     IntegerAttr,
     TensorType,
     UnrankedTensorType,
@@ -22,6 +23,7 @@ from xdsl.dialects.builtin import (
 )
 from xdsl.ir import Attribute, Dialect, Operation, SSAValue
 from xdsl.irdl import (
+    AtLeast,
     AttrConstraint,
     AttrSizedOperandSegments,
     ConstraintContext,
@@ -71,25 +73,6 @@ class ContiguousArrayOfIntArray(AttrConstraint):
         self, type_var_mapping: dict[TypeVar, AttrConstraint]
     ) -> ContiguousArrayOfIntArray:
         # No type variables to map in this constraint
-        return self
-
-
-class PositiveIntConstr(AttrConstraint):
-    """
-    Enforce that an IntegerAttr is positive (> 0).
-    """
-
-    def verify(self, attr: Attribute, constraint_context: ConstraintContext) -> None:
-        if not isinstance(attr, IntegerAttr):
-            raise VerifyException(
-                f"Expected {IntegerAttr.name} attribute, but got {attr.name}."
-            )
-        if attr.value.data < 0:
-            raise VerifyException(f"Expected positive integer, got {attr.value.data}.")
-
-    def mapping_type_vars(
-        self, type_var_mapping: dict[TypeVar, AttrConstraint]
-    ) -> PositiveIntConstr:
         return self
 
 
@@ -236,7 +219,14 @@ class EmptyOp(IRDLOperation):
 
 
 ReassociationAttr = Annotated[
-    ArrayAttr[ArrayAttr[Annotated[IntegerAttr[I64], PositiveIntConstr()]]],
+    ArrayAttr[
+        ArrayAttr[
+            Annotated[
+                IntegerAttr[I64],
+                IntegerAttr.constr(value=IntAttrConstraint(AtLeast(0))),
+            ]
+        ]
+    ],
     ContiguousArrayOfIntArray(),
 ]
 


### PR DESCRIPTION
Used to verify the ReassociationAttr

Maybe this should go somewhere it can be shared? Maybe the ShapeAttr could benefit from this as well.