### PR TITLE
dialects: (linalg) add LinalgOperation ABC

### DIFF
--- a/xdsl/dialects/linalg.py
+++ b/xdsl/dialects/linalg.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from abc import ABC
+from abc import ABC, abstractmethod
 from collections.abc import Mapping, Sequence
 from enum import auto
 from typing import ClassVar, cast
@@ -97,53 +97,20 @@ class IteratorTypeAttr(EnumAttribute[IteratorType]):
             super().print_parameter(printer)
 
 
-@irdl_op_definition
-class GenericOp(IRDLOperation):
-    name = "linalg.generic"
+class LinalgOperation(IRDLOperation, ABC):
+    """
+    Abstract base class for linalg operations, allowing them to be processed in with a
+    unified interface.
+    """
 
-    inputs = var_operand_def()
-    outputs = var_operand_def(base(ShapedType))
-
-    res = var_result_def(AnyTensorType)
-
-    body = region_def("single_block")
-
-    # Trait attributes
-    indexing_maps = prop_def(ArrayAttr[AffineMapAttr])
-    iterator_types = prop_def(ArrayAttr[IteratorTypeAttr])
-    doc = opt_prop_def(StringAttr)
-    library_call = opt_prop_def(StringAttr)
-
-    irdl_options = [AttrSizedOperandSegments(as_property=True)]
-
-    def __init__(
-        self,
-        inputs: Sequence[SSAValue],
-        outputs: Sequence[SSAValue],
-        body: Region,
-        indexing_maps: Sequence[AffineMapAttr] | ArrayAttr[AffineMapAttr],
-        iterator_types: Sequence[Attribute] | ArrayAttr[Attribute],
-        result_types: Sequence[Attribute] = (),
-        doc: StringAttr | None = None,
-        library_call: StringAttr | None = None,
-    ) -> None:
-        super().__init__(
-            operands=[inputs, outputs],
-            result_types=[result_types],
-            properties={
-                "indexing_maps": ArrayAttr(indexing_maps),
-                "iterator_types": ArrayAttr(iterator_types),
-                "doc": doc,
-                "library_call": library_call,
-            },
-            regions=[body],
-        )
-
-    def get_indexing_maps(self) -> list[AffineMap]:
-        return [attr.data for attr in self.indexing_maps]
+    @abstractmethod
+    def get_indexing_maps(self) -> Sequence[AffineMap]:
+        """
+        Get the indexing maps corresponding to this operation's operands, in order.
+        """
 
     def get_num_loops(self) -> int:
-        return self.indexing_maps.data[0].data.num_dims
+        return self.get_indexing_maps()[0].num_dims
 
     def get_loops_to_shapes_map(self) -> AffineMap:
         """
@@ -200,6 +167,52 @@ class GenericOp(IRDLOperation):
         shapes_to_loops = self.get_shapes_to_loops_map()
         static_shapes = self.get_static_shapes()
         return shapes_to_loops.eval(static_shapes, [])
+
+
+@irdl_op_definition
+class GenericOp(LinalgOperation):
+    name = "linalg.generic"
+
+    inputs = var_operand_def()
+    outputs = var_operand_def(base(ShapedType))
+
+    res = var_result_def(AnyTensorType)
+
+    body = region_def("single_block")
+
+    # Trait attributes
+    indexing_maps = prop_def(ArrayAttr[AffineMapAttr])
+    iterator_types = prop_def(ArrayAttr[IteratorTypeAttr])
+    doc = opt_prop_def(StringAttr)
+    library_call = opt_prop_def(StringAttr)
+
+    irdl_options = [AttrSizedOperandSegments(as_property=True)]
+
+    def __init__(
+        self,
+        inputs: Sequence[SSAValue],
+        outputs: Sequence[SSAValue],
+        body: Region,
+        indexing_maps: Sequence[AffineMapAttr] | ArrayAttr[AffineMapAttr],
+        iterator_types: Sequence[Attribute] | ArrayAttr[Attribute],
+        result_types: Sequence[Attribute] = (),
+        doc: StringAttr | None = None,
+        library_call: StringAttr | None = None,
+    ) -> None:
+        super().__init__(
+            operands=[inputs, outputs],
+            result_types=[result_types],
+            properties={
+                "indexing_maps": ArrayAttr(indexing_maps),
+                "iterator_types": ArrayAttr(iterator_types),
+                "doc": doc,
+                "library_call": library_call,
+            },
+            regions=[body],
+        )
+
+    def get_indexing_maps(self) -> Sequence[AffineMap]:
+        return tuple(attr.data for attr in self.indexing_maps)
 
     def print(self, printer: Printer):
         printer.print_string(" {indexing_maps = ")


### PR DESCRIPTION
This is the first change in a number that will let us operate on linalg operations whether or not they've been converted to generic, and actually to convert linalg ops to generic from within xDSL. Subsequent PRs will subclass the other Linalg ops to this interface.