### PR TITLE
misc: replace PipelinePass.iter_passes with parse_spec

### DIFF
--- a/tests/xdsl_opt/test_xdsl_opt.py
+++ b/tests/xdsl_opt/test_xdsl_opt.py
@@ -3,6 +3,7 @@ This test file needs the other files in the same folder to read and reprint them
 test functions below.
 """
 
+import re
 from contextlib import redirect_stdout
 from io import StringIO
 from typing import IO
@@ -76,15 +77,13 @@ def test_error_on_run(args: list[str], expected_error: str):
     [
         (
             ["tests/xdsl_opt/empty_program.mlir", "-p", "wrong"],
-            "Unrecognized pass: wrong",
+            "Unrecognized passes: ['wrong']",
         )
     ],
 )
 def test_error_on_construction(args: list[str], expected_error: str):
-    with pytest.raises(Exception) as e:
+    with pytest.raises(Exception, match=re.escape(expected_error)):
         _opt = xDSLOptMain(args=args)
-
-    assert e.value.args[0] == expected_error
 
 
 def test_wrong_target():

--- a/xdsl/interactive/app.py
+++ b/xdsl/interactive/app.py
@@ -51,7 +51,6 @@ from xdsl.parser import Parser
 from xdsl.passes import ModulePass, PipelinePass
 from xdsl.printer import Printer
 from xdsl.transforms import get_all_passes, individual_rewrite
-from xdsl.utils.parse_pipeline import parse_pipeline
 
 from ._pasteboard import pyclip_copy
 
@@ -725,9 +724,8 @@ def main():
     else:
         file_contents = None
 
-    pass_spec_pipeline = list(parse_pipeline(args.passes))
     pass_list = get_all_passes()
-    pipeline = tuple(PipelinePass.iter_passes(pass_list, pass_spec_pipeline))
+    pipeline = PipelinePass.parse_spec(pass_list, args.passes).passes
 
     return InputApp(
         tuple(get_all_dialects().items()),

--- a/xdsl/interpreters/transform.py
+++ b/xdsl/interpreters/transform.py
@@ -14,7 +14,6 @@ from xdsl.interpreter import (
     register_impls,
 )
 from xdsl.passes import ModulePass, PipelinePass
-from xdsl.utils import parse_pipeline
 
 
 @register_impls
@@ -45,13 +44,7 @@ class TransformFunctions(InterpreterFunctions):
         args: PythonValues,
     ) -> PythonValues:
         pass_name = op.pass_name.data
-
-        schedule = tuple(
-            PipelinePass.iter_passes(
-                self.passes, parse_pipeline.parse_pipeline(pass_name)
-            )
-        )
-        pipeline = PipelinePass(schedule)
+        pipeline = PipelinePass.parse_spec(self.passes, pass_name)
         pipeline.apply(self.ctx, args[0])
         return (args[0],)
 

--- a/xdsl/passes.py
+++ b/xdsl/passes.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import dataclasses
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Iterable
+from collections.abc import Callable
 from dataclasses import Field, dataclass, field
 from types import NoneType, UnionType
 from typing import (
@@ -21,6 +23,7 @@ from xdsl.utils.parse_pipeline import (
     PassArgElementType,
     PassArgListType,
     PipelinePassSpec,
+    parse_pipeline,
 )
 
 ModulePassT = TypeVar("ModulePassT", bound="ModulePass")
@@ -210,16 +213,23 @@ class PipelinePass(ModulePass):
 
         self.passes[-1].apply(ctx, op)
 
-    @classmethod
-    def iter_passes(
-        cls,
+    @staticmethod
+    def parse_spec(
         available_passes: dict[str, Callable[[], type[ModulePass]]],
-        pass_spec_pipeline: Iterable[PipelinePassSpec],
-    ) -> Iterable[ModulePass]:
-        for p in pass_spec_pipeline:
-            if p.name not in available_passes:
-                raise Exception(f"Unrecognized pass: {p.name}")
-            yield available_passes[p.name]().from_pass_spec(p)
+        spec: str,
+        callback: Callable[[ModulePass, builtin.ModuleOp, ModulePass], None]
+        | None = None,
+    ) -> PipelinePass:
+        specs = tuple(parse_pipeline(spec))
+        unrecognised_passes = tuple(
+            p.name for p in specs if p.name not in available_passes
+        )
+        if unrecognised_passes:
+            raise Exception(f"Unrecognized passes: {list(unrecognised_passes)}")
+
+        passes = tuple(available_passes[p.name]().from_pass_spec(p) for p in specs)
+
+        return PipelinePass(passes, callback)
 
 
 def _convert_pass_arg_to_type(

--- a/xdsl/xdsl_opt_main.py
+++ b/xdsl/xdsl_opt_main.py
@@ -15,7 +15,6 @@ from xdsl.tools.command_line_tool import CommandLineTool
 from xdsl.transforms import get_all_passes
 from xdsl.utils.exceptions import DiagnosticException, ParseError, ShrinkException
 from xdsl.utils.lexer import Span
-from xdsl.utils.parse_pipeline import parse_pipeline
 
 
 class xDSLOptMain(CommandLineTool):
@@ -315,12 +314,9 @@ class xDSLOptMain(CommandLineTool):
                 printer.print_op(module)
                 print("\n\n\n")
 
-        self.pipeline = PipelinePass(
-            tuple(
-                PipelinePass.iter_passes(
-                    self.available_passes, parse_pipeline(self.args.passes)
-                )
-            ),
+        self.pipeline = PipelinePass.parse_spec(
+            self.available_passes,
+            self.args.passes,
             callback,
         )
 


### PR DESCRIPTION
A minor change in the API that hopefully simplifies things a bit. I'd like to leverage this class a bit more, so I thought I'd simplify the point of use first.