### PR TITLE
dialects: Add a reshape_ops_utils.py

### DIFF
--- a/tests/filecheck/dialects/memref/invalid_ops.mlir
+++ b/tests/filecheck/dialects/memref/invalid_ops.mlir
@@ -24,7 +24,7 @@ builtin.module {
 
 
 
-// CHECK: Expected ArrayAttr[ArrayAttr[IntegerAttr[I64]]] but got array
+// CHECK: Expected attribute i64 but got i32
 
 // -----
 
@@ -34,7 +34,7 @@ builtin.module {
     "func.return"() : () -> ()
 }) {function_type = () -> (), sym_name = "invalid_reassociation"} : () -> ()
 
-// CHECK: Expected ArrayAttr[ArrayAttr[IntegerAttr[I64]]] but got array
+// CHECK: Expected attribute i64 but got i32
 
 
 // -----

--- a/tests/filecheck/dialects/memref/invalid_ops.mlir
+++ b/tests/filecheck/dialects/memref/invalid_ops.mlir
@@ -24,7 +24,7 @@ builtin.module {
 
 
 
-// CHECK: Expected attribute i64
+// CHECK: Expected ArrayAttr[ArrayAttr[IntegerAttr[I64]]] but got array
 
 // -----
 
@@ -34,7 +34,7 @@ builtin.module {
     "func.return"() : () -> ()
 }) {function_type = () -> (), sym_name = "invalid_reassociation"} : () -> ()
 
-// CHECK: Expected attribute i64
+// CHECK: Expected ArrayAttr[ArrayAttr[IntegerAttr[I64]]] but got array
 
 
 // -----

