### PR TITLE
interpreter: (pdl) Make pdl interpreter support memref.store operation

### DIFF
--- a/tests/filecheck/transforms/apply-pdl/apply_pdl_store_load.mlir
+++ b/tests/filecheck/transforms/apply-pdl/apply_pdl_store_load.mlir
@@ -1,28 +1,13 @@
 // RUN: xdsl-opt %s -p apply-pdl | filecheck %s
 
 
-// CHECK:       builtin.module {
-// CHECK-NEXT:    func.func @test(%x : memref<1xindex>) -> index {
+// CHECK:         func.func @test(%x : memref<1xindex>) -> index {
 // CHECK-NEXT:      %a = arith.constant 2 : index
 // CHECK-NEXT:      %c0 = arith.constant 0 : index
 // CHECK-NEXT:      memref.store %a, %x[%c0] : memref<1xindex>
 // CHECK-NEXT:      %d = arith.addi %a, %a : index
 // CHECK-NEXT:      func.return %d : index
 // CHECK-NEXT:    }
-// CHECK-NEXT:    pdl.pattern : benefit(1) {
-// CHECK-NEXT:      %memref_ty = pdl.type : memref<1xindex>
-// CHECK-NEXT:      %idx_ty = pdl.type : index
-// CHECK-NEXT:      %mem = pdl.operand : %memref_ty
-// CHECK-NEXT:      %idx = pdl.operand : %idx_ty
-// CHECK-NEXT:      %val = pdl.operand : %idx_ty
-// CHECK-NEXT:      %store = pdl.operation "memref.store" (%val, %mem, %idx : !pdl.value, !pdl.value, !pdl.value)
-// CHECK-NEXT:      %load = pdl.operation "memref.load" (%mem, %idx : !pdl.value, !pdl.value) -> (%idx_ty : !pdl.type)
-// CHECK-NEXT:      %loaded = pdl.result 0 of %load
-// CHECK-NEXT:      pdl.rewrite %load {
-// CHECK-NEXT:        pdl.replace %load with (%val : !pdl.value)
-// CHECK-NEXT:      }
-// CHECK-NEXT:    }
-// CHECK-NEXT:  }
 
 func.func @test(%x : memref<1xindex>) -> (index) {
   %a = arith.constant 2 : index

--- a/tests/filecheck/transforms/apply-pdl/apply_pdl_store_load.mlir
+++ b/tests/filecheck/transforms/apply-pdl/apply_pdl_store_load.mlir
@@ -1,0 +1,52 @@
+// RUN: xdsl-opt %s -p apply-pdl | filecheck %s
+
+
+// CHECK:       builtin.module {
+// CHECK-NEXT:    func.func @test(%x : memref<1xindex>) -> index {
+// CHECK-NEXT:      %a = arith.constant 2 : index
+// CHECK-NEXT:      %c0 = arith.constant 0 : index
+// CHECK-NEXT:      memref.store %a, %x[%c0] : memref<1xindex>
+// CHECK-NEXT:      %d = arith.addi %a, %a : index
+// CHECK-NEXT:      func.return %d : index
+// CHECK-NEXT:    }
+// CHECK-NEXT:    pdl.pattern : benefit(1) {
+// CHECK-NEXT:      %memref_ty = pdl.type : memref<1xindex>
+// CHECK-NEXT:      %idx_ty = pdl.type : index
+// CHECK-NEXT:      %mem = pdl.operand : %memref_ty
+// CHECK-NEXT:      %idx = pdl.operand : %idx_ty
+// CHECK-NEXT:      %val = pdl.operand : %idx_ty
+// CHECK-NEXT:      %store = pdl.operation "memref.store" (%val, %mem, %idx : !pdl.value, !pdl.value, !pdl.value)
+// CHECK-NEXT:      %load = pdl.operation "memref.load" (%mem, %idx : !pdl.value, !pdl.value) -> (%idx_ty : !pdl.type)
+// CHECK-NEXT:      %loaded = pdl.result 0 of %load
+// CHECK-NEXT:      pdl.rewrite %load {
+// CHECK-NEXT:        pdl.replace %load with (%val : !pdl.value)
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }
+
+func.func @test(%x : memref<1xindex>) -> (index) {
+  %a = arith.constant 2 : index
+  %c0 = arith.constant 0 : index
+  memref.store %a, %x[%c0] : memref<1xindex>
+  %b = memref.load %x[%c0] : memref<1xindex>
+  %c = memref.load %x[%c0] : memref<1xindex>
+  %d = arith.addi %b, %c : index
+  func.return %d : index
+}
+
+pdl.pattern : benefit(1) {
+  %memref_ty = pdl.type : memref<1xindex>
+  %idx_ty = pdl.type : index
+
+  %mem = pdl.operand : %memref_ty
+  %idx = pdl.operand : %idx_ty
+  %val = pdl.operand : %idx_ty
+
+  %store = pdl.operation "memref.store" (%val, %mem, %idx : !pdl.value, !pdl.value, !pdl.value)
+  %load = pdl.operation "memref.load" (%mem, %idx : !pdl.value, !pdl.value) -> (%idx_ty : !pdl.type)
+  %loaded = pdl.result 0 of %load
+
+  pdl.rewrite %load {
+    pdl.replace %load with (%val : !pdl.value)
+  }
+}

--- a/xdsl/dialects/pdl.py
+++ b/xdsl/dialects/pdl.py
@@ -92,6 +92,12 @@ def has_binding_use(op: Operation) -> bool:
                 use.operation
             ):
                 return True
+
+    if isinstance(op, OperationOp):
+        if op.opName is not None and op.opName.data == "memref.store":
+            # If the operation is a memref.store, we consider it as having a binding use.
+            return True
+
     return False
 
 

--- a/xdsl/interpreters/pdl.py
+++ b/xdsl/interpreters/pdl.py
@@ -249,7 +249,7 @@ class PDLRewritePattern(RewritePattern):
         if not matcher.match_operation(pdl_op_val, pdl_op, xdsl_op):
             return
 
-        # Special case for memref.load followed by memref.store
+        # Special case for memref.load that follows memref.store
         # If so, match corresponding memref.store operation to ensure context is matched
         if isinstance(pdl_op.prev_op, pdl.OperationOp):
             if (

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -309,6 +309,9 @@ class RewritePattern(ABC):
     A side-effect free rewrite pattern matching on a DAG.
     """
 
+    # A dictionary to store memref.store operations during pdl match_and_rewrite.
+    store_dict: dict[SSAValue, Operation] = {}
+
     # The / in the function signature makes the previous arguments positional, see
     # https://peps.python.org/pep-0570/
     # This is used by the op_type_rewrite_pattern


### PR DESCRIPTION
By adding a `store_dict` attribute in class `RewritePattern()`, pdl interpreter could catch and store the `memref.store` operation with the corresponding SSAValue of memrefType.
Then check a special case that `memref.load` follows `memref.store`, and find the `memref.store` operation of the SSAValue used in `memref.load` from `store_dict`. Thus, we could bind load and store operation manually though store operation has no result.
