### PR TITLE
dialects: (x86) remove redundant moves during canonicalization

### DIFF
--- a/tests/filecheck/dialects/x86/canonicalize.mlir
+++ b/tests/filecheck/dialects/x86/canonicalize.mlir
@@ -1,0 +1,16 @@
+// RUN: xdsl-opt -p canonicalize %s | filecheck %s
+
+// CHECK:       builtin.module {
+
+// CHECK-NEXT:    %i0, %i1, %i2 = "test.op"() : () -> (!riscv.reg<a0>, !riscv.reg<a1>, !riscv.reg)
+// CHECK-NEXT:    %o1 = riscv.mv %i1 : (!riscv.reg<a1>) -> !riscv.reg<a2>
+// CHECK-NEXT:    %o2 = riscv.mv %i2 : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:    "test.op"(%i0, %o1, %o2) : (!riscv.reg<a0>, !riscv.reg<a2>, !riscv.reg) -> ()
+
+%i0, %i1, %i2 = "test.op"() : () -> (!riscv.reg<a0>, !riscv.reg<a1>, !riscv.reg)
+%o0 = riscv.mv %i0 : (!riscv.reg<a0>) -> !riscv.reg<a0>
+%o1 = riscv.mv %i1 : (!riscv.reg<a1>) -> !riscv.reg<a2>
+%o2 = riscv.mv %i2 : (!riscv.reg) -> !riscv.reg
+"test.op"(%o0, %o1, %o2) : (!riscv.reg<a0>, !riscv.reg<a2>, !riscv.reg) -> ()
+
+// CHECK-NEXT:  }

--- a/xdsl/dialects/x86/ops.py
+++ b/xdsl/dialects/x86/ops.py
@@ -67,8 +67,9 @@ from xdsl.irdl import (
     var_operand_def,
 )
 from xdsl.parser import Parser, UnresolvedOperand
+from xdsl.pattern_rewriter import RewritePattern
 from xdsl.printer import Printer
-from xdsl.traits import IsTerminator
+from xdsl.traits import HasCanonicalizationPatternsTrait, IsTerminator, Pure
 from xdsl.utils.exceptions import VerifyException
 
 from .assembly import (
@@ -1096,6 +1097,14 @@ class RS_XorOp(RS_Operation[GeneralRegisterType, GeneralRegisterType]):
     name = "x86.rs.xor"
 
 
+class DS_MovOpHasCanonicalizationPatterns(HasCanonicalizationPatternsTrait):
+    @classmethod
+    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+        from xdsl.transforms.canonicalization_patterns.x86 import RemoveRedundantDS_Mov
+
+        return (RemoveRedundantDS_Mov(),)
+
+
 @irdl_op_definition
 class DS_MovOp(DS_Operation[X86RegisterType, GeneralRegisterType]):
     """
@@ -1108,6 +1117,8 @@ class DS_MovOp(DS_Operation[X86RegisterType, GeneralRegisterType]):
     """
 
     name = "x86.ds.mov"
+
+    traits = traits_def(Pure(), DS_MovOpHasCanonicalizationPatterns())
 
 
 @irdl_op_definition

--- a/xdsl/dialects/x86/ops.py
+++ b/xdsl/dialects/x86/ops.py
@@ -69,7 +69,7 @@ from xdsl.irdl import (
 from xdsl.parser import Parser, UnresolvedOperand
 from xdsl.pattern_rewriter import RewritePattern
 from xdsl.printer import Printer
-from xdsl.traits import HasCanonicalizationPatternsTrait, IsTerminator, Pure
+from xdsl.traits import HasCanonicalizationPatternsTrait, IsTerminator
 from xdsl.utils.exceptions import VerifyException
 
 from .assembly import (
@@ -1118,7 +1118,7 @@ class DS_MovOp(DS_Operation[X86RegisterType, GeneralRegisterType]):
 
     name = "x86.ds.mov"
 
-    traits = traits_def(Pure(), DS_MovOpHasCanonicalizationPatterns())
+    traits = traits_def(DS_MovOpHasCanonicalizationPatterns())
 
 
 @irdl_op_definition

--- a/xdsl/transforms/canonicalization_patterns/x86.py
+++ b/xdsl/transforms/canonicalization_patterns/x86.py
@@ -1,0 +1,13 @@
+from xdsl.dialects import x86
+from xdsl.pattern_rewriter import (
+    PatternRewriter,
+    RewritePattern,
+    op_type_rewrite_pattern,
+)
+
+
+class RemoveRedundantDS_Mov(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: x86.DS_MovOp, rewriter: PatternRewriter) -> None:
+        if op.destination.type == op.source.type and op.destination.type.is_allocated:
+            rewriter.replace_matched_op((), (op.source,))


### PR DESCRIPTION
Add pattern to remove moves to the same register.