### PR TITLE
API: add GenericConstraint as supertype of other constraints

### DIFF
--- a/docs/marimo/irdl.py
+++ b/docs/marimo/irdl.py
@@ -346,13 +346,13 @@ def _(ConstraintContext, IntAttr, VerifyException, irdl_to_attr_constraint):
             object.__setattr__(self, "elem_constr", irdl_to_attr_constraint(constr))
 
         # Check that an attribute satisfies the constraints
-        def verify(self, attr: Attribute, constraint_context: ConstraintContext) -> None:
+        def verify(self, value: Attribute, constraint_context: ConstraintContext) -> None:
             # We first check that the attribute is an ArrayAttr
-            if not isa(attr, ArrayAttr[Attribute]):
+            if not isa(value, ArrayAttr[Attribute]):
                 raise VerifyException(f"expected attribute ArrayData but got {attr}")
 
             # We check the constraint for all elements in the array
-            for e in attr.data:
+            for e in value.data:
                 self.elem_constr.verify(e, constraint_context)
 
         def mapping_type_vars(self, type_var_mapping: dict[TypeVar, AttrConstraint]):

--- a/tests/irdl/test_attribute_definition.py
+++ b/tests/irdl/test_attribute_definition.py
@@ -427,13 +427,13 @@ def test_union_constraint_fail():
 
 
 class PositiveIntConstr(AttrConstraint):
-    def verify(self, attr: Attribute, constraint_context: ConstraintContext) -> None:
-        if not isinstance(attr, IntData):
+    def verify(self, value: Attribute, constraint_context: ConstraintContext) -> None:
+        if not isinstance(value, IntData):
             raise VerifyException(
-                f"Expected {IntData.name} attribute, but got {attr.name}."
+                f"Expected {IntData.name} attribute, but got {value.name}."
             )
