### PR TITLE
transformations: add test-transform-dialect-erase-schedule

### DIFF
--- a/tests/filecheck/transforms/test_transform_dialect_erase_schedule.mlir
+++ b/tests/filecheck/transforms/test_transform_dialect_erase_schedule.mlir
@@ -1,0 +1,27 @@
+// RUN: xdsl-opt -p test-transform-dialect-erase-schedule %s | filecheck
+
+func.func @hello() {
+    return
+}
+
+module attributes {transform.with_named_sequence} {
+    transform.named_sequence @__transform_main(%arg0 : !transform.any_op {transform.readonly}) {
+        transform.yield
+    }
+}
+
+module attributes {transform.with_named_sequence} {
+    transform.named_sequence @entry(%arg0 : !transform.any_op {transform.readonly}) {
+        transform.yield
+    }
+}
+
+// CHECK:       builtin.module {
+// CHECK-NEXT:    func.func @hello() {
+// CHECK-NEXT:      func.return
+// CHECK-NEXT:    }
+// CHECK-NEXT:    builtin.module attributes {transform.with_named_sequence} {
+// CHECK-NEXT:    }
+// CHECK-NEXT:    builtin.module attributes {transform.with_named_sequence} {
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/xdsl/transforms/__init__.py
+++ b/xdsl/transforms/__init__.py
@@ -548,6 +548,13 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
 
         return test_lower_linalg_to_snitch.TestLowerLinalgToSnitchPass
 
+    def get_test_transform_dialect_erase_schedule():
+        from xdsl.transforms import test_transform_dialect_erase_schedule
+
+        return (
+            test_transform_dialect_erase_schedule.TestTransformDialectEraseSchedulePass
+        )
+
     def get_transform_interpreter():
         from xdsl.transforms import transform_interpreter
 
@@ -674,6 +681,7 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
         "test-constant-folding": get_test_constant_folding,
         "test-specialised-constant-folding": get_test_specialised_constant_folding,
         "test-lower-linalg-to-snitch": get_test_lower_linalg_to_snitch,
+        "test-transform-dialect-erase-schedule": get_test_transform_dialect_erase_schedule,
         "transform-interpreter": get_transform_interpreter,
         "varith-fuse-repeated-operands": get_varith_fuse_repeated_operands,
         "x86-allocate-registers": get_x86_allocate_registers,

--- a/xdsl/transforms/test_transform_dialect_erase_schedule.py
+++ b/xdsl/transforms/test_transform_dialect_erase_schedule.py
@@ -1,0 +1,35 @@
+from dataclasses import dataclass
+
+from xdsl.context import Context
+from xdsl.dialects import transform
+from xdsl.dialects.builtin import ModuleOp
+from xdsl.passes import ModulePass
+from xdsl.pattern_rewriter import (
+    PatternRewriter,
+    PatternRewriteWalker,
+    RewritePattern,
+    op_type_rewrite_pattern,
+)
+
+
+class EraseTransformNamedSequenceOps(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(
+        self, op: transform.NamedSequenceOp, rewriter: PatternRewriter
+    ) -> None:
+        rewriter.erase_op(op)
+
+
+@dataclass(frozen=True)
+class TestTransformDialectEraseSchedulePass(ModulePass):
+    """
+    Erases transform named sequence operations.
+    """
+
+    name = "test-transform-dialect-erase-schedule"
+
+    def apply(self, ctx: Context, op: ModuleOp) -> None:
+        PatternRewriteWalker(
+            EraseTransformNamedSequenceOps(),
+            apply_recursively=False,
+        ).rewrite_module(op)


### PR DESCRIPTION
Unlike the MLIR counterpart, we erase only named sequence, because we don't have a `TransformOpInterface`. Should get the same result in most cases though.

CC @erick-xanadu 