### PR TITLE
frontend: (pyast) add new decorator-based API for frontend code generation

### DIFF
--- a/tests/filecheck/frontend/programs/new_api.py
+++ b/tests/filecheck/frontend/programs/new_api.py
@@ -25,7 +25,7 @@ print(test_arith(1.0, 2.0, 3.0))
 # But the wrapper also provides a property to get an IR representation
 print(test_arith.module)
 # CHECK:       builtin.module {
-# CHECK-NEXT:  func.func @foo(%x : f64, %y : f64, %z : f64) -> f64 {
+# CHECK-NEXT:  func.func @test_arith(%x : f64, %y : f64, %z : f64) -> f64 {
 # CHECK-NEXT:    %0 = arith.mulf %y, %z : f64
 # CHECK-NEXT:    %1 = arith.addf %x, %0 : f64
 # CHECK-NEXT:    func.return %1 : f64

--- a/tests/filecheck/frontend/programs/new_api.py
+++ b/tests/filecheck/frontend/programs/new_api.py
@@ -40,7 +40,8 @@ def test_add(x: float, y: float) -> float:
 
 
 # And the extracted module is built only once, then cached
-assert (module := test_add.module) is test_add.module
+module = test_add.module
+assert module is test_add.module
 print(module)
 # CHECK:       builtin.module {
 # CHECK-NEXT:    func.func @test_add(%x : f64, %y : f64) -> f64 {

--- a/tests/filecheck/frontend/programs/new_api.py
+++ b/tests/filecheck/frontend/programs/new_api.py
@@ -31,3 +31,26 @@ print(test_arith.module)
 # CHECK-NEXT:    func.return %1 : f64
 # CHECK-NEXT:  }
 # CHECK-NEXT:}
+
+
+# The `ctx.parse_program` decorator can also be invoked with arguments
+@ctx.parse_program(desymref=False)
+def test_add(x: float, y: float) -> float:
+    return x + y
+
+
+# And the extracted module is built only once, then cached
+assert (module := test_add.module) is test_add.module
+print(module)
+# CHECK:       builtin.module {
+# CHECK-NEXT:    func.func @test_add(%x : f64, %y : f64) -> f64 {
+# CHECK-NEXT:      symref.declare "x"
+# CHECK-NEXT:      symref.update @x = %x : f64
+# CHECK-NEXT:      symref.declare "y"
+# CHECK-NEXT:      symref.update @y = %y : f64
+# CHECK-NEXT:      %0 = symref.fetch @y : f64
+# CHECK-NEXT:      %1 = symref.fetch @x : f64
+# CHECK-NEXT:      %2 = arith.addf %1, %0 : f64
+# CHECK-NEXT:      func.return %2 : f64
+# CHECK-NEXT:    }
+# CHECK-NEXT:  }

--- a/tests/filecheck/frontend/programs/new_api.py
+++ b/tests/filecheck/frontend/programs/new_api.py
@@ -1,0 +1,33 @@
+# RUN: python %s | filecheck %s
+
+from xdsl.dialects.arith import AddfOp, MulfOp
+from xdsl.dialects.builtin import f64
+from xdsl.frontend.pyast.context import PyASTContext
+
+# `FrontendContext` encapsulates the mapping from Python to xDSL constructs
+ctx = PyASTContext()
+ctx.register_type(float, f64)
+ctx.register_function(float.__add__, AddfOp)
+ctx.register_function(float.__mul__, MulfOp)
+
+
+# Functions can be parsed in a context to yield a lazy wrapper for the IR
+# representation of that function
+@ctx.parse_program
+def test_arith(x: float, y: float, z: float) -> float:
+    return x + y * z
+
+
+# The lazy wrapper can still be called as if it were a native Python function
+print(test_arith(1.0, 2.0, 3.0))
+# CHECK: 7.0
+
+# But the wrapper also provides a property to get an IR representation
+print(test_arith.module)
+# CHECK:       builtin.module {
+# CHECK-NEXT:  func.func @foo(%x : f64, %y : f64, %z : f64) -> f64 {
+# CHECK-NEXT:    %0 = arith.mulf %y, %z : f64
+# CHECK-NEXT:    %1 = arith.addf %x, %0 : f64
+# CHECK-NEXT:    func.return %1 : f64
+# CHECK-NEXT:  }
+# CHECK-NEXT:}

