### PR TITLE
misc: IRNode = Operation | Region | Block

### DIFF
--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -723,7 +723,7 @@ class ErasedSSAValue(SSAValue):
 @dataclass(init=False)
 class _IRNode(ABC):
     def is_ancestor(self, op: IRNode) -> bool:
-        "Returns true if the IRNode is an ancestor of another IRNode."
+        "Returns true if `self` is an ancestor of `op`."
         curr = op
         while curr is not None:
             if curr is self:
@@ -732,7 +732,10 @@ class _IRNode(ABC):
         return False
 
     def get_toplevel_object(self) -> IRNode:
-        """Get the operation, block, or region ancestor that has no parents."""
+        """
+        Get the ancestor of `self` that has no parent.
+        This can be an Operation, Block, or Region.
+        """
         current = self
         while (parent := current.parent_node) is not None:
             current = parent

--- a/xdsl/utils/diagnostic.py
+++ b/xdsl/utils/diagnostic.py
@@ -24,15 +24,15 @@ class Diagnostic:
         f = StringIO()
         p = Printer(stream=f, diagnostic=self, print_generic_format=True)
         toplevel = ir.get_toplevel_object()
-        if isinstance(toplevel, Operation):
-            p.print_op(toplevel)
-            p.print_string("\n")
-        elif isinstance(toplevel, Block):
-            p.print_block(toplevel)
-        elif isinstance(toplevel, Region):
-            p.print_region(toplevel)
-        else:
-            assert "xDSL internal error: get_toplevel_object returned unknown construct"
+        match toplevel:
+            case Operation():
+                p.print_op(toplevel)
+                p.print_string("\n")
+            case Block():
+                p.print_block(toplevel)
+            case Region():
+                p.print_region(toplevel)
+        p.print_string("\n")
 
         # __notes__ only in 3.11 and above
         if hasattr(underlying_error, "add_note"):

--- a/xdsl/utils/diagnostic.py
+++ b/xdsl/utils/diagnostic.py
@@ -32,7 +32,6 @@ class Diagnostic:
                 p.print_block(toplevel)
             case Region():
                 p.print_region(toplevel)
-        p.print_string("\n")
 
         # __notes__ only in 3.11 and above
         if hasattr(underlying_error, "add_note"):


### PR DESCRIPTION
There's a few places where types are actually one of a limited set, I propose to migrate to this pattern when this is the case. Two more places to do this: Attribute = ParametrizedAttribute | Data, and then some AST things in Toy.

As a drive-by fix, I replaced the recursive functions on IRNode with loopy ones, this isn't strictly necessary, but should be a bit faster.