### PR TITLE
dialects:(omp) add `LoopWrapper` trait

### DIFF
--- a/tests/filecheck/dialects/omp/ops_invalid.mlir
+++ b/tests/filecheck/dialects/omp/ops_invalid.mlir
@@ -11,4 +11,16 @@ func.func @omp_ordered(%arg0 : i32, %arg1 : i32, %arg2 : i32, %arg3 : i64, %arg4
     return
 }
 
-// CHECK: Operation does not verify: Body of omp.wsloop operation body must consist of one loop nest
+
+// CHECK: Operation does not verify: omp.wsloop is not a LoopWrapper: has 2 ops, expected 1
+
+// -----
+
+func.func @omp_ordered(%arg0 : i32, %arg1 : i32, %arg2 : i32, %arg3 : i64, %arg4 : i64, %arg5 : i64, %arg6 : i64) {
+    "omp.wsloop"() <{operandSegmentSizes = array<i32: 0, 0, 0, 0, 0, 0, 0>, ordered = 0 : i64}> ({
+        "omp.terminator"() : () -> ()
+    }) : () -> ()
+    return
+}
+
+// CHECK: omp.wsloop is not a LoopWrapper: should have a single operation which is either another LoopWrapper or omp.loop_nest


### PR DESCRIPTION
This is used by several operations upstream but currently only applies to `omp.wsloop` in xDSL.

Used to constrain operations which are only supposed to contain a `loop_nest` or another `LoopWrapper`.

