### PR TITLE
core: (SymbolNameConstraint) add assembly format symbol names

### DIFF
--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -21,7 +21,7 @@ from xdsl.dialects.builtin import (
     MemRefType,
     ModuleOp,
     StringAttr,
-    SymbolNameConstr,
+    SymbolNameConstraint,
     UnitAttr,
     i32,
 )
@@ -724,8 +724,8 @@ def test_symbol_name_variable(program: str, generic_program: str):
     class SymbolNameOp(IRDLOperation):
         name = "test.symbol"
 
-        sym_name = prop_def(SymbolNameConstr())
-        attr_sym_name = attr_def(SymbolNameConstr())
+        sym_name = prop_def(SymbolNameConstraint())
+        attr_sym_name = attr_def(SymbolNameConstraint())
 
         assembly_format = "$sym_name $attr_sym_name attr-dict"
 
@@ -755,9 +755,9 @@ def test_optional_symbol_name_variable(program: str, generic_program: str):
     class SymbolNameOp(IRDLOperation):
         name = "test.symbol"
 
-        sym_name = opt_prop_def(SymbolNameConstr())
+        sym_name = opt_prop_def(SymbolNameConstraint())
 
-        other_sym_name = opt_prop_def(SymbolNameConstr())
+        other_sym_name = opt_prop_def(SymbolNameConstraint())
 
         assembly_format = "$other_sym_name (`symbol` $sym_name^)? attr-dict"
 

--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -21,6 +21,7 @@ from xdsl.dialects.builtin import (
     MemRefType,
     ModuleOp,
     StringAttr,
+    SymbolNameConstr,
     UnitAttr,
     i32,
 )
@@ -699,6 +700,69 @@ def test_typed_attribute_variable(program: str, generic_program: str):
 
     ctx = Context()
     ctx.load_op(TypedAttributeOp)
+    ctx.load_dialect(Test)
+
+    check_roundtrip(program, ctx)
+    check_equivalence(program, generic_program, ctx)
+
+
+@pytest.mark.parametrize(
+    "program, generic_program",
+    [
+        (
+            "test.symbol @test @test2",
+            '"test.symbol"() <{sym_name = "test"}> {attr_sym_name = "test2"} : () -> ()',
+        ),
+        (
+            'test.symbol @"123" @"456"',
+            '"test.symbol"() <{sym_name = "123"}> {attr_sym_name = "456"} : () -> ()',
+        ),
+    ],
+)
+def test_symbol_name_variable(program: str, generic_program: str):
+    @irdl_op_definition
+    class SymbolNameOp(IRDLOperation):
+        name = "test.symbol"
+
+        sym_name = prop_def(SymbolNameConstr())
+        attr_sym_name = attr_def(SymbolNameConstr())
+
+        assembly_format = "$sym_name $attr_sym_name attr-dict"
+
+    ctx = Context()
+    ctx.load_op(SymbolNameOp)
+    ctx.load_dialect(Test)
+
+    check_roundtrip(program, ctx)
+    check_equivalence(program, generic_program, ctx)
+
+
+@pytest.mark.parametrize(
+    "program, generic_program",
+    [
+        (
+            "test.symbol @test symbol @test2",
+            '"test.symbol"() <{sym_name = "test2", other_sym_name = "test"}> : () -> ()',
+        ),
+        (
+            "test.symbol",
+            '"test.symbol"() : () -> ()',
+        ),
+    ],
+)
+def test_optional_symbol_name_variable(program: str, generic_program: str):
+    @irdl_op_definition
+    class SymbolNameOp(IRDLOperation):
+        name = "test.symbol"
+
+        sym_name = opt_prop_def(SymbolNameConstr())
+
+        other_sym_name = opt_prop_def(SymbolNameConstr())
+
+        assembly_format = "$other_sym_name (`symbol` $sym_name^)? attr-dict"
+
+    ctx = Context()
+    ctx.load_op(SymbolNameOp)
     ctx.load_dialect(Test)
 
     check_roundtrip(program, ctx)

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -255,6 +255,30 @@ class StringAttr(_BuiltinData[str]):
         printer.print_string_literal(self.data)
 
 
