### PR TITLE
documentation: (Toy) use NamedTuple for Toy AST

### DIFF
--- a/docs/Toy/Toy_Ch1.ipynb
+++ b/docs/Toy/Toy_Ch1.ipynb
@@ -183,7 +183,7 @@
      "output_type": "stream",
      "text": [
       "Module:\n",
-      "  Function \n",
+      "  Function\n",
       "    Proto 'multiply_transpose' @examples/ast.toy:4:1\n",
       "    Params: [a, b]\n",
       "    Block {\n",
@@ -196,7 +196,7 @@
       "            var: b @examples/ast.toy:5:35\n",
       "          ]\n",
       "    } // Block\n",
-      "  Function \n",
+      "  Function\n",
       "    Proto 'main' @examples/ast.toy:8:1\n",
       "    Params: []\n",
       "    Block {\n",

--- a/docs/Toy/examples/ast.toy
+++ b/docs/Toy/examples/ast.toy
@@ -1,4 +1,4 @@
-# RUN: python -m toy %s --emit=ast | filecheck %s
+# RUN: python -m toy %s --emit=ast | filecheck %s --strict-whitespace --match-full-lines
 
 # User defined generic function that operates on unknown shaped arguments.
 def multiply_transpose(a, b) {
@@ -29,47 +29,47 @@ def main() {
 }
 
 
-# CHECK: Module:
-# CHECK-NEXT:     Function
-# CHECK-NEXT:       Proto 'multiply_transpose' @{{.*}}ast.toy:4:1
-# CHECK-NEXT:       Params: [a, b]
-# CHECK-NEXT:       Block {
-# CHECK-NEXT:         Return
-# CHECK-NEXT:           BinOp: * @{{.*}}ast.toy:5:25
-# CHECK-NEXT:             Call 'transpose' [ @{{.*}}ast.toy:5:10
-# CHECK-NEXT:               var: a @{{.*}}ast.toy:5:20
-# CHECK-NEXT:             ]
-# CHECK-NEXT:             Call 'transpose' [ @{{.*}}ast.toy:5:25
-# CHECK-NEXT:               var: b @{{.*}}ast.toy:5:35
-# CHECK-NEXT:             ]
-# CHECK-NEXT:       } // Block
-# CHECK-NEXT:     Function
-# CHECK-NEXT:       Proto 'main' @{{.*}}ast.toy:8:1
-# CHECK-NEXT:       Params: []
-# CHECK-NEXT:       Block {
-# CHECK-NEXT:         VarDecl a<> @{{.*}}ast.toy:11:3
-# CHECK-NEXT:           Literal: <2, 3>[ <3>[ 1.000000e+00, 2.000000e+00, 3.000000e+00], <3>[ 4.000000e+00, 5.000000e+00, 6.000000e+00]] @{{.*}}ast.toy:11:11
-# CHECK-NEXT:         VarDecl b<2, 3> @{{.*}}ast.toy:15:3
-# CHECK-NEXT:           Literal: <6>[ 1.000000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00, 5.000000e+00, 6.000000e+00] @{{.*}}ast.toy:15:17
-# CHECK-NEXT:         VarDecl c<> @{{.*}}ast.toy:19:3
-# CHECK-NEXT:           Call 'multiply_transpose' [ @{{.*}}ast.toy:19:11
-# CHECK-NEXT:             var: a @{{.*}}ast.toy:19:30
-# CHECK-NEXT:             var: b @{{.*}}ast.toy:19:33
+#      CHECK: Module:
+# CHECK-NEXT:   Function
+# CHECK-NEXT:     Proto 'multiply_transpose' @{{.*}}ast.toy:4:1
+# CHECK-NEXT:     Params: [a, b]
+# CHECK-NEXT:     Block {
+# CHECK-NEXT:       Return
+# CHECK-NEXT:         BinOp: * @{{.*}}ast.toy:5:25
+# CHECK-NEXT:           Call 'transpose' [ @{{.*}}ast.toy:5:10
+# CHECK-NEXT:             var: a @{{.*}}ast.toy:5:20
 # CHECK-NEXT:           ]
-# CHECK-NEXT:         VarDecl d<> @{{.*}}ast.toy:22:3
-# CHECK-NEXT:           Call 'multiply_transpose' [ @{{.*}}ast.toy:22:11
-# CHECK-NEXT:             var: b @{{.*}}ast.toy:22:30
-# CHECK-NEXT:             var: a @{{.*}}ast.toy:22:33
+# CHECK-NEXT:           Call 'transpose' [ @{{.*}}ast.toy:5:25
+# CHECK-NEXT:             var: b @{{.*}}ast.toy:5:35
 # CHECK-NEXT:           ]
-# CHECK-NEXT:         VarDecl e<> @{{.*}}ast.toy:25:3
-# CHECK-NEXT:           Call 'multiply_transpose' [ @{{.*}}ast.toy:25:11
-# CHECK-NEXT:             var: b @{{.*}}ast.toy:25:30
-# CHECK-NEXT:             var: c @{{.*}}ast.toy:25:33
+# CHECK-NEXT:     } // Block
+# CHECK-NEXT:   Function
+# CHECK-NEXT:     Proto 'main' @{{.*}}ast.toy:8:1
+# CHECK-NEXT:     Params: []
+# CHECK-NEXT:     Block {
+# CHECK-NEXT:       VarDecl a<> @{{.*}}ast.toy:11:3
+# CHECK-NEXT:         Literal: <2, 3>[ <3>[ 1.000000e+00, 2.000000e+00, 3.000000e+00], <3>[ 4.000000e+00, 5.000000e+00, 6.000000e+00]] @{{.*}}ast.toy:11:11
+# CHECK-NEXT:       VarDecl b<2, 3> @{{.*}}ast.toy:15:3
+# CHECK-NEXT:         Literal: <6>[ 1.000000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00, 5.000000e+00, 6.000000e+00] @{{.*}}ast.toy:15:17
+# CHECK-NEXT:       VarDecl c<> @{{.*}}ast.toy:19:3
+# CHECK-NEXT:         Call 'multiply_transpose' [ @{{.*}}ast.toy:19:11
+# CHECK-NEXT:           var: a @{{.*}}ast.toy:19:30
+# CHECK-NEXT:           var: b @{{.*}}ast.toy:19:33
+# CHECK-NEXT:         ]
+# CHECK-NEXT:       VarDecl d<> @{{.*}}ast.toy:22:3
+# CHECK-NEXT:         Call 'multiply_transpose' [ @{{.*}}ast.toy:22:11
+# CHECK-NEXT:           var: b @{{.*}}ast.toy:22:30
+# CHECK-NEXT:           var: a @{{.*}}ast.toy:22:33
+# CHECK-NEXT:         ]
+# CHECK-NEXT:       VarDecl e<> @{{.*}}ast.toy:25:3
+# CHECK-NEXT:         Call 'multiply_transpose' [ @{{.*}}ast.toy:25:11
+# CHECK-NEXT:           var: b @{{.*}}ast.toy:25:30
+# CHECK-NEXT:           var: c @{{.*}}ast.toy:25:33
+# CHECK-NEXT:         ]
+# CHECK-NEXT:       VarDecl f<> @{{.*}}ast.toy:28:3
+# CHECK-NEXT:         Call 'multiply_transpose' [ @{{.*}}ast.toy:28:11
+# CHECK-NEXT:           Call 'transpose' [ @{{.*}}ast.toy:28:30
+# CHECK-NEXT:             var: a @{{.*}}ast.toy:28:40
 # CHECK-NEXT:           ]
-# CHECK-NEXT:         VarDecl f<> @{{.*}}ast.toy:28:3
-# CHECK-NEXT:           Call 'multiply_transpose' [ @{{.*}}ast.toy:28:11
-# CHECK-NEXT:             Call 'transpose' [ @{{.*}}ast.toy:28:30
-# CHECK-NEXT:               var: a @{{.*}}ast.toy:28:40
-# CHECK-NEXT:             ]
-# CHECK-NEXT:             var: c @{{.*}}ast.toy:28:44
-# CHECK-NEXT:           ]
+# CHECK-NEXT:           var: c @{{.*}}ast.toy:28:44
+# CHECK-NEXT:         ]

--- a/docs/Toy/toy/frontend/toy_ast.py
+++ b/docs/Toy/toy/frontend/toy_ast.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Iterable
-from dataclasses import dataclass
 from typing import NamedTuple
 
 from .location import Location
@@ -15,8 +14,7 @@ class VarType(NamedTuple):
     shape: list[int]
 
 
-@dataclass()
-class Dumper:
+class Dumper(NamedTuple):
     lines: list[str]
     indentation: int = 0
 

--- a/docs/Toy/toy/frontend/toy_ast.py
+++ b/docs/Toy/toy/frontend/toy_ast.py
@@ -149,6 +149,7 @@ class PrintExprAST(NamedTuple):
     arg: ExprAST
 
     def inner_dump(self, prefix: str, dumper: Dumper):
+        dumper.append(prefix, self.__class__.__name__)
         child = dumper.child()
         self.arg.inner_dump("arg: ", child)
 
@@ -187,7 +188,7 @@ class FunctionAST(NamedTuple):
         return dumper.message
 
     def inner_dump(self, prefix: str, dumper: Dumper):
-        dumper.append(prefix, "Function ")
+        dumper.append(prefix, "Function")
         child = dumper.child()
         self.proto.inner_dump("proto: ", child)
         child.append_list(


### PR DESCRIPTION
Relatively small change to use NamedTuple instead of dataclass in the Toy AST infrastructure.