### PR TITLE
misc: columns in debug messages start at 1

### DIFF
--- a/tests/filecheck/dialects/arm_neon/test_attrs.mlir
+++ b/tests/filecheck/dialects/arm_neon/test_attrs.mlir
@@ -2,7 +2,7 @@
 
 builtin.module attributes {bla=#arm_neon<arrangement hello>} {}
 
-// CHECK-NEXT:  tests/filecheck/dialects/arm_neon/test_attrs.mlir:3:53
+// CHECK-NEXT:  tests/filecheck/dialects/arm_neon/test_attrs.mlir:3:54
 // CHECK-NEXT:  builtin.module attributes {bla=#arm_neon<arrangement hello>} {}
 // CHECK-NEXT:                                                       ^^^^^
 // CHECK-NEXT:                                                       Expected `D`, `S`, or `H`.

--- a/tests/filecheck/parser-printer/graph_region.mlir
+++ b/tests/filecheck/parser-printer/graph_region.mlir
@@ -79,11 +79,11 @@ builtin.module {
         "test.op"() : () -> ()
 }
 
-// CHECK:       /graph_region.mlir:78:4
+// CHECK:       /graph_region.mlir:78:5
 // CHECK-NEXT:      ^blockA:
 // CHECK-NEXT:      ^^^^^^^
 // CHECK-NEXT:      re-declaration of block 'blockA'
 // CHECK-NEXT:  originally declared here:
-// CHECK-NEXT:  /graph_region.mlir:4:4
+// CHECK-NEXT:  /graph_region.mlir:4:5
 // CHECK-NEXT:      ^blockA:
 // CHECK-NEXT:      ^^^^^^^

--- a/tests/filecheck/parser-printer/parse_error.mlir
+++ b/tests/filecheck/parser-printer/parse_error.mlir
@@ -1,7 +1,7 @@
 // RUN: xdsl-opt %s --parsing-diagnostics --split-input-file | filecheck %s
 
 "test.op"(abc) : () -> ()
-// CHECK: {{.*}}tests/filecheck/parser-printer/parse_error.mlir:3:10
+// CHECK: {{.*}}tests/filecheck/parser-printer/parse_error.mlir:3:11
 // CHECK-NEXT: "test.op"(abc) : () -> ()
 // CHECK-NEXT:           ^^^
 // CHECK-NEXT:           operand expected
@@ -10,7 +10,7 @@
 
 test.op : () -> ()
 
-// CHECK: {{.*}}tests/filecheck/parser-printer/parse_error.mlir:11:8
+// CHECK: {{.*}}tests/filecheck/parser-printer/parse_error.mlir:11:9
 // CHECK-NEXT: test.op : () -> ()
 // CHECK-NEXT:         ^
 // CHECK-NEXT:         Operation test.op does not have a custom format.

--- a/tests/interactive/test_app.py
+++ b/tests/interactive/test_app.py
@@ -52,13 +52,13 @@ async def test_inputs():
         await pilot.pause()
         assert (
             app.output_text_area.text
-            == "<unknown>:1:5\ndkjfd\n     ^\n     Operation builtin.unregistered does not have a custom format.\n"
+            == "<unknown>:1:6\ndkjfd\n     ^\n     Operation builtin.unregistered does not have a custom format.\n"
         )
 
         assert isinstance(app.current_module, ParseError)
         assert (
             str(app.current_module)
-            == "<unknown>:1:5\ndkjfd\n     ^\n     Operation builtin.unregistered does not have a custom format.\n"
+            == "<unknown>:1:6\ndkjfd\n     ^\n     Operation builtin.unregistered does not have a custom format.\n"
         )
 
         # Test corect input

--- a/tests/test_parser_error.py
+++ b/tests/test_parser_error.py
@@ -39,7 +39,7 @@ def test_parser_missing_equal():
   %0 "test.unknown"() : () -> !i32
 }) : () -> ()
 """
-    check_error(prog, 3, 5, "Expected '=' after operation result list")
+    check_error(prog, 3, 6, "Expected '=' after operation result list")
 
 
 def test_parser_redefined_value():
@@ -53,7 +53,7 @@ def test_parser_redefined_value():
   %val = "test.unknown"() : () -> i32
 }) : () -> ()
 """
-    check_error(prog, 4, 2, "SSA value %val is already defined")
+    check_error(prog, 4, 3, "SSA value %val is already defined")
 
 
 def test_parser_missing_operation_name():
@@ -66,4 +66,4 @@ def test_parser_missing_operation_name():
   %val =
 }) : () -> ()
 """
-    check_error(prog, 4, 0, "operation name expected")
+    check_error(prog, 4, 1, "operation name expected")


### PR DESCRIPTION
This seems to be the convention in all IDEs and error messages, and can be verified by copy/pasting one of the changed messages in the filecheck tests to the terminal in VSCode, and command-clicking it, the new 1-indexed columns point to the right place.