### PR TITLE
CI: add specific Pyright ignores to frontend tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,13 +102,7 @@ reportUnnecessaryTypeIgnoreComment = true
 typeCheckingMode = "strict"
 extraPaths = ["tests"]
 "include" = ["docs", "xdsl", "tests"]
-"exclude" = [
-    "docs/marimo",
-    "tests/dialects/test_memref.py",
-    "tests/test_frontend_python_code_check.py",
-    "tests/filecheck/frontend/programs/code_generation_exceptions.py",
-    "tests/filecheck/frontend/programs/frontend_program_exceptions.py",
-]
+"exclude" = ["docs/marimo"]
 
 [tool.ruff]
 target-version = "py310"

--- a/tests/filecheck/frontend/programs/code_generation_exceptions.py
+++ b/tests/filecheck/frontend/programs/code_generation_exceptions.py
@@ -11,7 +11,7 @@ try:
     with CodeContext(p):
         # CHECK: Else clause in for loops is not supported.
         def test_not_supported_loop_I():
-            for i in range(10):
+            for _i in range(10):
                 pass
             else:
                 pass
@@ -26,7 +26,7 @@ try:
     with CodeContext(p):
         # CHECK: Only range-based loops are supported.
         def test_not_supported_loop_II():
-            for i, j in enumerate(range(10, 0, -1)):
+            for _i, _j in enumerate(range(10, 0, -1)):
                 pass
             return
 
@@ -39,7 +39,7 @@ try:
     with CodeContext(p):
         # CHECK: Range-based loop expected between 1 and 3 arguments, but got 4.
         def test_not_supported_loop_III():
-            for i in range(0, 1, 2, 3):
+            for _i in range(0, 1, 2, 3):  # pyright: ignore[reportCallIssue]
                 pass
             return
 
@@ -52,7 +52,7 @@ try:
     with CodeContext(p):
         # CHECK: Range-based loop must take a single target variable, e.g. `for i in range(10)`.
         def test_not_supported_loop_IV():
-            for i, j in range(100):
+            for _i, _j in range(100):  # pyright: ignore[reportGeneralTypeIssues, reportUnknownVariableType]
                 pass
             return
 

--- a/tests/filecheck/frontend/programs/frontend_program_exceptions.py
+++ b/tests/filecheck/frontend/programs/frontend_program_exceptions.py
@@ -26,7 +26,7 @@ except FrontendProgramException as e:
 # CHECK-NEXT:     p.compile()
 with CodeContext(p):
 
-    def foo():
+    def not_compiled():
         return
 
 
@@ -53,9 +53,9 @@ except FrontendProgramException as e:
 try:
     with CodeContext(p):
 
-        def foo():
-            # CHECK-NEXT: Cannot have an inner function 'bar' inside the function 'foo'.
-            def bar():
+        def outer():
+            # CHECK-NEXT: Cannot have an inner function 'inner' inside the function 'outer'.
+            def inner():  # pyright: ignore[reportUnusedFunction]
                 return
 
             return
@@ -68,11 +68,11 @@ except FrontendProgramException as e:
 try:
     with CodeContext(p):
 
-        def foo():
+        def function_in_block():
             @block
             def bb1():
-                # CHECK-NEXT: Cannot have a nested function 'foo' inside the block 'bb1'.
-                def foo():
+                # CHECK-NEXT: Cannot have a nested function 'block_inner' inside the block 'bb1'.
+                def block_inner():  # pyright: ignore[reportUnusedFunction]
                     return
 
                 return
@@ -87,7 +87,7 @@ except FrontendProgramException as e:
 try:
     with CodeContext(p):
 
-        def foo():
+        def block_in_block():
             @block
             def bb0():
                 # CHECK-NEXT: Cannot have a nested block 'bb1' inside the block 'bb0'.
@@ -107,9 +107,9 @@ except FrontendProgramException as e:
 try:
     with CodeContext(p):
 
-        def foo():
+        def redefined_block():
             @block
-            def bb0():
+            def bb0():  # pyright: ignore[reportRedeclaration]
                 return bb0()
 
             # CHECK-NEXT: Block 'bb0' is already defined
@@ -128,9 +128,9 @@ try:
     with CodeContext(p):
 
         def test():
-            a: Const[int] = 23
+            a: Const[int] = 23  # pyright: ignore[reportAssignmentType,reportUnusedVariable]
             # CHECK-NEXT: Constant 'a' is already defined and cannot be assigned to.
-            a = 3
+            a = 3  # pyright: ignore[reportAssignmentType, reportUnusedVariable]
             return
 
     p.compile(desymref=False)
@@ -140,11 +140,11 @@ except FrontendProgramException as e:
 
 try:
     with CodeContext(p):
-        a: Const[int] = 23
+        a: Const[int] = 23  # pyright: ignore[reportAssignmentType]
 
         # CHECK-NEXT: Constant 'a' is already defined.
         def test():
-            a: int = 3
+            a: int = 3  # pyright: ignore[reportUnusedVariable]
             return
 
     p.compile(desymref=False)
@@ -154,13 +154,13 @@ except FrontendProgramException as e:
 
 try:
     with CodeContext(p):
-        b: Const[int] = 23
+        b: Const[int] = 23  # pyright: ignore[reportAssignmentType]
 
         def test():
             @block
             def bb0():
                 # CHECK-NEXT: Constant 'b' is already defined and cannot be assigned to.
-                b = 3
+                b = 3  # pyright: ignore[reportUnusedVariable]
                 return
 
             return bb0()
@@ -172,11 +172,11 @@ except FrontendProgramException as e:
 
 try:
     with CodeContext(p):
