### PR TITLE
API: use variadic init on ParametrizedAttribute

### DIFF
--- a/tests/irdl/test_attr_constraint.py
+++ b/tests/irdl/test_attr_constraint.py
@@ -58,7 +58,7 @@ class AttrA(Base):
     name = "test.attr_a"
 
     def __init__(self):
-        super().__init__(())
+        super().__init__()
 
 
 @irdl_attr_definition
@@ -68,7 +68,7 @@ class AttrB(Base):
     param: ParameterDef[AttrA]
 
     def __init__(self, param: AttrA):
-        super().__init__((param,))
+        super().__init__(param)
 
 
 @irdl_attr_definition
@@ -76,7 +76,7 @@ class AttrC(Base):
     name = "test.attr_c"
 
     def __init__(self):
-        super().__init__(())
+        super().__init__()
 
 
 @irdl_attr_definition
@@ -86,7 +86,7 @@ class AttrD(Base):
     param: ParameterDef[AttrA | AttrC]
 
     def __init__(self, param: AttrA | AttrC):
-        super().__init__((param,))
+        super().__init__(param)
 
 
 @pytest.mark.parametrize(

--- a/tests/irdl/test_attribute_definition.py
+++ b/tests/irdl/test_attribute_definition.py
@@ -285,7 +285,7 @@ def test_typed_attribute_parsing_printing():
         type: ParameterDef[IntegerType]
 
         def __init__(self, value: IntAttr, type: IntegerType):
-            super().__init__((value, type))
+            super().__init__(value, type)
 
         @classmethod
         def parse_parameters(cls, parser: AttrParser) -> Sequence[Attribute]:
@@ -375,7 +375,7 @@ class BoolWrapperAttr(ParametrizedAttribute):
     param: ParameterDef[BoolData]
 
     def __init__(self, param: BoolData):
-        super().__init__((param,))
+        super().__init__(param)
 
 
 def test_bose_constraint():
@@ -407,7 +407,7 @@ class BoolOrIntParamAttr(ParametrizedAttribute):
     param: ParameterDef[BoolData | IntData]
 
     def __init__(self, param: BoolData | IntData):
-        super().__init__((param,))
+        super().__init__(param)
 
 
 def test_union_constraint_left():
@@ -461,7 +461,7 @@ class PositiveIntAttr(ParametrizedAttribute):
     param: ParameterDef[Annotated[IntData, PositiveIntConstr()]]
 
     def __init__(self, param: IntData):
-        super().__init__((param,))
+        super().__init__(param)
 
 
 def test_annotated_constraint():
@@ -493,7 +493,7 @@ class ParamWrapperAttr(Generic[_T], ParametrizedAttribute):
     param: ParameterDef[_T]
 
     def __init__(self, param: _T):
-        super().__init__((param,))
+        super().__init__(param)
 
 
 def test_typevar_attribute_int():
@@ -527,7 +527,7 @@ class ParamConstrAttr(ParametrizedAttribute):
     param: ParameterDef[ParamWrapperAttr[IntData]]
 
     def __init__(self, param: ParameterDef[ParamWrapperAttr[IntData]]):
-        super().__init__((param,))
+        super().__init__(param)
 
 
 def test_param_attr_constraint():
@@ -562,8 +562,8 @@ class NestedParamWrapperAttr(Generic[_U], ParametrizedAttribute):
 
     param: ParameterDef[ParamWrapperAttr[_U]]
 
-    def __init__(self, param: ParameterDef[ParamWrapperAttr[_U]]):
-        super().__init__((param,))
+    def __init__(self, param: ParamWrapperAttr[_U]):
+        super().__init__(param)
 
 
 def test_nested_generic_constraint():
@@ -599,7 +599,7 @@ class NestedParamConstrAttr(ParametrizedAttribute):
     param: ParameterDef[NestedParamWrapperAttr[Annotated[IntData, PositiveIntConstr()]]]
 
     def __init__(self, param: NestedParamWrapperAttr[IntData]):
-        super().__init__((param,))
+        super().__init__(param)
 
 
 def test_nested_param_attr_constraint():
@@ -644,7 +644,7 @@ class InformativeAttr(ParametrizedAttribute):
     ]
 
     def __init__(self, param: Attribute):
-        super().__init__((param,))
+        super().__init__(param)
 
 
 def test_informative_attribute():
@@ -794,7 +794,7 @@ class ListDataWrapper(ParametrizedAttribute):
     val: ParameterDef[ListData[BoolData]]
 
     def __init__(self, val: ListData[BoolData]):
-        super().__init__((val,))
+        super().__init__(val)
 
 
 def test_generic_data_wrapper_verifier():
