### PR TITLE
documentation: (Toy) remove flattened_values from LiteralExprAST

### DIFF
--- a/docs/Toy/toy/frontend/ir_gen.py
+++ b/docs/Toy/toy/frontend/ir_gen.py
@@ -283,7 +283,9 @@ class IRGen:
         """
 
         if isinstance(expr, LiteralExprAST):
-            return expr.flattened_values()
+            return [
+                value for inner in expr.values for value in self.collect_data(inner)
+            ]
         elif isinstance(expr, NumberExprAST):
             return [expr.val]
         else:

--- a/docs/Toy/toy/frontend/toy_ast.py
+++ b/docs/Toy/toy/frontend/toy_ast.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Generator, Iterable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 
 from .location import Location
@@ -117,16 +117,6 @@ class LiteralExprAST(ExprAST):
 
     def inner_dump(self, prefix: str, dumper: Dumper):
         dumper.append("Literal:", self.__dump() + f" @{self.loc}")
-
-    def iter_flattened_values(self) -> Generator[float, None, None]:
-        for value in self.values:
-            if isinstance(value, NumberExprAST):
-                yield value.val
-            else:
-                yield from value.iter_flattened_values()
-
-    def flattened_values(self) -> list[float]:
-        return list(self.iter_flattened_values())
 
 
 @dataclass


### PR DESCRIPTION
This is the only "functional" helper in the AST that's not to do with the data structure or printing, it belongs in the parser.