### PR TITLE
documentation: (Toy) LowerToAffinePass -> LowerToyPass

### DIFF
--- a/docs/Toy/toy/compiler.py
+++ b/docs/Toy/toy/compiler.py
@@ -38,7 +38,7 @@ from .dialects import toy
 from .frontend.ir_gen import IRGen
 from .frontend.parser import ToyParser
 from .rewrites.inline_toy import InlineToyPass
-from .rewrites.lower_toy_affine import LowerToAffinePass
+from .rewrites.lower_toy import LowerToyPass
 
 
 def context() -> Context:
@@ -87,7 +87,7 @@ def transform(
     if target == "shape-inference":
         return
 
-    LowerToAffinePass().apply(ctx, module_op)
+    LowerToyPass().apply(ctx, module_op)
     module_op.verify()
 
     if target == "affine":

--- a/docs/Toy/toy/rewrites/lower_toy.py
+++ b/docs/Toy/toy/rewrites/lower_toy.py
@@ -464,12 +464,12 @@ class TransposeOpLowering(RewritePattern):
 # endregion RewritePatterns
 
 
-class LowerToAffinePass(ModulePass):
+class LowerToyPass(ModulePass):
     """
-    A pass for lowering operations in the Toy dialect to Builtin.
+    A pass for lowering operations in the Toy dialect to built-in dialects.
     """
 
-    name = "toy-to-builtin"
+    name = "lower-toy"
 
     def apply(self, ctx: Context, op: ModuleOp) -> None:
         PatternRewriteWalker(


### PR DESCRIPTION
I'd like to at some point lower to linalg instead since we have much better support for that, this will minimise the diff when I merge that in the future. I also think that this is just a better name regardless of whether we change the target in the future, as it's more consistent with the other toy passes and xDSL's naming.