### PR TITLE
core: add AffineMap inverse_and_broadcast_projected_permutation and drop_results

### DIFF
--- a/tests/test_affine_builtins.py
+++ b/tests/test_affine_builtins.py
@@ -219,6 +219,33 @@ def test_inverse_permutation():
     )
 
 
+@pytest.mark.parametrize(
+    "input_map, expected_map",
+    [
+        (AffineMap.empty(), AffineMap.empty()),
+        (
+            AffineMap.from_callable(lambda d0, d1, d2: (d2, d1, d0)),
+            AffineMap.from_callable(lambda d0, d1, d2: (d2, d1, d0)),
+        ),
+        (
+            AffineMap.from_callable(lambda d0, d1, d2: (d1, d0)),
+            AffineMap.from_callable(lambda d0, d1: (d1, d0, 0)),
+        ),
+        (
+            AffineMap.from_callable(lambda d0, d1, d2: (d1, 0, d0)),
+            AffineMap.from_callable(lambda d0, d1, d2: (d2, d0, 0)),
+        ),
+    ],
+)
+def test_inverse_and_broadcast_projected_permutation(
+    input_map: AffineMap, expected_map: AffineMap
+):
+    inverse = input_map.inverse_and_broadcast_projected_permutation()
+    assert inverse == expected_map, f"{input_map} {expected_map}"
+    if inverse.is_projected_permutation():
+        assert inverse.inverse_and_broadcast_projected_permutation() == input_map
+
+
 def test_drop_dims():
     # (d0, d1, d2) -> (d1, d2) with [0,1,1] gives (d0, d1) -> (d0, d1)
     # (d0, d1, d2) -> (d2, d2) with [1,0,1] gives (d0, d1) -> (d1, d1)
@@ -230,6 +257,17 @@ def test_drop_dims():
     assert AffineMap.from_callable(lambda d0, d1, d2: (d2, d2)).drop_dims(
         [f, t, f]
     ) == AffineMap.from_callable(lambda d0, d1: (d1, d1))
+
+
+def test_drop_results():
+    t = True
+    f = False
+    assert AffineMap.from_callable(lambda d0, d1, d2: (d1, d2)).drop_results(
+        [t, f]
+    ) == AffineMap.from_callable(lambda d0, d1, d2: (d2,))
+    assert AffineMap.from_callable(lambda d0, d1, d2: (d1, d2)).drop_results(
+        [f, t]
+    ) == AffineMap.from_callable(lambda d0, d1, d2: (d1,))
 
 
 def test_affine_expr_affine_expr_binary_simplification():

--- a/tests/test_affine_builtins.py
+++ b/tests/test_affine_builtins.py
@@ -1,4 +1,5 @@
 import re
+from collections.abc import Sequence
 
 import pytest
 
