### PR TITLE
API: PipelinePass -> PassPipeline

### DIFF
--- a/docs/marimo/linalg_snitch.py
+++ b/docs/marimo/linalg_snitch.py
@@ -30,7 +30,7 @@ def _():
     from xdsl.dialects.riscv import riscv_code
     from xdsl.interpreters.utils.ptr import TypedPtr
     from xdsl.ir import Attribute, Block, Region, SSAValue
-    from xdsl.passes import PipelinePass
+    from xdsl.passes import PassPipeline
     from xdsl.tools.command_line_tool import get_all_dialects
     from xdsl.transforms import (
         arith_add_fastmath,
@@ -63,7 +63,7 @@ def _():
         ImplicitBuilder,
         MemRefType,
         ModuleOp,
-        PipelinePass,
+        PassPipeline,
         RISCVRegisterAllocation,
         Region,
         TypedPtr,
@@ -235,7 +235,7 @@ def _(mo):
 
 @app.cell
 def _(
-    PipelinePass,
+    PassPipeline,
     convert_arith_to_riscv,
     convert_func_to_riscv_func,
     convert_linalg_to_loops,
@@ -246,7 +246,7 @@ def _(
     reconcile_unrealized_casts,
     xmo,
 ):
-    lower_to_riscv = PipelinePass(
+    lower_to_riscv = PassPipeline(
         [
             convert_linalg_to_loops.ConvertLinalgToLoopsPass(),
             convert_func_to_riscv_func.ConvertFuncToRiscvFuncPass(),
@@ -280,13 +280,13 @@ def _(mo):
 @app.cell
 def _(
     CanonicalizePass,
-    PipelinePass,
+    PassPipeline,
     RISCVRegisterAllocation,
     riscv_ctx,
     riscv_module,
     xmo,
 ):
-    allocate_registers = PipelinePass(
+    allocate_registers = PassPipeline(
         [
             RISCVRegisterAllocation(),
             CanonicalizePass(),
@@ -305,12 +305,12 @@ def _(
 def _(
     CanonicalizePass,
     ConvertRiscvScfToRiscvCfPass,
-    PipelinePass,
+    PassPipeline,
     regalloc_ctx,
     regalloc_module,
     xmo,
 ):
-    lower_to_asm = PipelinePass(
+    lower_to_asm = PassPipeline(
         [
             ConvertRiscvScfToRiscvCfPass(),
             CanonicalizePass(),
@@ -358,7 +358,7 @@ def _(mo):
 
 @app.cell
 def _(
-    PipelinePass,
+    PassPipeline,
     arith_add_fastmath,
     convert_linalg_to_memref_stream,
     convert_riscv_scf_for_to_frep,
@@ -368,7 +368,7 @@ def _(
 ):
     from xdsl.transforms.test_lower_linalg_to_snitch import LOWER_MEMREF_STREAM_TO_SNITCH_STREAM_PASSES, OPTIMISE_MEMREF_STREAM_PASSES
 
-    convert_linalg_to_snitch = PipelinePass(
+    convert_linalg_to_snitch = PassPipeline(
         [
             convert_linalg_to_memref_stream.ConvertLinalgToMemRefStreamPass(),
             arith_add_fastmath.AddArithFastMathFlagsPass(),

--- a/xdsl/interactive/get_all_available_passes.py
+++ b/xdsl/interactive/get_all_available_passes.py
@@ -2,14 +2,13 @@ from collections.abc import Callable
 
 from xdsl.interactive.passes import (
     AvailablePass,
-    apply_passes_to_module,
     get_condensed_pass_list,
     get_new_registered_context,
 )
 from xdsl.interactive.rewrites import get_all_possible_rewrites
 from xdsl.ir import Dialect
 from xdsl.parser import Parser
-from xdsl.passes import ModulePass
+from xdsl.passes import ModulePass, PassPipeline
 from xdsl.pattern_rewriter import RewritePattern
 
 
@@ -28,7 +27,7 @@ def get_available_pass_list(
     parser = Parser(ctx, input_text)
     current_module = parser.parse_module()
 
-    current_module = apply_passes_to_module(current_module, ctx, pass_pipeline)
+    PassPipeline(pass_pipeline).apply(ctx, current_module)
 
     # get all individual rewrites
     individual_rewrites = get_all_possible_rewrites(

--- a/xdsl/interactive/passes.py
+++ b/xdsl/interactive/passes.py
@@ -4,7 +4,7 @@ from typing import NamedTuple
 from xdsl.context import Context
 from xdsl.dialects import builtin, get_all_dialects
 from xdsl.ir import Dialect
-from xdsl.passes import ModulePass, PipelinePass
+from xdsl.passes import ModulePass
 from xdsl.transforms.mlir_opt import MLIROptPass
 
 
@@ -28,20 +28,6 @@ def get_new_registered_context(
     for dialect_name, dialect_factory in all_dialects:
         ctx.register_dialect(dialect_name, dialect_factory)
     return ctx
-
-
-def apply_passes_to_module(
-    module: builtin.ModuleOp,
-    ctx: Context,
-    passes: tuple[ModulePass, ...],
-) -> builtin.ModuleOp:
-    """
-    Function that takes a ModuleOp, an Context and a pass_pipeline, applies the
-    passes to the ModuleOp and returns the modified ModuleOp.
-    """
-    pipeline = PipelinePass(passes=passes)
-    pipeline.apply(ctx, module)
-    return module
 
 
 def iter_condensed_passes(

--- a/xdsl/interpreters/transform.py
+++ b/xdsl/interpreters/transform.py
@@ -13,7 +13,7 @@ from xdsl.interpreter import (
     impl_terminator,
     register_impls,
 )
-from xdsl.passes import ModulePass, PipelinePass
+from xdsl.passes import ModulePass, PassPipeline
 
 
 @register_impls
@@ -44,7 +44,7 @@ class TransformFunctions(InterpreterFunctions):
         args: PythonValues,
     ) -> PythonValues:
         pass_name = op.pass_name.data
-        pipeline = PipelinePass.parse_spec(self.passes, pass_name)
+        pipeline = PassPipeline.parse_spec(self.passes, pass_name)
         pipeline.apply(self.ctx, args[0])
         return (args[0],)
 

--- a/xdsl/passes.py
+++ b/xdsl/passes.py
@@ -190,7 +190,7 @@ def get_pass_option_infos(
 
 
 @dataclass(frozen=True)
-class PipelinePass(ModulePass):
+class PassPipeline:
     passes: tuple[ModulePass, ...]
     callback: Callable[[ModulePass, builtin.ModuleOp, ModulePass], None] | None = field(
         default=None
@@ -219,7 +219,7 @@ class PipelinePass(ModulePass):
         spec: str,
         callback: Callable[[ModulePass, builtin.ModuleOp, ModulePass], None]
         | None = None,
-    ) -> PipelinePass:
+    ) -> PassPipeline:
         specs = tuple(parse_pipeline(spec))
         unrecognised_passes = tuple(
             p.name for p in specs if p.name not in available_passes
@@ -229,7 +229,7 @@ class PipelinePass(ModulePass):
 
         passes = tuple(available_passes[p.name]().from_pass_spec(p) for p in specs)
 
-        return PipelinePass(passes, callback)
+        return PassPipeline(passes, callback)
 
 
 def _convert_pass_arg_to_type(

--- a/xdsl/passes.py
+++ b/xdsl/passes.py
@@ -191,13 +191,21 @@ def get_pass_option_infos(
 
 @dataclass(frozen=True)
 class PassPipeline:
+    """
+    A representation of a pass pipeline, with an optional callback to be executed
+    between each of the passes.
+    """
+
     passes: tuple[ModulePass, ...]
+    """
+    These will be executed sequentially during the execution of the pipeline.
+    """
     callback: Callable[[ModulePass, builtin.ModuleOp, ModulePass], None] | None = field(
         default=None
     )
     """
-    Function called in between every pass, taking the pass that just ran, the module, and
-    the next pass.
+    Function called in between every pass, taking the pass that just ran, the module,
+    and the next pass.
     """
 
     def apply(self, ctx: Context, op: builtin.ModuleOp) -> None:

--- a/xdsl/utils/marimo.py
+++ b/xdsl/utils/marimo.py
@@ -5,7 +5,7 @@ import marimo as mo
 
 from xdsl.context import Context
 from xdsl.dialects.builtin import ModuleOp
-from xdsl.passes import ModulePass, PipelinePass
+from xdsl.passes import ModulePass, PassPipeline
 
 
 def asm_html(asm: str) -> mo.Html:
@@ -22,11 +22,11 @@ def module_html(module: ModuleOp) -> mo.Html:
     return mo.ui.code_editor(str(module), language="javascript", disabled=True)
 
 
-def _spec_str(p: ModulePass) -> str:
+def _spec_str(p: ModulePass | PassPipeline) -> str:
     """
     A string representation of the pass passed in, to display to the user.
     """
-    if isinstance(p, PipelinePass):
+    if isinstance(p, PassPipeline):
         return ",".join(str(c.pipeline_pass_spec()) for c in p.passes)
     else:
         return str(p.pipeline_pass_spec())

--- a/xdsl/xdsl_opt_main.py
+++ b/xdsl/xdsl_opt_main.py
@@ -9,7 +9,7 @@ from typing import IO, Any
 
 from xdsl.context import Context
 from xdsl.dialects.builtin import ModuleOp
-from xdsl.passes import ModulePass, PipelinePass
+from xdsl.passes import ModulePass, PassPipeline
 from xdsl.printer import Printer
 from xdsl.tools.command_line_tool import CommandLineTool
 from xdsl.transforms import get_all_passes
@@ -29,7 +29,7 @@ class xDSLOptMain(CommandLineTool):
     stream.
     """
 
-    pipeline: PipelinePass
+    pipeline: PassPipeline
     """ The pass-pipeline to be applied. """
 
     def __init__(
@@ -314,7 +314,7 @@ class xDSLOptMain(CommandLineTool):
                 printer.print_op(module)
                 print("\n\n\n")
 
-        self.pipeline = PipelinePass.parse_spec(
+        self.pipeline = PassPipeline.parse_spec(
             self.available_passes,
             self.args.passes,
             callback,


### PR DESCRIPTION
So I believe that the current situation is kind of broken, in that it's a pass with no name, which feels weird. I think this makes a bit more sense, where the class is not a pass but has a similar API, and cannot be mixed up with other passes as far as the type system is concerned, until it's specified explicitly.