### PR TITLE
dialects: (builtin) remove simple uses of `I{n}`

### DIFF
--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -11,7 +11,6 @@ from typing_extensions import TypeVar
 from xdsl.context import Context
 from xdsl.dialects import test
 from xdsl.dialects.builtin import (
-    I32,
     BoolAttr,
     Float64Type,
     FloatAttr,
@@ -693,7 +692,7 @@ def test_typed_attribute_variable(program: str, generic_program: str):
     @irdl_op_definition
     class TypedAttributeOp(IRDLOperation):
         name = "test.typed_attr"
-        attr = attr_def(IntegerAttr[I32])
+        attr = attr_def(IntegerAttr.constr(i32))
         float_attr = attr_def(FloatAttr[Annotated[Float64Type, Float64Type()]])
 
         assembly_format = "$attr $float_attr attr-dict"
@@ -2848,7 +2847,7 @@ def test_optional_else_group(
         name = "test.optional_else_group"
 
         v = opt_operand_def(i32)
-        a = opt_prop_def(IntegerAttr[I32])
+        a = opt_prop_def(IntegerAttr.constr(i32))
 
         assembly_format = """($v^):($a)? attr-dict"""
 
@@ -2871,7 +2870,7 @@ def test_impossible_optional_else_group():
         class OptionalImpossibleElseGroup(IRDLOperation):  # pyright: ignore[reportUnusedClass]
             name = "test.impossible_optional_else_group"
 
-            val = opt_prop_def(IntegerAttr[I32])
+            val = opt_prop_def(IntegerAttr.constr(i32))
 
             assembly_format = """($val^):($val)? attr-dict"""
 
@@ -2902,7 +2901,7 @@ def test_optional_optional_group_optional_operand_anchor(
         name = "test.optional_optional_group"
 
         prop = opt_prop_def(StringAttr)
-        arg = opt_operand_def(I32)
+        arg = opt_operand_def(i32)
 
         assembly_format = "(`with` $prop^ ($arg^)?)? attr-dict"
 

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -905,15 +905,15 @@ class IntegerAttr(
 
     @staticmethod
     def constr(
-        type: GenericAttrConstraint[_IntegerAttrType] = IntegerAttrTypeConstr,
+        type: IRDLGenericAttrConstraint[_IntegerAttrTypeInvT] = IntegerType | IndexType,
         *,
-        value: AttrConstraint | IntConstraint | None = None,
-    ) -> GenericAttrConstraint[IntegerAttr[_IntegerAttrType]]:
-        if value is None and type == AnyAttr():
-            return BaseAttr[IntegerAttr[_IntegerAttrType]](IntegerAttr)
+        value: IRDLAttrConstraint | IntConstraint | None = None,
+    ) -> GenericAttrConstraint[IntegerAttr[_IntegerAttrTypeInvT]]:
+        if value is None and type == IntegerType | IndexType:
+            return BaseAttr[IntegerAttr[_IntegerAttrTypeInvT]](IntegerAttr)
         if isinstance(value, IntConstraint):
             value = IntAttrConstraint(value)
-        return ParamAttrConstraint[IntegerAttr[_IntegerAttrType]](
+        return ParamAttrConstraint[IntegerAttr[_IntegerAttrTypeInvT]](
             IntegerAttr,
             (
                 value,

--- a/xdsl/dialects/comb.py
+++ b/xdsl/dialects/comb.py
@@ -14,11 +14,12 @@ from collections.abc import Sequence
 from typing import ClassVar
 
 from xdsl.dialects.builtin import (
-    I32,
-    I64,
     IntegerAttr,
     IntegerType,
     UnitAttr,
+    i1,
+    i32,
+    i64,
 )
 from xdsl.ir import Attribute, Dialect, Operation, SSAValue, TypeAttribute
 from xdsl.irdl import (
@@ -262,10 +263,10 @@ class ICmpOp(IRDLOperation, ABC):
 
     T: ClassVar = VarConstraint("T", base(IntegerType))
 
-    predicate = attr_def(IntegerAttr[I64])
+    predicate = attr_def(IntegerAttr.constr(i64))
     lhs = operand_def(T)
     rhs = operand_def(T)
-    result = result_def(IntegerType(1))
+    result = result_def(i1)
 
     two_state = opt_attr_def(UnitAttr, attr_name="twoState")
 
@@ -399,7 +400,7 @@ class ExtractOp(IRDLOperation):
     name = "comb.extract"
 
     input = operand_def(IntegerType)
-    low_bit = attr_def(IntegerAttr[I32], attr_name="lowBit")
+    low_bit = attr_def(IntegerAttr.constr(i32), attr_name="lowBit")
     result = result_def(IntegerType)
 
     def __init__(

--- a/xdsl/dialects/csl/csl_stencil.py
+++ b/xdsl/dialects/csl/csl_stencil.py
@@ -4,7 +4,6 @@ from typing import TypeAlias, cast
 
 from xdsl.dialects import builtin, memref, stencil
 from xdsl.dialects.builtin import (
-    I64,
     AnyTensorTypeConstr,
     DenseArrayBase,
     Float16Type,
@@ -12,6 +11,7 @@ from xdsl.dialects.builtin import (
     FloatAttr,
     IndexType,
     IntegerAttr,
+    IntegerType,
     MemRefType,
     TensorType,
     i64,
@@ -34,6 +34,7 @@ from xdsl.irdl import (
     lazy_traits_def,
     operand_def,
     opt_prop_def,
+    param_def,
     prop_def,
     region_def,
     result_def,
@@ -75,7 +76,7 @@ class ExchangeDeclarationAttr(ParametrizedAttribute):
 
     name = "csl_stencil.exchange"
 
-    neighbor_param: DenseArrayBase[I64]
+    neighbor_param: DenseArrayBase[IntegerType] = param_def(DenseArrayBase.constr(i64))
 
     def __init__(
         self,

--- a/xdsl/dialects/experimental/dmp.py
+++ b/xdsl/dialects/experimental/dmp.py
@@ -30,6 +30,7 @@ from xdsl.irdl import (
     irdl_op_definition,
     operand_def,
     opt_result_def,
+    param_def,
     traits_def,
 )
 from xdsl.parser import AttrParser
@@ -84,10 +85,18 @@ class ExchangeDeclarationAttr(ParametrizedAttribute):
 
     name = "dmp.exchange"
 
-    offset_: builtin.DenseArrayBase[builtin.I64]
-    size_: builtin.DenseArrayBase[builtin.I64]
-    source_offset_: builtin.DenseArrayBase[builtin.I64]
-    neighbor_: builtin.DenseArrayBase[builtin.I64]
+    offset_: builtin.DenseArrayBase[builtin.IntegerType] = param_def(
+        builtin.DenseArrayBase.constr(builtin.i64)
+    )
+    size_: builtin.DenseArrayBase[builtin.IntegerType] = param_def(
+        builtin.DenseArrayBase.constr(builtin.i64)
+    )
+    source_offset_: builtin.DenseArrayBase[builtin.IntegerType] = param_def(
+        builtin.DenseArrayBase.constr(builtin.i64)
+    )
+    neighbor_: builtin.DenseArrayBase[builtin.IntegerType] = param_def(
+        builtin.DenseArrayBase.constr(builtin.i64)
+    )
 
     def __init__(
         self,
@@ -258,10 +267,18 @@ class ShapeAttr(ParametrizedAttribute):
 
     name = "dmp.shape_with_halo"
 
-    buff_lb_: builtin.DenseArrayBase[builtin.I64]
-    buff_ub_: builtin.DenseArrayBase[builtin.I64]
-    core_lb_: builtin.DenseArrayBase[builtin.I64]
-    core_ub_: builtin.DenseArrayBase[builtin.I64]
+    buff_lb_: builtin.DenseArrayBase[builtin.IntegerType] = param_def(
+        builtin.DenseArrayBase.constr(builtin.i64)
+    )
+    buff_ub_: builtin.DenseArrayBase[builtin.IntegerType] = param_def(
+        builtin.DenseArrayBase.constr(builtin.i64)
+    )
+    core_lb_: builtin.DenseArrayBase[builtin.IntegerType] = param_def(
+        builtin.DenseArrayBase.constr(builtin.i64)
+    )
+    core_ub_: builtin.DenseArrayBase[builtin.IntegerType] = param_def(
+        builtin.DenseArrayBase.constr(builtin.i64)
+    )
 
     @property
     def buff_lb(self) -> tuple[int, ...]:
@@ -396,7 +413,9 @@ class RankTopoAttr(ParametrizedAttribute):
 
     name = "dmp.topo"
 
-    shape: builtin.DenseArrayBase[builtin.I64]
+    shape: builtin.DenseArrayBase[builtin.IntegerType] = param_def(
+        builtin.DenseArrayBase.constr(builtin.i64)
+    )
 
     def __init__(self, shape: Sequence[int]):
         if len(shape) < 1:

--- a/xdsl/dialects/irdl/irdl.py
+++ b/xdsl/dialects/irdl/irdl.py
@@ -7,12 +7,13 @@ from types import NoneType
 from typing import ClassVar
 
 from xdsl.dialects.builtin import (
-    I32,
     ArrayAttr,
     IntegerAttr,
+    IntegerType,
     StringAttr,
     SymbolRefAttr,
     UnitAttr,
+    i32,
 )
 from xdsl.ir import (
     Attribute,
@@ -677,7 +678,7 @@ class RegionOp(IRDLOperation):
 
     constrained_arguments = opt_attr_def(UnitAttr)
 
-    number_of_blocks = opt_attr_def(IntegerAttr[I32])
+    number_of_blocks = opt_attr_def(IntegerAttr.constr(i32))
 
     output = result_def(RegionType())
 
@@ -688,7 +689,7 @@ class RegionOp(IRDLOperation):
 
     def __init__(
         self,
-        number_of_blocks: IntegerAttr[I32],
+        number_of_blocks: IntegerAttr[IntegerType],
         entry_block_args: Sequence[SSAValue],
         constrained_arguments: UnitAttr | NoneType = None,
     ):

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -7,7 +7,6 @@ from types import EllipsisType
 from typing import ClassVar
 
 from xdsl.dialects.builtin import (
-    I64,
     AnyFloatConstr,
     ArrayAttr,
     ContainerType,
@@ -1139,7 +1138,7 @@ class InlineAsmOp(IRDLOperation):
     # 0 for AT&T inline assembly dialect
     # 1 for Intel inline assembly dialect
     # In this context dialect does not refer to an MLIR dialect
-    asm_dialect = opt_prop_def(IntegerAttr[I64])
+    asm_dialect = opt_prop_def(IntegerAttr.constr(i64))
 
     asm_string = prop_def(StringAttr)
     constraints = prop_def(StringAttr)

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -7,7 +7,6 @@ from typing import ClassVar, cast
 from typing_extensions import Self
 
 from xdsl.dialects.builtin import (
-    I64,
     AnyFloatConstr,
     ArrayAttr,
     BoolAttr,
@@ -363,7 +362,7 @@ class AtomicRMWOp(IRDLOperation):
     memref = operand_def(MemRefType.constr(T))
     indices = var_operand_def(IndexType)
 
-    kind = prop_def(IntegerAttr[I64])
+    kind = prop_def(IntegerAttr.constr(i64))
 
     result = result_def(T)
 
@@ -408,7 +407,7 @@ class GlobalOp(IRDLOperation):
     type = prop_def(MemRefType)
     initial_value = prop_def(UnitAttr | DenseIntOrFPElementsAttr)
     constant = opt_prop_def(UnitAttr)
-    alignment = opt_prop_def(IntegerAttr[I64])
+    alignment = opt_prop_def(IntegerAttr.constr(i64))
 
     traits = traits_def(SymbolOpInterface())
 

--- a/xdsl/dialects/pdl.py
+++ b/xdsl/dialects/pdl.py
@@ -6,12 +6,12 @@ from typing import Generic
 from typing_extensions import TypeVar
 
 from xdsl.dialects.builtin import (
-    I16,
-    I32,
     ArrayAttr,
     IntegerAttr,
     IntegerType,
     StringAttr,
+    i16,
+    i32,
 )
 from xdsl.ir import (
     Attribute,
@@ -513,7 +513,7 @@ class PatternOp(IRDLOperation):
     """
 
     name = "pdl.pattern"
-    benefit = prop_def(IntegerAttr[I16])
+    benefit = prop_def(IntegerAttr.constr(i16))
     sym_name = opt_prop_def(StringAttr)
     body = region_def("single_block")
 
@@ -724,7 +724,7 @@ class ResultOp(IRDLOperation):
     """
 
     name = "pdl.result"
-    index = prop_def(IntegerAttr[I32])
+    index = prop_def(IntegerAttr.constr(i32))
     parent_ = operand_def(OperationType)
     val = result_def(ValueType)
 

--- a/xdsl/dialects/pdl_interp.py
+++ b/xdsl/dialects/pdl_interp.py
@@ -8,8 +8,6 @@ from typing import ClassVar, cast
 from typing_extensions import TypeVar
 
 from xdsl.dialects.builtin import (
-    I16,
-    I32,
     ArrayAttr,
     ContainerOf,
     DictionaryAttr,
@@ -23,6 +21,8 @@ from xdsl.dialects.builtin import (
     StringAttr,
     SymbolRefAttr,
     UnitAttr,
+    i16,
+    i32,
 )
 from xdsl.dialects.pdl import (
     AnyPDLTypeConstr,
@@ -86,13 +86,15 @@ class GetOperandOp(IRDLOperation):
     """
 
     name = "pdl_interp.get_operand"
-    index = prop_def(IntegerAttr[I32])
+    index = prop_def(IntegerAttr.constr(i32))
     input_op = operand_def(OperationType)
     value = result_def(ValueType)
 
     assembly_format = "$index `of` $input_op attr-dict"
 
-    def __init__(self, index: int | IntegerAttr[I32], input_op: SSAValue) -> None:
+    def __init__(
+        self, index: int | IntegerAttr[IntegerType], input_op: SSAValue
+    ) -> None:
         if isinstance(index, int):
             index = IntegerAttr.from_int_and_width(index, 32)
         super().__init__(
@@ -157,7 +159,7 @@ class CheckOperandCountOp(IRDLOperation):
     name = "pdl_interp.check_operand_count"
     traits = traits_def(IsTerminator())
     input_op = operand_def(OperationType)
-    count = prop_def(IntegerAttr[I32])
+    count = prop_def(IntegerAttr.constr(i32))
     compareAtLeast = opt_prop_def(UnitAttr)
     true_dest = successor_def()
     false_dest = successor_def()
@@ -167,7 +169,7 @@ class CheckOperandCountOp(IRDLOperation):
     def __init__(
         self,
         input_op: SSAValue,
-        count: int | IntegerAttr[I32],
+        count: int | IntegerAttr[IntegerType],
         trueDest: Block,
         falseDest: Block,
         compareAtLeast: bool = False,
@@ -193,7 +195,7 @@ class CheckResultCountOp(IRDLOperation):
     name = "pdl_interp.check_result_count"
     traits = traits_def(IsTerminator())
     input_op = operand_def(OperationType)
-    count = prop_def(IntegerAttr[I32])
+    count = prop_def(IntegerAttr.constr(i32))
     compareAtLeast = opt_prop_def(UnitAttr)
     true_dest = successor_def()
     false_dest = successor_def()
@@ -203,7 +205,7 @@ class CheckResultCountOp(IRDLOperation):
     def __init__(
         self,
         input_op: SSAValue,
-        count: int | IntegerAttr[I32],
+        count: int | IntegerAttr[IntegerType],
         trueDest: Block,
         falseDest: Block,
         compareAtLeast: bool = False,
@@ -247,13 +249,15 @@ class GetResultOp(IRDLOperation):
     """
 
     name = "pdl_interp.get_result"
-    index = prop_def(IntegerAttr[I32])
+    index = prop_def(IntegerAttr.constr(i32))
     input_op = operand_def(OperationType)
     value = result_def(ValueType)
 
     assembly_format = "$index `of` $input_op attr-dict"
 
-    def __init__(self, index: int | IntegerAttr[I32], input_op: SSAValue) -> None:
+    def __init__(
+        self, index: int | IntegerAttr[IntegerType], input_op: SSAValue
+    ) -> None:
         if isinstance(index, int):
             index = IntegerAttr.from_int_and_width(index, 32)
         super().__init__(
@@ -268,7 +272,7 @@ class GetResultsOp(IRDLOperation):
     """
 
     name = "pdl_interp.get_results"
-    index = opt_prop_def(IntegerAttr[I32])
+    index = opt_prop_def(IntegerAttr.constr(i32))
     input_op = operand_def(OperationType)
     value = result_def(ValueType | RangeType[ValueType])
 
@@ -277,7 +281,7 @@ class GetResultsOp(IRDLOperation):
 
     def __init__(
         self,
-        index: int | IntegerAttr[I32] | None,
+        index: int | IntegerAttr[IntegerType] | None,
         input_op: SSAValue,
         result_type: ValueType | RangeType[ValueType],
     ) -> None:
@@ -428,7 +432,7 @@ class RecordMatchOp(IRDLOperation):
     rewriter = prop_def(SymbolRefAttr)
     rootKind = opt_prop_def(StringAttr)
     generatedOps = opt_prop_def(ArrayAttr)
-    benefit = prop_def(IntegerAttr[I16])
+    benefit = prop_def(IntegerAttr.constr(i16))
 
     inputs = var_operand_def(AnyPDLTypeConstr)
     matched_ops = var_operand_def(OperationType)
@@ -448,7 +452,7 @@ class RecordMatchOp(IRDLOperation):
         rewriter: str | SymbolRefAttr,
         root_kind: str | StringAttr,
         generated_ops: list[OperationType] | None,
-        benefit: int | IntegerAttr[I16],
+        benefit: int | IntegerAttr[IntegerType],
         inputs: Sequence[SSAValue],
         matched_ops: Sequence[SSAValue],
         dest: Block,

--- a/xdsl/dialects/riscv_func.py
+++ b/xdsl/dialects/riscv_func.py
@@ -6,7 +6,6 @@ from xdsl.backend.assembly_printer import AssemblyPrintable, AssemblyPrinter
 from xdsl.backend.register_type import RegisterType
 from xdsl.dialects import riscv
 from xdsl.dialects.builtin import (
-    I8,
     FunctionType,
     IntegerAttr,
     IntegerType,
@@ -156,7 +155,7 @@ class FuncOp(IRDLOperation, AssemblyPrintable):
     body = region_def()
     function_type = attr_def(FunctionType)
     sym_visibility = opt_attr_def(StringAttr)
-    p2align = opt_attr_def(IntegerAttr[I8])
+    p2align = opt_attr_def(IntegerAttr.constr(i8))
 
     traits = traits_def(
         SymbolOpInterface(),
@@ -170,7 +169,7 @@ class FuncOp(IRDLOperation, AssemblyPrintable):
         region: Region,
         function_type: FunctionType | tuple[Sequence[Attribute], Sequence[Attribute]],
         visibility: StringAttr | str | None = None,
-        p2align: int | IntegerAttr[I8] | None = None,
+        p2align: int | IntegerAttr[IntegerType] | None = None,
     ):
         if isinstance(function_type, tuple):
             inputs, outputs = function_type

--- a/xdsl/dialects/tosa.py
+++ b/xdsl/dialects/tosa.py
@@ -1,12 +1,12 @@
 from xdsl.dialects.builtin import (
-    I32,
-    I64,
     BoolAttr,
     DenseArrayBase,
     FloatAttr,
     IntegerAttr,
     StringAttr,
     TensorType,
+    i32,
+    i64,
 )
 from xdsl.ir import Dialect
 from xdsl.irdl import (
@@ -28,8 +28,8 @@ class ClampOp(IRDLOperation):
 
     name = "tosa.clamp"
 
-    min_int = prop_def(IntegerAttr[I64])
-    max_int = prop_def(IntegerAttr[I64])
+    min_int = prop_def(IntegerAttr.constr(i64))
+    max_int = prop_def(IntegerAttr.constr(i64))
 
     min_fp = prop_def(FloatAttr)
     max_fp = prop_def(FloatAttr)
@@ -52,8 +52,8 @@ class RescaleOp(IRDLOperation):
 
     name = "tosa.rescale"
 
-    input_zp = prop_def(IntegerAttr[I32])
-    output_zp = prop_def(IntegerAttr[I32])
+    input_zp = prop_def(IntegerAttr.constr(i32))
+    output_zp = prop_def(IntegerAttr.constr(i32))
     multiplier = prop_def(DenseArrayBase)
     shift = prop_def(DenseArrayBase)
     scale32 = prop_def(BoolAttr)

--- a/xdsl/dialects/vector.py
+++ b/xdsl/dialects/vector.py
@@ -5,7 +5,6 @@ from collections.abc import Sequence
 from typing import ClassVar, cast
 
 from xdsl.dialects.builtin import (
-    I1,
     AffineMapAttr,
     AnyFloatConstr,
     ArrayAttr,
@@ -733,7 +732,7 @@ class VectorTransferOperation(IRDLOperation, ABC):
     @staticmethod
     def infer_transfer_op_mask_type(
         vec_type: VectorType, perm_map: AffineMap
-    ) -> VectorType[I1]:
+    ) -> VectorType[IntegerType]:
         """
         Given a resulting vector type and a permutation map from the dimensions of the
         shaped type to the vector type dimensions, return the vector type of the mask.
@@ -856,7 +855,7 @@ class TransferReadOp(VectorTransferOperation):
     source = operand_def(TensorType | MemRefType)
     indices = var_operand_def(IndexType)
     padding = operand_def()
-    mask = opt_operand_def(VectorType[I1])
+    mask = opt_operand_def(VectorType.constr(i1))
 
     permutation_map = prop_def(AffineMapAttr)
 
@@ -960,7 +959,7 @@ class TransferWriteOp(VectorTransferOperation):
     vector = operand_def(VectorType[Attribute])
     source = operand_def(TensorType | MemRefType)
     indices = var_operand_def(IndexType)
-    mask = opt_operand_def(VectorType[I1])
+    mask = opt_operand_def(VectorType.constr(i1))
 
     permutation_map = prop_def(AffineMapAttr)
 


### PR DESCRIPTION
As the title says, looking towards deprecating `Annotated` things, this PR removes the easy uses of `I64` etc.

Also allows `IRDLAttrConstraints` in `IntegerAttr.constr` so that you can write `IntegerAttr.constr(i64)`.

As an aside, this PR has made me doubt the utility of `IntegerAttr` being generic.