### PR TITLE
core: (Constraints) deprecate `ConstraintVar`

### DIFF
--- a/tests/irdl/test_operation_definition.py
+++ b/tests/irdl/test_operation_definition.py
@@ -168,16 +168,17 @@ def test_attr_verify():
         op.verify()
 
 
-# TODO: remove this test once the Annotated API is deprecated
-@irdl_op_definition
-class ConstraintVarOp(IRDLOperation):
-    name = "test.constraint_var_op"
+with pytest.deprecated_call():
+    # TODO: remove this test once the Annotated API is deprecated
+    @irdl_op_definition
+    class ConstraintVarOp(IRDLOperation):
+        name = "test.constraint_var_op"
 
-    T = Annotated[IntegerType | IndexType, ConstraintVar("T")]
+        T = Annotated[IntegerType | IndexType, ConstraintVar("T")]
 
-    operand = operand_def(T)
-    result = result_def(T)
-    attribute = attr_def(T)
+        operand = operand_def(T)
+        result = result_def(T)
+        attribute = attr_def(T)
 
 
 def test_constraint_var():

--- a/xdsl/irdl/attributes.py
+++ b/xdsl/irdl/attributes.py
@@ -250,9 +250,16 @@ class ParamAttrDef:
                 continue
             if field_name in classvars:
                 continue
-            # Constraint variables are allowed
+            # Constraint variables are deprecated
             if get_origin(value) is Annotated:
                 if any(isinstance(arg, ConstraintVar) for arg in get_args(value)):
+                    import warnings
+
+                    warnings.warn(
+                        "The use of `ConstraintVar` is deprecated, please use `VarConstraint`",
+                        DeprecationWarning,
+                        stacklevel=2,
+                    )
                     continue
             raise PyRDLAttrDefinitionError(
                 f"{field_name} is not a parameter definition."

--- a/xdsl/irdl/operations.py
+++ b/xdsl/irdl/operations.py
@@ -1052,9 +1052,16 @@ class OpDef:
                     value, FunctionType | PropertyType | classmethod | staticmethod
                 ):
                     continue
-                # Constraint variables are allowed
+                # Constraint variables are deprecated
                 if get_origin(value) is Annotated:
                     if any(isinstance(arg, ConstraintVar) for arg in get_args(value)):
+                        import warnings
+
+                        warnings.warn(
+                            "The use of `ConstraintVar` is deprecated, please use `VarConstraint`",
+                            DeprecationWarning,
+                            stacklevel=2,
+                        )
                         continue
 
                 # Get attribute constraints from a list of pyrdl constraints


### PR DESCRIPTION
`param_def` api means that this can finally be scrapped.