### PR TITLE
dialects:(omp) add `omp.target_data` op

### DIFF
--- a/tests/filecheck/dialects/omp/ops.mlir
+++ b/tests/filecheck/dialects/omp/ops.mlir
@@ -138,8 +138,8 @@ builtin.module {
   }
   func.func @omp_map_info_bounds(%lb : index, %ub : index, %ptr : memref<1xf32>, %ptr_ptr : memref<1xmemref<1xf32>>) {
     %bounds = "omp.map.bounds"(%lb, %ub) <{operandSegmentSizes = array<i32: 1, 1, 0, 0, 0>}> : (index, index) -> !omp.map_bounds_ty
-    %ptr_info = "omp.map.info"(%ptr, %ptr_ptr, %bounds) <{operandSegmentSizes = array<i32: 1, 1, 0, 1>, var_type = memref<1xf32>, map_type = 1 : ui64, name = "ptr_info"}> : (memref<1xf32>, memref<1xmemref<1xf32>>, !omp.map_bounds_ty) -> memref<1xf32>
-    %ptr_ptr_info = "omp.map.info"(%ptr_ptr, %ptr_info, %bounds) <{operandSegmentSizes = array<i32: 1, 0, 1, 1>, map_capture_type = #omp<variable_capture_kind (ByCopy)>, var_type = memref<1xmemref<1xf32>>}> : (memref<1xmemref<1xf32>>, memref<1xf32>, !omp.map_bounds_ty) -> memref<1xmemref<1xf32>>
+    %ptr_info = "omp.map.info"(%ptr, %ptr_ptr, %bounds) <{operandSegmentSizes = array<i32: 1, 1, 0, 1>, var_type = memref<1xf32>, map_type = 1 : ui64, map_capture_type = #omp<variable_capture_kind(ByCopy)>, name = "ptr_info"}> : (memref<1xf32>, memref<1xmemref<1xf32>>, !omp.map_bounds_ty) -> memref<1xf32>
+    %ptr_ptr_info = "omp.map.info"(%ptr_ptr, %ptr_info, %bounds) <{operandSegmentSizes = array<i32: 1, 0, 1, 1>, map_type = 1 : ui64, map_capture_type = #omp<variable_capture_kind (ByCopy)>, var_type = memref<1xmemref<1xf32>>}> : (memref<1xmemref<1xf32>>, memref<1xf32>, !omp.map_bounds_ty) -> memref<1xmemref<1xf32>>
     func.return
   }
   func.func @omp_simd(%ub : index, %lb : index, %step : index, %if : i1, %nt : memref<1xi32>, %p1 : f32, %r1 : memref<1xf32>) {
@@ -173,6 +173,14 @@ builtin.module {
       }) : (index, index, index) -> ()
 
     }) : (memref<1xi32>, i32) -> ()
+    func.return
+  }
+  func.func @omp_target_data(%dev : i64, %if : i1, %m : memref<1xf32>, %d1 : memref<1xf32>, %d2 : memref<1xf32>) {
+    %m1 = "omp.map.info"(%m) <{operandSegmentSizes = array<i32: 1, 0, 0, 0>, var_type = memref<1xf32>, map_type = 1 : ui64, map_capture_type = #omp<variable_capture_kind(ByCopy)>}> : (memref<1xf32>) -> memref<1xf32>
+    "omp.target_data"(%dev, %if, %m1, %d1, %d2, %d2) <{operandSegmentSizes = array<i32: 1, 1, 1, 2, 1>}> ({
+    ^0(%0 : memref<1xf32>, %1 : memref<1xf32>, %2 : memref<1xf32>):
+      "omp.terminator"() : () -> ()
+    }) : (i64, i1, memref<1xf32>, memref<1xf32>, memref<1xf32>, memref<1xf32>) -> ()
     func.return
   }
 }
