### PR TITLE
testing: use match argument for error testing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,6 @@ select = ["E", "F", "W", "I", "UP", "PT", "TID251", "INP", "PYI"]
 ignore = [
     "E741",   # https://beta.ruff.rs/docs/rules/ambiguous-variable-name/
     "PT006",  # https://beta.ruff.rs/docs/rules/pytest-parametrize-names-wrong-type/
-    "PT011",  # https://beta.ruff.rs/docs/rules/pytest-raises-too-broad/
     "PT012",  # https://beta.ruff.rs/docs/rules/pytest-raises-with-multiple-statements/
     "PYI041", # https://docs.astral.sh/ruff/rules/redundant-numeric-union
 ]

--- a/tests/dialects/test_arith.py
+++ b/tests/dialects/test_arith.py
@@ -402,28 +402,26 @@ def test_cmpf_get():
     assert cmpf_op.predicate.value.data == 1
 
 
-def test_cmpf_missmatch_type():
+def test_cmpf_mismatch_type():
     a = ConstantOp(FloatAttr(1.0, f32))
     b = ConstantOp(FloatAttr(2.0, f64))
 
-    with pytest.raises(TypeError) as e:
+    with pytest.raises(
+        TypeError,
+        match="Comparison operands must have same type, but provided f32 and f64",
+    ):
         _cmpf_op = CmpfOp(a, b, 1)
-    assert (
-        e.value.args[0]
-        == "Comparison operands must have same type, but provided f32 and f64"
-    )
 
 
 def test_cmpi_mismatch_type():
     a = ConstantOp.from_int_and_width(1, i32)
     b = ConstantOp.from_int_and_width(2, i64)
 
-    with pytest.raises(TypeError) as e:
+    with pytest.raises(
+        TypeError,
+        match="Comparison operands must have same type, but provided i32 and i64",
+    ):
         _cmpi_op = CmpiOp(a, b, 1)
-    assert (
-        e.value.args[0]
-        == "Comparison operands must have same type, but provided i32 and i64"
-    )
 
 
 def test_cmpf_incorrect_comparison():

--- a/tests/dialects/test_llvm.py
+++ b/tests/dialects/test_llvm.py
@@ -155,7 +155,9 @@ def test_llvm_getelementptr_op_invalid_construction():
     opaque_ptr = llvm.AllocaOp(size, builtin.i32, as_untyped_ptr=True)
 
     # check that passing an opaque pointer to GEP without a pointee type fails
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="Opaque types must have a pointee type passed"
+    ):
         llvm.GEPOp(
             opaque_ptr,
             indices=[1],
@@ -163,7 +165,10 @@ def test_llvm_getelementptr_op_invalid_construction():
         )
 
     # check that non-pointer arguments fail
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError,
+        match="Expected <class 'xdsl.dialects.llvm.LLVMPointerType'> but got SSAValue with type i32.",
+    ):
         llvm.GEPOp(
             size,
             indices=[1],

--- a/tests/dialects/test_pdl.py
+++ b/tests/dialects/test_pdl.py
@@ -211,5 +211,7 @@ def test_empty_range():
 
 
 def test_range_cannot_infer():
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="Empty range constructions require a return type."
+    ):
         pdl.RangeOp(())  # Cannot infer return type

--- a/tests/irdl/test_operation_builder.py
+++ b/tests/irdl/test_operation_builder.py
@@ -56,7 +56,7 @@ def test_result_builder():
 
 
 def test_result_builder_exception():
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Expected 1 result, but got 0"):
         ResultOp.build()
 
 
@@ -80,7 +80,13 @@ def test_opt_result_builder():
 
 
 def test_opt_result_builder_two_args():
-    with pytest.raises(ValueError) as _:
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Error in test.opt_result_op builder: optional VarIRConstruct.RESULT 0 "
+            "'res' expects a list of size at most 1 or None, but got a list of size 2"
+        ),
+    ):
         OptResultOp.build(result_types=[[StringAttr(""), StringAttr("")]])
 
 
@@ -207,7 +213,7 @@ def test_operand_builder_value():
 
 
 def test_operand_builder_exception():
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Expected 1 operand, but got 0"):
         OperandOp.build()
 
 
@@ -230,7 +236,13 @@ def test_opt_operand_builder():
 
 def test_opt_operand_builder_two_args():
     op = ResultOp.build(result_types=[StringAttr("0")])
-    with pytest.raises(ValueError) as _:
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Error in test.opt_operand_op builder: optional VarIRConstruct.OPERAND 0 "
+            "'res' expects a list of size at most 1 or None, but got a list of size 2"
+        ),
+    ):
         OptOperandOp.build(operands=[[op, op]])
 
 
