### PR TITLE
core: (ConstraintContext) deprecate copy and update

### DIFF
--- a/xdsl/irdl/constraints.py
+++ b/xdsl/irdl/constraints.py
@@ -75,6 +75,7 @@ class ConstraintContext:
     def int_variables(self) -> AbstractSet[str]:
         return self._int_variables.keys()
 
+    @deprecated("ConstraintContexts should not be copied")
     def copy(self):
         return ConstraintContext(
             self._variables.copy(),
@@ -82,6 +83,7 @@ class ConstraintContext:
             self._int_variables.copy(),
         )
 
+    @deprecated("ConstraintContexts should only be updated by set_* methods")
     def update(self, other: ConstraintContext):
         self._variables.update(other._variables)
         self._range_variables.update(other._range_variables)


### PR DESCRIPTION
These are no longer used (and as far as I know we have no plans to use them?)