### PR TITLE
core: (affine) add apply_permutation helper to AffineMap

### DIFF
--- a/tests/test_affine_builtins.py
+++ b/tests/test_affine_builtins.py
@@ -2,6 +2,7 @@ import re
 from collections.abc import Sequence
 
 import pytest
+from typing_extensions import TypeVar
 
 from xdsl.ir.affine import (
     AffineBinaryOpExpr,
@@ -411,3 +412,29 @@ def test_is_projected_permutation():
     assert AffineMap.from_callable(
         lambda d0, d1, d2: (d1, 0, d0)
     ).is_projected_permutation(allow_zero_in_results=True)
+
+
+_T = TypeVar("_T")
+
+
+@pytest.mark.parametrize(
+    "permutation_map, inputs, expected",
+    [
+        (
+            AffineMap.from_callable(lambda d0, d1, d2: (d1, d0)),
+            (10, 20, 30),
+            (20, 10),
+        ),
+        (
+            AffineMap(
+                8, 0, tuple(AffineExpr.dimension(d) for d in (4, 1, 6, 0, 3, 2, 5, 7))
+            ),
+            "policemr",
+            ("c", "o", "m", "p", "i", "l", "e", "r"),
+        ),
+    ],
+)
+def test_apply_permutation_map(
+    permutation_map: AffineMap, inputs: Sequence[_T], expected: tuple[_T, ...]
+):
+    assert permutation_map.apply_permutation(inputs) == expected

--- a/xdsl/ir/affine/affine_map.py
+++ b/xdsl/ir/affine/affine_map.py
@@ -439,8 +439,8 @@ class AffineMap:
 
     def apply_permutation(self, source: Sequence[_T]) -> tuple[_T, ...]:
         """
-        Assert that `self` represents a permutation, and apply the permutation to
-        `source`.
+        Assert that `self` represents a projected permutation, and apply the permutation
+        to `source`.
         The number of inputs must match the size of the source.
 
         Example:


### PR DESCRIPTION
Reopen #4210, I realised that I actually would be useful to have a shortcut to apply permutations to non-int inputs, such as permuting tuples of attributes.