--- a/xdsl/frontend/builder.py
+++ b/xdsl/frontend/builder.py
@@ -1,0 +1,17 @@
+from attr import dataclass
+
+from xdsl.dialects.builtin import ModuleOp
+from xdsl.frontend.pyast.utils.type_conversion import FunctionRegistry, TypeRegistry
+
+
+@dataclass
+class PyASTBuilder:
+    """Build an operation ."""
+
+    type_registry: TypeRegistry
+    function_registry: FunctionRegistry
+    desymref: bool
+
+    @property
+    def module(self) -> ModuleOp:
+        return ModuleOp([])

--- a/xdsl/frontend/builder.py
+++ b/xdsl/frontend/builder.py
@@ -49,7 +49,3 @@ class PyASTBuilder:
             module.verify()
 
         return module
-
-    # @property
-    # def module(self) -> ModuleOp:
-    #     return ModuleOp([])

--- a/xdsl/frontend/builder.py
+++ b/xdsl/frontend/builder.py
@@ -1,7 +1,16 @@
-from attr import dataclass
+import ast
+from dataclasses import dataclass
+from typing import Any
 
 from xdsl.dialects.builtin import ModuleOp
-from xdsl.frontend.pyast.utils.type_conversion import FunctionRegistry, TypeRegistry
+from xdsl.frontend.pyast.code_generation import CodeGeneration
+from xdsl.frontend.pyast.utils.python_code_check import PythonCodeCheck
+from xdsl.frontend.pyast.utils.type_conversion import (
+    FunctionRegistry,
+    TypeConverter,
+    TypeRegistry,
+)
+from xdsl.transforms.desymref import Desymrefier
 
 
 @dataclass
@@ -10,8 +19,37 @@ class PyASTBuilder:
 
     type_registry: TypeRegistry
     function_registry: FunctionRegistry
+
+    file: str
+    globals: dict[str, Any]
+    ast: ast.FunctionDef
+
     desymref: bool
 
-    @property
-    def module(self) -> ModuleOp:
-        return ModuleOp([])
+    def build(self) -> ModuleOp:
+        # Get the functions and blocks from the builder state
+        functions_and_blocks = PythonCodeCheck.run([self.ast], self.file)
+
+        # Convert the Python AST into xDSL IR objects
+        type_converter = TypeConverter(
+            globals=self.globals,
+            type_registry=self.type_registry,
+            function_registry=self.function_registry,
+        )
+        module = CodeGeneration.run_with_type_converter(
+            type_converter,
+            functions_and_blocks,
+            self.file,
+        )
+        module.verify()
+
+        # Optionally run desymrefication pass to produce actual SSA
+        if self.desymref:
+            Desymrefier().desymrefy(module)
+            module.verify()
+
+        return module
+
+    # @property
+    # def module(self) -> ModuleOp:
+    #     return ModuleOp([])

--- a/xdsl/frontend/builder.py
+++ b/xdsl/frontend/builder.py
@@ -15,18 +15,28 @@ from xdsl.transforms.desymref import Desymrefier
 
 @dataclass
 class PyASTBuilder:
-    """Build an operation ."""
+    """Builder for xDSL modules from aspects of a Python function."""
 
     type_registry: TypeRegistry
+    """Mappings between source code and IR type."""
+
     function_registry: FunctionRegistry
+    """Mappings between functions and their operation types."""
 
     file: str
+    """The file path of the function being built."""
+
     globals: dict[str, Any]
+    """Global information for the function being built, including all the imports."""
+
     ast: ast.FunctionDef
+    """The AST tree for the function being built."""
 
     desymref: bool
+    """Whether to apply the desymref flag to the built module."""
 
     def build(self) -> ModuleOp:
+        """Build a module from the builder state."""
         # Get the functions and blocks from the builder state
         functions_and_blocks = PythonCodeCheck.run([self.ast], self.file)
 

--- a/xdsl/frontend/pyast/context.py
+++ b/xdsl/frontend/pyast/context.py
@@ -1,4 +1,5 @@
 import ast
+import functools
 from collections.abc import Callable
 from contextlib import AbstractContextManager
 from dataclasses import dataclass, field
@@ -93,11 +94,13 @@ class PyASTContext:
             )
 
             # Return a PyAST program for this function with the builder
-            return PyASTProgram[P, R](
+            program = PyASTProgram[P, R](
                 name=func.__name__,
                 func=func,
                 _builder=builder,
             )
+            functools.update_wrapper(program, func)
+            return program
 
         if decorated_func is None:
             return decorator

--- a/xdsl/frontend/pyast/context.py
+++ b/xdsl/frontend/pyast/context.py
@@ -100,6 +100,7 @@ class PyASTContext:
                 _builder=builder,
             )
             functools.update_wrapper(program, func)