@@ -485,7 +497,13 @@ def test_opt_region_builder():
 
 
 def test_opt_region_builder_two_args():
-    with pytest.raises(ValueError) as _:
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Error in test.opt_region_op builder: optional VarIRConstruct.REGION 0 "
+            "'reg' expects a list of size at most 1 or None, but got a list of size 2"
+        ),
+    ):
         OptRegionOp.build(regions=[[Region(), Region()]])
 
 

--- a/tests/test_dialect_interfaces.py
+++ b/tests/test_dialect_interfaces.py
@@ -30,7 +30,9 @@ def test_op_asm_interface():
     interf.parse_resource(key, "0x0800000002")
     assert interf.lookup(key) == "0x0800000002"
 
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="Blob must be a hex string, got: normal string"
+    ):
         interf.parse_resource("some_key", "normal string")
 
     with pytest.raises(KeyError):

--- a/tests/test_frontend_op_inserter.py
+++ b/tests/test_frontend_op_inserter.py
@@ -10,41 +10,42 @@ from xdsl.ir import Block, Region
 
 def test_raises_exception_on_empty_stack():
     inserter = OpInserter(Block())
-    with pytest.raises(FrontendProgramException) as err:
+    with pytest.raises(
+        FrontendProgramException, match="Trying to get an operand from an empty stack."
+    ):
         inserter.get_operand()
-    assert err.value.msg == "Trying to get an operand from an empty stack."
 
 
 def test_raises_exception_on_op_with_no_regions():
     inserter = OpInserter(Block())
     op_with_no_region = ConstantOp.from_int_and_width(1, i32)
-    with pytest.raises(FrontendProgramException) as err:
+    with pytest.raises(
+        FrontendProgramException,
+        match="Trying to set the insertion point for operation"
+        " 'arith.constant' with no regions.",
+    ):
         inserter.set_insertion_point_from_op(op_with_no_region)
-    assert err.value.msg == (
-        "Trying to set the insertion point for operation"
-        " 'arith.constant' with no regions."
-    )
 
 
 def test_raises_exception_on_op_with_no_blocks():
     inserter = OpInserter(Block())
     op_with_no_region = ForOp.from_region([], [], [], [], 0, 10, Region())
-    with pytest.raises(FrontendProgramException) as err:
+    with pytest.raises(
+        FrontendProgramException,
+        match="Trying to set the insertion point for operation"
+        " 'affine.for' with no blocks in its last region.",
+    ):
         inserter.set_insertion_point_from_op(op_with_no_region)
-    assert err.value.msg == (
-        "Trying to set the insertion point for operation"
-        " 'affine.for' with no blocks in its last region."
-    )
 
 
 def test_raises_exception_on_op_with_no_blocks_II():
     inserter = OpInserter(Block())
     empty_region = Region()
-    with pytest.raises(FrontendProgramException) as err:
+    with pytest.raises(
+        FrontendProgramException,
+        match="Trying to set the insertion point from the region without blocks.",
+    ):
         inserter.set_insertion_point_from_region(empty_region)
-    assert err.value.msg == (
-        "Trying to set the insertion point from the region without blocks."
-    )
 
 
 def test_inserts_ops():

--- a/tests/test_frontend_python_code_check.py
+++ b/tests/test_frontend_python_code_check.py
@@ -68,9 +68,11 @@ a: Const[i32] = 2 ** 5
 a = 34
 """
     stmts = ast.parse(src).body
-    with pytest.raises(CodeGenerationException) as err:
+    with pytest.raises(
+        CodeGenerationException,
+        match="Constant 'a' is already defined and cannot be assigned to.",
+    ):
         CheckAndInlineConstants.run(stmts, __file__)
-    assert err.value.msg == "Constant 'a' is already defined and cannot be assigned to."
 
 
 def test_raises_exception_on_assignemnt_to_const_II():
@@ -81,9 +83,11 @@ def foo():
     return
 """
     stmts = ast.parse(src).body
-    with pytest.raises(CodeGenerationException) as err:
+    with pytest.raises(
+        CodeGenerationException,
+        match="Constant 'x' is already defined.",
+    ):
         CheckAndInlineConstants.run(stmts, __file__)
-    assert err.value.msg == "Constant 'x' is already defined."
 
 
 def test_raises_exception_on_assignemnt_to_const_III():
@@ -96,9 +100,11 @@ def bb0():
 bb0()
 """
     stmts = ast.parse(src).body
-    with pytest.raises(CodeGenerationException) as err:
+    with pytest.raises(
+        CodeGenerationException,
+        match="Constant 'y' is already defined and cannot be assigned to.",
+    ):
         CheckAndInlineConstants.run(stmts, __file__)
-    assert err.value.msg == "Constant 'y' is already defined and cannot be assigned to."
 
 
 def test_raises_exception_on_assignemnt_to_const_IV():
@@ -111,12 +117,14 @@ def foo(x: i32):
     bb0(x)
 """
     stmts = ast.parse(src).body
