### PR TITLE
dialects: (tensor) Fix ExpandShapeOp parsing

### DIFF
--- a/tests/filecheck/dialects/tensor/ops.mlir
+++ b/tests/filecheck/dialects/tensor/ops.mlir
@@ -25,9 +25,9 @@
 // CHECK-NEXT:   %insert1 = tensor.insert %extract1 into %tensor[%index, %index1] : tensor<?x?xf32>
 // CHECK-NEXT:   %fromelements = tensor.from_elements %index, %index1 : tensor<2xindex>
 // CHECK-NEXT:   %res_collapse1 = tensor.collapse_shape %tensor [[0 : i64, 1 : i64], [2 : i64]] : tensor<?x?xf32> into tensor<4x1xf32>
-// CHECK-NEXT:   %expanded = tensor.expand_shape %tensor [[0 : i64, 1 : i64, 2 : i64], [3 : i64]] static_output_shape [%dim1, 1, 1, %dim2] : tensor<?x?xf32> into tensor<?x1x1x?xf32>
-// CHECK-NEXT:   %expanded_with_attr_dict = tensor.expand_shape %tensor [[0 : i64, 1 : i64, 2 : i64], [3 : i64]] static_output_shape [%dim1, 1, 1, %dim2] {test_attr = 42 : i8} : tensor<?x?xf32> into tensor<?x1x1x?xf32>
-// CHECK-NEXT:   %expanded_generic = tensor.expand_shape %tensor [[0 : i64, 1 : i64, 2 : i64], [3 : i64]] static_output_shape [%dim1, 1, 1, %dim2] : tensor<?x?xf32> into tensor<?x1x1x?xf32>
+// CHECK-NEXT:   %expanded = tensor.expand_shape %tensor [[0 : i64, 1 : i64, 2 : i64], [3 : i64]] output_shape [%dim1, 1, 1, %dim2] : tensor<?x?xf32> into tensor<?x1x1x?xf32>
+// CHECK-NEXT:   %expanded_with_attr_dict = tensor.expand_shape %tensor [[0 : i64, 1 : i64, 2 : i64], [3 : i64]] output_shape [%dim1, 1, 1, %dim2] {test_attr = 42 : i8} : tensor<?x?xf32> into tensor<?x1x1x?xf32>
+// CHECK-NEXT:   %expanded_generic = tensor.expand_shape %tensor [[0 : i64, 1 : i64, 2 : i64], [3 : i64]] output_shape [%dim1, 1, 1, %dim2] : tensor<?x?xf32> into tensor<?x1x1x?xf32>
 // CHECK-NEXT: }
 
 // CHECK-GENERIC: "builtin.module"() ({

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/tensor/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/tensor/ops.mlir
@@ -18,6 +18,11 @@
 %extracted = tensor.extract %t2[%i1] : tensor<2xf32>
 %tensor_with_ins = tensor.insert %extracted into %t2[%i1] : tensor<2xf32>
 %fromelements = tensor.from_elements %i1, %i1: tensor<2xindex>
+%index, %index1, %tensor = "test.op"() : () -> (index, index, tensor<?x?xf32>)
+%expanded = tensor.expand_shape %tensor [[0, 1, 2], [3]] output_shape [%dim1, 1, 1, %dim2] : tensor<?x?xf32> into tensor<?x1x1x?xf32>
+%expanded_with_attr_dict = tensor.expand_shape %tensor [[0, 1, 2], [3]] output_shape [%dim1, 1, 1, %dim2] {test_attr = 42 : i8} : tensor<?x?xf32> into tensor<?x1x1x?xf32>
+%expanded_generic = "tensor.expand_shape"(%tensor, %dim1, %dim2) <{reassociation = [[0 : i64, 1 : i64, 2 : i64], [3 : i64]], static_output_shape = array<i64: -9223372036854775808, 1, 1, -9223372036854775808>}> : (tensor<?x?xf32>, index, index) -> tensor<?x1x1x?xf32>
+
 
 
 // CHECK:       module {
@@ -39,4 +44,8 @@
 // CHECK-NEXT:  %extracted = tensor.extract %1[%2] : tensor<2xf32>
 // CHECK-NEXT:  %{{.*}} = tensor.insert %extracted into %1[%2] : tensor<2xf32>
 // CHECK-NEXT:  %{{.*}} = tensor.from_elements %2, %2 : tensor<2xindex>
+// CHECK-NEXT:  %7:3 = "test.op"() : () -> (index, index, tensor<?x?xf32>)
+// CHECK-NEXT:  %expanded = tensor.expand_shape %7#2 [[0, 1, 2], [3]] output_shape [%dim, 1, 1, %dim_0] : tensor<?x?xf32> into tensor<?x1x1x?xf32>
+// CHECK-NEXT:  %expanded_2 = tensor.expand_shape %7#2 [[0, 1, 2], [3]] output_shape [%dim, 1, 1, %dim_0] {test_attr = 42 : i8} : tensor<?x?xf32> into tensor<?x1x1x?xf32>
+// CHECK-NEXT:  %expanded_3 = tensor.expand_shape %7#2 [[0, 1, 2], [3]] output_shape [%dim, 1, 1, %dim_0] : tensor<?x?xf32> into tensor<?x1x1x?xf32>
 // CHECK-NEXT: }

--- a/xdsl/dialects/tensor.py
+++ b/xdsl/dialects/tensor.py
@@ -394,7 +394,7 @@ class ExpandShapeOp(IRDLOperation):
         printer.print_ssa_value(self.src)
         printer.print_string(" ")
         printer.print_attribute(self.reassociation)
-        printer.print_string(" static_output_shape ")
+        printer.print_string(" output_shape ")
         print_dynamic_index_list(
             printer,
             self.DYNAMIC_INDEX,


### PR DESCRIPTION
and add MLIR tests for the expand shape op

Fixes: e5ae7c81f2479619238badaebecb5de929f19094

#4245 was missing MLIR xdsl to MLIR and back checks so the broken parsing of the expand shape op was not caught
