### PR TITLE
dialects: (emitc) Add OpaqueType

### DIFF
--- a/tests/filecheck/dialects/emitc/emitc_types.mlir
+++ b/tests/filecheck/dialects/emitc/emitc_types.mlir
@@ -28,16 +28,26 @@
 // CHECK: f64 = !emitc.lvalue<f64>
 // CHECK-SAME: i32 = !emitc.lvalue<i32>
 // CHECK-SAME: index = !emitc.lvalue<index>
-// CHECK-SAME: tensor_i32 = !emitc.lvalue<tensor<1xi32>>
+// CHECK-SAME: opaque_int = !emitc.lvalue<!emitc.opaque<"int">>
+// CHECK-SAME: tensor_i32 = !emitc.lvalue<tensor<1xi32>>,
 // CHECK-SAME: tuple_i32 = !emitc.lvalue<tuple<i32, i32>>
 "test.op"() {
   f64 = !emitc.lvalue<f64>,
   i32 = !emitc.lvalue<i32>,
   index = !emitc.lvalue<index>,
+  opaque_int = !emitc.lvalue<!emitc.opaque<"int">>,
   tensor_i32 = !emitc.lvalue<tensor<1xi32>>,
   tuple_i32 = !emitc.lvalue<tuple<i32, i32>>
-  // emitc.ptr and emitc.opaque types are not supported yet.
-  // Once they are supported, the following lines can be uncommented:
+  // emitc.ptr type is not supported yet.
+  // Once it is supported, the following lines can be uncommented:
   // ptr_i32 = !emitc.lvalue<!emitc.ptr<i32>>,
-  // opaque_int = !emitc.lvalue<!emitc.opaque<"int">>
+}: ()->()
+
+//===----------------------------------------------------------------------===//
+// OpaqueType
+//===----------------------------------------------------------------------===//
+
+// CHECK: opaque_type = !emitc.opaque<"my_custom_type">
+"test.op"() {
+  opaque_type = !emitc.opaque<"my_custom_type">
 }: ()->()

--- a/tests/filecheck/dialects/emitc/emitc_types_invalid.mlir
+++ b/tests/filecheck/dialects/emitc/emitc_types_invalid.mlir
@@ -111,3 +111,17 @@
 "test.op"() {
   illegal_lvalue_tuple_emitc_array_i32 = !emitc.lvalue<tuple<!emitc.array<1xi32>>>
 }: ()->()
+
+// -----
+
+// CHECK: expected non empty string in !emitc.opaque type
+"test.op"() {
+  empty_str = !emitc.opaque<"">
+}: ()->()
+
+// -----
+
+// CHECK: pointer not allowed as outer type with !emitc.opaque, use !emitc.ptr instead
+"test.op"() {
+  with_ptr = !emitc.opaque<"foo*">
+}: ()->()

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/emitc/emitc_types.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/emitc/emitc_types.mlir
@@ -28,16 +28,26 @@
 // CHECK: f64 = !emitc.lvalue<f64>
 // CHECK-SAME: i32 = !emitc.lvalue<i32>
 // CHECK-SAME: index = !emitc.lvalue<index>
+// CHECK-SAME: opaque_int = !emitc.lvalue<!emitc.opaque<"int">>
 // CHECK-SAME: tensor_i32 = !emitc.lvalue<tensor<1xi32>>,
 // CHECK-SAME: tuple_i32 = !emitc.lvalue<tuple<i32, i32>>
 "test.op"() {
   f64 = !emitc.lvalue<f64>,
   i32 = !emitc.lvalue<i32>,
   index = !emitc.lvalue<index>,
+  opaque_int = !emitc.lvalue<!emitc.opaque<"int">>,
   tensor_i32 = !emitc.lvalue<tensor<1xi32>>,
   tuple_i32 = !emitc.lvalue<tuple<i32, i32>>
-  // emitc.ptr and emitc.opaque types are not supported yet.
-  // Once they are supported, the following lines can be uncommented:
+  // emitc.ptr type is not supported yet.
+  // Once it is supported, the following lines can be uncommented:
   // ptr_i32 = !emitc.lvalue<!emitc.ptr<i32>>,
-  // opaque_int = !emitc.lvalue<!emitc.opaque<"int">>
+}: ()->()
+
+//===----------------------------------------------------------------------===//
+// OpaqueType
+//===----------------------------------------------------------------------===//
+
+// CHECK: opaque_type = !emitc.opaque<"my_custom_type">
+"test.op"() {
+  opaque_type = !emitc.opaque<"my_custom_type">
 }: ()->()


### PR DESCRIPTION
Add the [emitc opaque](https://mlir.llvm.org/docs/Dialects/EmitC/#opaquetype) type with some tests.