### PR TITLE
API: add region_utils and used_values_defined_above

### DIFF
--- a/tests/ir/test_region_utils.py
+++ b/tests/ir/test_region_utils.py
@@ -1,0 +1,58 @@
+import pytest
+
+from xdsl.builder import ImplicitBuilder
+from xdsl.dialects.builtin import i1
+from xdsl.dialects.test import TestOp
+from xdsl.ir import Block, Region
+from xdsl.ir.region_utils import used_values_defined_above
+
+
+def test_used_values_defined_above():
+    r = Region(Block())
+    r0 = Region(Block())
+    r1 = Region(Block())
+    r00 = Region(Block())
+    r01 = Region(Block())
+
+    with ImplicitBuilder(r.block):
+        (v, _) = TestOp(result_types=(i1, i1)).results
+        TestOp(regions=(r0, r1))
+        with ImplicitBuilder(r0):
+            (v0, _) = TestOp(operands=(v,), result_types=(i1, i1)).results
+            TestOp(regions=(r00, r01))
+            with ImplicitBuilder(r00):
+                (v00, _) = TestOp(
+                    operands=(
+                        v,
+                        v0,
+                    ),
+                    result_types=(i1, i1),
+                ).results
+                TestOp(operands=(v00,))
+            with ImplicitBuilder(r01):
+                (v01, _) = TestOp(
+                    operands=(
+                        v,
+                        v0,
+                    ),
+                    result_types=(i1, i1),
+                ).results
+                TestOp(operands=(v01,))
+        with ImplicitBuilder(r1):
+            (v1, _) = TestOp(operands=(v,), result_types=(i1, i1)).results
+            TestOp(operands=(v1,))
+
+    assert used_values_defined_above(r) == set()
+    assert used_values_defined_above(r0) == {v}
+    assert used_values_defined_above(r1) == {v}
+    assert used_values_defined_above(r00) == {v, v0}
+    assert used_values_defined_above(r01) == {v, v0}
+
+    assert used_values_defined_above(r00, r0) == {v}
+    assert used_values_defined_above(r01, r0) == {v}
+
+    with pytest.raises(
+        AssertionError,
+        match="expected isolation limit to be an ancestor of the given region",
+    ):
+        used_values_defined_above(r0, r1)

--- a/xdsl/ir/region_utils.py
+++ b/xdsl/ir/region_utils.py
@@ -1,0 +1,40 @@
+"""
+Collection of helpers for dealing with `Region`s, similar to `RegionUtils.cpp` in MLIR.
+"""
+
+from xdsl.ir import Region
+
+
+def iter_used_values_defined_above(region: Region, limit: Region | None = None):
+    """
+    An iterator over the values used within `region` defined outside of `limit`.
+    If `limit` is `None`, it is set to `region`.
+    Values may be repeated.
+    """
+    if limit is not None:
+        assert limit.is_ancestor(region), (
+            "expected isolation limit to be an ancestor of the given region"
+        )
+    else:
+        limit = region
+
+    # Collect proper ancestors of `limit` upfront to avoid traversing the region
+    # tree for every value.
+    proper_ancestors = set[Region]()
+    ancestor = limit.parent_region()
+    while ancestor is not None:
+        proper_ancestors.add(ancestor)
+        ancestor = ancestor.parent_region()
+
+    for op in region.walk():
+        for operand in op.operands:
+            if operand.owner.parent_region() in proper_ancestors:
+                yield operand
+
+
+def used_values_defined_above(region: Region, limit: Region | None = None):
+    """
+    The set of values used within `region` defined outside of `limit`.
+    If `limit` is `None`, it is set to `region`.
+    """
+    return set(iter_used_values_defined_above(region, limit))


### PR DESCRIPTION
MLIR has a number of utils files with useful functions. I think we would benefit from this kind of pattern to make the surface area of core.py smaller. This file adds a function I'll need to port the vectorization infrastructure.