+            assert program.__doc__ == func.__doc__
             return program
 
         if decorated_func is None:

--- a/xdsl/frontend/pyast/program.py
+++ b/xdsl/frontend/pyast/program.py
@@ -29,9 +29,16 @@ class PyASTProgram(Generic[P, R]):
     """Wrapper to associate an IR representation with a Python function."""
 
     name: Final[str]
+    """The name of the function describing the program."""
+
     func: Final[Callable[P, R]]
+    """A callable object for the function describing the program."""
+
     _builder: Final[PyASTBuilder]
+    """An internal object to contextually build an IR module from the function."""
+
     _module: ModuleOp | None = None
+    """An internal object to cache the built IR module."""
 
     @property
     def module(self) -> ModuleOp:

--- a/xdsl/frontend/pyast/program.py
+++ b/xdsl/frontend/pyast/program.py
@@ -37,7 +37,7 @@ class PyASTProgram(Generic[P, R]):
     def module(self) -> ModuleOp:
         """Lazily build the module when required, once."""
         if self._module is None:
-            self._module = self._builder.module
+            self._module = self._builder.build()
         return self._module
 
     def __call__(self, *args: P.args, **kwargs: P.kwargs) -> R:

--- a/xdsl/frontend/pyast/program.py
+++ b/xdsl/frontend/pyast/program.py
@@ -2,9 +2,12 @@ import ast
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from io import StringIO
-from typing import Any
+from typing import Any, Final, Generic, ParamSpec
+
+from typing_extensions import TypeVar
 
 from xdsl.dialects.builtin import ModuleOp
+from xdsl.frontend.builder import PyASTBuilder
 from xdsl.frontend.pyast.code_generation import CodeGeneration
 from xdsl.frontend.pyast.utils.exceptions import FrontendProgramException
 from xdsl.frontend.pyast.utils.python_code_check import FunctionMap
@@ -16,6 +19,30 @@ from xdsl.frontend.pyast.utils.type_conversion import (
 from xdsl.ir import Operation, TypeAttribute
 from xdsl.printer import Printer
 from xdsl.transforms.desymref import Desymrefier
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+
+@dataclass
+class PyASTProgram(Generic[P, R]):
+    """Wrapper to associate an IR representation with a Python function."""
+
+    name: Final[str]
+    func: Final[Callable[P, R]]
+    _builder: Final[PyASTBuilder]
+    _module: ModuleOp | None = None
+
+    @property
+    def module(self) -> ModuleOp:
+        """Lazily build the module when required, once."""
+        if self._module is None:
+            self._module = self._builder.module
+        return self._module
+
+    def __call__(self, *args: P.args, **kwargs: P.kwargs) -> R:
+        """Pass through calling the object to its Python implementation."""
+        return self.func(*args, **kwargs)
 
 
 @dataclass


### PR DESCRIPTION
This PR adds a new decorator-based API for frontend code generation. This will supersede the old context manager API.

An example of this new API is as follows:

```python
from xdsl.dialects.arith import AddfOp, MulfOp
from xdsl.dialects.builtin import f64
from xdsl.frontend.pyast.context import PyASTContext

# `FrontendContext` encapsulates the mapping from Python to xDSL constructs
ctx = PyASTContext()
ctx.register_type(float, f64)
ctx.register_function(float.__add__, AddfOp)
ctx.register_function(float.__mul__, MulfOp)

# Functions can be parsed in a context to yield a lazy wrapper for the IR
# representation of that function
@ctx.parse_program
def test_arith(x: float, y: float, z: float) -> float:
    return x + y * z

# The lazy wrapper can still be called as if it were a native Python function
print(test_arith(1.0, 2.0, 3.0))
# CHECK: 7.0

# But the wrapper also provides a property to get an IR representation
print(test_arith.module)
# CHECK:       builtin.module {
# CHECK-NEXT:  func.func @test_arith(%x : f64, %y : f64, %z : f64) -> f64 {
# CHECK-NEXT:    %0 = arith.mulf %y, %z : f64
# CHECK-NEXT:    %1 = arith.addf %x, %0 : f64
# CHECK-NEXT:    func.return %1 : f64
# CHECK-NEXT:  }
# CHECK-NEXT:}
```