### PR TITLE
dialects:(omp) add task based data mapping ops

### DIFF
--- a/tests/filecheck/dialects/omp/ops_invalid.mlir
+++ b/tests/filecheck/dialects/omp/ops_invalid.mlir
@@ -155,7 +155,7 @@ func.func @omp_target_update_to_from_same_map(%m : memref<1xf32>) {
   func.return
 }
 
-// CHECK: omp.target_update expected to have exactly one of TO, FROM as map_type
+// CHECK: omp.target_update expected to have exactly one of TO or FROM as map_type
 
 // -----
 
@@ -166,4 +166,4 @@ func.func @omp_target_update_to_from_same_operand(%m : memref<1xf32>) {
   func.return
 }
 
-// CHECK: omp.target_update expected to have exactly one of TO, FROM as map_type
+// CHECK: omp.target_update expected to have exactly one of TO or FROM as map_type

--- a/tests/filecheck/dialects/omp/ops_invalid.mlir
+++ b/tests/filecheck/dialects/omp/ops_invalid.mlir
@@ -106,3 +106,64 @@ func.func @omp_target_data_to_and_delete(%dev : i64, %if : i1, %m : memref<1xf32
 }
 
 // CHECK: Cannot have map_type DELETE in omp.target_data
+
+// -----
+
+func.func @omp_target_enter_data_from(%m : memref<1xf32>) {
+  %from = "omp.map.info"(%m) <{operandSegmentSizes = array<i32: 1, 0, 0, 0>, var_type = memref<1xf32>, map_type = 0x2 : ui64, map_capture_type = #omp<variable_capture_kind(ByCopy)>}> : (memref<1xf32>) -> memref<1xf32>
+"omp.target_enter_data"(%from) <{operandSegmentSizes = array<i32: 0, 0, 0, 1>}> : (memref<1xf32>) -> ()
+  func.return
+}
+
+// CHECK: Cannot have map_type FROM in omp.target_enter_data
+
+// -----
+
+func.func @omp_target_enter_data_delete(%m : memref<1xf32>) {
+  %del = "omp.map.info"(%m) <{operandSegmentSizes = array<i32: 1, 0, 0, 0>, var_type = memref<1xf32>, map_type = 0x8 : ui64, map_capture_type = #omp<variable_capture_kind(ByCopy)>}> : (memref<1xf32>) -> memref<1xf32>
+"omp.target_enter_data"(%del) <{operandSegmentSizes = array<i32: 0, 0, 0, 1>}> : (memref<1xf32>) -> ()
+  func.return
+}
+
+// CHECK: Cannot have map_type DELETE in omp.target_enter_data
+
+// -----
+
+func.func @omp_target_exit_data_to(%m : memref<1xf32>) {
+  %to = "omp.map.info"(%m) <{operandSegmentSizes = array<i32: 1, 0, 0, 0>, var_type = memref<1xf32>, map_type = 0x1 : ui64, map_capture_type = #omp<variable_capture_kind(ByCopy)>}> : (memref<1xf32>) -> memref<1xf32>
+  "omp.target_exit_data"(%to) <{operandSegmentSizes = array<i32: 0, 0, 0, 1>}> : (memref<1xf32>) -> ()
+  func.return
+}
+
+// CHECK: Cannot have map_type TO in omp.target_exit_data
+
+// -----
+
+func.func @omp_target_update_del(%m : memref<1xf32>) {
+  %del = "omp.map.info"(%m) <{operandSegmentSizes = array<i32: 1, 0, 0, 0>, var_type = memref<1xf32>, map_type = 0x8 : ui64, map_capture_type = #omp<variable_capture_kind(ByCopy)>}> : (memref<1xf32>) -> memref<1xf32>
+  "omp.target_update"(%del) <{operandSegmentSizes = array<i32: 0, 0, 0, 1>}> : (memref<1xf32>) -> ()
+  func.return
+}
+
+// CHECK: Cannot have map_type DELETE in omp.target_update
+
+// -----
+
+func.func @omp_target_update_to_from_same_map(%m : memref<1xf32>) {
+  %tofrom = "omp.map.info"(%m) <{operandSegmentSizes = array<i32: 1, 0, 0, 0>, var_type = memref<1xf32>, map_type = 0x3 : ui64, map_capture_type = #omp<variable_capture_kind(ByCopy)>}> : (memref<1xf32>) -> memref<1xf32>
+  "omp.target_update"(%tofrom) <{operandSegmentSizes = array<i32: 0, 0, 0, 1>}> : (memref<1xf32>) -> ()
+  func.return
+}
+
+// CHECK: omp.target_update expected to have exactly one of TO, FROM as map_type
+
+// -----
+
+func.func @omp_target_update_to_from_same_operand(%m : memref<1xf32>) {
+  %to = "omp.map.info"(%m) <{operandSegmentSizes = array<i32: 1, 0, 0, 0>, var_type = memref<1xf32>, map_type = 0x1 : ui64, map_capture_type = #omp<variable_capture_kind(ByCopy)>}> : (memref<1xf32>) -> memref<1xf32>
+  %from = "omp.map.info"(%m) <{operandSegmentSizes = array<i32: 1, 0, 0, 0>, var_type = memref<1xf32>, map_type = 0x2 : ui64, map_capture_type = #omp<variable_capture_kind(ByCopy)>}> : (memref<1xf32>) -> memref<1xf32>
+  "omp.target_update"(%to, %from) <{operandSegmentSizes = array<i32: 0, 0, 0, 2>}> : (memref<1xf32>, memref<1xf32>) -> ()
+  func.return
+}
+
+// CHECK: omp.target_update expected to have exactly one of TO, FROM as map_type

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/omp/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/omp/ops.mlir
@@ -185,6 +185,16 @@ builtin.module {
     }) : (i64, i1, memref<1xf32>, memref<1xf32>, memref<1xf32>, memref<1xf32>) -> ()
     func.return
   }
+
+  func.func @omp_target_data_task(%dep: memref<1xi32>, %dev : i32, %if : i1, %m1 : memref<1xf32>, %m2 : memref<1xf32>, %m3: memref<1xf32>) {
+    %to = "omp.map.info"  (%m1) <{operandSegmentSizes = array<i32: 1, 0, 0, 0>, var_type = memref<1xf32>, map_type = 0x01 : ui64, map_capture_type = #omp<variable_capture_kind(ByCopy)>}> : (memref<1xf32>) -> memref<1xf32>
+    %from = "omp.map.info"(%m2) <{operandSegmentSizes = array<i32: 1, 0, 0, 0>, var_type = memref<1xf32>, map_type = 0x02 : ui64, map_capture_type = #omp<variable_capture_kind(ByCopy)>}> : (memref<1xf32>) -> memref<1xf32>
+    %del = "omp.map.info" (%m3) <{operandSegmentSizes = array<i32: 1, 0, 0, 0>, var_type = memref<1xf32>, map_type = 0x08 : ui64, map_capture_type = #omp<variable_capture_kind(ByCopy)>}> : (memref<1xf32>) -> memref<1xf32>
+    "omp.target_enter_data"(%dep, %dev, %if, %to)         <{operandSegmentSizes = array<i32: 1, 1, 1, 1>, "nowait", depend_kinds=[#omp<clause_task_depend(taskdependin)>]}>: (memref<1xi32>, i32, i1, memref<1xf32>) -> ()
+    "omp.target_update"    (%dep, %dev, %if, %to, %from)  <{operandSegmentSizes = array<i32: 1, 1, 1, 2>, "nowait", depend_kinds=[#omp<clause_task_depend(taskdependin)>]}>: (memref<1xi32>, i32, i1, memref<1xf32>, memref<1xf32>) -> ()
+    "omp.target_exit_data" (%dep, %dev, %if, %from, %del) <{operandSegmentSizes = array<i32: 1, 1, 1, 2>, "nowait", depend_kinds=[#omp<clause_task_depend(taskdependin)>]}>: (memref<1xi32>, i32, i1, memref<1xf32>, memref<1xf32>) -> ()
+    func.return
+  }
 }
 
 // CHECK:       builtin.module {
@@ -364,6 +374,15 @@ builtin.module {
 // CHECK-NEXT:      ^{{.*}}(%{{.*}} : memref<1xf32>, %{{.*}} : memref<1xf32>, %{{.*}} : memref<1xf32>):
 // CHECK-NEXT:        "omp.terminator"() : () -> ()
 // CHECK-NEXT:      }) : (i64, i1, memref<1xf32>, memref<1xf32>, memref<1xf32>, memref<1xf32>) -> ()
+// CHECK-NEXT:      func.return
+// CHECK-NEXT:    }
+// CHECK-NEXT:    func.func @omp_target_data_task(%{{.*}} : memref<1xi32>, %{{.*}} : i32, %{{.*}} : i1, %{{.*}} : memref<1xf32>, %{{.*}} : memref<1xf32>, %{{.*}} : memref<1xf32>) {
+// CHECK-NEXT:      %{{.*}} = "omp.map.info"(%{{.*}}) <{map_capture_type = #omp<variable_capture_kind (ByCopy)>, map_type = 1 : ui64, operandSegmentSizes = array<i32: 1, 0, 0, 0>, partial_map = false, var_type = memref<1xf32>}> : (memref<1xf32>) -> memref<1xf32>
+// CHECK-NEXT:      %{{.*}} = "omp.map.info"(%{{.*}}) <{map_capture_type = #omp<variable_capture_kind (ByCopy)>, map_type = 2 : ui64, operandSegmentSizes = array<i32: 1, 0, 0, 0>, partial_map = false, var_type = memref<1xf32>}> : (memref<1xf32>) -> memref<1xf32>
+// CHECK-NEXT:      %{{.*}} = "omp.map.info"(%{{.*}}) <{map_capture_type = #omp<variable_capture_kind (ByCopy)>, map_type = 8 : ui64, operandSegmentSizes = array<i32: 1, 0, 0, 0>, partial_map = false, var_type = memref<1xf32>}> : (memref<1xf32>) -> memref<1xf32>
+// CHECK-NEXT:      "omp.target_enter_data"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) <{depend_kinds = [#omp<clause_task_depend (taskdependin)>], nowait, operandSegmentSizes = array<i32: 1, 1, 1, 1>}> : (memref<1xi32>, i32, i1, memref<1xf32>) -> ()
+// CHECK-NEXT:      "omp.target_update"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) <{depend_kinds = [#omp<clause_task_depend (taskdependin)>], nowait, operandSegmentSizes = array<i32: 1, 1, 1, 2>}> : (memref<1xi32>, i32, i1, memref<1xf32>, memref<1xf32>) -> ()
+// CHECK-NEXT:      "omp.target_exit_data"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) <{depend_kinds = [#omp<clause_task_depend (taskdependin)>], nowait, operandSegmentSizes = array<i32: 1, 1, 1, 2>}> : (memref<1xi32>, i32, i1, memref<1xf32>, memref<1xf32>) -> ()
 // CHECK-NEXT:      func.return
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }


### PR DESCRIPTION
Also adds an extra constraint on mapped values which was missed in the previous PR: When the `map_type` is constrained to one of a number of flags, these constraints are on the `var_ptr` operand to `omp.map.info`, not on the result of `omp.map.info`. So we need to keep track of which flags have already been used with which operands.

**Operations added:**

* TargetEnterDataOp
* TargetExitDataOp
* TargetUpdateOp