@@ -832,7 +832,7 @@ class ListDataNoGenericsWrapper(ParametrizedAttribute):
     val: ParameterDef[AnyListData]
 
     def __init__(self, val: AnyListData):
-        super().__init__((val,))
+        super().__init__(val)
 
 
 def test_generic_data_no_generics_wrapper_verifier():
@@ -909,9 +909,9 @@ class OveriddenInitAttr(ParametrizedAttribute):
     def __init__(self, param: int | str):
         match param:
             case int():
-                super().__init__((IntData(param),))
+                super().__init__(IntData(param))
             case str():
-                super().__init__((StringData(param),))
+                super().__init__(StringData(param))
 
 
 def test_generic_constructor():

--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -3429,7 +3429,7 @@ class MyAttr(ParametrizedAttribute):
     param: ParameterDef[StringAttr]
 
     def __init__(self, param: StringAttr):
-        super().__init__((param,))
+        super().__init__(param)
 
 
 @irdl_op_definition

--- a/tests/test_is_satisfying_hint.py
+++ b/tests/test_is_satisfying_hint.py
@@ -361,7 +361,7 @@ class MyParamAttr(Generic[_T], ParametrizedAttribute):
     v: ParameterDef[_T]
 
     def __init__(self, v: _T):
-        super().__init__((v,))
+        super().__init__(v)
 
 
 def test_parametrized_attribute():

--- a/tests/test_pyrdl.py
+++ b/tests/test_pyrdl.py
@@ -81,7 +81,7 @@ class DoubleParamAttr(ParametrizedAttribute):
     param2: ParameterDef[Attribute]
 
     def __init__(self, param1: Attribute, param2: Attribute):
-        super().__init__((param1, param2))
+        super().__init__(param1, param2)
 
 
 def test_eq_attr_verify():

--- a/xdsl/backend/register_type.py
+++ b/xdsl/backend/register_type.py
@@ -32,7 +32,7 @@ class RegisterType(ParametrizedAttribute, TypeAttribute, ABC):
     register_name: ParameterDef[StringAttr]
 
     def __init__(self, index: IntAttr | NoneAttr, register_name: StringAttr):
-        super().__init__((index, register_name))
+        super().__init__(index, register_name)
 
     @classmethod
     def unallocated(cls) -> Self:

--- a/xdsl/dialects/accfg.py
+++ b/xdsl/dialects/accfg.py
@@ -86,7 +86,7 @@ class TokenType(ParametrizedAttribute, TypeAttribute):
     def __init__(self, accelerator: str | StringAttr):
         if not isinstance(accelerator, StringAttr):
             accelerator = StringAttr(accelerator)
-        super().__init__([accelerator])
+        super().__init__(accelerator)
 
 
 @irdl_attr_definition
@@ -102,7 +102,7 @@ class StateType(ParametrizedAttribute, TypeAttribute):
     def __init__(self, accelerator: str | StringAttr):
         if not isinstance(accelerator, StringAttr):
             accelerator = StringAttr(accelerator)
-        return super().__init__([accelerator])
+        return super().__init__(accelerator)
 
 
 @irdl_op_definition

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -283,7 +283,7 @@ class SymbolRefAttr(ParametrizedAttribute, BuiltinAttribute):
             nested = ArrayAttr(
                 [StringAttr(x) if isinstance(x, str) else x for x in nested]
             )
-        super().__init__([root, nested])
+        super().__init__(root, nested)
 
     def string_value(self):
         root = self.root_reference.data
