### PR TITLE
transformations: (convert-ptr-to-x86) insert mov to inout reg

### DIFF
--- a/tests/filecheck/backend/x86/convert_ptr_to_x86.mlir
+++ b/tests/filecheck/backend/x86/convert_ptr_to_x86.mlir
@@ -142,6 +142,7 @@ ptr_xdsl.store %v6, %ptr6 : f32, !ptr_xdsl.ptr
 // CHECK-NEXT:   %idx = "test.op"() : () -> index
 // CHECK-NEXT:   %r0 = builtin.unrealized_conversion_cast %p : !ptr_xdsl.ptr to !x86.reg
 // CHECK-NEXT:   %r0_1 = builtin.unrealized_conversion_cast %idx : index to !x86.reg
-// CHECK-NEXT:   %r0_2 = x86.rs.add %r0, %r0_1 : (!x86.reg, !x86.reg) -> !x86.reg
-// CHECK-NEXT:   %r0_3 = builtin.unrealized_conversion_cast %r0_2 : !x86.reg to !ptr_xdsl.ptr
+// CHECK-NEXT:   %r0_2 = x86.ds.mov %r0 : (!x86.reg) -> !x86.reg
+// CHECK-NEXT:   %r0_3 = x86.rs.add %r0_2, %r0_1 : (!x86.reg, !x86.reg) -> !x86.reg
+// CHECK-NEXT:   %r0_4 = builtin.unrealized_conversion_cast %r0_3 : !x86.reg to !ptr_xdsl.ptr
 // CHECK-NEXT: }


### PR DESCRIPTION
We should watch out for this pattern. When lowering from SSA to SSA-with-registers, it's important to not introduce aliasing via same-register constraints. In SSA, values are immutable, but when we add registers to the mix mutation can occur, so copies have to be added to be safe. The standard RISC-V ISA doesn't have inout registers, so I've not had to deal with this, but x86 and ARM have plenty of it so we'll have to be careful.