### PR TITLE
documentation: (Toy) use keyword tokens for return, def, and var

### DIFF
--- a/docs/Toy/toy/frontend/lexer.py
+++ b/docs/Toy/toy/frontend/lexer.py
@@ -49,6 +49,12 @@ SINGLE_CHAR_TOKENS = {
     "/": ToyTokenKind.OPERATOR,
 }
 
+KEYWORD_TOKENS = {
+    "return": ToyTokenKind.RETURN,
+    "def": ToyTokenKind.DEF,
+    "var": ToyTokenKind.VAR,
+}
+
 IDENTIFIER_CHARS = re.compile(r"[\w]|[\d]|_")
 SPECIAL_CHARS = set(",")
 
@@ -144,7 +150,9 @@ class ToyLexer(Lexer[ToyTokenKind]):
         """
         self._consume_regex(self.bare_identifier_suffix_regex)
 
-        return self._form_token(ToyTokenKind.IDENTIFIER, start_pos)
+        span = Span(start_pos, self.pos, self.input)
+        kind = KEYWORD_TOKENS.get(span.text, ToyTokenKind.IDENTIFIER)
+        return Token(kind, span)
 
     _hexdigits_star_regex = re.compile(r"[0-9a-fA-F]*")
     _digits_star_regex = re.compile(r"[0-9]*")

--- a/docs/Toy/toy/frontend/parser.py
+++ b/docs/Toy/toy/frontend/parser.py
@@ -101,7 +101,7 @@ class ToyParser(GenericParser[ToyTokenKind]):
         Parse a return statement.
         return :== return ; | return expr ;
         """
-        returnToken = self.pop_pattern("return")
+        returnToken = self.pop_token(ToyTokenKind.RETURN)
         expr = None
 
         # Return takes an optional argument
@@ -319,7 +319,7 @@ class ToyParser(GenericParser[ToyTokenKind]):
         initializer.
         decl ::= var identifier [ type ] = expr
         """
-        var = self.pop_pattern("var")
+        var = self.pop_token(ToyTokenKind.VAR)
         name = self.pop_token(ToyTokenKind.IDENTIFIER).text
 
         # Type is optional, it can be inferred
@@ -350,10 +350,10 @@ class ToyParser(GenericParser[ToyTokenKind]):
             self.pop_pattern(";")
 
         while not self.check("}"):
-            if self.check("var"):
+            if self.check(ToyTokenKind.VAR):
                 # Variable declaration
                 exprList.append(self.parse_declaration())
-            elif self.check("return"):
+            elif self.check(ToyTokenKind.RETURN):
                 # Return statement
                 exprList.append(self.parse_return())
             else:
@@ -376,7 +376,7 @@ class ToyParser(GenericParser[ToyTokenKind]):
         prototype ::= def id '(' decl_list ')'
         decl_list ::= identifier | identifier, decl_list
         """
-        defToken = self.pop_pattern("def")
+        defToken = self.pop_token(ToyTokenKind.DEF)
         fnName = self.pop_token(ToyTokenKind.IDENTIFIER).text
         self.pop_pattern("(")
 


### PR DESCRIPTION
This is something I implemented incorrectly two years ago, a fix is better late than never, I guess.