### PR TITLE
core: don't use try/finally for delimited helper

### DIFF
--- a/tests/filecheck/dialects/emitc/emitc_types_invalid.mlir
+++ b/tests/filecheck/dialects/emitc/emitc_types_invalid.mlir
@@ -65,7 +65,7 @@
 
 // -----
 
-// CHECK: '>' expected
+// CHECK: Expected shape type.
 "test.op"() {
   illegal_array_unranked = !emitc.array<*xi32>
 }: ()->()

--- a/xdsl/parser/generic_parser.py
+++ b/xdsl/parser/generic_parser.py
@@ -309,10 +309,8 @@ class GenericParser(Generic[TokenKindT]):
     @contextmanager
     def delimited(self, start: str, end: str):
         self.parse_characters(start)
-        try:
-            yield
-        finally:
-            self.parse_characters(end)
+        yield
+        self.parse_characters(end)
 
     def in_angle_brackets(self):
         return self.delimited("<", ">")

--- a/xdsl/utils/base_printer.py
+++ b/xdsl/utils/base_printer.py
@@ -71,10 +71,8 @@ class BasePrinter:
     @contextmanager
     def delimited(self, start: str, end: str):
         self.print_string(start)
-        try:
-            yield
-        finally:
-            self.print_string(end)
+        yield
+        self.print_string(end)
 
     def in_angle_brackets(self):
         return self.delimited("<", ">")


### PR DESCRIPTION
If an error is raised in the yield, it is then swallowed, and another is raised with an expected delimiter, which is not ideal.