### PR TITLE
dialects: (builtin) add TensorType.constr

### DIFF
--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -1405,6 +1405,18 @@ class TensorType(
     def get_element_type(self) -> AttributeCovT:
         return self.element_type
 
+    @classmethod
+    def constr(
+        cls,
+        *,
+        element_type: IRDLGenericAttrConstraint[AttributeInvT] | None = None,
+    ) -> GenericAttrConstraint[TensorType[AttributeInvT]]:
+        if element_type is None:
+            return BaseAttr[TensorType[AttributeInvT]](TensorType)
+        return ParamAttrConstraint[TensorType[AttributeInvT]](
+            TensorType, (AnyAttr(), element_type, AnyAttr())
+        )
+
 
 AnyTensorType: TypeAlias = TensorType[Attribute]
 AnyTensorTypeConstr = BaseAttr[TensorType[Attribute]](TensorType)


### PR DESCRIPTION
Adds a `constr` method for `TensorType`.

While writing this I realised I have forgot why we wanted these to be `classmethod`s, when they don't use the class information at all.