### PR TITLE
dialects: (snitch-runtime) remove `ConstraintVar`

### DIFF
--- a/tests/filecheck/dialects/snitch_runtime/snitch_runtime_invalid.mlir
+++ b/tests/filecheck/dialects/snitch_runtime/snitch_runtime_invalid.mlir
@@ -1,0 +1,14 @@
+// RUN: xdsl-opt %s --split-input-file --verify-diagnostics | filecheck %s
+
+%dst_i64 = arith.constant 100 : i64
+%src_i64 = arith.constant 0 : i64
+%size = arith.constant 100 : i32
+%transfer_id = "snrt.dma_start_1d"(%dst_i64, %src_i64, %size) : (i64, i64, i32) -> i32
+// CHECK: Expected attribute i32 but got i64
+
+// -----
+%dst_i32 = arith.constant 100 : i32
+%src_i32 = arith.constant 0 : i32
+%size = arith.constant 100 : i32
+%transfer_id_1 = "snrt.dma_start_1d_wideptr"(%dst_i32, %src_i32, %size) : (i32, i32, i32) -> i32
+// CHECK: Expected attribute i64 but got i32

--- a/xdsl/dialects/snitch_runtime.py
+++ b/xdsl/dialects/snitch_runtime.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
-from typing import Annotated, Generic
+from typing import Annotated, ClassVar, Generic
 
 from typing_extensions import TypeVar
 
@@ -16,9 +16,12 @@ from xdsl.dialects.builtin import (
 )
 from xdsl.ir import Attribute, Dialect, Operation, SSAValue
 from xdsl.irdl import (
+    AnyAttr,
     AttrSizedOperandSegments,
     ConstraintVar,
     IRDLOperation,
+    TypeVarConstraint,
+    VarConstraint,
     irdl_op_definition,
     operand_def,
     prop_def,
@@ -322,11 +325,11 @@ class DmaStart1DBaseOperation(SnitchRuntimeBaseOperation, Generic[_T], ABC):
     Initiate an asynchronous 1D DMA transfer
     """
 
-    T = Annotated[Attribute, ConstraintVar("T"), _T]
+    _T: ClassVar = VarConstraint("T", TypeVarConstraint(_T, AnyAttr()))
+
     dst = operand_def(_T)
     src = operand_def(_T)
-    # Pylance was complaining about the below.
-    # size = operand_def(Annotated[Attribute, i32])
+
     size = operand_def(i32)
     transfer_id = result_def(tx_id)
 

--- a/xdsl/dialects/snitch_runtime.py
+++ b/xdsl/dialects/snitch_runtime.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
-from typing import Annotated, ClassVar, Generic
+from typing import Generic
 
 from typing_extensions import TypeVar
 
@@ -16,12 +16,8 @@ from xdsl.dialects.builtin import (
 )
 from xdsl.ir import Attribute, Dialect, Operation, SSAValue
 from xdsl.irdl import (
-    AnyAttr,
     AttrSizedOperandSegments,
-    ConstraintVar,
     IRDLOperation,
-    TypeVarConstraint,
-    VarConstraint,
     irdl_op_definition,
     operand_def,
     prop_def,
@@ -325,8 +321,6 @@ class DmaStart1DBaseOperation(SnitchRuntimeBaseOperation, Generic[_T], ABC):
     Initiate an asynchronous 1D DMA transfer
     """
 
-    _T: ClassVar = VarConstraint("T", TypeVarConstraint(_T, AnyAttr()))
-
     dst = operand_def(_T)
     src = operand_def(_T)
 
@@ -347,7 +341,6 @@ class DmaStart2DBaseOperation(SnitchRuntimeBaseOperation, Generic[_T], ABC):
     Generic base class for starting asynchronous 2D DMA transfers
     """
 
-    T = Annotated[Attribute, ConstraintVar("T"), _T]
     dst = operand_def(_T)
     src = operand_def(_T)
     dst_stride = operand_def(i32)


### PR DESCRIPTION
Seems to be the only generic operation we have, but it's interesting that this seems to work.