### PR TITLE
WIP: core:(assembly-format) allow empty region blocks to be optional in assembly format

### DIFF
--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -930,6 +930,12 @@ class RegionVariable(RegionDirective, VariableDirective):
         state.last_was_punctuation = False
         state.should_emit_space = True
 
+    def is_anchorable(self) -> bool:
+        return True
+
+    def set_empty(self, state: ParsingState):
+        state.regions[self.index] = Region()
+
 
 @dataclass(frozen=True)
 class VariadicRegionVariable(RegionDirective, VariadicVariable):


### PR DESCRIPTION
This allows non-optional regions to be anchorable by treating missing regions as empty.

As far as I can tell this is consistent with upstream.

