### PR TITLE
dialects: (fir) Add BoxOffsetOp to FIR dialect

### DIFF
--- a/xdsl/dialects/experimental/fir.py
+++ b/xdsl/dialects/experimental/fir.py
@@ -1091,6 +1091,29 @@ class BoxIsptrOp(IRDLOperation):
 
 
 @irdl_op_definition
+class BoxOffsetOp(IRDLOperation):
+    """
+    Given the address of a fir.box, compute the address of a field inside
+    the fir.box.
+    This allows keeping the actual runtime descriptor layout abstract in
+    FIR while providing access to the pointer addresses in the runtime
+    descriptor for OpenMP/OpenACC target mapping.
+
+    To avoid requiring too much information about the fields that the runtime
+    descriptor implementation must have, only the base_addr and derived_type
+    descriptor fields can be addressed.
+
+    %addr = fir.box_offset %box base_addr : (!fir.ref<!fir.box<!fir.array<?xi32>>>) -> !fir.llvm_ptr<!fir.ref<!fir.array<?xi32>>>
+    %tdesc = fir.box_offset %box derived_type : (!fir.ref<!fir.box<!fir.type<t>>>) -> !fir.llvm_ptr<!fir.tdesc<!fir.type<t>>>
+    """
+
+    name = "fir.box_offset"
+    field = prop_def(Attribute)
+    val = operand_def()
+    result_0 = result_def()
+
+
+@irdl_op_definition
 class BoxprocHostOp(IRDLOperation):
     """
     Extract the host context pointer from a boxproc value.
@@ -2398,6 +2421,7 @@ FIR = Dialect(
         BoxIsallocOp,
         BoxIsarrayOp,
         BoxIsptrOp,
+        BoxOffsetOp,
         BoxprocHostOp,
         BoxRankOp,
         BoxTdescOp,


### PR DESCRIPTION
Added BoxOffsetOp to the FIR experimental dialect which is used by Flang 20.1.7 to extract the underlying LLVM pointer of a box which can then be passed to external APIs, such as OpenMP or OpenACC