+@dataclass(frozen=True)
+class SymbolNameConstr(GenericAttrConstraint[StringAttr]):
+    """
+    Constrain an attribute to be a StringAttr.
+    This constraint has special assembly format support.
+    """
+
+    def verify(
+        self,
+        attr: Attribute,
+        constraint_context: ConstraintContext,
+    ) -> None:
+        if not isinstance(attr, StringAttr):
+            raise VerifyException(f"{attr} should be a string")
+
+    def get_bases(self) -> set[type[Attribute]] | None:
+        return {StringAttr}
+
+    def mapping_type_vars(
+        self, type_var_mapping: dict[TypeVar, AttrConstraint]
+    ) -> GenericAttrConstraint[StringAttr]:
+        return self
+
+
 @irdl_attr_definition
 class BytesAttr(_BuiltinData[bytes]):
     name = "bytes"

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -256,7 +256,7 @@ class StringAttr(_BuiltinData[str]):
 
 
 @dataclass(frozen=True)
-class SymbolNameConstr(GenericAttrConstraint[StringAttr]):
+class SymbolNameConstraint(GenericAttrConstraint[StringAttr]):
     """
     Constrain an attribute to be a StringAttr.
     This constraint has special assembly format support.

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -13,7 +13,7 @@ from typing import Literal
 
 from typing_extensions import TypeVar
 
-from xdsl.dialects.builtin import UnitAttr
+from xdsl.dialects.builtin import StringAttr, UnitAttr
 from xdsl.ir import (
     Attribute,
     Data,
@@ -1093,7 +1093,7 @@ class OptionalSuccessorVariable(OptionalVariable, SuccessorDirective):
 class AttributeVariable(FormatDirective):
     """
     An attribute variable, with the following format:
-      result-directive ::= dollar-ident
+      attribute-variable ::= dollar-ident
     The directive will request a space to be printed right after.
     """
 
@@ -1105,10 +1105,15 @@ class AttributeVariable(FormatDirective):
     """The known base class of the Attribute, if any."""
     unique_type: Attribute | None
     """The known type of the Attribute, if any."""
+    is_symbol_name: bool
+    """Should this attribute be parsed and printed as a symbol name."""
 
     def parse(self, parser: Parser, state: ParsingState) -> bool:
         unique_base = self.unique_base
-        if unique_base is None:
+
+        if self.is_symbol_name:
+            attr = parser.parse_symbol_name()
+        elif unique_base is None:
             attr = parser.parse_attribute()
         elif self.unique_type is not None:
             assert issubclass(unique_base, TypedAttribute)
@@ -1131,16 +1136,22 @@ class AttributeVariable(FormatDirective):
         return True
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
+        if self.is_property:
+            attr = op.properties.get(self.name)
+        else:
+            attr = op.attributes.get(self.name)
+
+        if attr is None:
+            return
+
         if state.should_emit_space or not state.last_was_punctuation:
             printer.print_string(" ")
         state.should_emit_space = True
         state.last_was_punctuation = False
 
-        if self.is_property:
-            attr = op.properties[self.name]
-        else:
-            attr = op.attributes[self.name]
-
+        if self.is_symbol_name:
+            assert isinstance(attr, StringAttr)
+            return printer.print_symbol_name(attr.data)
         if self.unique_type is not None:
             assert isinstance(attr, TypedAttribute)
             return attr.print_without_type(printer)
@@ -1182,18 +1193,22 @@ class OptionalAttributeVariable(AttributeVariable):
     """
 
     def parse(self, parser: Parser, state: ParsingState) -> bool:
-        # Only qualified optional attributes can be optionally parsed currently.
+        # Only qualified optional attributes and symbol names can be optionally
+        # parsed currently.
         # Other attributes are parsed as required attributes.
