### PR TITLE
dialects: (llvm) Fixed bug in GlobalOp where body was always empty when initialised

### DIFF
--- a/tests/dialects/test_llvm.py
+++ b/tests/dialects/test_llvm.py
@@ -4,7 +4,7 @@ import pytest
 
 from xdsl.dialects import arith, builtin, llvm, test
 from xdsl.dialects.builtin import UnitAttr, i32
-from xdsl.ir import Attribute, Region, Block
+from xdsl.ir import Attribute, Block, Region
 from xdsl.printer import Printer
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.test_value import create_ssa_value

--- a/tests/dialects/test_llvm.py
+++ b/tests/dialects/test_llvm.py
@@ -4,7 +4,7 @@ import pytest
 
 from xdsl.dialects import arith, builtin, llvm, test
 from xdsl.dialects.builtin import UnitAttr, i32
-from xdsl.ir import Attribute
+from xdsl.ir import Attribute, Region, Block
 from xdsl.printer import Printer
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.test_value import create_ssa_value
@@ -261,6 +261,19 @@ def test_global_op():
     assert isinstance(global_op.linkage, llvm.LinkageAttr)
     assert isinstance(global_op_value := global_op.value, builtin.IntegerAttr)
     assert global_op_value.value.data == 76
+    assert len(global_op.body.blocks) == 0
+
+
+def test_global_op_with_body():
+    global_op = llvm.GlobalOp(
+        builtin.i32,
+        "testsymbol",
+        "internal",
+        body=Region([Block([llvm.UnreachableOp()])]),
+    )
+
+    assert len(global_op.body.blocks) == 1
+    assert len(global_op.body.blocks[0].ops) == 1
 
 
 def test_addressof_op():

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -1430,7 +1430,7 @@ class GlobalOp(IRDLOperation):
             props["section"] = section
 
         if body is None:
-            body = Region([])
+            body = Region()
 
         super().__init__(properties=props, regions=[body])
 

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -1391,6 +1391,7 @@ class GlobalOp(IRDLOperation):
         alignment: int | None = None,
         unnamed_addr: int | None = None,
         section: str | StringAttr | None = None,
+        body: Region = None,
     ):
         if isinstance(sym_name, str):
             sym_name = StringAttr(sym_name)
@@ -1428,7 +1429,10 @@ class GlobalOp(IRDLOperation):
                 section = StringAttr(section)
             props["section"] = section
 
-        super().__init__(properties=props, regions=[Region([])])
+        if body is None:
+            body = Region([])
+
+        super().__init__(properties=props, regions=[body])
 
 
 @irdl_op_definition

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -1432,7 +1432,7 @@ class GlobalOp(IRDLOperation):
         if body is None:
             body = Region()
 
-        super().__init__(properties=props, regions=[body])
+        super().__init__(properties=props, regions=(body,))
 
 
 @irdl_op_definition

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -1391,7 +1391,7 @@ class GlobalOp(IRDLOperation):
         alignment: int | None = None,
         unnamed_addr: int | None = None,
         section: str | StringAttr | None = None,
-        body: Region = None,
+        body: Region | None = None,
     ):
         if isinstance(sym_name, str):
             sym_name = StringAttr(sym_name)


### PR DESCRIPTION
The llvm.GlobalOp operation can have a body associated with it, however the operation's initialisation in xDSL always set this to be empty. Therefore have added an optional body parameter to the function so that this can be set by the caller.

The xDSL MLIR filecheck test for globalop already has a body associated with it
