### PR TITLE
misc: use ValueError in xdsl_opt_main.py

### DIFF
--- a/xdsl/xdsl_opt_main.py
+++ b/xdsl/xdsl_opt_main.py
@@ -348,7 +348,7 @@ class xDSLOptMain(CommandLineTool):
         if file_extension not in self.available_frontends:
             for chunk, _ in chunks:
                 chunk.close()
-            raise Exception(f"Unrecognized file extension '{file_extension}'")
+            raise ValueError(f"Unrecognized file extension '{file_extension}'")
 
         return chunks, file_extension
 
@@ -371,7 +371,7 @@ class xDSLOptMain(CommandLineTool):
         """Get the resulting program."""
         output = StringIO()
         if self.args.target not in self.available_targets:
-            raise Exception(f"Unknown target {self.args.target}")
+            raise ValueError(f"Unknown target {self.args.target}")
 
         self.available_targets[self.args.target](prog, output)
         return output.getvalue()


### PR DESCRIPTION
I was surprised that there wasn't a better Exception subclass for command-line options, but ValueError seems better to me than Exception.