@@ -246,28 +247,66 @@ def test_inverse_and_broadcast_projected_permutation(
         assert inverse.inverse_and_broadcast_projected_permutation() == input_map
 
 
-def test_drop_dims():
-    # (d0, d1, d2) -> (d1, d2) with [0,1,1] gives (d0, d1) -> (d0, d1)
-    # (d0, d1, d2) -> (d2, d2) with [1,0,1] gives (d0, d1) -> (d1, d1)
-    t = True
-    f = False
-    assert AffineMap.from_callable(lambda d0, d1, d2: (d1, d2)).drop_dims(
-        [t, f, f]
-    ) == AffineMap.from_callable(lambda d0, d1: (d0, d1))
-    assert AffineMap.from_callable(lambda d0, d1, d2: (d2, d2)).drop_dims(
-        [f, t, f]
-    ) == AffineMap.from_callable(lambda d0, d1: (d1, d1))
+t = True
+f = False
 
 
-def test_drop_results():
-    t = True
-    f = False
-    assert AffineMap.from_callable(lambda d0, d1, d2: (d1, d2)).drop_results(
-        [t, f]
-    ) == AffineMap.from_callable(lambda d0, d1, d2: (d2,))
-    assert AffineMap.from_callable(lambda d0, d1, d2: (d1, d2)).drop_results(
-        [f, t]
-    ) == AffineMap.from_callable(lambda d0, d1, d2: (d1,))
+@pytest.mark.parametrize(
+    "input_map, drop_dims_mask, expected_map",
+    [
+        (
+            AffineMap.from_callable(lambda d0, d1, d2: (d1, d2)),
+            [t, f, f],
+            AffineMap.from_callable(lambda d0, d1: (d0, d1)),
+        ),
+        (
+            AffineMap.from_callable(lambda d0, d1, d2: (d2, d2)),
+            [f, t, f],
+            AffineMap.from_callable(lambda d0, d1: (d1, d1)),
+        ),
+    ],
+)
+def test_drop_dims(
+    input_map: AffineMap, drop_dims_mask: Sequence[bool], expected_map: AffineMap
+):
+    assert input_map.drop_dims(drop_dims_mask) == expected_map
+
+
+@pytest.mark.parametrize(
+    "input_map, drop_results_mask, expected_map",
+    [
+        (
+            AffineMap.from_callable(lambda d0, d1, d2: (d1, d2)),
+            [t, f],
+            AffineMap.from_callable(lambda d0, d1, d2: (d2,)),
+        ),
+        (
+            AffineMap.from_callable(lambda d0, d1, d2: (d1, d2)),
+            [f, t],
+            AffineMap.from_callable(lambda d0, d1, d2: (d1,)),
+        ),
+        (
+            AffineMap.from_callable(
+                lambda d0, d1, s0: (d0 + s0, d1), dim_symbol_split=(2, 1)
+            ),
+            [t, f],
+            AffineMap.from_callable(lambda d0, d1, s0: (d1,), dim_symbol_split=(2, 1)),
+        ),
+        (
+            AffineMap.from_callable(
+                lambda d0, d1, s0: (d0 + s0, d1), dim_symbol_split=(2, 1)
+            ),
+            [f, t],
+            AffineMap.from_callable(
+                lambda d0, d1, s0: (d0 + s0,), dim_symbol_split=(2, 1)
+            ),
+        ),
+    ],
+)
+def test_drop_results(
+    input_map: AffineMap, drop_results_mask: Sequence[bool], expected_map: AffineMap
+):
+    assert input_map.drop_results(drop_results_mask) == expected_map
 
 
 def test_affine_expr_affine_expr_binary_simplification():

--- a/xdsl/ir/affine/affine_map.py
+++ b/xdsl/ir/affine/affine_map.py
@@ -277,8 +277,8 @@ class AffineMap:
 
         Examples:
         ```
-        (d0, d1, d2) -> (d1, d2) with [1,0,0] gives (d0, d1) -> (d0, d1)
-        (d0, d1, d2) -> (d2, d2) with [0,1,0] gives (d0, d1) -> (d1, d1)
+        (d0, d1, d2) -> (d1, d2) with [T,F,F] gives (d0, d1) -> (d0, d1)
+        (d0, d1, d2) -> (d2, d2) with [F,T,F] gives (d0, d1) -> (d1, d1)
         ```
 
         Corresponds to MLIR's `compressDims`.
@@ -302,13 +302,13 @@ class AffineMap:
 
     def drop_results(self, unused_results: Sequence[bool]) -> AffineMap:
         """
-        Given a sequence of `unused_results` indicating the resuts to drop,
+        Given a sequence of `unused_results` indicating the results to drop,
         return a new map only with the new results.
 
         Examples:
         ```
-        (d0, d1, d2) -> (d1, d2) with [1,0] gives (d0, d1, d2) -> (d1)
-        (d0, d1, d2) -> (d2, d2) with [0,1] gives (d0, d1, d2) -> (d2)
+        (d0, d1, d2) -> (d1, d2) with [T,F] gives (d0, d1, d2) -> (d1)
+        (d0, d1, d2) -> (d1, d2) with [F,T] gives (d0, d1, d2) -> (d1)
         ```
 
         Corresponds to MLIR's `dropResults`, but passing a mask instead of integer

--- a/xdsl/ir/affine/affine_map.py
+++ b/xdsl/ir/affine/affine_map.py
@@ -235,6 +235,39 @@ class AffineMap:
             results=results,
         )
 
+    def inverse_and_broadcast_projected_permutation(self):
+        """
+        If `self` is a projected permutation, with possible constant 0 expression
+        results, returns the inverse permutation.
+
+        Examples:
+        ```
+        (d0, d1, d2) -> (d2, d1, d0) => (d0, d1, d2) -> (d2, d1, d0)
+        (d0, d1, d2) -> (d1, d0)     => (d0, d1)     -> (d1, d0, 0)
+        (d0, d1, d2) -> (d1, 0, d0)  => (d0, d1, d2) -> (d2, d0, 0)
+        ```
+
+        Equivalent to `inverseAndBroadcastProjectedPermutation` in MLIR.
+        """
+        assert self.is_projected_permutation(allow_zero_in_results=True), f"{self}"
+        zero = AffineExpr.constant(0)
+        # Start with all the results as 0.
+        exprs = [zero] * self.num_dims
+        for i, res in enumerate(self.results):
+            # Skip zeros from input map. 'exprs' is already initialized to zero.
+            if isinstance(const_expr := res, AffineConstantExpr):
+                assert const_expr.value == 0, (
+                    "Unexpected constant in projected permutation"
+                )
+                continue
+
+            assert isinstance(dim_expr := res, AffineDimExpr)
+
+            # Reverse each dimension existing in the original map result.
+            exprs[dim_expr.position] = AffineExpr.dimension(i)
+
+        return AffineMap(len(self.results), 0, tuple(exprs))
+
     def eval(self, dims: Sequence[int], symbols: Sequence[int]) -> tuple[int, ...]:
         """Evaluate the AffineMap given the values of dimensions and symbols."""
         assert len(dims) == self.num_dims, f"{len(dims)}, {self.num_dims}"
@@ -271,6 +304,36 @@ class AffineMap:
 
         return self.replace_dims_and_symbols(
             new_dims, new_symbols, result_num_dims, self.num_symbols
+        )
+
+    def drop_results(self, unused_results: Sequence[bool]) -> AffineMap:
+        """
+        Given a sequence of `unused_results` indicating the resuts to drop,
+        return a new map only with the new results.
+
+        Examples:
+        ```
+        (d0, d1, d2) -> (d1, d2) with [1,0] gives (d0, d1, d2) -> (d1)
+        (d0, d1, d2) -> (d2, d2) with [0,1] gives (d0, d1, d2) -> (d2)
+        ```
+
+        Corresponds to MLIR's `dropResults`, but passing a mask instead of integer
+        indices to drop.
+        """
+        if len(unused_results) != len(self.results):
+            raise ValueError(
+                f"Invalid `unused_results`, expected {len(self.results)} `bool` values, got "
+                f"{len(unused_results)}"
+            )
+
+        return AffineMap(
+            self.num_dims,
+            self.num_symbols,
+            tuple(
+                result
+                for (mask, result) in zip(unused_results, self.results)
+                if not mask
+            ),
         )
 
     def used_dims(self) -> set[int]:


### PR DESCRIPTION
Add some more helpers from MLIR's AffineMap.