### PR TITLE
dialects: (x86) move from register and immediate are pure

### DIFF
--- a/tests/filecheck/dialects/x86/canonicalize.mlir
+++ b/tests/filecheck/dialects/x86/canonicalize.mlir
@@ -13,10 +13,9 @@
 %o2 = x86.ds.mov %i2 : (!x86.reg) -> !x86.reg
 "test.op"(%o0, %o1, %o2) : (!x86.reg<rdi>, !x86.reg<rdx>, !x86.reg) -> ()
 
-// CHECK-NEXT:    %c0 = x86.di.mov 0 : () -> !x86.reg
-// CHECK-NEXT:    "test.op"(%c0) : (!x86.reg) -> ()
+// Unused constants get optimized out
 %c0 = x86.di.mov 0 : () -> !x86.reg
-"test.op"(%c0) : (!x86.reg) -> ()
+%c0_0 = x86.ds.mov %c0 : (!x86.reg) -> !x86.reg
 
 // CHECK-NEXT:    "test.op"(%i0) : (!x86.reg<rdi>) -> ()
 %add_immediate_zero_reg = x86.rs.add %i0, %c0 : (!x86.reg<rdi>, !x86.reg) -> !x86.reg<rdi>

--- a/xdsl/dialects/x86/ops.py
+++ b/xdsl/dialects/x86/ops.py
@@ -1128,7 +1128,7 @@ class DS_MovOp(DS_Operation[X86RegisterType, GeneralRegisterType]):
 
     name = "x86.ds.mov"
 
-    traits = traits_def(DS_MovOpHasCanonicalizationPatterns())
+    traits = traits_def(Pure(), DS_MovOpHasCanonicalizationPatterns())
 
 
 @irdl_op_definition
@@ -1573,6 +1573,8 @@ class DI_MovOp(DI_Operation[GeneralRegisterType]):
     """
 
     name = "x86.di.mov"
+
+    traits = traits_def(Pure())
 
 
 @irdl_op_definition


### PR DESCRIPTION
If the output of a mov is not used, we can remove it.