-        c: Const[int] = 23
+        c: Const[int] = 23  # pyright: ignore[reportAssignmentType]
 
-        def foo():
+        def redefined_constant():
             # CHECK-NEXT: Constant 'c' is already defined and cannot be assigned to.
-            c = 2
+            c = 2  # pyright: ignore[reportUnusedVariable]
             return
 
     p.compile(desymref=False)
@@ -186,11 +186,11 @@ except FrontendProgramException as e:
 
 try:
     with CodeContext(p):
-        c: Const[int] = 23
+        c: Const[int] = 23  # pyright: ignore[reportAssignmentType]
 
         def foo():
             # CHECK-NEXT: Constant 'c' is already defined.
-            c: int = 2
+            c: int = 2  # pyright: ignore[reportUnusedVariable]
             return
 
     p.compile(desymref=False)
@@ -200,10 +200,10 @@ except FrontendProgramException as e:
 
 try:
     with CodeContext(p):
-        c: Const[int] = 23
+        c: Const[int] = 23  # pyright: ignore[reportAssignmentType]
 
         # CHECK-NEXT: Constant 'c' is already defined and cannot be used as a function/block argument name.
-        def foo(c: int):
+        def constant_as_argument(c: int):
             return
 
     p.compile(desymref=False)
@@ -213,13 +213,13 @@ except FrontendProgramException as e:
 
 try:
     with CodeContext(p):
-        d: Const[int] = 23
+        d: Const[int] = 23  # pyright: ignore[reportAssignmentType]
 
-        def foo():
+        def redefined_constant_in_block():
             @block
             def bb0():
                 # CHECK-NEXT: Constant 'd' is already defined and cannot be assigned to.
-                d = 2
+                d = 2  # pyright: ignore[reportUnusedVariable]
                 return
 
             return bb0()
@@ -230,9 +230,9 @@ except FrontendProgramException as e:
     print(e.msg)
 
 with CodeContext(p):
-    # CHECK-NEXT: Expected non-zero number of return types in function 'foo', but got 0.
-    def foo() -> int:
-        return
+    # CHECK-NEXT: Expected non-zero number of return types in function 'missing_return_value', but got 0.
+    def missing_return_value() -> int:
+        return  # pyright: ignore[reportReturnType]
 
 
 try:
@@ -274,7 +274,7 @@ try:
     with CodeContext(p):
         # CHECK: Expected non-zero number of return types in function 'test_no_return_type', but got 0.
         def test_no_return_type(a: int) -> int:
-            return
+            return  # pyright: ignore[reportReturnType]
 
     p.compile(desymref=False)
     exit(1)
@@ -285,7 +285,7 @@ try:
     with CodeContext(p):
         # CHECK: Type signature and the type of the return value do not match at position 0: expected i1, got !bigint.bigint.
         def test_wrong_return_type(a: bool, b: int) -> bool:
-            return b
+            return b  # pyright: ignore[reportReturnType]
 
     p.compile(desymref=False)
     exit(1)
@@ -294,8 +294,8 @@ except FrontendProgramException as e:
 
 try:
     with CodeContext(p):
-        # CHECK: Expected no return types in function 'test_wrong_return_type'.
-        def test_wrong_return_type(a: int):
+        # CHECK: Expected no return types in function 'test_no_return_types'.
+        def test_no_return_types(a: int):
             return a
 
     p.compile(desymref=False)

--- a/tests/test_frontend_python_code_check.py
+++ b/tests/test_frontend_python_code_check.py
@@ -13,7 +13,7 @@ x = a
 """
     stmts = ast.parse(src).body
     CheckAndInlineConstants.run(stmts, __file__)
-    assert ast.unparse(stmts).endswith("x = 32")
+    assert ast.unparse(stmts).endswith("x = 32")  # pyright: ignore[reportArgumentType]
 
 
 def test_const_correctly_evaluated_II():
@@ -23,7 +23,7 @@ x: i64 = a + 2
 """
     stmts = ast.parse(src).body
     CheckAndInlineConstants.run(stmts, __file__)
-    assert ast.unparse(stmts).endswith("x: i64 = 4 + 2")
+    assert ast.unparse(stmts).endswith("x: i64 = 4 + 2")  # pyright: ignore[reportArgumentType]
 
 
 def test_const_correctly_evaluated_III():
@@ -35,7 +35,7 @@ y = x
 """
     stmts = ast.parse(src).body
     CheckAndInlineConstants.run(stmts, __file__)
-    assert ast.unparse(stmts).endswith("y = 8")
+    assert ast.unparse(stmts).endswith("y = 8")  # pyright: ignore[reportArgumentType]
 
 
 def test_const_correctly_evaluated_IV():
@@ -46,7 +46,7 @@ def foo(y: i32):
 """
     stmts = ast.parse(src).body
     CheckAndInlineConstants.run(stmts, __file__)
-    assert ast.unparse(stmts).endswith("x: i32 = 4 + y")
+    assert ast.unparse(stmts).endswith("x: i32 = 4 + y")  # pyright: ignore[reportArgumentType]
 
 
 def test_const_correctly_evaluated_V():
@@ -59,7 +59,7 @@ def foo(y: i32):
 """
     stmts = ast.parse(src).body
     CheckAndInlineConstants.run(stmts, __file__)
-    assert ast.unparse(stmts).endswith("x: i32 = 10")
+    assert ast.unparse(stmts).endswith("x: i32 = 10")  # pyright: ignore[reportArgumentType]
 
 
 def test_raises_exception_on_assignemnt_to_const_I():


### PR DESCRIPTION
Removes the last non-marimo Pyright file-wide exceptions!