### PR TITLE
misc: remove cast from builtin.py

### DIFF
--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -2233,17 +2233,12 @@ class MemRefType(
         layout: MemRefLayoutAttr | NoneAttr = NoneAttr(),
         memory_space: Attribute = NoneAttr(),
     ):
-        s: ArrayAttr[IntAttr]
-        if isa(shape, ArrayAttr[IntAttr]):
-            # Temporary cast until Pyright is fixed to not infer ArrayAttr[int] as a
-            # possible value for shape
-            s = shape
-        else:
-            s = ArrayAttr(
+        if not isa(shape, ArrayAttr[IntAttr]):
+            shape = ArrayAttr(
                 [IntAttr(dim) if isinstance(dim, int) else dim for dim in shape]
             )
         super().__init__(
-            s,
+            shape,
             element_type,
             layout,
             memory_space,


### PR DESCRIPTION
Much of the time it's a matter of using isa instead of isinstance, sometimes it's just a pyright ignore, when we already know from control flow that the value is of the right type.