@@ -315,8 +323,8 @@ builtin.module {
 // CHECK-NEXT:    }
 // CHECK-NEXT:    func.func @omp_map_info_bounds(%lb : index, %ub : index, %ptr : memref<1xf32>, %ptr_ptr : memref<1xmemref<1xf32>>) {
 // CHECK-NEXT:      %bounds = "omp.map.bounds"(%lb, %ub) <{operandSegmentSizes = array<i32: 1, 1, 0, 0, 0>, stride_in_bytes = false}> : (index, index) -> !omp.map_bounds_ty
-// CHECK-NEXT:      %ptr_info = "omp.map.info"(%ptr, %ptr_ptr, %bounds) <{operandSegmentSizes = array<i32: 1, 1, 0, 1>, var_type = memref<1xf32>, map_type = 1 : ui64, name = "ptr_info"}> : (memref<1xf32>, memref<1xmemref<1xf32>>, !omp.map_bounds_ty) -> memref<1xf32>
-// CHECK-NEXT:      %ptr_ptr_info = "omp.map.info"(%ptr_ptr, %ptr_info, %bounds) <{operandSegmentSizes = array<i32: 1, 0, 1, 1>, map_capture_type = #omp<variable_capture_kind (ByCopy)>, var_type = memref<1xmemref<1xf32>>}> : (memref<1xmemref<1xf32>>, memref<1xf32>, !omp.map_bounds_ty) -> memref<1xmemref<1xf32>>
+// CHECK-NEXT:      %ptr_info = "omp.map.info"(%ptr, %ptr_ptr, %bounds) <{operandSegmentSizes = array<i32: 1, 1, 0, 1>, var_type = memref<1xf32>, map_type = 1 : ui64, map_capture_type = #omp<variable_capture_kind (ByCopy)>, name = "ptr_info"}> : (memref<1xf32>, memref<1xmemref<1xf32>>, !omp.map_bounds_ty) -> memref<1xf32>
+// CHECK-NEXT:      %ptr_ptr_info = "omp.map.info"(%ptr_ptr, %ptr_info, %bounds) <{operandSegmentSizes = array<i32: 1, 0, 1, 1>, map_type = 1 : ui64, map_capture_type = #omp<variable_capture_kind (ByCopy)>, var_type = memref<1xmemref<1xf32>>}> : (memref<1xmemref<1xf32>>, memref<1xf32>, !omp.map_bounds_ty) -> memref<1xmemref<1xf32>>
 // CHECK-NEXT:      func.return
 // CHECK-NEXT:    }
 // CHECK-NEXT:    func.func @omp_simd(%ub : index, %lb : index, %step : index, %if : i1, %nt : memref<1xi32>, %p1 : f32, %r1 : memref<1xf32>) {
@@ -345,6 +353,14 @@ builtin.module {
 // CHECK-NEXT:          omp.yield
 // CHECK-NEXT:        }) : (index, index, index) -> ()
 // CHECK-NEXT:      }) : (memref<1xi32>, i32) -> ()
+// CHECK-NEXT:      func.return
+// CHECK-NEXT:    }
+// CHECK-NEXT:    func.func @omp_target_data(%dev : i64, %if : i1, %m : memref<1xf32>, %d1 : memref<1xf32>, %d2 : memref<1xf32>) {
+// CHECK-NEXT:      %m1 = "omp.map.info"(%m) <{operandSegmentSizes = array<i32: 1, 0, 0, 0>, var_type = memref<1xf32>, map_type = 1 : ui64, map_capture_type = #omp<variable_capture_kind (ByCopy)>}> : (memref<1xf32>) -> memref<1xf32>
+// CHECK-NEXT:      "omp.target_data"(%dev, %if, %m1, %d1, %d2, %d2) <{operandSegmentSizes = array<i32: 1, 1, 1, 2, 1>}> ({
+// CHECK-NEXT:      ^0(%0 : memref<1xf32>, %1 : memref<1xf32>, %2 : memref<1xf32>):
+// CHECK-NEXT:        "omp.terminator"() : () -> ()
+// CHECK-NEXT:      }) : (i64, i1, memref<1xf32>, memref<1xf32>, memref<1xf32>, memref<1xf32>) -> ()
 // CHECK-NEXT:      func.return
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/omp/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/omp/ops.mlir
@@ -139,9 +139,9 @@ builtin.module {
   }
   func.func @omp_map_info_bounds(%lb : index, %ub : index, %ptr : memref<1xf32>, %ptr_ptr : memref<1xmemref<1xf32>>) {
     %bounds = "omp.map.bounds"(%lb, %ub) <{operandSegmentSizes = array<i32: 1, 1, 0, 0, 0>}> : (index, index) -> !omp.map_bounds_ty
-    %ptr_info = "omp.map.info"(%ptr, %ptr_ptr, %bounds) <{operandSegmentSizes = array<i32: 1, 1, 0, 1>, var_type = memref<1xf32>, map_type = 1 : ui64, name = "ptr_info"}> : (memref<1xf32>, memref<1xmemref<1xf32>>, !omp.map_bounds_ty) -> memref<1xf32>
+    %ptr_info = "omp.map.info"(%ptr, %ptr_ptr, %bounds) <{operandSegmentSizes = array<i32: 1, 1, 0, 1>, var_type = memref<1xf32>, map_type = 1 : ui64, map_capture_type = #omp<variable_capture_kind(ByCopy)>, name = "ptr_info"}> : (memref<1xf32>, memref<1xmemref<1xf32>>, !omp.map_bounds_ty) -> memref<1xf32>
     %ptr_ptr_info = "omp.map.info"(%ptr_ptr, %ptr_info, %bounds) <{operandSegmentSizes = array<i32: 1, 0, 1, 1>, map_capture_type =
-    #omp<variable_capture_kind(ByCopy)>, var_type = memref<1xmemref<1xf32>>, partial_map = true}> : (memref<1xmemref<1xf32>>, memref<1xf32>, !omp.map_bounds_ty) -> memref<1xmemref<1xf32>>
+    #omp<variable_capture_kind(ByCopy)>, var_type = memref<1xmemref<1xf32>>, map_type = 2 : ui64, partial_map = true}> : (memref<1xmemref<1xf32>>, memref<1xf32>, !omp.map_bounds_ty) -> memref<1xmemref<1xf32>>
     func.return
   }
   func.func @omp_simd(%ub : index, %lb : index, %step : index, %if : i1, %nt : memref<1xi32>, %p1 : f32, %r1 : memref<1xf32>) {
@@ -175,6 +175,14 @@ builtin.module {
       }) : (index, index, index) -> ()
 
     }) : (memref<1xi32>, i32) -> ()
+    func.return
+  }
+  func.func @omp_target_data(%dev : i64, %if : i1, %m : memref<1xf32>, %d1 : memref<1xf32>, %d2 : memref<1xf32>) {
+    %m1 = "omp.map.info"(%m) <{operandSegmentSizes = array<i32: 1, 0, 0, 0>, var_type = memref<1xf32>, map_type = 1 : ui64, map_capture_type = #omp<variable_capture_kind(ByCopy)>}> : (memref<1xf32>) -> memref<1xf32>
+    "omp.target_data"(%dev, %if, %m1, %d1, %d2, %d2) <{operandSegmentSizes = array<i32: 1, 1, 1, 2, 1>}> ({
+    ^0(%0 : memref<1xf32>, %1 : memref<1xf32>, %2 : memref<1xf32>):
+      "omp.terminator"() : () -> ()
+    }) : (i64, i1, memref<1xf32>, memref<1xf32>, memref<1xf32>, memref<1xf32>) -> ()
     func.return
   }
 }
@@ -318,8 +326,8 @@ builtin.module {
 // CHECK-NEXT:    }
 // CHECK-NEXT:    func.func @omp_map_info_bounds(%{{.*}} : index, %{{.*}} : index, %{{.*}} : memref<1xf32>, %{{.*}} : memref<1xmemref<1xf32>>) {
 // CHECK-NEXT:      %{{.*}} = "omp.map.bounds"(%{{.*}}, %{{.*}}) <{operandSegmentSizes = array<i32: 1, 1, 0, 0, 0>, stride_in_bytes = false}> : (index, index) -> !omp.map_bounds_ty
-// CHECK-NEXT:      %{{.*}} = "omp.map.info"(%{{.*}}, %{{.*}}, %{{.*}}) <{map_type = 1 : ui64, name = "ptr_info", operandSegmentSizes = array<i32: 1, 1, 0, 1>, partial_map = false, var_type = memref<1xf32>}> : (memref<1xf32>, memref<1xmemref<1xf32>>, !omp.map_bounds_ty) -> memref<1xf32>
-// CHECK-NEXT:      %{{.*}} = "omp.map.info"(%{{.*}}, %{{.*}}, %{{.*}}) <{map_capture_type = #omp<variable_capture_kind (ByCopy)>, operandSegmentSizes = array<i32: 1, 0, 1, 1>, partial_map = true, var_type = memref<1xmemref<1xf32>>}> : (memref<1xmemref<1xf32>>, memref<1xf32>, !omp.map_bounds_ty) -> memref<1xmemref<1xf32>>
+// CHECK-NEXT:      %{{.*}} = "omp.map.info"(%{{.*}}, %{{.*}}, %{{.*}}) <{map_capture_type = #omp<variable_capture_kind (ByCopy)>, map_type = 1 : ui64, name = "ptr_info", operandSegmentSizes = array<i32: 1, 1, 0, 1>, partial_map = false, var_type = memref<1xf32>}> : (memref<1xf32>, memref<1xmemref<1xf32>>, !omp.map_bounds_ty) -> memref<1xf32>
+// CHECK-NEXT:      %{{.*}} = "omp.map.info"(%{{.*}}, %{{.*}}, %{{.*}}) <{map_capture_type = #omp<variable_capture_kind (ByCopy)>, map_type = 2 : ui64, operandSegmentSizes = array<i32: 1, 0, 1, 1>, partial_map = true, var_type = memref<1xmemref<1xf32>>}> : (memref<1xmemref<1xf32>>, memref<1xf32>, !omp.map_bounds_ty) -> memref<1xmemref<1xf32>>
 // CHECK-NEXT:      func.return
 // CHECK-NEXT:    }
 // CHECK-NEXT:    func.func @omp_simd(%{{.*}} : index, %{{.*}} : index, %{{.*}} : index, %{{.*}} : i1, %{{.*}} : memref<1xi32>, %{{.*}} : f32, %{{.*}} : memref<1xf32>) {
@@ -348,6 +356,14 @@ builtin.module {
 // CHECK-NEXT:          omp.yield
 // CHECK-NEXT:        }) : (index, index, index) -> ()
 // CHECK-NEXT:      }) : (memref<1xi32>, i32) -> ()
+// CHECK-NEXT:      func.return
+// CHECK-NEXT:    }
+// CHECK-NEXT:    func.func @omp_target_data(%{{.*}} : i64, %{{.*}} : i1, %{{.*}} : memref<1xf32>, %{{.*}} : memref<1xf32>, %{{.*}} : memref<1xf32>) {
+// CHECK-NEXT:      %{{.*}} = "omp.map.info"(%{{.*}}) <{map_capture_type = #omp<variable_capture_kind (ByCopy)>, map_type = 1 : ui64, operandSegmentSizes = array<i32: 1, 0, 0, 0>, partial_map = false, var_type = memref<1xf32>}> : (memref<1xf32>) -> memref<1xf32>
+// CHECK-NEXT:      "omp.target_data"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) <{operandSegmentSizes = array<i32: 1, 1, 1, 2, 1>}> ({
+// CHECK-NEXT:      ^{{.*}}(%{{.*}} : memref<1xf32>, %{{.*}} : memref<1xf32>, %{{.*}} : memref<1xf32>):
+// CHECK-NEXT:        "omp.terminator"() : () -> ()
+// CHECK-NEXT:      }) : (i64, i1, memref<1xf32>, memref<1xf32>, memref<1xf32>, memref<1xf32>) -> ()
 // CHECK-NEXT:      func.return
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }

--- a/xdsl/dialects/omp.py
+++ b/xdsl/dialects/omp.py
@@ -119,6 +119,12 @@ class OpenMPOffloadMappingFlags(IntFlag):
     MEMBER_OF = 0xFFFF000000000000
     """ The 16 MSBs of the flags indicate whether the entry is member of some struct/class. """
 
+    def __iter__(self):
+        """
+        available in the standard library since python 3.11
+        """
+        return (flag for flag in type(self) if self & flag)
+
 
 def verify_map_vars(
     vars: VarOperand,

--- a/xdsl/dialects/omp.py
+++ b/xdsl/dialects/omp.py
@@ -37,6 +37,7 @@ from xdsl.irdl import (
     ParameterDef,
     RangeOf,
     SameVariadicOperandSize,
+    VarOperand,
     base,
     eq,
     irdl_attr_definition,
@@ -117,6 +118,28 @@ class OpenMPOffloadMappingFlags(IntFlag):
     """
     MEMBER_OF = 0xFFFF000000000000
     """ The 16 MSBs of the flags indicate whether the entry is member of some struct/class. """
+
+
+def verify_map_vars(
+    vars: VarOperand,
+    op_name: str,
+    *,
+    disallowed_types: OpenMPOffloadMappingFlags = OpenMPOffloadMappingFlags.NONE,
+    one_of: OpenMPOffloadMappingFlags = OpenMPOffloadMappingFlags.NONE,
+):
+    for var in vars:
+        if not isinstance(owner := var.owner, MapInfoOp):
+            raise VerifyException(
+                f"All mapped operands of {op_name} must be results of a {MapInfoOp.name}"
+            )
+        for t in disallowed_types:
+            if owner.map_type.value.data & t:
+                raise VerifyException(f"Cannot have map_type {t.name} in {op_name}")
+        if one_of and (owner.map_type.value.data & one_of).bit_count() != 1:
+            one_of_names = ", ".join(bit.name for bit in one_of if bit.name)
+            raise VerifyException(
+                f"{op_name} expected to have exactly one of {one_of_names} as map_type"
+            )
 
 
 class ScheduleKind(StrEnum):
@@ -534,6 +557,14 @@ class TargetOp(IRDLOperation):
     irdl_options = [AttrSizedOperandSegments(as_property=True)]
     traits = traits_def(IsolatedFromAbove())
 
+    def verify_(self) -> None:
+        verify_map_vars(
+            self.map_vars,
+            self.name,
+            disallowed_types=OpenMPOffloadMappingFlags.DELETE,
+        )
+        return super().verify_()
+
 
 @irdl_op_definition
 class MapBoundsOp(IRDLOperation):
@@ -573,11 +604,11 @@ class MapInfoOp(IRDLOperation):
     bounds = var_operand_def(MapBoundsType)
 
     var_type = prop_def(TypeAttribute)
-    map_type = opt_prop_def(IntegerAttr[_ui64])
+    map_type = prop_def(IntegerAttr[_ui64])
     """
     To set or test flags in `map_type` use the bits defined in `OpenMPOffloadMappingFlags`
     """
-    map_capture_type = opt_prop_def(VariableCaptureKindAttr)
+    map_capture_type = prop_def(VariableCaptureKindAttr)
     members_index = opt_prop_def(ArrayAttr[i64])
     var_name = opt_prop_def(StringAttr, prop_name="name")
     partial_map = opt_prop_def(BoolAttr, default_value=BoolAttr.from_bool(False))
@@ -587,11 +618,7 @@ class MapInfoOp(IRDLOperation):
     irdl_options = [AttrSizedOperandSegments(as_property=True)]
 
     def verify_(self) -> None:
-        for mem in self.members:
-            if not isinstance(mem.owner, MapInfoOp):
-                raise VerifyException(
-                    f"All `members` must be results of another {self.name}"
-                )
+        verify_map_vars(self.members, self.name)
         return super().verify_()
 
 
@@ -644,6 +671,34 @@ class SimdOp(IRDLOperation):
         return super().verify_()
 
 
+@irdl_op_definition
+class TargetDataOp(IRDLOperation):
+    """
+    Implementation of upstream omp.target_data
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/OpenMPDialect/ODS/#omptarget_data-omptargetdataop).
+    """
+
+    name = "omp.target_data"
+
+    device = opt_operand_def(IntegerType)
+    if_expr = opt_operand_def(i1)
+    map_vars = var_operand_def()  # TODO: OpenMP_PointerLikeTypeInterface
+    use_device_addr_vars = var_operand_def()  # TODO: OpenMP_PointerLikeTypeInterface
+    use_device_ptr_vars = var_operand_def()  # TODO: OpenMP_PointerLikeTypeInterface
+
+    region = region_def()
+
+    irdl_options = [AttrSizedOperandSegments(as_property=True)]
+
+    def verify_(self) -> None:
+        verify_map_vars(
+            self.map_vars,
+            self.name,
+            disallowed_types=(OpenMPOffloadMappingFlags.DELETE),
+        )
+        return super().verify_()
+
+
 OMP = Dialect(
     "omp",
     [
@@ -656,6 +711,7 @@ OMP = Dialect(
         MapBoundsOp,
         MapInfoOp,
         SimdOp,
+        TargetDataOp,
     ],
     [
         ClauseRequiresKindAttr,


### PR DESCRIPTION
This also makes `map_type` and `map_capture_type` required properties of `omp.map.info`. Upstream, in `llvmorg-20.1.7` they are defined as `OptionalAttr<UI64Attr>` and `OptionalAttr<VariableCaptureKindAttr>` respectively, but later assumed to be present, this appears to be a bug.

Both are non-optional on HEAD.

`TargetEnterDataOp`, `TargetExitDataOp` and `TargetUpdateOp` will follow in a separate PR.