### PR TITLE
dialects:(omp) add omp.simd operation

### DIFF
--- a/tests/filecheck/dialects/omp/ops_invalid.mlir
+++ b/tests/filecheck/dialects/omp/ops_invalid.mlir
@@ -23,3 +23,48 @@ func.func @omp_ordered(%arg0 : i32, %arg1 : i32, %arg2 : i32, %arg3 : i64, %arg4
 }
 
 // CHECK: omp.wsloop is not a LoopWrapper: should have a single operation which is either another LoopWrapper or omp.loop_nest
+
+// -----
+
+func.func @omp_simd_aligned(%ub : index, %lb : index, %step : index, %a1 : memref<1xi32>, %a2 : memref<10xf32>) {
+  "omp.simd"(%a1, %a2) <{operandSegmentSizes = array<i32: 2, 0, 0, 0, 0, 0, 0>, alignments = [64, 8, 16]}> ({
+    "omp.loop_nest"(%lb, %ub, %step) ({
+    ^0(%iter : index):
+      omp.yield
+    }) : (index, index, index) -> ()
+
+  }) : (memref<1xi32>, memref<10xf32>) -> ()
+  func.return
+}
+
+// CHECK: integer 2 expected from int variable 'ALIGN_COUNT', but got 3
+
+// -----
+
+func.func @omp_simd_linear(%ub : index, %lb : index, %step : index, %l1 : memref<1xi32>, %lstep1 : i32, %lstep2 : i32) {
+  "omp.simd"(%l1, %lstep1, %lstep2) <{operandSegmentSizes = array<i32: 0, 0, 1, 2, 0, 0, 0>}> ({
+    "omp.loop_nest"(%lb, %ub, %step) ({
+    ^0(%iter : index):
+      omp.yield
+    }) : (index, index, index) -> ()
+
+  }) : (memref<1xi32>, i32, i32) -> ()
+  func.return
+}
+
+// CHECK: integer 1 expected from int variable 'LINEAR_COUNT', but got 2
+
+// -----
+
+func.func @omp_simd_simdlen(%ub : index, %lb : index, %step : index) {
+  "omp.simd"() <{operandSegmentSizes = array<i32: 0, 0, 0, 0, 0, 0, 0>, simdlen=8, safelen=2}> ({
+    "omp.loop_nest"(%lb, %ub, %step) ({
+    ^0(%iter : index):
+      omp.yield
+    }) : (index, index, index) -> ()
+
+  }) : () -> ()
+  func.return
+}
+
+// CHECK: `safelen` must be greater than or equal to `simdlen`


### PR DESCRIPTION
Implements the upstream `omp.simd` operation.


I wasn't sure how to handle the "less than or equal to" constraint on `safelen` and `simdlen`. @superlopuh is there some way to do this without the `verify_`?