### PR TITLE
interpreter: (pdl_interp) Return `None` when `get_defining_op` doesn't find an operation

### DIFF
--- a/xdsl/interpreters/eqsat_pdl_interp.py
+++ b/xdsl/interpreters/eqsat_pdl_interp.py
@@ -206,9 +206,6 @@ class EqsatPDLInterpFunctions(PDLInterpFunctions):
         if not isinstance(args[0], OpResult):
             return (None,)
         else:
-            assert isinstance(args[0].owner, Operation), (
-                "Cannot get defining op of a Block argument"
-            )
             defining_op = args[0].owner
 
         if not isinstance(defining_op, eqsat.EClassOp):
@@ -236,7 +233,8 @@ class EqsatPDLInterpFunctions(PDLInterpFunctions):
                 )
             )
         defining_op = eclass_op.operands[index].owner
-        assert isinstance(defining_op, Operation)
+        if not isinstance(defining_op, Operation):
+            return (None,)
 
         return (defining_op,)
 

--- a/xdsl/interpreters/pdl_interp.py
+++ b/xdsl/interpreters/pdl_interp.py
@@ -132,9 +132,6 @@ class PDLInterpFunctions(InterpreterFunctions):
         assert isinstance(args[0], SSAValue)
         if not isinstance(args[0], OpResult):
             return (None,)
-        assert isinstance(args[0].owner, Operation), (
-            "Cannot get defining op of a Block argument"
-        )
         return (args[0].owner,)
 
     @impl_terminator(pdl_interp.CheckOperationNameOp)


### PR DESCRIPTION
If the value passed to it is a BlockArgument, for example, that's valid, it should just return None.
https://mlir.llvm.org/docs/Dialects/PDLInterpOps/#pdl_interpget_defining_op-pdl_interpgetdefiningopop
