### PR TITLE
dialects: (x86) add get_constant_value

### DIFF
--- a/tests/dialects/test_x86.py
+++ b/tests/dialects/test_x86.py
@@ -1,7 +1,8 @@
 import pytest
 
 from xdsl.dialects import x86
-from xdsl.dialects.builtin import IntegerAttr
+from xdsl.dialects.builtin import IntegerAttr, i32
+from xdsl.transforms.canonicalization_patterns.x86 import get_constant_value
 from xdsl.utils.test_value import create_ssa_value
 
 
@@ -270,3 +271,15 @@ def test_rm_vops(
     op = OpClass(memory=input, destination=dest, memory_offset=IntegerAttr(0, 64))
     assert op.memory.type == src
     assert op.destination.type == dest
+
+
+def test_get_constant_value():
+    U = x86.register.UNALLOCATED_GENERAL
+    unknown_value = create_ssa_value(U)
+    assert get_constant_value(unknown_value) is None
+    known_value = x86.DI_MovOp(42, destination=U).destination
+    assert get_constant_value(known_value) == IntegerAttr(42, i32)
+    moved_once = x86.DS_MovOp(known_value, destination=U).destination
+    assert get_constant_value(moved_once) == IntegerAttr(42, i32)
+    moved_twice = x86.DS_MovOp(known_value, destination=U).destination
+    assert get_constant_value(moved_twice) == IntegerAttr(42, i32)

--- a/xdsl/transforms/canonicalization_patterns/x86.py
+++ b/xdsl/transforms/canonicalization_patterns/x86.py
@@ -1,4 +1,5 @@
 from xdsl.dialects import x86
+from xdsl.ir import Attribute, OpResult, SSAValue
 from xdsl.pattern_rewriter import (
     PatternRewriter,
     RewritePattern,
@@ -11,3 +12,14 @@ class RemoveRedundantDS_Mov(RewritePattern):
     def match_and_rewrite(self, op: x86.DS_MovOp, rewriter: PatternRewriter) -> None:
         if op.destination.type == op.source.type and op.destination.type.is_allocated:
             rewriter.replace_matched_op((), (op.source,))
+
+
+def get_constant_value(value: SSAValue) -> Attribute | None:
+    if not isinstance(value, OpResult):
+        return
+
+    if isinstance(value.op, x86.DS_MovOp):
+        return get_constant_value(value.op.source)
+
+    if isinstance(value.op, x86.DI_MovOp):
+        return value.op.immediate


### PR DESCRIPTION
This helper will be used in canonicalization patterns to fold constants, wanted to add it separately first.