-        if self.unique_base is None:
+        if self.is_symbol_name:
+            attr = parser.parse_optional_symbol_name()
+        elif self.unique_base is None:
             attr = parser.parse_optional_attribute()
-            if attr is None:
-                return False
-            if self.is_property:
-                state.properties[self.name] = attr
-            else:
-                state.attributes[self.name] = attr
-            return True
-        return super().parse(parser, state)
+        else:
+            return super().parse(parser, state)
+        if attr is None:
+            return False
+        if self.is_property:
+            state.properties[self.name] = attr
+        else:
+            state.attributes[self.name] = attr
+        return True
 
     def is_present(self, op: IRDLOperation) -> bool:
         if self.is_property:
@@ -1206,7 +1221,7 @@ class OptionalAttributeVariable(AttributeVariable):
         return True
 
     def is_optional_like(self) -> bool:
-        return self.unique_base is None
+        return self.unique_base is None or self.is_symbol_name
 
 
 class OptionalUnitAttrVariable(OptionalAttributeVariable):

--- a/xdsl/irdl/declarative_assembly_format_parser.py
+++ b/xdsl/irdl/declarative_assembly_format_parser.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 from itertools import pairwise
 from typing import cast
 
-from xdsl.dialects.builtin import Builtin, SymbolNameConstr, UnitAttr
+from xdsl.dialects.builtin import Builtin, SymbolNameConstraint, UnitAttr
 from xdsl.ir import Attribute, TypedAttribute
 from xdsl.irdl import (
     AttrOrPropDef,
@@ -531,7 +531,7 @@ class FormatParser(BaseParser):
                 unique_base = cast(type[Attribute] | None, unique_base)
 
                 # We special case `SymbolNameConstr`, just as MLIR does.
-                is_symbol_name = isinstance(attr_def.constr, SymbolNameConstr)
+                is_symbol_name = isinstance(attr_def.constr, SymbolNameConstraint)
 
                 if attr_def.default_value is not None:
                     return DefaultValuedAttributeVariable(

--- a/xdsl/irdl/declarative_assembly_format_parser.py
+++ b/xdsl/irdl/declarative_assembly_format_parser.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 from itertools import pairwise
 from typing import cast
 
-from xdsl.dialects.builtin import Builtin, UnitAttr
+from xdsl.dialects.builtin import Builtin, SymbolNameConstr, UnitAttr
 from xdsl.ir import Attribute, TypedAttribute
 from xdsl.irdl import (
     AttrOrPropDef,
@@ -499,7 +499,7 @@ class FormatParser(BaseParser):
                 )
                 if unique_base == UnitAttr:
                     return OptionalUnitAttrVariable(
-                        variable_name, is_property, None, None
+                        variable_name, is_property, None, None, False
                     )
 
                 # Always qualify builtin attributes
@@ -530,12 +530,16 @@ class FormatParser(BaseParser):
                 # Chill pyright with TypedAttribute without parameter
                 unique_base = cast(type[Attribute] | None, unique_base)
 
+                # We special case `SymbolNameConstr`, just as MLIR does.
+                is_symbol_name = isinstance(attr_def.constr, SymbolNameConstr)
+
                 if attr_def.default_value is not None:
                     return DefaultValuedAttributeVariable(
                         variable_name,
                         is_property,
                         unique_base,
                         unique_type,
+                        is_symbol_name,
                         attr_def.default_value,
                     )
 
@@ -545,7 +549,7 @@ class FormatParser(BaseParser):
                     else AttributeVariable
                 )
                 return variable_type(
-                    variable_name, is_property, unique_base, unique_type
+                    variable_name, is_property, unique_base, unique_type, is_symbol_name
                 )
 
         self.raise_error(


### PR DESCRIPTION
Adds a new constraint `SymbolNameConstr`, which takes the role that `SymbolNameAttr` does in MLIR (note that `SymbolNameAttr` is not an attribute in MLIR, but some tablegen construct that I think translates to a constraint).
The assembly format then uses this information to parse/print the attribute as a symbol. Made this work with optional attributes and optional groups.