### PR TITLE
CI: add back weekly remake lockfile

### DIFF
--- a/.github/workflows/remake-lockfile.yml
+++ b/.github/workflows/remake-lockfile.yml
@@ -1,0 +1,39 @@
+name: Remake UV Lockfile
+
+on:
+  workflow_dispatch:
+  # Set the schedule, every week at 8:00am on Monday
+  schedule:
+    - cron: 0 8 * * 1
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  lock:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v3
+
+      - run: |
+          rm uv.lock
+          echo "\`\`\`" > uv_output.md
+          make venv &>> uv_output.md
+          echo "\`\`\`" >> uv_output.md
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "CI: Update uv lockfile"
+          title: "CI: Update uv lockfile"
+          body-path: uv_output.md
+          branch: ci/update-uv
+          base: main
+          labels: CI
+          delete-branch: true
+          add-paths: uv.lock
+          assignees: math-fehr, alexarice, superlopuh


### PR DESCRIPTION
Renovate only updates the direct dependency and not the transitive dependencies.