@@ -570,7 +570,7 @@ class IntegerType(
             data = IntAttr(data)
         if isinstance(signedness, Signedness):
             signedness = SignednessAttr(signedness)
-        super().__init__([data, signedness])
+        super().__init__(data, signedness)
 
     def print_builtin(self, printer: Printer) -> None:
         if self.signedness.data == Signedness.SIGNLESS:
@@ -690,7 +690,7 @@ class UnitAttr(ParametrizedAttribute, BuiltinAttribute):
     name = "unit"
 
     def __init__(self):
-        super().__init__(())
+        super().__init__()
 
     def print_builtin(self, printer: Printer) -> None:
         printer.print_string("unit")
@@ -783,7 +783,7 @@ class IntegerAttr(
             )
             if normalized_value is not None:
                 value = normalized_value
-        super().__init__([IntAttr(value), value_type])
+        super().__init__(IntAttr(value), value_type)
 
     @staticmethod
     def from_int_and_width(value: int, width: int) -> IntegerAttr[IntegerType]:
@@ -1046,7 +1046,7 @@ class FloatAttr(Generic[_FloatAttrType], BuiltinAttribute, TypedAttribute):
 
         data_attr = FloatData(value)
 
-        super().__init__([data_attr, type])
+        super().__init__(data_attr, type)
 
     @staticmethod
     def parse_with_type(
@@ -1105,7 +1105,7 @@ class ComplexType(
     element_type: ParameterDef[ComplexElementCovT]
 
     def __init__(self, element_type: ComplexElementCovT):
-        super().__init__([element_type])
+        super().__init__(element_type)
 
     def print_builtin(self, printer: Printer):
         printer.print_string("complex")
@@ -1203,7 +1203,7 @@ class TupleType(ParametrizedAttribute, BuiltinAttribute, TypeAttribute):
     def __init__(self, types: list[TypeAttribute] | ArrayAttr[TypeAttribute]) -> None:
         if isinstance(types, list):
             types = ArrayAttr(types)
-        super().__init__([types])
+        super().__init__(types)
 
     def print_builtin(self, printer: Printer):
         printer.print_string("tuple")
@@ -1238,7 +1238,7 @@ class VectorType(
         if scalable_dims is None:
             false = BoolAttr(False, i1)
             scalable_dims = ArrayAttr(false for _ in shape)
-        super().__init__([shape, element_type, scalable_dims])
+        super().__init__(shape, element_type, scalable_dims)
 
     @staticmethod
     def _print_vector_dim(printer: Printer, pair: tuple[IntAttr, BoolAttr]):
@@ -1338,7 +1338,7 @@ class TensorType(
         shape = ArrayAttr(
             [IntAttr(dim) if isinstance(dim, int) else dim for dim in shape]
         )
-        super().__init__([shape, element_type, encoding])
+        super().__init__(shape, element_type, encoding)
 
     def print_builtin(self, printer: Printer):
         printer.print_string("tensor")
@@ -1386,7 +1386,7 @@ class UnrankedTensorType(
     element_type: ParameterDef[AttributeCovT]
 
     def __init__(self, element_type: AttributeCovT) -> None:
-        super().__init__([element_type])
+        super().__init__(element_type)
 
     def get_element_type(self) -> AttributeCovT:
         return self.element_type
@@ -1523,7 +1523,7 @@ class DenseResourceAttr(BuiltinAttribute, TypedAttribute):
     type: ParameterDef[ShapedType]
 
     def __init__(self, resource_handle: StringAttr, type: ShapedType) -> None:
-        return super().__init__((resource_handle, type))
+        return super().__init__(resource_handle, type)
 
     def print_without_type(self, printer: Printer):
         printer.print_string("dense_resource")
@@ -1569,7 +1569,7 @@ class DenseArrayBase(
     data: ParameterDef[BytesAttr]
 
     def __init__(self, elt_type: DenseArrayT, data: BytesAttr):
-        super().__init__((elt_type, data))
+        super().__init__(elt_type, data)
 
     def print_builtin(self, printer: Printer):
         printer.print_string("array")
@@ -1707,7 +1707,7 @@ class FunctionType(ParametrizedAttribute, BuiltinAttribute, TypeAttribute):
         inputs: ArrayAttr[Attribute],
         outputs: ArrayAttr[Attribute],
     ):
-        super().__init__((inputs, outputs))
+        super().__init__(inputs, outputs)
 
     def print_builtin(self, printer: Printer):
         with printer.in_parens():
@@ -1742,7 +1742,7 @@ class OpaqueAttr(ParametrizedAttribute, BuiltinAttribute):
     type: ParameterDef[Attribute]
 
     def __init__(self, ident: StringAttr, value: StringAttr, type: Attribute) -> None:
-        return super().__init__((ident, value, type))
+        super().__init__(ident, value, type)
 
     def print_builtin(self, printer: Printer):
         printer.print_string("opaque")
@@ -1830,7 +1830,7 @@ class StridedLayoutAttr(MemRefLayoutAttr, BuiltinAttribute, ParametrizedAttribut
         if offset is None:
             offset = NoneAttr()
 
-        super().__init__([strides, offset])
+        super().__init__(strides, offset)
 
     @staticmethod
     def _print_int_or_question(printer: Printer, value: IntAttr | NoneAttr) -> None:
@@ -2105,7 +2105,7 @@ class UnregisteredAttr(ParametrizedAttribute, BuiltinAttribute, ABC):
             is_opaque = IntAttr(int(is_opaque))
         if isinstance(value, str):
             value = StringAttr(value)
-        super().__init__([attr_name, is_type, is_opaque, value])
+        super().__init__(attr_name, is_type, is_opaque, value)
 
     def print_builtin(self, printer: Printer):
         # Do not print `!` or `#` for unregistered builtin attributes
@@ -2275,12 +2275,10 @@ class MemRefType(
                 [IntAttr(dim) if isinstance(dim, int) else dim for dim in shape]
             )
         super().__init__(
-            (
-                s,
-                element_type,
-                layout,
-                memory_space,
-            )
+            s,
+            element_type,
+            layout,
+            memory_space,
         )
 
     def get_num_dims(self) -> int:
@@ -2429,7 +2427,7 @@ class UnrankedMemRefType(
     def __init__(
         self, element_type: _UnrankedMemRefTypeElems, memory_space: Attribute
     ) -> None:
-        return super().__init__((element_type, memory_space))
+        return super().__init__(element_type, memory_space)
 
     def print_builtin(self, printer: Printer):
         printer.print_string("memref<*x")
@@ -2476,7 +2474,7 @@ class DenseIntOrFPElementsAttr(
     data: ParameterDef[BytesAttr]
 
     def __init__(self, type: RankedStructure[DenseElementCovT], data: BytesAttr):
-        super().__init__((type, data))
+        super().__init__(type, data)
 
     # The type stores the shape data
     def get_shape(self) -> tuple[int, ...]:

--- a/xdsl/dialects/csl/csl.py
+++ b/xdsl/dialects/csl/csl.py
@@ -316,7 +316,7 @@ class PtrType(ParametrizedAttribute, TypeAttribute, ContainerType[Attribute]):
     constness: ParameterDef[PtrConstAttr]
 
     def __init__(self, type: TypeAttribute, kind: PtrKindAttr, constness: PtrConstAttr):
-        super().__init__((type, kind, constness))
+        super().__init__(type, kind, constness)
 
     @staticmethod
     def get(typ: Attribute, is_single: bool, is_const: bool):
@@ -408,7 +408,7 @@ class VarType(ParametrizedAttribute, TypeAttribute, ContainerType[Attribute]):
     child_type: ParameterDef[TypeAttribute]
 
     def __init__(self, child_type: TypeAttribute):
-        super().__init__((child_type,))
+        super().__init__(child_type)
 
     def get_element_type(self) -> TypeAttribute:
         return self.child_type

--- a/xdsl/dialects/csl/csl_stencil.py
+++ b/xdsl/dialects/csl/csl_stencil.py
@@ -85,13 +85,9 @@ class ExchangeDeclarationAttr(ParametrizedAttribute):
     ):
         data_type = builtin.i64
         super().__init__(
-            [
-                (
-                    neighbor
-                    if isinstance(neighbor, DenseArrayBase)
-                    else DenseArrayBase.from_list(data_type, neighbor)
-                ),
-            ]
+            neighbor
+            if isinstance(neighbor, DenseArrayBase)
+            else DenseArrayBase.from_list(data_type, neighbor)
         )
 
     @classmethod
@@ -170,7 +166,7 @@ class CoeffAttr(ParametrizedAttribute):
     coeff: ParameterDef[FloatAttr[AnyFloat]]
 
     def __init__(self, offset: stencil.IndexAttr, coeff: FloatAttr[AnyFloat]):
-        super().__init__([offset, coeff])
+        super().__init__(offset, coeff)
 
 
 class ApplyOpHasCanonicalizationPatternsTrait(HasCanonicalizationPatternsTrait):

--- a/xdsl/dialects/csl/csl_wrapper.py
+++ b/xdsl/dialects/csl/csl_wrapper.py
@@ -61,7 +61,7 @@ class ParamAttribute(ParametrizedAttribute):
         value: IntegerAttr[IntegerType] | NoneAttr,
         type: IntegerType,
     ):
-        super().__init__((key, value, type))
+        super().__init__(key, value, type)
 
     def print_parameters(self, printer: Printer) -> None:
         with printer.in_angle_brackets():

--- a/xdsl/dialects/emitc.py
+++ b/xdsl/dialects/emitc.py
@@ -56,7 +56,7 @@ class EmitC_ArrayType(
         shape = ArrayAttr(
             [IntAttr(dim) if isinstance(dim, int) else dim for dim in shape]
         )
-        super().__init__([shape, element_type])
+        super().__init__(shape, element_type)
 
     def verify(self) -> None:
         if not self.shape.data:
@@ -126,7 +126,7 @@ class EmitC_LValueType(ParametrizedAttribute, TypeAttribute):
     value_type: ParameterDef[TypeAttribute]
 
     def __init__(self, value_type: TypeAttribute):
-        super().__init__([value_type])
+        super().__init__(value_type)
 
     def verify(self) -> None:
         """

--- a/xdsl/dialects/experimental/dmp.py
+++ b/xdsl/dialects/experimental/dmp.py
@@ -99,12 +99,10 @@ class ExchangeDeclarationAttr(ParametrizedAttribute):
     ):
         data_type = builtin.i64
         super().__init__(
-            [
-                builtin.DenseArrayBase.from_list(data_type, offset),
-                builtin.DenseArrayBase.from_list(data_type, size),
-                builtin.DenseArrayBase.from_list(data_type, source_offset),
-                builtin.DenseArrayBase.from_list(data_type, neighbor),
-            ]
+            builtin.DenseArrayBase.from_list(data_type, offset),
+            builtin.DenseArrayBase.from_list(data_type, size),
+            builtin.DenseArrayBase.from_list(data_type, source_offset),
+            builtin.DenseArrayBase.from_list(data_type, neighbor),
         )
 
     @classmethod
@@ -273,7 +271,7 @@ class ShapeAttr(ParametrizedAttribute):
         core_lb_: builtin.DenseArrayBase[builtin.I64],
         core_ub_: builtin.DenseArrayBase[builtin.I64],
     ):
-        super().__init__((buff_lb_, buff_ub_, core_lb_, core_ub_))
+        super().__init__(buff_lb_, buff_ub_, core_lb_, core_ub_)
 
     @property
     def buff_lb(self) -> tuple[int, ...]:
@@ -413,7 +411,7 @@ class RankTopoAttr(ParametrizedAttribute):
     def __init__(self, shape: Sequence[int]):
         if len(shape) < 1:
             raise ValueError("dmp.grid must have at least one dimension!")
-        super().__init__([builtin.DenseArrayBase.from_list(builtin.i64, shape)])
+        super().__init__(builtin.DenseArrayBase.from_list(builtin.i64, shape))
 
     def as_tuple(self) -> tuple[int, ...]:
         shape = self.shape.get_values()
@@ -468,9 +466,7 @@ class GridSlice2dAttr(DomainDecompositionStrategy):
     diagonals: ParameterDef[builtin.BoolAttr]
 
     def __init__(self, topo: tuple[int, ...]):
-        super().__init__(
-            [RankTopoAttr(topo), builtin.BoolAttr.from_int_and_width(0, 1)]
-        )
+        super().__init__(RankTopoAttr(topo), builtin.BoolAttr.from_int_and_width(0, 1))
 
     def _verify(self):
         assert len(self.topology.as_tuple()) >= 2, (
@@ -516,9 +512,7 @@ class GridSlice3dAttr(DomainDecompositionStrategy):
     diagonals: ParameterDef[builtin.BoolAttr]
 
     def __init__(self, topo: tuple[int, ...]):
-        super().__init__(
-            [RankTopoAttr(topo), builtin.BoolAttr.from_int_and_width(0, 1)]
-        )
+        super().__init__(RankTopoAttr(topo), builtin.BoolAttr.from_int_and_width(0, 1))
 
     def _verify(self):
         assert len(self.topology.as_tuple()) >= 3, (

--- a/xdsl/dialects/experimental/fir.py
+++ b/xdsl/dialects/experimental/fir.py
@@ -225,7 +225,7 @@ class SequenceType(ParametrizedAttribute, TypeAttribute):
         type2: ParameterDef[IntegerType | AnyFloat | ReferenceType] | None = None,
     ):
         if type2 is not None:
-            super().__init__([ArrayAttr([NoneType()]), type1, type2])
+            super().__init__(ArrayAttr([NoneType()]), type1, type2)
         else:
             if shape is None:
                 shape = [1]
@@ -236,11 +236,9 @@ class SequenceType(ParametrizedAttribute, TypeAttribute):
                 ]
             )
             super().__init__(
-                [
-                    shape_array_attr,
-                    type1,
-                    NoneType(),
-                ]
+                shape_array_attr,
+                type1,
+                NoneType(),
             )
 
     def print_parameters(self, printer: Printer) -> None:

--- a/xdsl/dialects/experimental/hls.py
+++ b/xdsl/dialects/experimental/hls.py
@@ -95,7 +95,7 @@ class HLSStreamType(ParametrizedAttribute, TypeAttribute):
     element_type: ParameterDef[Attribute]
 
     def __init__(self, element_type: Attribute):
-        super().__init__((element_type,))
+        super().__init__(element_type)
 
 
 @irdl_op_definition

--- a/xdsl/dialects/gpu.py
+++ b/xdsl/dialects/gpu.py
@@ -117,7 +117,7 @@ class LoopDimMapAttr(ParametrizedAttribute):
     def __init__(
         self, processor: ProcessorAttr, map: AffineMapAttr, bound: AffineMapAttr
     ):
-        super().__init__((processor, map, bound))
+        super().__init__(processor, map, bound)
 
     def print_parameters(self, printer: Printer) -> None:
         with printer.in_angle_brackets():

--- a/xdsl/dialects/hw.py
+++ b/xdsl/dialects/hw.py
@@ -109,7 +109,7 @@ class InnerRefAttr(ParametrizedAttribute):
             module = StringAttr(module)
         if isinstance(name, str):
             name = StringAttr(name)
-        super().__init__((SymbolRefAttr(module), name))
+        super().__init__(SymbolRefAttr(module), name)
 
     @classmethod
     def get_from_operation(
@@ -302,7 +302,7 @@ class InnerSymPropertiesAttr(ParametrizedAttribute):
             field_id = IntAttr(field_id)
         if isinstance(sym_visibility, str):
             sym_visibility = StringAttr(sym_visibility)
-        super().__init__([sym, field_id, sym_visibility])
+        super().__init__(sym, field_id, sym_visibility)
 
     @classmethod
     def parse_parameters(
@@ -377,7 +377,7 @@ class InnerSymAttr(
             syms = [InnerSymPropertiesAttr(syms)]
         if not isinstance(syms, ArrayAttr):
             syms = ArrayAttr(syms)
-        super().__init__([syms])
+        super().__init__(syms)
 
     def get_sym_if_exists(self, field_id: IntAttr | int) -> StringAttr | None:
         """Get the inner sym name for field_id, if it exists."""
@@ -513,7 +513,7 @@ class ModulePort(ParametrizedAttribute):
         type: TypeAttribute,
         dir: DirectionAttr,
     ):
-        super().__init__((port_name, type, dir))
+        super().__init__(port_name, type, dir)
 
 
 @irdl_attr_definition
@@ -523,7 +523,7 @@ class ModuleType(ParametrizedAttribute, TypeAttribute):
     ports: ParameterDef[ArrayAttr[ModulePort]]
 
     def __init__(self, ports: ArrayAttr[ModulePort]):
-        super().__init__((ports,))
+        super().__init__(ports)
 
     @classmethod
     def parse_parameters(cls, parser: AttrParser) -> Sequence[Attribute]:
@@ -567,7 +567,7 @@ class ParamDeclAttr(ParametrizedAttribute):
     type: ParameterDef[TypeAttribute]
 
     def __init__(self, port_name: StringAttr, type: TypeAttribute):
-        super().__init__((port_name, type))
+        super().__init__(port_name, type)
 
     @classmethod
     def parse_free_standing_parameters(

--- a/xdsl/dialects/irdl/irdl.py
+++ b/xdsl/dialects/irdl/irdl.py
@@ -81,7 +81,7 @@ class VariadicityArrayAttr(ParametrizedAttribute, SpacedOpaqueSyntaxAttribute):
     value: ParameterDef[ArrayAttr[VariadicityAttr]]
 
     def __init__(self, variadicities: ArrayAttr[VariadicityAttr]) -> None:
-        super().__init__((variadicities,))
+        super().__init__(variadicities)
 
     @classmethod
     def parse_parameters(cls, parser: AttrParser) -> tuple[ArrayAttr[VariadicityAttr]]:

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -119,7 +119,7 @@ class LLVMStructType(ParametrizedAttribute, TypeAttribute):
     #  bitmask = ParameterDef(StringAttr)
 
     def __init__(self, struct_name: StringAttr, type: ArrayAttr):
-        super().__init__((struct_name, type))
+        super().__init__(struct_name, type)
 
     @staticmethod
     def from_type_list(types: Sequence[Attribute]) -> LLVMStructType:
@@ -159,7 +159,7 @@ class LLVMPointerType(
     addr_space: ParameterDef[IntAttr | NoneAttr]
 
     def __init__(self, type: Attribute, addr_space: IntAttr | NoneAttr):
-        super().__init__((type, addr_space))
+        super().__init__(type, addr_space)
 
     def print_parameters(self, printer: Printer) -> None:
         if isinstance(self.type, NoneAttr):
@@ -213,7 +213,7 @@ class LLVMArrayType(ParametrizedAttribute, TypeAttribute):
     type: ParameterDef[Attribute]
 
     def __init__(self, size: IntAttr, type: Attribute):
-        super().__init__((size, type))
+        super().__init__(size, type)
 
     def print_parameters(self, printer: Printer) -> None:
         with printer.in_angle_brackets():
@@ -266,7 +266,7 @@ class LLVMFunctionType(ParametrizedAttribute, TypeAttribute):
         if output is None:
             output = LLVMVoidType()
         variad_attr = UnitAttr() if is_variadic else NoneAttr()
-        super().__init__([inputs, output, variad_attr])
+        super().__init__(inputs, output, variad_attr)
 
     @property
     def is_variadic(self) -> bool:
@@ -333,7 +333,7 @@ class LinkageAttr(ParametrizedAttribute):
     def __init__(self, linkage: str | StringAttr) -> None:
         if isinstance(linkage, str):
             linkage = StringAttr(linkage)
-        super().__init__([linkage])
+        super().__init__(linkage)
 
     def print_parameters(self, printer: Printer) -> None:
         printer.print_string("<")
@@ -1490,7 +1490,7 @@ class CallingConventionAttr(ParametrizedAttribute):
         return self.convention.data
 
     def __init__(self, conv: str):
-        super().__init__([StringAttr(conv)])
+        super().__init__(StringAttr(conv))
 
     def _verify(self):
         if self.cconv_name not in LLVM_CALLING_CONVS:

--- a/xdsl/dialects/memref_stream.py
+++ b/xdsl/dialects/memref_stream.py
@@ -85,7 +85,7 @@ class ReadableStreamType(
         return self.element_type
 
     def __init__(self, element_type: _StreamTypeElement):
-        super().__init__([element_type])
+        super().__init__(element_type)
 
     @classmethod
     def constr(
@@ -112,7 +112,7 @@ class WritableStreamType(
         return self.element_type
 
     def __init__(self, element_type: _StreamTypeElement):
-        super().__init__([element_type])
+        super().__init__(element_type)
 
     @classmethod
     def constr(
@@ -201,7 +201,7 @@ class StridePattern(ParametrizedAttribute):
         ub: ArrayAttr[IntegerAttr[IndexType]],
         index_map: ParameterDef[AffineMapAttr],
     ):
-        super().__init__((ub, index_map))
+        super().__init__(ub, index_map)
 
     @classmethod
     def parse_parameters(cls, parser: AttrParser) -> Sequence[Attribute]:

--- a/xdsl/dialects/mpi.py
+++ b/xdsl/dialects/mpi.py
@@ -58,7 +58,7 @@ class OperationType(ParametrizedAttribute, TypeAttribute):
     op_str: ParameterDef[StringAttr]
 
     def __init__(self, op_str: StringAttr):
-        super().__init__((op_str,))
+        super().__init__(op_str)
 
 
 class MpiOp:
@@ -128,7 +128,7 @@ class VectorType(Generic[_VectorT], ParametrizedAttribute, TypeAttribute):
     wrapped_type: ParameterDef[_VectorT]
 
     def __init__(self, wrapped_type: _VectorT) -> None:
-        super().__init__((wrapped_type,))
+        super().__init__(wrapped_type)
 
 
 class StatusTypeField(Enum):

--- a/xdsl/dialects/pdl.py
+++ b/xdsl/dialects/pdl.py
@@ -148,7 +148,7 @@ class RangeType(Generic[_RangeT], ParametrizedAttribute, TypeAttribute):
     element_type: ParameterDef[_RangeT]
 
     def __init__(self, element_type: _RangeT):
-        super().__init__([element_type])
+        super().__init__(element_type)
 
     @classmethod
     def parse_parameters(cls, parser: AttrParser) -> Sequence[Attribute]:

--- a/xdsl/dialects/smt.py
+++ b/xdsl/dialects/smt.py
@@ -67,7 +67,7 @@ class BitVectorType(ParametrizedAttribute, TypeAttribute):
     def __init__(self, width: int | IntAttr):
         if isinstance(width, int):
             width = IntAttr(width)
-        super().__init__([width])
+        super().__init__(width)
 
     @classmethod
     def parse_parameters(cls, parser: AttrParser) -> Sequence[Attribute]:
@@ -114,7 +114,7 @@ class FuncType(ParametrizedAttribute, TypeAttribute):
     def __init__(
         self, domain_types: Sequence[NonFuncSMTType], range_type: NonFuncSMTType
     ):
-        super().__init__([ArrayAttr[NonFuncSMTType](domain_types), range_type])
+        super().__init__(ArrayAttr[NonFuncSMTType](domain_types), range_type)
 
     @classmethod
     def parse_parameters(cls, parser: AttrParser) -> Sequence[Attribute]:
@@ -157,7 +157,7 @@ class BitVectorAttr(TypedAttribute):
             value = IntAttr(value)
         if isinstance(type, int):
             type = BitVectorType(type)
-        super().__init__([value, type])
+        super().__init__(value, type)
 
     def verify(self) -> None:
         super().verify()

--- a/xdsl/dialects/snitch.py
+++ b/xdsl/dialects/snitch.py
@@ -61,7 +61,7 @@ class ReadableStreamType(
         return self.element_type
 
     def __init__(self, element_type: _StreamTypeElement):
-        super().__init__([element_type])
+        super().__init__(element_type)
 
     @classmethod
     def constr(
@@ -88,7 +88,7 @@ class WritableStreamType(
         return self.element_type
 
     def __init__(self, element_type: _StreamTypeElement):
-        super().__init__([element_type])
+        super().__init__(element_type)
 
     @classmethod
     def constr(

--- a/xdsl/dialects/snitch_stream.py
+++ b/xdsl/dialects/snitch_stream.py
@@ -86,7 +86,7 @@ class StridePattern(ParametrizedAttribute):
         strides: ArrayAttr[IntAttr],
         repeat: IntAttr = IntAttr(1),
     ):
-        super().__init__((ub, strides, repeat))
+        super().__init__(ub, strides, repeat)
 
     @classmethod
     def parse_parameters(cls, parser: AttrParser) -> Sequence[Attribute]:

--- a/xdsl/dialects/stencil.py
+++ b/xdsl/dialects/stencil.py
@@ -86,7 +86,7 @@ class IndexAttr(ParametrizedAttribute, Iterable[int]):
     array: ParameterDef[ArrayAttr[IntAttr]]
 
     def __init__(self, array: ArrayAttr[IntAttr]):
-        super().__init__((array,))
+        super().__init__(array)
 
     @classmethod
     def parse_parameters(cls, parser: AttrParser) -> list[Attribute]:
@@ -191,10 +191,8 @@ class StencilBoundsAttr(ParametrizedAttribute):
         else:
             lb, ub = (), ()
         super().__init__(
-            [
-                IndexAttr.get(*lb),
-                IndexAttr.get(*ub),
-            ]
+            IndexAttr.get(*lb),
+            IndexAttr.get(*ub),
         )
 
     def print_parameters(self, printer: Printer) -> None:
@@ -357,7 +355,7 @@ class StencilType(
             nbounds = IntAttr(bounds)
         else:
             nbounds = bounds
-        return super().__init__([nbounds, element_type])
+        return super().__init__(nbounds, element_type)
 
     @classmethod
     def constr(
@@ -419,7 +417,7 @@ class ResultType(ParametrizedAttribute, TypeAttribute):
     elem: ParameterDef[Attribute]
 
     def __init__(self, type: Attribute) -> None:
-        super().__init__([type])
+        super().__init__(type)
 
 
 class ApplyOpHasCanonicalizationPatternsTrait(HasCanonicalizationPatternsTrait):

--- a/xdsl/dialects/stim/ops.py
+++ b/xdsl/dialects/stim/ops.py
@@ -31,7 +31,7 @@ class QubitAttr(StimPrintable, ParametrizedAttribute, TypeAttribute):
     def __init__(self, qubit: int | IntAttr) -> None:
         if not isinstance(qubit, IntAttr):
             qubit = IntAttr(qubit)
-        super().__init__(parameters=[qubit])
+        super().__init__(qubit)
 
     @classmethod
     def parse_parameters(cls, parser: AttrParser) -> Sequence[IntAttr]:
@@ -83,7 +83,7 @@ class QubitMappingAttr(StimPrintable, ParametrizedAttribute):
                 (IntAttr(int(arg))) if (type(arg) is int) else (FloatData(arg))
                 for arg in coords
             )
-        super().__init__(parameters=[coords, qubit_name])
+        super().__init__(coords, qubit_name)
 
     @classmethod
     def parse_parameters(

--- a/xdsl/dialects/transform.py
+++ b/xdsl/dialects/transform.py
@@ -116,7 +116,7 @@ class OperationType(TransformOpHandleType):
     operation: ParameterDef[StringAttr]
 
     def __init__(self, operation: str):
-        super().__init__(parameters=[StringAttr(operation)])
+        super().__init__(StringAttr(operation))
 
 
 @irdl_attr_definition
@@ -129,7 +129,7 @@ class ParamType(TransformParamHandleType):
     type: ParameterDef[TypeAttribute]
 
     def __init__(self, type: TypeAttribute):
-        super().__init__(parameters=[type])
+        super().__init__(type)
 
 
 @irdl_attr_definition

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -423,7 +423,7 @@ class BitEnumAttribute(Generic[EnumType], Data[tuple[EnumType, ...]]):
 class ParametrizedAttribute(Attribute):
     """An attribute parametrized by other attributes."""
 
-    def __init__(self, parameters: Sequence[Attribute] = ()):
+    def __init__(self, *parameters: Attribute):
         for (f, _), param in zip(
             self.get_irdl_definition().parameters, parameters, strict=True
         ):
@@ -454,7 +454,7 @@ class ParametrizedAttribute(Attribute):
 
         # Call the __init__ of ParametrizedAttribute, which will set the
         # parameters field.
-        ParametrizedAttribute.__init__(attr, tuple(params))
+        ParametrizedAttribute.__init__(attr, *params)
         return attr
 
     @classmethod


### PR DESCRIPTION
A bit like #4684, but the init is not typed, the idea is that this initial step would give a nicer API for subclasses to call super init with, and potentially let us not use the dataclass generated init at all, using our existing init instead.