### PR TITLE
API: unify PatternRewriter.insert and .insert_op

### DIFF
--- a/xdsl/builder.py
+++ b/xdsl/builder.py
@@ -58,17 +58,30 @@ class Builder(BuilderListener):
         """
         Inserts op at the current location and returns it.
         """
-        self.insert_op(op)
-        return op
+        return self.insert_op(op)
+
+    @overload
+    def insert_op(
+        self,
+        op: OperationInvT,
+        insertion_point: InsertPoint | None = None,
+    ) -> OperationInvT: ...
+
+    @overload
+    def insert_op(
+        self,
+        op: Sequence[Operation],
+        insertion_point: InsertPoint | None = None,
+    ) -> None: ...
 
     def insert_op(
         self,
         op: Operation | Sequence[Operation],
         insertion_point: InsertPoint | None = None,
-    ):
+    ) -> Operation | None:
         """Inserts `op` at the current insertion point."""
-        op = (op,) if isinstance(op, Operation) else op
-        if not op:
+        res, ops = (op, (op,)) if isinstance(op, Operation) else (None, op)
+        if not ops:
             return
 
         implicit_builder = ImplicitBuilder.get()
@@ -81,10 +94,10 @@ class Builder(BuilderListener):
             op, self.insertion_point if insertion_point is None else insertion_point
         )
 
-        for op_ in op:
+        for op_ in ops:
             self.handle_operation_insertion(op_)
 
-        return op
+        return res
 
     def create_block(
         self, insert_point: BlockInsertPoint, arg_types: Iterable[Attribute] = ()

--- a/xdsl/builder.py
+++ b/xdsl/builder.py
@@ -71,7 +71,7 @@ class Builder(BuilderListener):
         insertion_point: InsertPoint | None = None,
     ) -> InsertOpInvT:
         """Inserts `op` at the current insertion point."""
-        res, ops = (op, (op,)) if isinstance(op, Operation) else (op, op)
+        ops = (op,) if isinstance(op, Operation) else op
         if not ops:
             return ops
 
@@ -88,7 +88,7 @@ class Builder(BuilderListener):
         for op_ in ops:
             self.handle_operation_insertion(op_)
 
-        return res
+        return op
 
     def create_block(
         self, insert_point: BlockInsertPoint, arg_types: Iterable[Attribute] = ()

--- a/xdsl/builder.py
+++ b/xdsl/builder.py
@@ -55,22 +55,34 @@ class Builder(BuilderListener):
     """Operations will be inserted at this location."""
 
     def insert(self, op: OperationInvT) -> OperationInvT:
+        """
+        Inserts op at the current location and returns it.
+        """
+        self.insert_op(op)
+        return op
+
+    def insert_op(
+        self,
+        op: Operation | Sequence[Operation],
+        insertion_point: InsertPoint | None = None,
+    ):
         """Inserts `op` at the current insertion point."""
+        op = (op,) if isinstance(op, Operation) else op
+        if not op:
+            return
 
         implicit_builder = ImplicitBuilder.get()
-
         if implicit_builder is not None and implicit_builder is not self:
             raise ValueError(
                 "Cannot insert operation explicitly when an implicit builder exists."
             )
 
-        block = self.insertion_point.block
-        insert_before = self.insertion_point.insert_before
-        if insert_before is not None:
-            block.insert_op_before(op, insert_before)
-        else:
-            block.add_op(op)
-        self.handle_operation_insertion(op)
+        Rewriter.insert_op(
+            op, self.insertion_point if insertion_point is None else insertion_point
+        )
+
+        for op_ in op:
+            self.handle_operation_insertion(op_)
 
         return op
 

--- a/xdsl/builder.py
+++ b/xdsl/builder.py
@@ -70,7 +70,7 @@ class Builder(BuilderListener):
         op: InsertOpInvT,
         insertion_point: InsertPoint | None = None,
     ) -> InsertOpInvT:
-        """Inserts `op` at the current insertion point."""
+        """Inserts op(s) at the current insertion point."""
         ops = (op,) if isinstance(op, Operation) else op
         if not ops:
             return ops

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -6,11 +6,11 @@ from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass, field
 from functools import wraps
 from types import UnionType
-from typing import Union, final, get_args, get_origin, overload
+from typing import Union, final, get_args, get_origin
 
 from typing_extensions import TypeVar
 
