### PR TITLE
dialects: (stablehlo) Make batching attributes of stablehlo.dot optional

### DIFF
--- a/tests/filecheck/dialects/stablehlo/attrs.mlir
+++ b/tests/filecheck/dialects/stablehlo/attrs.mlir
@@ -27,6 +27,17 @@
     >
 } : () -> ()
 
+// CHECK-NEXT:    "test.op"() {dot = #stablehlo.dot<
+// CHECK-NEXT:      lhs_contracting_dimensions = [0],
+// CHECK-NEXT:      rhs_contracting_dimensions = [1]
+// CHECK-NEXT:    >} : () -> ()
+"test.op"() {
+    dot = #stablehlo.dot<
+        lhs_contracting_dimensions = [0],
+        rhs_contracting_dimensions = [1]
+    >
+} : () -> ()
+
 // CHECK-NEXT:    "test.op"() {
 // CHECK-SAME:      eq = #stablehlo<comparison_direction EQ>,
 // CHECK-SAME:      ne = #stablehlo<comparison_direction NE>,


### PR DESCRIPTION
Currently, xDSL's `stablehlo.dot` attribute requires all of these four parameters:

* `lhs_batching_dimensions`
* `rhs_batching_dimensions`
* `lhs_contracting_dimensions`
* `rhs_contracting_dimensions`

However, the batching-dimension parameters should be optional, as described [here](https://github.com/openxla/stablehlo/blob/9df3b5564c2101c251a73e04c82df76aacfcf471/stablehlo/dialect/AssemblyFormat.h#L297-L316) in the openxla repository. This PR makes the `lhs/rhs_batching_dimensions` parameter-pair optional by updating the `DotAttr`'s `print_parameters()` and `parse_parameters()` methods.

For example, both of the generic assembly formats are now accepted:

```mlir
"test.op"() {
    dot = #stablehlo.dot<
        lhs_batching_dimensions = [0],
        rhs_batching_dimensions = [1],
        lhs_contracting_dimensions = [2],
        rhs_contracting_dimensions = [3]
    >
} : () -> ()
```

and

```mlir
"test.op"() {
    dot = #stablehlo.dot<
        lhs_contracting_dimensions = [0],
        rhs_contracting_dimensions = [1]
    >
} : () -> ()
```

Fixes https://github.com/xdslproject/xdsl/issues/4691