-    with pytest.raises(CodeGenerationException) as err:
+    with pytest.raises(
+        CodeGenerationException,
+        match=(
+            "Constant 'z' is already defined and cannot be used as a function/block "
+            "argument name."
+        ),
+    ):
         CheckAndInlineConstants.run(stmts, __file__)
-    assert (
-        err.value.msg
-        == "Constant 'z' is already defined and cannot be used as a function/block argument name."
-    )
 
 
 def test_raises_exception_on_duplicate_const():
@@ -125,9 +133,11 @@ z: Const[i32] = 100
 z: Const[i32] = 2
 """
     stmts = ast.parse(src).body
-    with pytest.raises(CodeGenerationException) as err:
+    with pytest.raises(
+        CodeGenerationException,
+        match="Constant 'z' is already defined.",
+    ):
         CheckAndInlineConstants.run(stmts, __file__)
-    assert err.value.msg == "Constant 'z' is already defined."
 
 
 def test_raises_exception_on_evaluation_error_I():
@@ -135,12 +145,14 @@ def test_raises_exception_on_evaluation_error_I():
 z: Const[i32] = 23 / 0
 """
     stmts = ast.parse(src).body
-    with pytest.raises(CodeGenerationException) as err:
+    with pytest.raises(
+        CodeGenerationException,
+        match=(
+            "Non-constant expression cannot be assigned to constant variable 'z' or "
+            "cannot be evaluated."
+        ),
+    ):
         CheckAndInlineConstants.run(stmts, __file__)
-    assert (
-        err.value.msg
-        == "Non-constant expression cannot be assigned to constant variable 'z' or cannot be evaluated."
-    )
 
 
 def test_raises_exception_on_evaluation_error_II():