--- a/tests/filecheck/dialects/tensor/invalid_ops.mlir
+++ b/tests/filecheck/dialects/tensor/invalid_ops.mlir
@@ -85,5 +85,5 @@ builtin.module {
 
 // -----
 
-// CHECK: Expected ArrayAttr[ArrayAttr[IntegerAttr[I64]]] but got array
+// CHECK: expected integer >= 0, got -2
 %res_collapse2 = tensor.collapse_shape %t0 [ [-2, 3], [0, 1] ] : tensor<4x1xf32> into tensor<4x1xf32>

--- a/tests/filecheck/dialects/tensor/invalid_ops.mlir
+++ b/tests/filecheck/dialects/tensor/invalid_ops.mlir
@@ -85,7 +85,5 @@ builtin.module {
 
 // -----
 
-// CHECK: The following constraints were not satisfied:
-// CHECK-NEXT: expected integer >= 0, got -2
-// CHECK-NEXT: All inner arrays must be contiguous: [[-2 : i64, 3 : i64], [0 : i64, 1 : i64]]
+// CHECK: Expected ArrayAttr[ArrayAttr[IntegerAttr[I64]]] but got array
 %res_collapse2 = tensor.collapse_shape %t0 [ [-2, 3], [0, 1] ] : tensor<4x1xf32> into tensor<4x1xf32>

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import abc
 from collections.abc import Iterable, Sequence
-from typing import Annotated, ClassVar, cast
+from typing import ClassVar, cast
 
 from typing_extensions import Self
 
@@ -35,6 +35,7 @@ from xdsl.dialects.utils import (
     split_dynamic_index_list,
 )
 from xdsl.dialects.utils.dynamic_index_list import verify_dynamic_index_list
+from xdsl.dialects.utils.reshape_ops_utils import ReassociationAttr
 from xdsl.ir import Attribute, Dialect, Operation, SSAValue
 from xdsl.irdl import (
     AnyAttr,
@@ -473,11 +474,6 @@ class RankOp(IRDLOperation):
     @staticmethod
     def from_memref(memref: Operation | SSAValue):
         return RankOp.build(operands=[memref], result_types=[IndexType()])
-
-
-ReassociationAttr = ArrayAttr[
-    ArrayAttr[IntegerAttr[Annotated[IntegerType, IntegerType(64)]]]
-]
 
 
 class AlterShapeOperation(IRDLOperation, abc.ABC):

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -35,7 +35,9 @@ from xdsl.dialects.utils import (
     split_dynamic_index_list,
 )
 from xdsl.dialects.utils.dynamic_index_list import verify_dynamic_index_list
-from xdsl.dialects.utils.reshape_ops_utils import ReassociationAttr
+from xdsl.dialects.utils.reshape_ops_utils import (
+    ContiguousArrayOfIntArray,
+)
 from xdsl.ir import Attribute, Dialect, Operation, SSAValue
 from xdsl.irdl import (
     AnyAttr,
@@ -478,7 +480,7 @@ class RankOp(IRDLOperation):
 
 class AlterShapeOperation(IRDLOperation, abc.ABC):
     result = result_def(MemRefType)
-    reassociation = prop_def(ReassociationAttr)
+    reassociation = prop_def(ContiguousArrayOfIntArray())
 
     traits = traits_def(NoMemoryEffect())
 

--- a/xdsl/dialects/tensor.py
+++ b/xdsl/dialects/tensor.py
@@ -16,7 +16,9 @@ from xdsl.dialects.builtin import (
     UnrankedTensorType,
     i64,
 )
-from xdsl.dialects.utils.reshape_ops_utils import ReassociationAttr
+from xdsl.dialects.utils.reshape_ops_utils import (
+    ContiguousArrayOfIntArray,
+)
 from xdsl.ir import Attribute, Dialect, Operation, SSAValue
 from xdsl.irdl import (
     AttrSizedOperandSegments,
@@ -185,7 +187,7 @@ class CollapseShapeOp(IRDLOperation):
 
     src = operand_def(TensorType[Attribute])
     result = result_def(TensorType[Attribute])
-    reassociation = prop_def(ReassociationAttr)
+    reassociation = prop_def(ContiguousArrayOfIntArray())
     assembly_format = (
         "$src $reassociation attr-dict `:` type($src) `into` type($result)"
     )

--- a/xdsl/dialects/utils/reshape_ops_utils.py
+++ b/xdsl/dialects/utils/reshape_ops_utils.py
@@ -10,13 +10,22 @@ from typing_extensions import TypeVar
 
 from xdsl.dialects.builtin import I64, Annotated, ArrayAttr, IntegerAttr
 from xdsl.ir import Attribute
-from xdsl.irdl import AtLeast, AttrConstraint, ConstraintContext
+from xdsl.irdl import AtLeast, AttrConstraint, ConstraintContext, GenericAttrConstraint
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.hints import isa
 
+_ReassociationAttrBase = ArrayAttr[
+    ArrayAttr[
+        Annotated[
+            IntegerAttr[I64],
+            IntegerAttr.constr(value=AtLeast(0)),
+        ]
+    ]
+]
+
 
 @dataclass(frozen=True)
-class ContiguousArrayOfIntArray(GenericAttrConstraint[ArrayAttr[ArrayAttr[IntegerAttr]]]):
+class ContiguousArrayOfIntArray(GenericAttrConstraint[_ReassociationAttrBase]):
     """
     Enforce an ArrayAttr of ArrayAttr[IntegerAttr] to contain contiguous integer values across all inner arrays.
     For example: [[0, 1], [2, 3]] is valid, but [[3, 4], [0, 1]] is not.
@@ -45,14 +54,4 @@ class ContiguousArrayOfIntArray(GenericAttrConstraint[ArrayAttr[ArrayAttr[Intege
         return self
 
 
-ReassociationAttr = Annotated[
-    ArrayAttr[
-        ArrayAttr[
-            Annotated[
-                IntegerAttr[I64],
-                IntegerAttr.constr(value=AtLeast(0)),
-            ]
-        ]
-    ],
-    ContiguousArrayOfIntArray(),
-]
+ReassociationAttr = ContiguousArrayOfIntArray()

--- a/xdsl/dialects/utils/reshape_ops_utils.py
+++ b/xdsl/dialects/utils/reshape_ops_utils.py
@@ -52,6 +52,3 @@ class ContiguousArrayOfIntArray(GenericAttrConstraint[_ReassociationAttrBase]):
     ) -> "ContiguousArrayOfIntArray":
         # No type variables to map in this constraint
         return self
-
-
-ReassociationAttr = ContiguousArrayOfIntArray()

--- a/xdsl/dialects/utils/reshape_ops_utils.py
+++ b/xdsl/dialects/utils/reshape_ops_utils.py
@@ -5,25 +5,32 @@ for more details.
 """
 
 from dataclasses import dataclass
+from typing import cast
 
 from typing_extensions import TypeVar
 
 from xdsl.dialects.builtin import I64, Annotated, ArrayAttr, IntegerAttr
 from xdsl.ir import Attribute
-from xdsl.irdl import AtLeast, AttrConstraint, ConstraintContext, GenericAttrConstraint
-from xdsl.utils.exceptions import VerifyException
-from xdsl.utils.hints import isa
-
-
-_CONTIGUOUS_ARRAY_TYPE_CONSTRAINT = irdl_to_attr_constraint(ArrayAttr[
-	    ArrayAttr[
-	        Annotated[
-	            IntegerAttr[I64],
-	            IntegerAttr.constr(value=AtLeast(0)),
-	        ]
-	    ]
-	]
+from xdsl.irdl import (
+    AtLeast,
+    AttrConstraint,
+    ConstraintContext,
+    GenericAttrConstraint,
+    irdl_to_attr_constraint,
 )
+from xdsl.utils.exceptions import VerifyException
+
+_CONTIGUOUS_ARRAY_TYPE_CONSTRAINT = irdl_to_attr_constraint(
+    ArrayAttr[
+        ArrayAttr[
+            Annotated[
+                IntegerAttr[I64],
+                IntegerAttr.constr(value=AtLeast(0)),
+            ]
+        ]
+    ]
+)
+
 
 @dataclass(frozen=True)
 class ContiguousArrayOfIntArray(
@@ -35,10 +42,10 @@ class ContiguousArrayOfIntArray(
     An empty inner array is considered contiguous.
     """
 
-    def verify(
-        self, attr: Attribute, constraint_context: ConstraintContext | None = None
-    ) -> None:
-        _CONTIGUOUS_ARRAY_TYPE_CONSTRAINT.verify(attr)
+    def verify(self, attr: Attribute, constraint_context: ConstraintContext) -> None:
+        _CONTIGUOUS_ARRAY_TYPE_CONSTRAINT.verify(
+            attr, constraint_context=constraint_context
+        )
         attr = cast(ArrayAttr[ArrayAttr[IntegerAttr]], attr)
 
         # Flatten all integer values from all inner arrays

--- a/xdsl/dialects/utils/reshape_ops_utils.py
+++ b/xdsl/dialects/utils/reshape_ops_utils.py
@@ -17,7 +17,7 @@ from xdsl.utils.hints import isa
 _ReassociationAttrBase = ArrayAttr[
     ArrayAttr[
         Annotated[
-            IntegerAttr[I64],
+            IntegerAttr,
             IntegerAttr.constr(value=AtLeast(0)),
         ]
     ]
@@ -35,7 +35,7 @@ class ContiguousArrayOfIntArray(GenericAttrConstraint[_ReassociationAttrBase]):
     def verify(
         self, attr: Attribute, constraint_context: ConstraintContext | None = None
     ) -> None:
-        if not isa(attr, ArrayAttr[ArrayAttr[IntegerAttr]]):
+        if not isa(attr, ArrayAttr[ArrayAttr[IntegerAttr[I64]]]):
             raise VerifyException(
                 f"Expected ArrayAttr but got {getattr(attr, 'name', type(attr))}"
             )

--- a/xdsl/dialects/utils/reshape_ops_utils.py
+++ b/xdsl/dialects/utils/reshape_ops_utils.py
@@ -1,0 +1,58 @@
+"""
+Utilities used by reshape ops.
+See [MLIR counterpart](https://github.com/llvm/llvm-project/blob/main/mlir/include/mlir/Dialect/Utils/ReshapeOpsUtils.h)
+for more details.
+"""
+
+from dataclasses import dataclass
+
+from typing_extensions import TypeVar
+
+from xdsl.dialects.builtin import I64, Annotated, ArrayAttr, IntegerAttr
+from xdsl.ir import Attribute
+from xdsl.irdl import AtLeast, AttrConstraint, ConstraintContext
+from xdsl.utils.exceptions import VerifyException
+from xdsl.utils.hints import isa
+
+
+@dataclass(frozen=True)
+class ContiguousArrayOfIntArray(AttrConstraint):
+    """
+    Enforce an ArrayAttr of ArrayAttr[IntegerAttr] to contain contiguous integer values across all inner arrays.
+    For example: [[0, 1], [2, 3]] is valid, but [[3, 4], [0, 1]] is not.
+    An empty inner array is considered contiguous.
+    """
+
+    def verify(
+        self, attr: Attribute, constraint_context: ConstraintContext | None = None
+    ) -> None:
+        if not isa(attr, ArrayAttr[ArrayAttr[IntegerAttr]]):
+            raise VerifyException(
+                f"Expected ArrayAttr but got {getattr(attr, 'name', type(attr))}"
+            )
+
+        # Flatten all integer values from all inner arrays
+        flat_values = [e.value.data for inner in attr.data for e in inner.data]
+        # Check that the flattened list is contiguous
+        for prev, curr in zip(flat_values, flat_values[1:]):
+            if curr != prev + 1:
+                raise VerifyException(f"All inner arrays must be contiguous: {attr}")
+
+    def mapping_type_vars(
+        self, type_var_mapping: dict[TypeVar, AttrConstraint]
+    ) -> "ContiguousArrayOfIntArray":
+        # No type variables to map in this constraint
+        return self
+
+
+ReassociationAttr = Annotated[
+    ArrayAttr[
+        ArrayAttr[
+            Annotated[
+                IntegerAttr[I64],
+                IntegerAttr.constr(value=AtLeast(0)),
+            ]
+        ]
+    ],
+    ContiguousArrayOfIntArray(),
+]

--- a/xdsl/dialects/utils/reshape_ops_utils.py
+++ b/xdsl/dialects/utils/reshape_ops_utils.py
@@ -14,18 +14,11 @@ from xdsl.irdl import AtLeast, AttrConstraint, ConstraintContext, GenericAttrCon
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.hints import isa
 
-_ReassociationAttrBase = ArrayAttr[
-    ArrayAttr[
-        Annotated[
-            IntegerAttr,
-            IntegerAttr.constr(value=AtLeast(0)),
-        ]
-    ]
-]
-
 
 @dataclass(frozen=True)
-class ContiguousArrayOfIntArray(GenericAttrConstraint[_ReassociationAttrBase]):
+class ContiguousArrayOfIntArray(
+    GenericAttrConstraint[ArrayAttr[ArrayAttr[IntegerAttr]]]
+):
     """
     Enforce an ArrayAttr of ArrayAttr[IntegerAttr] to contain contiguous integer values across all inner arrays.
     For example: [[0, 1], [2, 3]] is valid, but [[3, 4], [0, 1]] is not.
@@ -35,9 +28,19 @@ class ContiguousArrayOfIntArray(GenericAttrConstraint[_ReassociationAttrBase]):
     def verify(
         self, attr: Attribute, constraint_context: ConstraintContext | None = None
     ) -> None:
-        if not isa(attr, ArrayAttr[ArrayAttr[IntegerAttr[I64]]]):
+        if not isa(
+            attr,
+            ArrayAttr[
+                ArrayAttr[
+                    Annotated[
+                        IntegerAttr[I64],
+                        IntegerAttr.constr(value=AtLeast(0)),
+                    ]
+                ]
+            ],
+        ):
             raise VerifyException(
-                f"Expected ArrayAttr but got {getattr(attr, 'name', type(attr))}"
+                f"Expected ArrayAttr[ArrayAttr[IntegerAttr[I64]]] but got {getattr(attr, 'name', type(attr))}"
             )
 
         # Flatten all integer values from all inner arrays

--- a/xdsl/dialects/utils/reshape_ops_utils.py
+++ b/xdsl/dialects/utils/reshape_ops_utils.py
@@ -15,6 +15,16 @@ from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.hints import isa
 
 
+_CONTIGUOUS_ARRAY_TYPE_CONSTRAINT = irdl_to_attr_constraint(ArrayAttr[
+	    ArrayAttr[
+	        Annotated[
+	            IntegerAttr[I64],
+	            IntegerAttr.constr(value=AtLeast(0)),
+	        ]
+	    ]
+	]
+)
+
 @dataclass(frozen=True)
 class ContiguousArrayOfIntArray(
     GenericAttrConstraint[ArrayAttr[ArrayAttr[IntegerAttr]]]
@@ -28,20 +38,8 @@ class ContiguousArrayOfIntArray(
     def verify(
         self, attr: Attribute, constraint_context: ConstraintContext | None = None
     ) -> None:
-        if not isa(
-            attr,
-            ArrayAttr[
-                ArrayAttr[
-                    Annotated[
-                        IntegerAttr[I64],
-                        IntegerAttr.constr(value=AtLeast(0)),
-                    ]
-                ]
-            ],
-        ):
-            raise VerifyException(
-                f"Expected ArrayAttr[ArrayAttr[IntegerAttr[I64]]] but got {getattr(attr, 'name', type(attr))}"
-            )
+        _CONTIGUOUS_ARRAY_TYPE_CONSTRAINT.verify(attr)
+        attr = cast(ArrayAttr[ArrayAttr[IntegerAttr]], attr)
 
         # Flatten all integer values from all inner arrays
         flat_values = [e.value.data for inner in attr.data for e in inner.data]

--- a/xdsl/dialects/utils/reshape_ops_utils.py
+++ b/xdsl/dialects/utils/reshape_ops_utils.py
@@ -16,7 +16,7 @@ from xdsl.utils.hints import isa
 
 
 @dataclass(frozen=True)
-class ContiguousArrayOfIntArray(AttrConstraint):
+class ContiguousArrayOfIntArray(GenericAttrConstraint[ArrayAttr[ArrayAttr[IntegerAttr]]]):
     """
     Enforce an ArrayAttr of ArrayAttr[IntegerAttr] to contain contiguous integer values across all inner arrays.
     For example: [[0, 1], [2, 3]] is valid, but [[3, 4], [0, 1]] is not.


### PR DESCRIPTION
Used by #4245

Inspired by the MLIR counterpart:
https://github.com/llvm/llvm-project/blob/main/mlir/include/mlir/Dialect/Utils/ReshapeOpsUtils.h

I'm thinking that in theory reshape utils can be shared by any dialect having reshape-like ops
