### PR TITLE
dialects: (x86) store and load at constant offset canonicalization pattern

### DIFF
--- a/tests/filecheck/dialects/x86/canonicalize.mlir
+++ b/tests/filecheck/dialects/x86/canonicalize.mlir
@@ -16,9 +16,23 @@
 // Unused constants get optimized out
 %c0 = x86.di.mov 0 : () -> !x86.reg
 %c0_0 = x86.ds.mov %c0 : (!x86.reg) -> !x86.reg
+%c32 = x86.di.mov 32 : () -> !x86.reg
 
 // CHECK-NEXT:    "test.op"(%i0) : (!x86.reg<rdi>) -> ()
 %add_immediate_zero_reg = x86.rs.add %i0, %c0 : (!x86.reg<rdi>, !x86.reg) -> !x86.reg<rdi>
 "test.op"(%add_immediate_zero_reg) : (!x86.reg<rdi>) -> ()
+
+// Constant memory offsets get optimized out
+%offset_ptr = x86.rs.add %i0, %c32 : (!x86.reg<rdi>, !x86.reg) -> !x86.reg<rdi>
+
+// CHECK-NEXT:     %rm_mov = x86.dm.mov %i0, 40 : (!x86.reg<rdi>) -> !x86.reg<rax>
+// CHECK-NEXT:     x86.ms.mov %i0, %rm_mov, 40 : (!x86.reg<rdi>, !x86.reg<rax>) -> ()
+%rm_mov = x86.dm.mov %offset_ptr, 8 : (!x86.reg<rdi>) -> !x86.reg<rax>
+x86.ms.mov %offset_ptr, %rm_mov, 8 : (!x86.reg<rdi>, !x86.reg<rax>) -> ()
+
+// CHECK-NEXT:     %avx = x86.dm.vmovupd %i0, 64 : (!x86.reg<rdi>) -> !x86.avx2reg<ymm1>
+// CHECK-NEXT:     x86.ms.vmovapd %i0, %avx, 64 : (!x86.reg<rdi>, !x86.avx2reg<ymm1>) -> ()
+%avx = x86.dm.vmovupd %offset_ptr, 32 : (!x86.reg<rdi>) -> !x86.avx2reg<ymm1>
+x86.ms.vmovapd %offset_ptr, %avx, 32 : (!x86.reg<rdi>, !x86.avx2reg<ymm1>) -> ()
 
 // CHECK-NEXT:  }

--- a/xdsl/dialects/x86/ops.py
+++ b/xdsl/dialects/x86/ops.py
@@ -415,6 +415,16 @@ class RM_Operation(
         )
 
 
+class DM_OperationHasCanonicalizationPatterns(HasCanonicalizationPatternsTrait):
+    @classmethod
+    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+        from xdsl.transforms.canonicalization_patterns.x86 import (
+            DM_Operation_ConstantOffset,
+        )
+
+        return (DM_Operation_ConstantOffset(),)
+
+
 class DM_Operation(
     Generic[R1InvT, R2InvT], X86Instruction, X86CustomFormatOperation, ABC
 ):
@@ -425,6 +435,8 @@ class DM_Operation(
     destination = result_def(R1InvT)
     memory = operand_def(R2InvT)
     memory_offset = attr_def(IntegerAttr, default_value=IntegerAttr(0, 64))
+
+    traits = traits_def(DM_OperationHasCanonicalizationPatterns())
 
     def __init__(
         self,
@@ -570,6 +582,16 @@ class RI_Operation(Generic[R1InvT], X86Instruction, X86CustomFormatOperation, AB
         return RegisterConstraints((), (), ((self.register_in, self.register_out),))
 
 
+class MS_OperationHasCanonicalizationPatterns(HasCanonicalizationPatternsTrait):
+    @classmethod
+    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+        from xdsl.transforms.canonicalization_patterns.x86 import (
+            MS_Operation_ConstantOffset,
+        )
+
+        return (MS_Operation_ConstantOffset(),)
+
+
 class MS_Operation(
     Generic[R1InvT, R2InvT], X86Instruction, X86CustomFormatOperation, ABC
 ):
@@ -581,6 +603,8 @@ class MS_Operation(
     memory = operand_def(R1InvT)
     memory_offset = attr_def(IntegerAttr, default_value=IntegerAttr(0, 64))
     source = operand_def(R2InvT)
+
+    traits = traits_def(MS_OperationHasCanonicalizationPatterns())
 
     def __init__(
         self,

--- a/xdsl/transforms/canonicalization_patterns/x86.py
+++ b/xdsl/transforms/canonicalization_patterns/x86.py
@@ -1,6 +1,9 @@
+from typing import cast
+
 from xdsl.dialects import x86
 from xdsl.dialects.builtin import IntegerAttr
-from xdsl.ir import OpResult, SSAValue
+from xdsl.dialects.x86.register import X86RegisterType
+from xdsl.ir import Operation, OpResult, SSAValue
 from xdsl.pattern_rewriter import (
     PatternRewriter,
     RewritePattern,
@@ -23,6 +26,36 @@ class RS_Add_Zero(RewritePattern):
         ) is not None and value.value.data == 0:
             # The register would be updated in-place, so no need to move
             rewriter.replace_matched_op((), (op.register_in,))
+
+
+class MS_Operation_ConstantOffset(RewritePattern):
+    def match_and_rewrite(self, op: Operation, rewriter: PatternRewriter) -> None:
+        if (
+            isinstance(op, x86.ops.MS_Operation)
+            and isinstance(add_op := op.memory.owner, x86.RS_AddOp)
+            and ((value := get_constant_value(add_op.source)) is not None)
+        ):
+            op = cast(x86.ops.MS_Operation[X86RegisterType, X86RegisterType], op)
+            new_offset = op.memory_offset.value.data + value.value.data
+            rewriter.replace_matched_op(
+                type(op)(add_op.register_in, op.source, new_offset)
+            )
+
+
+class DM_Operation_ConstantOffset(RewritePattern):
+    def match_and_rewrite(self, op: Operation, rewriter: PatternRewriter) -> None:
+        if (
+            isinstance(op, x86.ops.DM_Operation)
+            and isinstance(add_op := op.memory.owner, x86.RS_AddOp)
+            and ((value := get_constant_value(add_op.source)) is not None)
+        ):
+            op = cast(x86.ops.DM_Operation[X86RegisterType, X86RegisterType], op)
+            new_offset = op.memory_offset.value.data + value.value.data
+            rewriter.replace_matched_op(
+                type(op)(
+                    add_op.register_in, new_offset, destination=op.destination.type
+                )
+            )
 
 
 def get_constant_value(value: SSAValue) -> IntegerAttr | None:


### PR DESCRIPTION
Added the patterns to the abstract superclass ops, seems safe to me for now but I'm not 100% sure the rules are the same for all memory operations.