### PR TITLE
core: (ParametrizedAttribute) allow ClassVar

### DIFF
--- a/tests/irdl/test_attribute_definition.py
+++ b/tests/irdl/test_attribute_definition.py
@@ -836,18 +836,6 @@ def test_invalid_typed_field():
         irdl_attr_definition(InvalidTypedFieldTestAttr)
 
 
-class InvalidUntypedFieldTestAttr(ParametrizedAttribute):
-    name = "test.invalid_untyped_field"
-
-    x = 2
-
-
-def test_invalid_field():
-    """Check that untyped fields are not allowed."""
-    with pytest.raises(PyRDLAttrDefinitionError):
-        irdl_attr_definition(InvalidUntypedFieldTestAttr)
-
-
 @irdl_attr_definition
 class OveriddenInitAttr(ParametrizedAttribute):
     name = "test.overidden_init"

--- a/xdsl/irdl/attributes.py
+++ b/xdsl/irdl/attributes.py
@@ -244,9 +244,6 @@ class ParamAttrDef:
             if get_origin(value) is Annotated:
                 if any(isinstance(arg, ConstraintVar) for arg in get_args(value)):
                     continue
-            raise PyRDLAttrDefinitionError(
-                f"{field_name} is not a parameter definition."
-            )
 
         return ParamAttrDef(name, list(parameters.items()))
 

--- a/xdsl/irdl/attributes.py
+++ b/xdsl/irdl/attributes.py
@@ -14,6 +14,7 @@ from typing import (
     TYPE_CHECKING,
     Annotated,
     Any,
+    ClassVar,
     Generic,
     Literal,
     TypeAlias,
@@ -210,6 +211,8 @@ class ParamAttrDef:
         parameters: dict[str, AttrConstraint] = {}
 
         for field_name, field_type in field_types.items():
+            if field_type is ClassVar:
+                continue
             try:
                 constraint = irdl_to_attr_constraint(field_type, allow_type_var=True)
             except TypeError as e:


### PR DESCRIPTION
The param_def api allows us to add constraint variables, but we never actually allowed `ClassVar` to appear in the class, which we use heavily in operation definitions. There's three options:
- Allow any field with no type or a ClassVar type. As far as I'm aware this keeps closer to pythons dataclass model, as any annotationless field should be treated as a ClassVar. This is what I've implemented here.
- Only allow fields that are explicitly marked as `ClassVar`. This has the advantage that we catch "dodgy" param_def fields with no annotation
- Allow all fields but error if there's an annotationless `param_def`.

Any thoughts?