### PR TITLE
core: (ParametrizedAttribute) add `ParamDef` for "resolved" fields

### DIFF
--- a/tests/irdl/test_attribute_definition.py
+++ b/tests/irdl/test_attribute_definition.py
@@ -49,6 +49,7 @@ from xdsl.irdl import (
     MessageConstraint,
     ParamAttrConstraint,
     ParamAttrDef,
+    ParamDef,
     TypeVarConstraint,
     VarConstraint,
     base,
@@ -791,7 +792,8 @@ class ParamAttrDefAttr(ParametrizedAttribute):
 def test_irdl_definition():
     """Test that we can get the IRDL definition of a parametrized attribute."""
     assert ParamAttrDefAttr.get_irdl_definition() == ParamAttrDef(
-        "test.param_attr_def_attr", [("arg1", AnyAttr()), ("arg2", BaseAttr(BoolData))]
+        "test.param_attr_def_attr",
+        [("arg1", ParamDef(AnyAttr())), ("arg2", ParamDef(BaseAttr(BoolData)))],
     )
 
 
@@ -819,7 +821,10 @@ def test_irdl_definition2():
 
     assert ParamAttrDefAttr2.get_irdl_definition() == ParamAttrDef(
         "test.param_attr_def_attr",
-        [("arg1", AnyAttr() & BaseAttr(IntAttr)), ("arg2", BaseAttr(BoolData))],
+        [
+            ("arg1", ParamDef(AnyAttr() & BaseAttr(IntAttr))),
+            ("arg2", ParamDef(BaseAttr(BoolData))),
+        ],
     )
 
 
@@ -893,9 +898,11 @@ def test_generic_attr():
         [
             (
                 "param",
-                TypeVarConstraint(
-                    type_var=AttributeInvT,
-                    base_constraint=AnyAttr(),
+                ParamDef(
+                    TypeVarConstraint(
+                        type_var=AttributeInvT,
+                        base_constraint=AnyAttr(),
+                    )
                 ),
             )
         ],

--- a/xdsl/dialects/irdl/pyrdl_to_irdl.py
+++ b/xdsl/dialects/irdl/pyrdl_to_irdl.py
@@ -116,7 +116,7 @@ def attr_def_to_irdl(
     param_values: list[SSAValue] = []
     names: list[StringAttr] = []
     for param in attr_def.parameters:
-        param_values.append(constraint_to_irdl(builder, param[1]))
+        param_values.append(constraint_to_irdl(builder, param[1].constr))
         names.append(StringAttr(depython_name(param[0])))
     builder.insert(ParametersOp(param_values, ArrayAttr(names)))
 

--- a/xdsl/interpreters/irdl.py
+++ b/xdsl/interpreters/irdl.py
@@ -21,6 +21,7 @@ from xdsl.irdl import (
     OperandDef,
     ParamAttrConstraint,
     ParamAttrDef,
+    ParamDef,
     ResultDef,
     VarConstraint,
     get_accessors_from_op_def,
@@ -211,7 +212,7 @@ class IRDLFunctions(InterpreterFunctions):
         attr_op = cast(irdl.AttributeOp | irdl.TypeOp, op.parent_op())
         attr_name = attr_op.qualified_name
         self._get_attr_def(interpreter, attr_name).parameters = list(
-            (python_name(name.data), a) for name, a in zip(op.names, args)
+            (python_name(name.data), ParamDef(a)) for name, a in zip(op.names, args)
         )
         return ()
 

--- a/xdsl/irdl/attributes.py
+++ b/xdsl/irdl/attributes.py
@@ -17,6 +17,7 @@ from typing import (
     ClassVar,
     Generic,
     Literal,
+    NamedTuple,
     TypeAlias,
     Union,
     cast,
@@ -154,12 +155,21 @@ _PARAMETRIZED_ATTRIBUTE_DICT_KEYS = {
 _IGNORED_PARAM_ATTR_FIELD_TYPES = set(("name", "parameters"))
 
 
+class ParamDef(NamedTuple):
+    """
+    Contains information about a parameter,
+    effectively acting as a resolved `_ParameterDef`
+    """
+
+    constr: AttrConstraint
+
+
 @dataclass
 class ParamAttrDef:
     """The IRDL definition of a parametrized attribute."""
 
     name: str
-    parameters: list[tuple[str, AttrConstraint]]
+    parameters: list[tuple[str, ParamDef]]
 
     @staticmethod
     def from_pyrdl(
@@ -208,7 +218,7 @@ class ParamAttrDef:
         }
 
         # The resulting parameters
-        parameters: dict[str, AttrConstraint] = {}
+        parameters: dict[str, ParamDef] = {}
 
         for field_name, field_type in field_types.items():
             if is_classvar(field_type):
@@ -254,7 +264,7 @@ class ParamAttrDef:
                         f"{field_name} is not a parameter definition."
                     )
 
-            parameters[field_name] = constraint
+            parameters[field_name] = ParamDef(constraint)
 
         for field_name, value in field_values.items():
             # Anything left is a field without an annotation or a constaint var.
@@ -280,7 +290,7 @@ class ParamAttrDef:
 
         constraint_context = ConstraintContext()
         for field, param_def in self.parameters:
-            param_def.verify(getattr(attr, field), constraint_context)
+            param_def.constr.verify(getattr(attr, field), constraint_context)
 
 
 _PAttrTT = TypeVar("_PAttrTT", bound=type[ParametrizedAttribute])
@@ -511,9 +521,9 @@ def irdl_to_attr_constraint(
         origin_parameters = attr_def.parameters
 
         origin_constraints = [
-            irdl_to_attr_constraint(param, allow_type_var=True).mapping_type_vars(
-                type_var_mapping
-            )
+            irdl_to_attr_constraint(
+                param.constr, allow_type_var=True
+            ).mapping_type_vars(type_var_mapping)
             for _, param in origin_parameters
         ]
         return cast(

--- a/xdsl/utils/dialect_stub.py
+++ b/xdsl/utils/dialect_stub.py
@@ -136,7 +136,7 @@ class DialectStubGenerator:
         # Generate the parameters' stubs, if any
         attr_def = attr.get_irdl_definition()
         for name, param in attr_def.parameters:
-            yield f'    {name} : "{self._generate_constraint_type(param)}"'
+            yield f'    {name} : "{self._generate_constraint_type(param.constr)}"'
         # Otherwise, generate a pass for Python's indentation
         if not attr_def.parameters:
             yield "    pass"


### PR DESCRIPTION
As suggested in #4755, adds a named tuple for holding information on a parameter. In the future this will hold a converter and possibly default values (if this makes sense).