### PR TITLE
dialects: (builtin) make `type` positional in IntegerAttr.constr

### DIFF
--- a/tests/filecheck/utils/codegen/simple.py
+++ b/tests/filecheck/utils/codegen/simple.py
@@ -156,7 +156,7 @@ ops = [
             name="test.properties",
             properties={
                 "int_attr": PropertyDef(
-                    IntegerAttr.constr(type=EqAttrConstraint(IntegerType(16)))
+                    IntegerAttr.constr(EqAttrConstraint(IntegerType(16)))
                 ),
                 "in": PropertyDef(AnyAttr()),
             },

--- a/tests/xdsl_tblgen/test.py
+++ b/tests/xdsl_tblgen/test.py
@@ -45,7 +45,7 @@ class Test_AnyAttrOfOp(IRDLOperation):
     attr = prop_def(
         AnyOf(
             [
-                IntegerAttr.constr(type=EqAttrConstraint(IntegerType(32))),
+                IntegerAttr.constr(EqAttrConstraint(IntegerType(32))),
                 BaseAttr(StringAttr),
             ]
         )
@@ -56,7 +56,7 @@ class Test_AnyAttrOfOp(IRDLOperation):
 class Test_AnyAttrOfSingleOp(IRDLOperation):
     name = "test.any_attr_of_i32"
 
-    attr = prop_def(AnyOf([IntegerAttr.constr(type=EqAttrConstraint(IntegerType(32)))]))
+    attr = prop_def(AnyOf([IntegerAttr.constr(EqAttrConstraint(IntegerType(32)))]))
 
 
 @irdl_op_definition
@@ -91,7 +91,7 @@ class Test_AssemblyFormatLong(IRDLOperation):
 class Test_AttributesOp(IRDLOperation):
     name = "test.attributes"
 
-    int_attr = prop_def(IntegerAttr.constr(type=EqAttrConstraint(IntegerType(16))))
+    int_attr = prop_def(IntegerAttr.constr(EqAttrConstraint(IntegerType(16))))
 
     in_ = prop_def(BaseAttr(Test_TestAttr), prop_name="in")
 

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -134,7 +134,7 @@ class ConstantOp(IRDLOperation):
     result = result_def(_T)
     value = prop_def(
         TypedAttributeConstraint(
-            IntegerAttr.constr(type=SignlessIntegerConstraint | IndexTypeConstr)
+            IntegerAttr.constr(SignlessIntegerConstraint | IndexTypeConstr)
             | BaseAttr(FloatAttr)
             | BaseAttr(DenseIntOrFPElementsAttr)
             | BaseAttr(DenseResourceAttr),

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -881,9 +881,9 @@ class IntegerAttr(
 
     @staticmethod
     def constr(
+        type: GenericAttrConstraint[_IntegerAttrType] = IntegerAttrTypeConstr,
         *,
         value: AttrConstraint | IntConstraint | None = None,
-        type: GenericAttrConstraint[_IntegerAttrType] = IntegerAttrTypeConstr,
     ) -> GenericAttrConstraint[IntegerAttr[_IntegerAttrType]]:
         if value is None and type == AnyAttr():
             return BaseAttr[IntegerAttr[_IntegerAttrType]](IntegerAttr)

--- a/xdsl/tools/xdsl_tblgen.py
+++ b/xdsl/tools/xdsl_tblgen.py
@@ -319,7 +319,7 @@ class TblgenLoader:
                 return "BaseAttr(BoolAttr)"
             case "IndexAttr":
                 return textwrap.dedent("""
-                IntegerAttr.constr(type=IndexTypeConstr)
+                IntegerAttr.constr(IndexTypeConstr)
                 """)
 
             case "APIntAttr":
@@ -350,7 +350,7 @@ class TblgenLoader:
             or "UnsignedIntegerAttrBase" in rec.superclasses
         ):
             return textwrap.dedent(f"""
-            IntegerAttr.constr(type={self._resolve_type_constraint(rec["valueType"]["def"])})
+            IntegerAttr.constr({self._resolve_type_constraint(rec["valueType"]["def"])})
             """)
 
         if "FloatAttrBase" in rec.superclasses:


### PR DESCRIPTION
Based on #4785, it seems like prioritising a single parameter to be positional is ergonomic. I propose here making the `type` parameter of `IntegerAttr` positional, as it is by far the most used.