-from xdsl.builder import Builder, BuilderListener
+from xdsl.builder import Builder, BuilderListener, InsertOpInvT
 from xdsl.dialects.builtin import ArrayAttr, DictionaryAttr, ModuleOp
 from xdsl.ir import (
     Attribute,
@@ -18,7 +18,6 @@ from xdsl.ir import (
     BlockArgument,
     ErasedSSAValue,
     Operation,
-    OperationInvT,
     OpResult,
     ParametrizedAttribute,
     Region,
@@ -100,36 +99,22 @@ class PatternRewriter(Builder, PatternRewriterListener):
         self.current_operation = current_operation
         Builder.__init__(self, InsertPoint.before(current_operation))
 
-    @overload
     def insert_op(
         self,
-        op: OperationInvT,
+        op: InsertOpInvT,
         insertion_point: InsertPoint | None = None,
-    ) -> OperationInvT: ...
-
-    @overload
-    def insert_op(
-        self,
-        op: Sequence[Operation],
-        insertion_point: InsertPoint | None = None,
-    ) -> None: ...
-
-    def insert_op(
-        self,
-        op: Operation | Sequence[Operation],
-        insertion_point: InsertPoint | None = None,
-    ) -> Operation | None:
+    ) -> InsertOpInvT:
         """Insert operations at a certain location in a block."""
         self.has_done_action = True
         return super().insert_op(op, insertion_point)
 
-    def insert_op_before_matched_op(self, op: Operation | Sequence[Operation]):
+    def insert_op_before_matched_op(self, op: InsertOpInvT) -> InsertOpInvT:
         """Insert operations before the matched operation."""
-        self.insert_op(op, InsertPoint.before(self.current_operation))
+        return self.insert_op(op, InsertPoint.before(self.current_operation))
 
-    def insert_op_after_matched_op(self, op: Operation | Sequence[Operation]):
+    def insert_op_after_matched_op(self, op: InsertOpInvT) -> InsertOpInvT:
         """Insert operations after the matched operation."""
-        self.insert_op(op, InsertPoint.after(self.current_operation))
+        return self.insert_op(op, InsertPoint.after(self.current_operation))
 
     def erase_matched_op(self, safe_erase: bool = True):
         """

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -106,7 +106,7 @@ class PatternRewriter(Builder, PatternRewriterListener):
     ):
         """Insert operations at a certain location in a block."""
         self.has_done_action = True
-        super().insert_op(op)
+        super().insert_op(op, insertion_point)
 
     def insert_op_before_matched_op(self, op: Operation | Sequence[Operation]):
         """Insert operations before the matched operation."""

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -6,7 +6,7 @@ from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass, field
 from functools import wraps
 from types import UnionType
-from typing import Union, final, get_args, get_origin
+from typing import Union, final, get_args, get_origin, overload
 
 from typing_extensions import TypeVar
 
@@ -18,6 +18,7 @@ from xdsl.ir import (
     BlockArgument,
     ErasedSSAValue,
     Operation,
+    OperationInvT,
     OpResult,
     ParametrizedAttribute,
     Region,
@@ -99,14 +100,28 @@ class PatternRewriter(Builder, PatternRewriterListener):
         self.current_operation = current_operation
         Builder.__init__(self, InsertPoint.before(current_operation))
 
+    @overload
+    def insert_op(
+        self,
+        op: OperationInvT,
+        insertion_point: InsertPoint | None = None,
+    ) -> OperationInvT: ...
+
+    @overload
+    def insert_op(
+        self,
+        op: Sequence[Operation],
+        insertion_point: InsertPoint | None = None,
+    ) -> None: ...
+
     def insert_op(
         self,
         op: Operation | Sequence[Operation],
         insertion_point: InsertPoint | None = None,
-    ):
+    ) -> Operation | None:
         """Insert operations at a certain location in a block."""
         self.has_done_action = True
-        super().insert_op(op, insertion_point)
+        return super().insert_op(op, insertion_point)
 
     def insert_op_before_matched_op(self, op: Operation | Sequence[Operation]):
         """Insert operations before the matched operation."""

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -100,17 +100,13 @@ class PatternRewriter(Builder, PatternRewriterListener):
         Builder.__init__(self, InsertPoint.before(current_operation))
 
     def insert_op(
-        self, op: Operation | Sequence[Operation], insertion_point: InsertPoint
+        self,
+        op: Operation | Sequence[Operation],
+        insertion_point: InsertPoint | None = None,
     ):
         """Insert operations at a certain location in a block."""
         self.has_done_action = True
-        op = (op,) if isinstance(op, Operation) else op
-        if not op:
-            return
-        Rewriter.insert_op(op, insertion_point)
-
-        for op_ in op:
-            self.handle_operation_insertion(op_)
+        super().insert_op(op)
 
     def insert_op_before_matched_op(self, op: Operation | Sequence[Operation]):
         """Insert operations before the matched operation."""


### PR DESCRIPTION
Spotted this bit of weirdness where we actually have two operations on PatternRewriter, `insert` and `insert_op`. It feels like we should probably have just one, but they're different enough that it would be a bit of a painful transition. This PR makes it so that they at least both set `has_done_action`, maybe we should deprecate one of them in the future.