### PR TITLE
core: (Constraints) make int constraint IntAttr constraints

### DIFF
--- a/tests/filecheck/dialects/omp/ops_invalid.mlir
+++ b/tests/filecheck/dialects/omp/ops_invalid.mlir
@@ -37,7 +37,7 @@ func.func @omp_simd_aligned(%ub : index, %lb : index, %step : index, %a1 : memre
   func.return
 }
 
-// CHECK: integer 2 expected from int variable 'ALIGN_COUNT', but got 3
+// CHECK: attribute #builtin.int<2> expected from variable 'ALIGN_COUNT', but got #builtin.int<3>
 
 // -----
 
@@ -52,7 +52,7 @@ func.func @omp_simd_linear(%ub : index, %lb : index, %step : index, %l1 : memref
   func.return
 }
 
-// CHECK: integer 1 expected from int variable 'LINEAR_COUNT', but got 2
+// CHECK: attribute #builtin.int<1> expected from variable 'LINEAR_COUNT', but got #builtin.int<2>
 
 // -----
 

--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -33,14 +33,13 @@ from xdsl.ir import (
 from xdsl.irdl import (
     AllOf,
     AnyAttr,
-    AnyInt,
+    AnyIntConstr,
     AttrSizedOperandSegments,
     AttrSizedRegionSegments,
     AttrSizedResultSegments,
     BaseAttr,
     EqAttrConstraint,
     GenericAttrConstraint,
-    IntVarConstraint,
     IRDLOperation,
     ParamAttrConstraint,
     ParsePropInAttrDict,
@@ -2574,7 +2573,7 @@ def test_int_var_inference():
     @irdl_op_definition
     class IntVarOp(IRDLOperation):
         name = "test.int_var"
-        T: ClassVar = IntVarConstraint("T", AnyInt())
+        T: ClassVar = VarConstraint("T", AnyIntConstr)
         ins = var_operand_def(RangeOf(eq(IndexType()), length=T))
         outs = var_result_def(RangeOf(eq(IntegerType(64)), length=T))
 
@@ -3318,7 +3317,7 @@ def test_multiple_operand_extraction_fails():
 class IntAttrExtractOp(IRDLOperation):
     name = "test.int_attr_extract"
 
-    _I: ClassVar = IntVarConstraint("I", AnyInt())
+    _I: ClassVar = VarConstraint("I", AnyIntConstr)
 
     prop = prop_def(IntegerAttr.constr(value=_I, type=eq(IndexType())))
 
@@ -3363,7 +3362,7 @@ def test_int_attr_extraction_errors(program: str, error: str):
 class IntAttrVerifyOp(IRDLOperation):
     name = "test.int_attr_verify"
 
-    _I: ClassVar = IntVarConstraint("I", AnyInt())
+    _I: ClassVar = VarConstraint("I", AnyIntConstr)
 
     prop = prop_def(IntegerAttr.constr(value=_I, type=eq(IndexType())))
 
@@ -3395,19 +3394,19 @@ def test_int_attr_verify(program: str):
     [
         (
             "test.int_attr_verify 1, %0, %1",
-            "integer 2 expected from int variable 'I', but got 1",
+            "attribute #builtin.int<2> expected from variable 'I', but got #builtin.int<1>",
         ),
         (
             "test.int_attr_verify 1 and 2, %0",
-            "integer 1 expected from int variable 'I', but got 2",
+            "attribute #builtin.int<1> expected from variable 'I', but got #builtin.int<2>",
         ),
         (
             "test.int_attr_verify 2, %0",
-            "integer 1 expected from int variable 'I'",
+            "attribute #builtin.int<1> expected from variable 'I', but got #builtin.int<2>",
         ),
         (
             "test.int_attr_verify 2 and 1, %0, %1",
-            "integer 2 expected from int variable 'I', but got 1",
+            "attribute #builtin.int<2> expected from variable 'I', but got #builtin.int<1>",
         ),
     ],
 )

--- a/tests/irdl/test_int_constraint.py
+++ b/tests/irdl/test_int_constraint.py
@@ -2,6 +2,7 @@ import re
 
 import pytest
 
+from xdsl.dialects.builtin import IntAttr
 from xdsl.irdl import AtLeast, ConstraintContext
 from xdsl.utils.exceptions import VerifyException
 
@@ -9,22 +10,22 @@ from xdsl.utils.exceptions import VerifyException
 def test_failing_inference():
     with pytest.raises(
         ValueError,
-        match=re.escape(r"Cannot infer integer from constraint AtLeast(bound=3)"),
+        match=re.escape(r"Cannot infer attribute from constraint AtLeast(bound=3)"),
     ):
         AtLeast(3).infer(ConstraintContext())
 
 
 def test_at_least():
-    AtLeast(0).verify(0, ConstraintContext())
+    AtLeast(0).verify(IntAttr(0), ConstraintContext())
 
-    AtLeast(1).verify(1, ConstraintContext())
-    AtLeast(1).verify(2, ConstraintContext())
+    AtLeast(1).verify(IntAttr(1), ConstraintContext())
+    AtLeast(1).verify(IntAttr(2), ConstraintContext())
     with pytest.raises(VerifyException):
-        AtLeast(1).verify(0, ConstraintContext())
+        AtLeast(1).verify(IntAttr(0), ConstraintContext())
 
-    AtLeast(2).verify(2, ConstraintContext())
-    AtLeast(2).verify(3, ConstraintContext())
+    AtLeast(2).verify(IntAttr(2), ConstraintContext())
+    AtLeast(2).verify(IntAttr(3), ConstraintContext())
     with pytest.raises(VerifyException):
-        AtLeast(2).verify(1, ConstraintContext())
+        AtLeast(2).verify(IntAttr(1), ConstraintContext())
     with pytest.raises(VerifyException):
-        AtLeast(2).verify(0, ConstraintContext())
+        AtLeast(2).verify(IntAttr(0), ConstraintContext())

--- a/tests/irdl/test_operation_definition.py
+++ b/tests/irdl/test_operation_definition.py
@@ -20,7 +20,7 @@ from xdsl.dialects.test import TestType
 from xdsl.ir import Attribute, Block, Region
 from xdsl.irdl import (
     AnyAttr,
-    AnyInt,
+    AnyIntConstr,
     AnyOf,
     AttributeDef,
     AttrSizedOperandSegments,
@@ -29,7 +29,6 @@ from xdsl.irdl import (
     BaseAttr,
     ConstraintVar,
     EqAttrConstraint,
-    IntVarConstraint,
     IRDLOperation,
     OpDef,
     OperandDef,
@@ -420,7 +419,7 @@ class SameLengthOp(IRDLOperation):
 
     name = "test.same_length"
 
-    LENGTH: ClassVar = IntVarConstraint("length", AnyInt())
+    LENGTH: ClassVar = VarConstraint("length", AnyIntConstr)
     operand = var_operand_def(RangeOf(AnyAttr(), length=LENGTH))
     result = var_result_def(RangeOf(AnyAttr(), length=LENGTH))
 
@@ -434,14 +433,14 @@ def test_same_length_op():
 
     with pytest.raises(
         VerifyException,
-        match="incorrect length for range variable:\ninteger 2 expected from int variable 'length', but got 1",
+        match="incorrect length for range variable:\nattribute #builtin.int<2> expected from variable 'length', but got #builtin.int<1>",
     ):
         op2 = SameLengthOp.create(operands=[operand1, operand2], result_types=[i32])
         op2.verify()
 
     with pytest.raises(
         VerifyException,
-        match="incorrect length for range variable:\ninteger 1 expected from int variable 'length', but got 2",
+        match="incorrect length for range variable:\nattribute #builtin.int<1> expected from variable 'length', but got #builtin.int<2>",
     ):
         op3 = SameLengthOp.create(operands=[operand1], result_types=[i32, i32])
         op3.verify()

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -53,7 +53,6 @@ from xdsl.irdl import (
     GenericAttrConstraint,
     GenericData,
     GenericRangeConstraint,
-    IntConstraint,
     IRDLAttrConstraint,
     IRDLGenericAttrConstraint,
     IRDLOperation,
@@ -321,37 +320,6 @@ FlatSymbolRefAttrConstr = MessageConstraint(
 
 FlatSymbolRefAttr = Annotated[SymbolRefAttr, FlatSymbolRefAttrConstr]
 """SymbolRef constrained to have an empty `nested_references` property."""
-
-
-@dataclass(frozen=True)
-class IntAttrConstraint(GenericAttrConstraint[IntAttr]):
-    """
-    Constrains the value of an IntAttr.
-    """
-
-    int_constraint: IntConstraint
-
-    def verify(self, attr: Attribute, constraint_context: ConstraintContext) -> None:
-        if not isinstance(attr, IntAttr):
-            raise VerifyException(f"attribute {attr} expected to be an IntAttr")
-        self.int_constraint.verify(attr.data, constraint_context)
-
-    def variables(self) -> set[str]:
-        return self.int_constraint.variables()
-
-    def can_infer(self, var_constraint_names: AbstractSet[str]) -> bool:
-        return self.int_constraint.can_infer(var_constraint_names)
-
-    def infer(self, context: ConstraintContext) -> IntAttr:
-        return IntAttr(self.int_constraint.infer(context))
-
-    def get_bases(self) -> set[type[Attribute]] | None:
-        return {IntAttr}
-
-    def mapping_type_vars(
-        self, type_var_mapping: dict[TypeVar, AttrConstraint]
-    ) -> Self:
-        return self
 
 
 class Signedness(Enum):
@@ -865,13 +833,11 @@ class IntegerAttr(
     def constr(
         cls,
         *,
-        value: AttrConstraint | IntConstraint | None = None,
+        value: AttrConstraint | None = None,
         type: GenericAttrConstraint[_IntegerAttrType] = IntegerAttrTypeConstr,
     ) -> GenericAttrConstraint[IntegerAttr[_IntegerAttrType]]:
         if value is None and type == AnyAttr():
             return BaseAttr[IntegerAttr[_IntegerAttrType]](IntegerAttr)
-        if isinstance(value, IntConstraint):
-            value = IntAttrConstraint(value)
         return ParamAttrConstraint[IntegerAttr[_IntegerAttrType]](
             IntegerAttr,
             (

--- a/xdsl/dialects/omp.py
+++ b/xdsl/dialects/omp.py
@@ -30,14 +30,14 @@ from xdsl.ir import (
 )
 from xdsl.irdl import (
     AnyAttr,
-    AnyInt,
+    AnyIntConstr,
     AttrSizedOperandSegments,
-    IntVarConstraint,
     IRDLOperation,
     Operand,
     Operation,
     RangeOf,
     SameVariadicOperandSize,
+    VarConstraint,
     VarOperand,
     base,
     eq,
@@ -522,7 +522,7 @@ class TargetOp(IRDLOperation):
 
     name = "omp.target"
 
-    DEP_COUNT: ClassVar = IntVarConstraint("DEP_COUNT", AnyInt())
+    DEP_COUNT: ClassVar = VarConstraint("DEP_COUNT", AnyIntConstr)
 
     allocate_vars = var_operand_def()
     allocator_vars = var_operand_def()
@@ -632,8 +632,8 @@ class SimdOp(IRDLOperation):
 
     name = "omp.simd"
 
-    ALIGN_COUNT: ClassVar = IntVarConstraint("ALIGN_COUNT", AnyInt())
-    LINEAR_COUNT: ClassVar = IntVarConstraint("LINEAR_COUNT", AnyInt())
+    ALIGN_COUNT: ClassVar = VarConstraint("ALIGN_COUNT", AnyIntConstr)
+    LINEAR_COUNT: ClassVar = VarConstraint("LINEAR_COUNT", AnyIntConstr)
 
     aligned_vars = var_operand_def(
         RangeOf(
@@ -678,7 +678,7 @@ class TargetTaskBasedDataOp(IRDLOperation):
     this includes enter and exit data pragmas along with data update
     """
 
-    DEP_COUNT: ClassVar = IntVarConstraint("DEP_COUNT", AnyInt())
+    DEP_COUNT: ClassVar = VarConstraint("DEP_COUNT", AnyIntConstr)
 
     depend_vars = var_operand_def(
         RangeOf(

--- a/xdsl/utils/dialect_codegen.py
+++ b/xdsl/utils/dialect_codegen.py
@@ -10,7 +10,6 @@ from typing import TextIO
 
 from xdsl.ir import Attribute, ParametrizedAttribute, TypeAttribute
 from xdsl.irdl import (
-    AnyInt,
     OpDef,
     OperandDef,
     OptOperandDef,
@@ -51,7 +50,7 @@ def get_str_from_operand_or_result(
     match operand_or_result.constr:
         case SingleOf():
             inner_constr = operand_or_result.constr.constr
-        case RangeOf(length=AnyInt()):
+        case RangeOf():
             inner_constr = operand_or_result.constr.constr
         case _:
             raise NotImplementedError(


### PR DESCRIPTION
There's some nasty import loops, and the error messages aren't quite as good, but this should be worth it to simplify the infrastructure (hopefully).

I guess the alternative is to try what @superlopuh said and have AttrConstraint be generic on its input as well as output. I don't think this would capture range constraints but might be able to capture both int and attr constraints nicely, though perhaps this PR is good enough.

We could also consider giving `IntAttr` a nicer printing/parsing (say `int<n>`) as it is a builtin attribute.