@@ -148,9 +160,11 @@ def test_raises_exception_on_evaluation_error_II():
 a: Const[i32] = x + 12
 """
     stmts = ast.parse(src).body
-    with pytest.raises(CodeGenerationException) as err:
+    with pytest.raises(
+        CodeGenerationException,
+        match=(
+            "Non-constant expression cannot be assigned to constant variable 'a' or "
+            "cannot be evaluated."
+        ),
+    ):
         CheckAndInlineConstants.run(stmts, __file__)
-    assert (
-        err.value.msg
-        == "Non-constant expression cannot be assigned to constant variable 'a' or cannot be evaluated."
-    )

--- a/tests/test_immutable_list.py
+++ b/tests/test_immutable_list.py
@@ -14,7 +14,7 @@ def test_append_to_frozen():
     i, j, k = 1, 2, 3
     list: IList[int] = IList([i, j])
     list.freeze()
-    with pytest.raises(Exception):
+    with pytest.raises(Exception, match="frozen list can not be modified"):
         list.append(k)
 
 
@@ -31,7 +31,7 @@ def test_extend_frozen():
     list0: IList[int] = IList([i, j, k])
     list1: IList[int] = IList([i, j, k])
     list0.freeze()
-    with pytest.raises(Exception):
+    with pytest.raises(Exception, match="frozen list can not be modified"):
         list0.extend(list1)
 
 
@@ -46,7 +46,7 @@ def test_insert_frozen():
     i, j, k = 1, 2, 3
     list: IList[int] = IList([i, j])
     list.freeze()
-    with pytest.raises(Exception):
+    with pytest.raises(Exception, match="frozen list can not be modified"):
         list.insert(1, k)
 
 
@@ -61,7 +61,7 @@ def test_remove_frozen():
     i, j, k = 1, 2, 3
     list: IList[int] = IList([i, j, k])
     list.freeze()
-    with pytest.raises(Exception):
+    with pytest.raises(Exception, match="frozen list can not be modified"):
         list.remove(k)
 
 
@@ -76,7 +76,7 @@ def test_pop_frozen():
     i, j, k = 1, 2, 3
     list: IList[int] = IList([i, j, k])
     list.freeze()
-    with pytest.raises(Exception):
+    with pytest.raises(Exception, match="frozen list can not be modified"):
         list.pop(-1)
 
 
@@ -91,7 +91,7 @@ def test_clear_frozen():
     i, j, k = 1, 2, 3
     list: IList[int] = IList([i, j, k])
     list.freeze()
-    with pytest.raises(Exception):
+    with pytest.raises(Exception, match="frozen list can not be modified"):
         list.clear()
 
 
@@ -106,7 +106,7 @@ def test_setitem_frozen():
     i, j, k = 1, 2, 3
     list: IList[int] = IList([i, j, k])
     list.freeze()
-    with pytest.raises(Exception):
+    with pytest.raises(Exception, match="frozen list can not be modified"):
         list[1] = 4
 
 
@@ -121,7 +121,7 @@ def test_delitem_frozen():
     i, j, k = 1, 2, 3
     list: IList[int] = IList([i, j, k])
     list.freeze()
-    with pytest.raises(Exception):
+    with pytest.raises(Exception, match="frozen list can not be modified"):
         del list[1]
 
 
@@ -156,7 +156,7 @@ def test_iadd_frozen():
     list0: IList[int] = IList([i, j])
     list1: IList[int] = IList([k])
     list0.freeze()
-    with pytest.raises(Exception):
+    with pytest.raises(Exception, match="frozen list can not be modified"):
         list0 += list1
 
 

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -44,10 +44,8 @@ def test_import_functions():
 
     i.register_implementations(B())
 
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(ValueError, match="Use `@register_impls` on class A"):
         i.register_implementations(A())
-
-    assert e.value.args[0] == "Use `@register_impls` on class A"
 
 
 def test_cast():

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -930,18 +930,19 @@ class CustomVerifyOp(IRDLOperation):
 def test_op_custom_verify_is_called():
     a = ConstantOp.from_int_and_width(1, i64)
     b = CustomVerifyOp.get(a.result)
-    with pytest.raises(Exception) as e:
+    with pytest.raises(Exception, match="Custom Verification Check"):
         b.verify()
-    assert e.value.args[0] == "Custom Verification Check"
 
 
 def test_op_custom_verify_is_done_last():
     a = ConstantOp.from_int_and_width(1, i32)
     # CustomVerify expects a i64, not i32
     b = CustomVerifyOp.get(a.result)
-    with pytest.raises(VerifyException) as e:
+    with pytest.raises(
+        VerifyException,
+        match="operand at position 0 does not verify:\nExpected attribute i64 but got i32",
+    ):
         b.verify()
-    assert "Custom Verification Check" not in e.value.args[0]
 
 
 def test_block_walk():

--- a/tests/test_op_builder.py
+++ b/tests/test_op_builder.py
@@ -320,7 +320,10 @@ def test_build_nested_implicit_region():
 
 
 def test_build_implicit_region_fail():
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(
+        ValueError,
+        match="Cannot insert operation explicitly when an implicit builder exists.",
+    ):
         one = IntAttr(1)
         two = IntAttr(2)
         three = IntAttr(3)
@@ -344,6 +347,3 @@ def test_build_implicit_region_fail():
             IfOp(cond, (), then_0)
 
         _ = region
-    assert e.value.args[0] == (
-        "Cannot insert operation explicitly when an implicit builder exists."
-    )

--- a/tests/test_rewriter.py
+++ b/tests/test_rewriter.py
@@ -479,7 +479,10 @@ def test_erase_op():
 
     rewrite_and_compare(prog, expected, transformation_unsafe)
 
-    with pytest.raises(Exception):
+    with pytest.raises(
+        Exception,
+        match="Attempting to delete SSA value that still has uses",
+    ):
         rewrite_and_compare(prog, expected, transformation_safe)
 
 

--- a/tests/test_ssa_value.py
+++ b/tests/test_ssa_value.py
@@ -18,7 +18,9 @@ class TwoResultOp(IRDLOperation):
 def test_var_mixed_builder():
     op = TwoResultOp.build(result_types=[StringAttr("0"), StringAttr("2")])
 
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="SSAValue.get: expected operation with a single result."
+    ):
         _ = SSAValue.get(op)
 
 
@@ -59,7 +61,7 @@ def test_invalid_ssa_vals(name: str):
     structured.
     """
     val = BlockArgument(i32, Block(), 0)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Invalid SSA Value name format"):
         val.name_hint = name
 
 

--- a/tests/test_traits.py
+++ b/tests/test_traits.py
@@ -59,7 +59,7 @@ from xdsl.traits import (
     SymbolTable,
     is_speculatable,
 )
-from xdsl.utils.exceptions import VerifyException
+from xdsl.utils.exceptions import PyRDLOpDefinitionError, VerifyException
 from xdsl.utils.test_value import create_ssa_value
 
 
@@ -221,7 +221,13 @@ class WrongTraitsType(IRDLOperation):
 
 
 def test_traits_wrong_type():
-    with pytest.raises(Exception):
+    with pytest.raises(
+        PyRDLOpDefinitionError,
+        match=(
+            "pyrdl operation definition 'WrongTraitsType' traits field should be an "
+            "instance of'OpTraits'."
+        ),
+    ):
         irdl_op_definition(WrongTraitsType)
 
 


### PR DESCRIPTION
I think this is a nice linting error. I also moved the message testing to the match clause, which is important for when the exception type is not initialised with just a string.