-        if attr.data <= 0:
-            raise VerifyException(f"Expected positive integer, got {attr.data}.")
+        if value.data <= 0:
+            raise VerifyException(f"Expected positive integer, got {value.data}.")
 
     def mapping_type_vars(
         self, type_var_mapping: dict[TypeVar, AttrConstraint]
@@ -683,14 +683,14 @@ class DataListAttr(GenericAttrConstraint[ListData[AttributeInvT]]):
 
     def verify(
         self,
-        attr: Attribute,
+        value: Attribute,
         constraint_context: ConstraintContext,
     ) -> None:
-        if not isa(attr, ListData):
+        if not isa(value, ListData):
             raise VerifyException(
-                f"Expected {attr} to be instance of {ListData.__name__}"
+                f"Expected {value} to be instance of {ListData.__name__}"
             )
-        for e in attr.data:
+        for e in value.data:
             self.elem_constr.verify(e, constraint_context)
 
     def mapping_type_vars(

--- a/tests/irdl/test_range_constraint.py
+++ b/tests/irdl/test_range_constraint.py
@@ -11,7 +11,7 @@ class AnyRangeConstraint(RangeConstraint):
     """Constraint for testing default infer"""
 
     def verify(
-        self, attrs: Sequence[Attribute], constraint_context: ConstraintContext
+        self, value: Sequence[Attribute], constraint_context: ConstraintContext
     ) -> None:
         return
 

--- a/tests/test_pyrdl.py
+++ b/tests/test_pyrdl.py
@@ -152,13 +152,13 @@ class LessThan(AttrConstraint):
 
     def verify(
         self,
-        attr: Attribute,
+        value: Attribute,
         constraint_context: ConstraintContext,
     ) -> None:
-        if not isinstance(attr, IntData):
-            raise VerifyException(f"{attr} should be of base attribute {IntData.name}")
-        if attr.data >= self.bound:
-            raise VerifyException(f"{attr} should hold a value less than {self.bound}")
+        if not isinstance(value, IntData):
+            raise VerifyException(f"{value} should be of base attribute {IntData.name}")
+        if value.data >= self.bound:
+            raise VerifyException(f"{value} should hold a value less than {self.bound}")
 
     def mapping_type_vars(
         self, type_var_mapping: dict[TypeVar, AttrConstraint]
@@ -170,12 +170,12 @@ class LessThan(AttrConstraint):
 class GreaterThan(AttrConstraint):
     bound: int
 
-    def verify(self, attr: Attribute, constraint_context: ConstraintContext) -> None:
-        if not isinstance(attr, IntData):
-            raise VerifyException(f"{attr} should be of base attribute {IntData.name}")
-        if attr.data <= self.bound:
+    def verify(self, value: Attribute, constraint_context: ConstraintContext) -> None:
+        if not isinstance(value, IntData):
+            raise VerifyException(f"{value} should be of base attribute {IntData.name}")
+        if value.data <= self.bound:
             raise VerifyException(
-                f"{attr} should hold a value greater than {self.bound}"
+                f"{value} should hold a value greater than {self.bound}"
             )
 
     def mapping_type_vars(

--- a/xdsl/dialects/bufferization.py
+++ b/xdsl/dialects/bufferization.py
@@ -77,12 +77,12 @@ class TensorFromMemRefConstraint(
         memref_type = self.memref_constraint.infer(context)
         return self.memref_to_tensor(memref_type)
 
-    def verify(self, attr: Attribute, constraint_context: ConstraintContext) -> None:
-        if isa(attr, TensorType | UnrankedTensorType):
-            memref_type = self.tensor_to_memref(attr)
+    def verify(self, value: Attribute, constraint_context: ConstraintContext) -> None:
+        if isa(value, TensorType | UnrankedTensorType):
+            memref_type = self.tensor_to_memref(value)
         else:
             raise VerifyException(
-                f"Expected tensor or unranked tensor type, got {attr}"
+                f"Expected tensor or unranked tensor type, got {value}"
             )
         return self.memref_constraint.verify(memref_type, constraint_context)
 

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -216,14 +216,14 @@ class ArrayOfConstraint(GenericAttrConstraint[ArrayAttr[AttributeCovT]]):
 
     def verify(
         self,
-        attr: Attribute,
+        value: Attribute,
         constraint_context: ConstraintContext,
     ) -> None:
-        if not isa(attr, ArrayAttr):
+        if not isa(value, ArrayAttr):
             raise VerifyException(
-                f"expected ArrayAttr attribute, but got '{type(attr)}'"
+                f"expected ArrayAttr attribute, but got '{type(value)}'"
             )
-        self.elem_range_constraint.verify(attr.data, constraint_context)
+        self.elem_range_constraint.verify(value.data, constraint_context)
 
     def can_infer(self, var_constraint_names: AbstractSet[str]) -> bool:
         return self.elem_range_constraint.can_infer(
@@ -300,11 +300,11 @@ class EmptyArrayAttrConstraint(AttrConstraint):
     Constrain attribute to be empty ArrayData
     """
 
-    def verify(self, attr: Attribute, constraint_context: ConstraintContext) -> None:
-        if not isa(attr, ArrayAttr):
-            raise VerifyException(f"expected ArrayData attribute, but got {attr}")
-        if attr.data:
-            raise VerifyException(f"expected empty array, but got {attr}")
+    def verify(self, value: Attribute, constraint_context: ConstraintContext) -> None:
+        if not isa(value, ArrayAttr):
+            raise VerifyException(f"expected ArrayData attribute, but got {value}")
+        if value.data:
+            raise VerifyException(f"expected empty array, but got {value}")
 
     def mapping_type_vars(
         self, type_var_mapping: dict[TypeVar, AttrConstraint]
@@ -349,10 +349,10 @@ class IntAttrConstraint(GenericAttrConstraint[IntAttr]):
 
     int_constraint: IntConstraint
 
-    def verify(self, attr: Attribute, constraint_context: ConstraintContext) -> None:
-        if not isinstance(attr, IntAttr):
-            raise VerifyException(f"attribute {attr} expected to be an IntAttr")
-        self.int_constraint.verify(attr.data, constraint_context)
+    def verify(self, value: Attribute, constraint_context: ConstraintContext) -> None:
+        if not isinstance(value, IntAttr):
+            raise VerifyException(f"attribute {value} expected to be an IntAttr")
+        self.int_constraint.verify(value.data, constraint_context)
 
     def variables(self) -> set[str]:
         return self.int_constraint.variables()
@@ -1453,11 +1453,11 @@ class ContainerOf(
     ) -> None:
         object.__setattr__(self, "elem_constr", irdl_to_attr_constraint(elem_constr))
 
-    def verify(self, attr: Attribute, constraint_context: ConstraintContext) -> None:
-        if isa(attr, VectorType) or isa(attr, TensorType):
-            self.elem_constr.verify(attr.element_type, constraint_context)
+    def verify(self, value: Attribute, constraint_context: ConstraintContext) -> None:
+        if isa(value, VectorType) or isa(value, TensorType):
+            self.elem_constr.verify(value.element_type, constraint_context)
         else:
-            self.elem_constr.verify(attr, constraint_context)
+            self.elem_constr.verify(value, constraint_context)
 
     def get_bases(self) -> set[type[Attribute]] | None:
         bases = self.elem_constr.get_bases()
@@ -1486,12 +1486,12 @@ class VectorRankConstraint(AttrConstraint):
     expected_rank: int
     """The expected vector rank."""
 
-    def verify(self, attr: Attribute, constraint_context: ConstraintContext) -> None:
-        if not isinstance(attr, VectorType):
-            raise VerifyException(f"{attr} should be of type VectorType.")
-        if attr.get_num_dims() != self.expected_rank:
+    def verify(self, value: Attribute, constraint_context: ConstraintContext) -> None:
+        if not isinstance(value, VectorType):
+            raise VerifyException(f"{value} should be of type VectorType.")
+        if value.get_num_dims() != self.expected_rank:
             raise VerifyException(
-                f"Expected vector rank to be {self.expected_rank}, got {attr.get_num_dims()}."
+                f"Expected vector rank to be {self.expected_rank}, got {value.get_num_dims()}."
             )
 
     def mapping_type_vars(
@@ -1509,12 +1509,12 @@ class VectorBaseTypeConstraint(AttrConstraint):
     expected_type: Attribute
     """The expected vector base type."""
 
-    def verify(self, attr: Attribute, constraint_context: ConstraintContext) -> None:
-        if not isa(attr, VectorType):
-            raise VerifyException(f"{attr} should be of type VectorType.")
-        if attr.element_type != self.expected_type:
+    def verify(self, value: Attribute, constraint_context: ConstraintContext) -> None:
+        if not isa(value, VectorType):
+            raise VerifyException(f"{value} should be of type VectorType.")
+        if value.element_type != self.expected_type:
             raise VerifyException(
-                f"Expected vector type to be {self.expected_type}, got {attr.element_type}."
+                f"Expected vector type to be {self.expected_type}, got {value.element_type}."
             )
 
     def mapping_type_vars(
@@ -1535,11 +1535,11 @@ class VectorBaseTypeAndRankConstraint(AttrConstraint):
     expected_rank: int
     """The expected vector rank."""
 
-    def verify(self, attr: Attribute, constraint_context: ConstraintContext) -> None:
+    def verify(self, value: Attribute, constraint_context: ConstraintContext) -> None:
         constraint = VectorBaseTypeConstraint(
             self.expected_type
         ) & VectorRankConstraint(self.expected_rank)
-        constraint.verify(attr, constraint_context)
+        constraint.verify(value, constraint_context)
 
     def mapping_type_vars(
         self, type_var_mapping: dict[TypeVar, AttrConstraint]

--- a/xdsl/dialects/pdl_interp.py
+++ b/xdsl/dialects/pdl_interp.py
@@ -490,14 +490,14 @@ class ValueConstrFromResultConstr(
             return RangeType(ValueType())
         return ValueType()
 
-    def verify(self, attr: Attribute, constraint_context: ConstraintContext) -> None:
-        if isa(attr, RangeType[ValueType]):
+    def verify(self, value: Attribute, constraint_context: ConstraintContext) -> None:
+        if isa(value, RangeType[ValueType]):
             result_type = RangeType(TypeType())
-        elif isa(attr, ValueType):
+        elif isa(value, ValueType):
             result_type = TypeType()
         else:
             raise VerifyException(
-                f"Expected an attribute of type ValueType or RangeType[ValueType], but got {attr}"
+                f"Expected an attribute of type ValueType or RangeType[ValueType], but got {value}"
             )
         return self.result_constr.verify(result_type, constraint_context)
 

--- a/xdsl/dialects/stencil.py
+++ b/xdsl/dialects/stencil.py
@@ -1208,16 +1208,16 @@ class TensorIgnoreSizeConstraint(VarConstraint[Attribute]):
             and attr.get_element_type() == other.get_element_type()
         )
 
-    def verify(self, attr: Attribute, constraint_context: ConstraintContext) -> None:
+    def verify(self, value: Attribute, constraint_context: ConstraintContext) -> None:
         ctx_attr = constraint_context.get_variable(self.name)
         if ctx_attr is not None:
             if isa(
-                attr, TensorType[Attribute]
+                value, TensorType[Attribute]
             ) and TensorIgnoreSizeConstraint.ranks_and_element_types_match(
-                attr, ctx_attr
+                value, ctx_attr
             ):
                 return
-        super().verify(attr, constraint_context)
+        super().verify(value, constraint_context)
 
 
 @irdl_op_definition

--- a/xdsl/dialects/utils/reshape_ops_utils.py
+++ b/xdsl/dialects/utils/reshape_ops_utils.py
@@ -42,18 +42,18 @@ class ContiguousArrayOfIntArray(GenericAttrConstraint[ArrayOfIntArrayAttr]):
     An empty inner array is considered contiguous.
     """
 
-    def verify(self, attr: Attribute, constraint_context: ConstraintContext) -> None:
+    def verify(self, value: Attribute, constraint_context: ConstraintContext) -> None:
         _CONTIGUOUS_ARRAY_TYPE_CONSTRAINT.verify(
-            attr, constraint_context=constraint_context
+            value, constraint_context=constraint_context
         )
-        attr = cast(ArrayOfIntArrayAttr, attr)
+        value = cast(ArrayOfIntArrayAttr, value)
 
         # Flatten all integer values from all inner arrays
-        flat_values = [e.value.data for inner in attr.data for e in inner.data]
+        flat_values = [e.value.data for inner in value.data for e in inner.data]
         # Check that the flattened list is contiguous
         for prev, curr in zip(flat_values, flat_values[1:]):
             if curr != prev + 1:
-                raise VerifyException(f"All inner arrays must be contiguous: {attr}")
+                raise VerifyException(f"All inner arrays must be contiguous: {value}")
 
     def mapping_type_vars(
         self, type_var_mapping: dict[TypeVar, AttrConstraint]

--- a/xdsl/irdl/constraints.py
+++ b/xdsl/irdl/constraints.py
@@ -97,32 +97,37 @@ ConstraintVariableType: TypeAlias = Attribute | Sequence[Attribute] | int
 Possible types that a constraint variable can have.
 """
 
+ConstraintInputT = TypeVar("ConstraintInputT")
+ConstraintOutputT = TypeVar("ConstraintOutputT", covariant=True)
+
 
 @dataclass(frozen=True)
-class GenericAttrConstraint(Generic[AttributeCovT], ABC):
-    """Constrain an attribute to a certain value."""
-
+class GenericConstraint(Generic[ConstraintInputT, ConstraintOutputT], ABC):
     @abstractmethod
     def verify(
-        self,
-        attr: Attribute,
-        constraint_context: ConstraintContext,
+        self, value: ConstraintInputT, constraint_context: ConstraintContext
     ) -> None:
         """
-        Check if the attribute satisfies the constraint,
-        or raise an exception otherwise.
+        Check if the value satisfies the constraint, or raise an exception otherwise.
         """
         ...
 
-    def verifies(self, attr: Attribute) -> TypeGuard[AttributeCovT]:
+    def verifies(self, value: ConstraintInputT) -> TypeGuard[ConstraintOutputT]:
         """
-        A helper method to check whether a given attribute matches `self`.
+        A helper method to check whether a given value matches `self`.
         """
         try:
-            self.verify(attr, ConstraintContext())
+            self.verify(value, ConstraintContext())
             return True
         except VerifyException:
             return False
+
+
+@dataclass(frozen=True)
+class GenericAttrConstraint(
+    Generic[AttributeCovT], GenericConstraint[Attribute, AttributeCovT], ABC
+):
+    """Constrain an attribute to a certain value."""
 
     def variables(self) -> set[str]:
         """
@@ -202,11 +207,11 @@ class TypedAttributeConstraint(GenericAttrConstraint[TypedAttributeCovT]):
     attr_constraint: GenericAttrConstraint[TypedAttributeCovT]
     type_constraint: GenericAttrConstraint[Attribute]
 
-    def verify(self, attr: Attribute, constraint_context: ConstraintContext) -> None:
-        if not isinstance(attr, TypedAttribute):
-            raise VerifyException(f"attribute {attr} expected to be a TypedAttribute")
-        self.attr_constraint.verify(attr, constraint_context)
-        self.type_constraint.verify(attr.get_type(), constraint_context)
+    def verify(self, value: Attribute, constraint_context: ConstraintContext) -> None:
+        if not isinstance(value, TypedAttribute):
+            raise VerifyException(f"attribute {value} expected to be a TypedAttribute")
+        self.attr_constraint.verify(value, constraint_context)
+        self.type_constraint.verify(value.get_type(), constraint_context)
 
     def variables(self) -> set[str]:
         return self.type_constraint.variables() | self.attr_constraint.variables()
@@ -244,19 +249,19 @@ class VarConstraint(GenericAttrConstraint[AttributeCovT]):
 
     def verify(
         self,
-        attr: Attribute,
+        value: Attribute,
         constraint_context: ConstraintContext,
     ) -> None:
         ctx_attr = constraint_context.get_variable(self.name)
         if ctx_attr is not None:
-            if attr != ctx_attr:
+            if value != ctx_attr:
                 raise VerifyException(
                     f"attribute {constraint_context.get_variable(self.name)} expected from variable "
-                    f"'{self.name}', but got {attr}"
+                    f"'{self.name}', but got {value}"
                 )
         else:
-            self.constraint.verify(attr, constraint_context)
-            constraint_context.set_attr_variable(self.name, attr)
+            self.constraint.verify(value, constraint_context)
+            constraint_context.set_attr_variable(self.name, value)
 
     def variables(self) -> set[str]:
         return self.constraint.variables() | {self.name}
@@ -293,10 +298,10 @@ class TypeVarConstraint(AttrConstraint):
 
     def verify(
         self,
-        attr: Attribute,
+        value: Attribute,
         constraint_context: ConstraintContext,
     ) -> None:
-        self.base_constraint.verify(attr, constraint_context)
+        self.base_constraint.verify(value, constraint_context)
 
     def get_bases(self) -> set[type[Attribute]] | None:
         return self.base_constraint.get_bases()
@@ -334,11 +339,11 @@ class EqAttrConstraint(Generic[AttributeCovT], GenericAttrConstraint[AttributeCo
 
     def verify(
         self,
-        attr: Attribute,
+        value: Attribute,
         constraint_context: ConstraintContext,
     ) -> None:
-        if attr != self.attr:
-            raise VerifyException(f"Expected attribute {self.attr} but got {attr}")
+        if value != self.attr:
+            raise VerifyException(f"Expected attribute {self.attr} but got {value}")
 
     def can_infer(self, var_constraint_names: AbstractSet[str]) -> bool:
         return True
@@ -367,12 +372,12 @@ class BaseAttr(Generic[AttributeCovT], GenericAttrConstraint[AttributeCovT]):
 
     def verify(
         self,
-        attr: Attribute,
+        value: Attribute,
         constraint_context: ConstraintContext,
     ) -> None:
-        if not isinstance(attr, self.attr):
+        if not isinstance(value, self.attr):
             raise VerifyException(
-                f"{attr} should be of base attribute {self.attr.name}"
+                f"{value} should be of base attribute {self.attr.name}"
             )
 
     def can_infer(self, var_constraint_names: AbstractSet[str]) -> bool:
@@ -417,7 +422,7 @@ class AnyAttr(GenericAttrConstraint[Attribute]):
 
     def verify(
         self,
-        attr: Attribute,
+        value: Attribute,
         constraint_context: ConstraintContext,
     ) -> None:
         pass
@@ -505,13 +510,13 @@ class AnyOf(Generic[AttributeCovT], GenericAttrConstraint[AttributeCovT]):
             based_constrs,
         )
 
-    def verify(self, attr: Attribute, constraint_context: ConstraintContext) -> None:
-        if attr in self._eq_constrs:
+    def verify(self, value: Attribute, constraint_context: ConstraintContext) -> None:
+        if value in self._eq_constrs:
             return
-        constr = self._based_constrs.get(attr.__class__)
+        constr = self._based_constrs.get(value.__class__)
         if constr is None:
-            raise VerifyException(f"Unexpected attribute {attr}")
-        constr.verify(attr, constraint_context)
+            raise VerifyException(f"Unexpected attribute {value}")
+        constr.verify(value, constraint_context)
 
     def __or__(
         self, value: GenericAttrConstraint[_AttributeCovT], /
@@ -550,14 +555,14 @@ class AllOf(GenericAttrConstraint[AttributeCovT]):
 
     def verify(
         self,
-        attr: Attribute,
+        value: Attribute,
         constraint_context: ConstraintContext,
     ) -> None:
         exc_bucket: list[VerifyException] = []
 
         for attr_constr in self.attr_constrs:
             try:
-                attr_constr.verify(attr, constraint_context)
+                attr_constr.verify(value, constraint_context)
             except VerifyException as e:
                 exc_bucket.append(e)
 
@@ -650,14 +655,14 @@ class ParamAttrConstraint(
 
     def verify(
         self,
-        attr: Attribute,
+        value: Attribute,
         constraint_context: ConstraintContext,
     ) -> None:
-        if not isinstance(attr, self.base_attr):
+        if not isinstance(value, self.base_attr):
             raise VerifyException(
-                f"{attr} should be of base attribute {self.base_attr.name}"
+                f"{value} should be of base attribute {self.base_attr.name}"
             )
-        parameters = attr.parameters
+        parameters = value.parameters
         if len(self.param_constrs) != len(parameters):
             raise VerifyException(
                 f"{len(self.param_constrs)} parameters expected, "
@@ -734,11 +739,11 @@ class MessageConstraint(GenericAttrConstraint[AttributeCovT]):
 
     def verify(
         self,
-        attr: Attribute,
+        value: Attribute,
         constraint_context: ConstraintContext,
     ) -> None:
         try:
-            return self.constr.verify(attr, constraint_context)
+            return self.constr.verify(value, constraint_context)
         except VerifyException as e:
             raise VerifyException(
                 f"{self.message}\nUnderlying verification failure: {e.args[0]}",
@@ -766,19 +771,8 @@ class MessageConstraint(GenericAttrConstraint[AttributeCovT]):
 
 
 @dataclass(frozen=True)
-class IntConstraint(ABC):
+class IntConstraint(GenericConstraint[int, int], ABC):
     """Constrain an integer to certain values."""
-
-    @abstractmethod
-    def verify(
-        self,
-        i: int,
-        constraint_context: ConstraintContext,
-    ) -> None:
-        """
-        Check if the integer satisfies the constraint, or raise an exception otherwise.
-        """
-        ...
 
     def variables(self) -> set[str]:
         """
@@ -811,7 +805,7 @@ class AnyInt(IntConstraint):
     Constraint that is verified by all integers.
     """
 
-    def verify(self, i: int, constraint_context: ConstraintContext) -> None:
+    def verify(self, value: int, constraint_context: ConstraintContext) -> None:
         pass
 
 
@@ -822,9 +816,9 @@ class AtLeast(IntConstraint):
     bound: int
     """The minimum value the integer can take."""
 
-    def verify(self, i: int, constraint_context: ConstraintContext) -> None:
-        if i < self.bound:
-            raise VerifyException(f"expected integer >= {self.bound}, got {i}")
+    def verify(self, value: int, constraint_context: ConstraintContext) -> None:
+        if value < self.bound:
+            raise VerifyException(f"expected integer >= {self.bound}, got {value}")
 
 
 @dataclass(frozen=True)
@@ -842,18 +836,18 @@ class IntVarConstraint(IntConstraint):
 
     def verify(
         self,
-        i: int,
+        value: int,
         constraint_context: ConstraintContext,
     ) -> None:
         if self.name in constraint_context.int_variables:
-            if i != constraint_context.get_int_variable(self.name):
+            if value != constraint_context.get_int_variable(self.name):
                 raise VerifyException(
                     f"integer {constraint_context.get_int_variable(self.name)} expected from int variable "
-                    f"'{self.name}', but got {i}"
+                    f"'{self.name}', but got {value}"
                 )
         else:
-            self.constraint.verify(i, constraint_context)
-            constraint_context.set_int_variable(self.name, i)
+            self.constraint.verify(value, constraint_context)
+            constraint_context.set_int_variable(self.name, value)
 
     def variables(self) -> set[str]:
         return self.constraint.variables() | {self.name}
@@ -871,19 +865,12 @@ class IntVarConstraint(IntConstraint):
 
 
 @dataclass(frozen=True)
-class GenericRangeConstraint(Generic[AttributeCovT], ABC):
+class GenericRangeConstraint(
+    Generic[AttributeCovT],
+    GenericConstraint[Sequence[Attribute], Sequence[AttributeCovT]],
+    ABC,
+):
     """Constrain a range of attributes to certain values."""
-
-    @abstractmethod
-    def verify(
-        self,
-        attrs: Sequence[Attribute],
-        constraint_context: ConstraintContext,
-    ) -> None:
-        """
-        Check if the range satisfies the constraint, or raise an exception otherwise.
-        """
-        ...
 
     @abstractmethod
     def verify_length(self, length: int, constraint_context: ConstraintContext) -> None:
@@ -961,19 +948,19 @@ class RangeVarConstraint(GenericRangeConstraint[AttributeCovT]):
 
     def verify(
         self,
-        attrs: Sequence[Attribute],
+        value: Sequence[Attribute],
         constraint_context: ConstraintContext,
     ) -> None:
         ctx_attrs = constraint_context.get_range_variable(self.name)
         if ctx_attrs is not None:
-            if attrs != ctx_attrs:
+            if value != ctx_attrs:
                 raise VerifyException(
                     f"attributes {tuple(str(x) for x in ctx_attrs)} expected from range variable "
-                    f"'{self.name}', but got {tuple(str(x) for x in attrs)}"
+                    f"'{self.name}', but got {tuple(str(x) for x in value)}"
                 )
         else:
-            self.constraint.verify(attrs, constraint_context)
-            constraint_context.set_range_variable(self.name, tuple(attrs))
+            self.constraint.verify(value, constraint_context)
+            constraint_context.set_range_variable(self.name, tuple(value))
 
     def verify_length(self, length: int, constraint_context: ConstraintContext) -> None:
         # It is not possible to fully verify the constraint from just the length, so we don't try.
@@ -1013,13 +1000,13 @@ class RangeOf(GenericRangeConstraint[AttributeCovT]):
 
     def verify(
         self,
-        attrs: Sequence[Attribute],
+        value: Sequence[Attribute],
         constraint_context: ConstraintContext,
     ) -> None:
-        for a in attrs:
+        for a in value:
             self.constr.verify(a, constraint_context)
         try:
-            self.length.verify(len(attrs), constraint_context)
+            self.length.verify(len(value), constraint_context)
         except VerifyException as e:
             raise VerifyException(
                 "incorrect length for range variable:\n" + str(e)
@@ -1067,12 +1054,12 @@ class SingleOf(GenericRangeConstraint[AttributeCovT]):
 
     def verify(
         self,
-        attrs: Sequence[Attribute],
+        value: Sequence[Attribute],
         constraint_context: ConstraintContext,
     ) -> None:
-        if len(attrs) != 1:
-            raise VerifyException(f"Expected a single attribute, got {len(attrs)}")
-        self.constr.verify(attrs[0], constraint_context)
+        if len(value) != 1:
+            raise VerifyException(f"Expected a single attribute, got {len(value)}")
+        self.constr.verify(value[0], constraint_context)
 
     def verify_length(self, length: int, constraint_context: ConstraintContext) -> None:
         if length != 1:


### PR DESCRIPTION
As a kind of companion to #4760, I thought I'd try making a supertype of the constraints. I wonder how much logic we can share between the constraints without needing to unspecialcase integers? Might be a useful avenue to go down.