### PR TITLE
core: add diagnostic info to original error __notes__

### DIFF
--- a/tests/irdl/test_operation_definition.py
+++ b/tests/irdl/test_operation_definition.py
@@ -872,19 +872,19 @@ def test_entry_args_op():
 
     op = EntryArgsOp.create(regions=[Region(Block(arg_types=[i64]))])
     with pytest.raises(
-        DiagnosticException,
+        VerifyException,
         match="""\
 Operation does not verify: region #0 entry arguments do not verify:
-Expected attribute i32 but got i64""",
+.*Expected attribute i32 but got i64""",
     ):
         op.verify()
 
     op = EntryArgsOp.create(regions=[Region(Block(arg_types=[i64, i32]))])
     with pytest.raises(
-        DiagnosticException,
+        VerifyException,
         match="""\
 Operation does not verify: region #0 entry arguments do not verify:
-Expected attribute i32 but got i64""",
+.*Expected attribute i32 but got i64""",
     ):
         op.verify()
 

--- a/tests/pattern_rewriter/test_pattern_rewriter.py
+++ b/tests/pattern_rewriter/test_pattern_rewriter.py
@@ -1760,8 +1760,6 @@ builtin.module {
 }
 """
     expected = """\
-Error while applying pattern: Expected operation to not be erroneous!
-
 "builtin.module"() ({
   "test.op"() {erroneous = false} : () -> ()
   "test.op"() : () -> ()

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -47,7 +47,7 @@ from xdsl.irdl import (
 from xdsl.parser import AttrParser, Parser
 from xdsl.printer import Printer
 from xdsl.utils.diagnostic import Diagnostic
-from xdsl.utils.exceptions import DiagnosticException, ParseError
+from xdsl.utils.exceptions import ParseError
 from xdsl.utils.test_value import create_ssa_value
 
 
@@ -306,10 +306,12 @@ def test_diagnostic():
     parser = Parser(ctx, prog)
     module = parser.parse_op()
 
+    class MyException(Exception): ...
+
     diag = Diagnostic()
     diag.add_message(module, "Test")
-    with pytest.raises(DiagnosticException):
-        diag.raise_exception("test message", module)
+    with pytest.raises(MyException, match="Test"):
+        diag.raise_exception(module, MyException("hello"))
 
 
 #  ____ ____    _    _   _

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -1162,7 +1162,8 @@ class Operation(IRNode):
             self.verify_()
         except VerifyException as err:
             self.emit_error(
-                "Operation does not verify: " + str(err), underlying_error=err
+                f"Operation does not verify: {err}",
+                err,
             )
 
     def verify_(self) -> None:
@@ -1352,15 +1353,14 @@ class Operation(IRNode):
     def emit_error(
         self,
         message: str,
-        exception_type: type[Exception] = VerifyException,
-        underlying_error: Exception | None = None,
+        underlying_error: Exception,
     ) -> NoReturn:
         """Emit an error with the given message."""
         from xdsl.utils.diagnostic import Diagnostic
 
         diagnostic = Diagnostic()
         diagnostic.add_message(self, message)
-        diagnostic.raise_exception(message, self, exception_type, underlying_error)
+        diagnostic.raise_exception(self, underlying_error)
 
     @classmethod
     def dialect_name(cls) -> str:

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -780,8 +780,7 @@ class PatternRewriteWalker:
                 self.pattern.match_and_rewrite(op, rewriter)
             except Exception as err:
                 op.emit_error(
-                    f"Error while applying pattern: {str(err)}",
-                    exception_type=type(err),
+                    f"Error while applying pattern: {err}",
                     underlying_error=err,
                 )
             rewriter_has_done_action |= rewriter.has_done_action

--- a/xdsl/utils/diagnostic.py
+++ b/xdsl/utils/diagnostic.py
@@ -5,7 +5,6 @@ from io import StringIO
 from typing import NoReturn
 
 from xdsl.ir import Block, IRNode, Operation, Region
-from xdsl.utils.exceptions import DiagnosticException
 
 
 @dataclass
@@ -18,13 +17,7 @@ class Diagnostic:
         """Add a message to an operation."""
         self.op_messages.setdefault(op, []).append(message)
 
-    def raise_exception(
-        self,
-        message: str,
-        ir: IRNode,
-        exception_type: type[Exception] = DiagnosticException,
-        underlying_error: Exception | None = None,
-    ) -> NoReturn:
+    def raise_exception(self, ir: IRNode, underlying_error: Exception) -> NoReturn:
         """Raise an exception, that will also print all messages in the IR."""
         from xdsl.printer import Printer
 
@@ -41,4 +34,14 @@ class Diagnostic:
         else:
             assert "xDSL internal error: get_toplevel_object returned unknown construct"
 
-        raise exception_type(message + "\n\n" + f.getvalue()) from underlying_error
+        # __notes__ only in 3.11 and above
+        if hasattr(underlying_error, "add_note"):
+            # Use official API if present
+            underlying_error.add_note(f.getvalue())
+        else:
+            # Add our own __notes__ if not
+            if not hasattr(underlying_error, "__notes__"):
+                underlying_error.__notes__ = []
+            underlying_error.__notes__.append(f.getvalue())
+
+        raise underlying_error

--- a/xdsl/xdsl_opt_main.py
+++ b/xdsl/xdsl_opt_main.py
@@ -84,6 +84,10 @@ class xDSLOptMain(CommandLineTool):
                 except DiagnosticException as e:
                     if self.args.verify_diagnostics:
                         print(e)
+                        # __notes__ only in Python 3.11 and above
+                        if hasattr(e, "__notes__"):
+                            for e in e.__notes__:
+                                print(e)
                     else:
                         raise
                 finally:


### PR DESCRIPTION
Leverage the notes feature of 3.11+ Pythons to append information to exceptions, in a way that also works for 3.10. This lets us avoid the excessive "This was caused by" and multiple stack traces, making the error messages more focused on the real cause. Also removes the need to create extra exceptions with dodgy exception types that may not have the expected init method.