### PR TITLE
dialects: (all) use SymbolNameConstraint for sym_name props/attrs

### DIFF
--- a/docs/Toy/toy/dialects/toy.py
+++ b/docs/Toy/toy/dialects/toy.py
@@ -12,6 +12,7 @@ from xdsl.dialects.builtin import (
     Float64Type,
     FunctionType,
     StringAttr,
+    SymbolNameConstraint,
     SymbolRefAttr,
     TensorType,
     UnrankedTensorType,
@@ -197,7 +198,7 @@ class FuncOp(IRDLOperation):
 
     name = "toy.func"
     body = region_def("single_block")
-    sym_name = attr_def(StringAttr)
+    sym_name = attr_def(SymbolNameConstraint())
     function_type = attr_def(FunctionType)
     sym_visibility = opt_attr_def(StringAttr)
 

--- a/tests/backend/test_jax_executable.py
+++ b/tests/backend/test_jax_executable.py
@@ -4,7 +4,13 @@ import pytest
 
 from xdsl.builder import ImplicitBuilder
 from xdsl.dialects import func, stablehlo
-from xdsl.dialects.builtin import ModuleOp, StringAttr, TensorType, i32
+from xdsl.dialects.builtin import (
+    ModuleOp,
+    StringAttr,
+    SymbolNameConstraint,
+    TensorType,
+    i32,
+)
 from xdsl.irdl import IRDLOperation, attr_def, irdl_op_definition, traits_def
 from xdsl.traits import SymbolOpInterface
 
@@ -105,7 +111,7 @@ def test_main_not_func():
     class SymNameOp(IRDLOperation):
         name = "sym_name"
 
-        sym_name = attr_def(StringAttr)
+        sym_name = attr_def(SymbolNameConstraint())
         traits = traits_def(SymbolOpInterface())
 
     module = ModuleOp([SymNameOp(attributes={"sym_name": StringAttr("main")})])

--- a/tests/dialects/test_func.py
+++ b/tests/dialects/test_func.py
@@ -7,6 +7,7 @@ from xdsl.dialects.builtin import (
     IntegerType,
     ModuleOp,
     StringAttr,
+    SymbolNameConstraint,
     i32,
     i64,
 )
@@ -188,7 +189,7 @@ def test_call_not_function():
     class SymbolOp(IRDLOperation):
         name = "test.symbol"
 
-        sym_name = attr_def(StringAttr)
+        sym_name = attr_def(SymbolNameConstraint())
 
         traits = traits_def(SymbolOpInterface())
 

--- a/tests/dialects/test_hw.py
+++ b/tests/dialects/test_hw.py
@@ -7,7 +7,14 @@ from unittest.mock import ANY, patch
 import pytest
 
 from xdsl.context import Context
-from xdsl.dialects.builtin import ArrayAttr, StringAttr, SymbolRefAttr, i32, i64
+from xdsl.dialects.builtin import (
+    ArrayAttr,
+    StringAttr,
+    SymbolNameConstraint,
+    SymbolRefAttr,
+    i32,
+    i64,
+)
 from xdsl.dialects.hw import (
     HW,
     Direction,
@@ -72,7 +79,7 @@ def test_inner_sym_target():
 class ModuleOp(IRDLOperation):
     name = "module"
     region = region_def()
-    sym_name = attr_def(StringAttr)
+    sym_name = attr_def(SymbolNameConstraint())
     traits = traits_def(InnerSymbolTableTrait(), SymbolOpInterface())
 
 
@@ -86,7 +93,7 @@ class OutputOp(IRDLOperation):
 class CircuitOp(IRDLOperation):
     name = "circuit"
     region: Region | None = opt_region_def()
-    sym_name = attr_def(StringAttr)
+    sym_name = attr_def(SymbolNameConstraint())
     traits = traits_def(
         InnerRefNamespaceTrait(),
         SymbolTable(),
@@ -101,7 +108,7 @@ class CircuitOp(IRDLOperation):
 @irdl_op_definition
 class WireOp(IRDLOperation):
     name = "wire"
-    sym_name = attr_def(StringAttr)
+    sym_name = attr_def(SymbolNameConstraint())
     traits = traits_def(InnerRefUserOpInterfaceTrait())
 
 
@@ -144,7 +151,7 @@ def test_inner_symbol_table_interface():
     class MissingTraitModuleOp(IRDLOperation):
         name = "module"
         region = region_def()
-        sym_name = attr_def(StringAttr)
+        sym_name = attr_def(SymbolNameConstraint())
         traits = traits_def(InnerSymbolTableTrait())
 
     mod_missing_trait = MissingTraitModuleOp(
@@ -184,7 +191,7 @@ def test_inner_ref_namespace_interface():
     class MissingTraitCircuitOp(IRDLOperation):
         name = "circuit"
         region: Region | None = opt_region_def()
-        sym_name = attr_def(StringAttr)
+        sym_name = attr_def(SymbolNameConstraint())
         traits = traits_def(
             InnerRefNamespaceTrait(), SingleBlockImplicitTerminator(OutputOp)
         )

--- a/tests/test_traits.py
+++ b/tests/test_traits.py
@@ -22,6 +22,7 @@ from xdsl.dialects.builtin import (
     MemRefType,
     NoneAttr,
     StringAttr,
+    SymbolNameConstraint,
     SymbolRefAttr,
     TensorType,
     UnrankedTensorType,
@@ -328,7 +329,7 @@ def test_symbol_op_interface():
     class SymNameOp(IRDLOperation):
         name = "sym_name"
 
-        sym_name = attr_def(StringAttr)
+        sym_name = attr_def(SymbolNameConstraint())
         traits = traits_def(SymbolOpInterface())
 
     op2 = SymNameOp(attributes={"sym_name": StringAttr("symbol_name")})
@@ -367,7 +368,7 @@ def test_optional_symbol_op_interface():
 class SymbolOp(IRDLOperation):
     name = "test.symbol"
 
-    sym_name = attr_def(StringAttr)
+    sym_name = attr_def(SymbolNameConstraint())
 
     traits = traits_def(SymbolOpInterface())
 
@@ -379,7 +380,7 @@ class SymbolOp(IRDLOperation):
 class PropSymbolOp(IRDLOperation):
     name = "test.symbol"
 
-    sym_name = prop_def(StringAttr)
+    sym_name = prop_def(SymbolNameConstraint())
 
     traits = traits_def(SymbolOpInterface())
 

--- a/xdsl/dialects/arm_func.py
+++ b/xdsl/dialects/arm_func.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 
 from xdsl.dialects import arm
-from xdsl.dialects.builtin import FunctionType, StringAttr
+from xdsl.dialects.builtin import FunctionType, StringAttr, SymbolNameConstraint
 from xdsl.dialects.utils import (
     parse_func_op_like,
     print_func_op_like,
@@ -49,7 +49,7 @@ class FuncOp(arm.ops.ARMOperation):
     """ARM function definition operation"""
 
     name = "arm_func.func"
-    sym_name = attr_def(StringAttr)
+    sym_name = attr_def(SymbolNameConstraint())
     body = region_def()
     function_type = attr_def(FunctionType)
     sym_visibility = opt_attr_def(StringAttr)

--- a/xdsl/dialects/csl/csl.py
+++ b/xdsl/dialects/csl/csl.py
@@ -31,6 +31,7 @@ from xdsl.dialects.builtin import (
     ModuleOp,
     Signedness,
     StringAttr,
+    SymbolNameConstraint,
     SymbolRefAttr,
     TensorType,
     i8,
@@ -133,7 +134,7 @@ class _FuncBase(IRDLOperation, ABC):
     """
 
     body = region_def()
-    sym_name = prop_def(StringAttr)
+    sym_name = prop_def(SymbolNameConstraint())
     function_type = prop_def(FunctionType)
     arg_attrs = opt_prop_def(ArrayAttr[DictionaryAttr])
     res_attrs = opt_prop_def(ArrayAttr[DictionaryAttr])
@@ -545,7 +546,7 @@ class CslModuleOp(IRDLOperation):
     name = "csl.module"
     body = region_def("single_block")
     kind = prop_def(ModuleKindAttr)
-    sym_name = attr_def(StringAttr)
+    sym_name = attr_def(SymbolNameConstraint())
 
     traits = traits_def(
         HasParent(ModuleOp),

--- a/xdsl/dialects/experimental/fir.py
+++ b/xdsl/dialects/experimental/fir.py
@@ -24,6 +24,7 @@ from xdsl.dialects.builtin import (
     IntegerAttr,
     IntegerType,
     StringAttr,
+    SymbolNameConstraint,
     SymbolRefAttr,
     UnitAttr,
 )
@@ -1388,7 +1389,7 @@ class DispatchTableOp(IRDLOperation):
 
     name = "fir.dispatch_table"
 
-    sym_name = prop_def(StringAttr)
+    sym_name = prop_def(SymbolNameConstraint())
     regs = var_region_def()
 
     traits = traits_def(SymbolOpInterface())
@@ -1739,7 +1740,7 @@ class GlobalOp(IRDLOperation):
 
     name = "fir.global"
     regs = var_region_def()
-    sym_name = prop_def(StringAttr)
+    sym_name = prop_def(SymbolNameConstraint())
     symref = prop_def(SymbolRefAttr)
     type = prop_def(Attribute)
     linkName = opt_prop_def(StringAttr)

--- a/xdsl/dialects/fsm.py
+++ b/xdsl/dialects/fsm.py
@@ -16,6 +16,7 @@ from xdsl.dialects.builtin import (
     FlatSymbolRefAttrConstr,
     FunctionType,
     StringAttr,
+    SymbolNameConstraint,
     SymbolRefAttr,
 )
 from xdsl.ir import (
@@ -69,7 +70,7 @@ class MachineOp(IRDLOperation):
 
     body = region_def()
 
-    sym_name = attr_def(StringAttr)
+    sym_name = attr_def(SymbolNameConstraint())
     initialState = attr_def(StringAttr)
     function_type = attr_def(FunctionType)
     arg_attrs = opt_attr_def(ArrayAttr[DictionaryAttr])
@@ -142,7 +143,7 @@ class StateOp(IRDLOperation):
 
     transitions = region_def()
 
-    sym_name = attr_def(StringAttr)
+    sym_name = attr_def(SymbolNameConstraint())
 
     traits = traits_def(NoTerminator(), SymbolOpInterface(), HasParent(MachineOp))
 
@@ -375,7 +376,7 @@ class InstanceOp(IRDLOperation):
 
     name = "fsm.instance"
 
-    sym_name = attr_def(StringAttr)
+    sym_name = attr_def(SymbolNameConstraint())
 
     machine = attr_def(FlatSymbolRefAttrConstr)
 
@@ -464,7 +465,7 @@ class HWInstanceOp(IRDLOperation):
 
     name = "fsm.hw_instance"
 
-    sym_name = attr_def(StringAttr)
+    sym_name = attr_def(SymbolNameConstraint())
     machine = attr_def(FlatSymbolRefAttrConstr)
     inputs = var_operand_def()
     clock = operand_def(signlessIntegerLike)

--- a/xdsl/dialects/func.py
+++ b/xdsl/dialects/func.py
@@ -8,6 +8,7 @@ from xdsl.dialects.builtin import (
     FlatSymbolRefAttrConstr,
     FunctionType,
     StringAttr,
+    SymbolNameConstraint,
     SymbolRefAttr,
 )
 from xdsl.dialects.utils import (
@@ -109,7 +110,7 @@ class FuncOp(IRDLOperation):
     name = "func.func"
 
     body = region_def()
-    sym_name = prop_def(StringAttr)
+    sym_name = prop_def(SymbolNameConstraint())
     function_type = prop_def(FunctionType)
     sym_visibility = opt_prop_def(StringAttr)
     arg_attrs = opt_prop_def(ArrayAttr[DictionaryAttr])

--- a/xdsl/dialects/gpu.py
+++ b/xdsl/dialects/gpu.py
@@ -10,6 +10,7 @@ from xdsl.dialects.builtin import (
     FunctionType,
     IndexType,
     StringAttr,
+    SymbolNameConstraint,
     SymbolRefAttr,
     UnitAttr,
     i32,
@@ -343,7 +344,7 @@ class ModuleOp(IRDLOperation):
     name = "gpu.module"
 
     body = region_def("single_block")
-    sym_name = prop_def(StringAttr)
+    sym_name = prop_def(SymbolNameConstraint())
 
     traits = traits_def(
         IsolatedFromAbove(),
@@ -361,7 +362,7 @@ class FuncOp(IRDLOperation):
     name = "gpu.func"
 
     body = region_def()
-    sym_name = attr_def(StringAttr)
+    sym_name = attr_def(SymbolNameConstraint())
     function_type = prop_def(FunctionType)
     kernel = opt_prop_def(UnitAttr)
     known_block_size = opt_attr_def(

--- a/xdsl/dialects/hw.py
+++ b/xdsl/dialects/hw.py
@@ -19,6 +19,7 @@ from xdsl.dialects.builtin import (
     IntAttr,
     LocationAttr,
     StringAttr,
+    SymbolNameConstraint,
     SymbolRefAttr,
 )
 from xdsl.ir import (
@@ -811,7 +812,7 @@ class HWModuleOp(IRDLOperation):
 
     name = "hw.module"
 
-    sym_name = attr_def(StringAttr)
+    sym_name = attr_def(SymbolNameConstraint())
     module_type = attr_def(ModuleType)
     sym_visibility = opt_attr_def(StringAttr)
     parameters = opt_attr_def(ArrayAttr[ParamDeclAttr])
@@ -928,7 +929,7 @@ class HWModuleExternOp(IRDLOperation):
 
     name = "hw.module.extern"
 
-    sym_name = attr_def(StringAttr)
+    sym_name = attr_def(SymbolNameConstraint())
     module_type = attr_def(ModuleType)
     sym_visibility = opt_attr_def(StringAttr)
     parameters = opt_attr_def(ArrayAttr[ParamDeclAttr])

--- a/xdsl/dialects/irdl/irdl.py
+++ b/xdsl/dialects/irdl/irdl.py
@@ -11,6 +11,7 @@ from xdsl.dialects.builtin import (
     ArrayAttr,
     IntegerAttr,
     StringAttr,
+    SymbolNameConstraint,
     SymbolRefAttr,
     UnitAttr,
 )
@@ -112,7 +113,7 @@ class DialectOp(IRDLOperation):
 
     name = "irdl.dialect"
 
-    sym_name = attr_def(StringAttr)
+    sym_name = attr_def(SymbolNameConstraint())
     body = region_def("single_block")
 
     traits = traits_def(NoTerminator(), SymbolOpInterface(), SymbolTable())
@@ -144,7 +145,7 @@ class TypeOp(IRDLOperation):
 
     name = "irdl.type"
 
-    sym_name = attr_def(StringAttr)
+    sym_name = attr_def(SymbolNameConstraint())
     body = region_def("single_block")
 
     traits = traits_def(NoTerminator(), HasParent(DialectOp), SymbolOpInterface())
@@ -201,7 +202,7 @@ class AttributeOp(IRDLOperation):
 
     name = "irdl.attribute"
 
-    sym_name = attr_def(StringAttr)
+    sym_name = attr_def(SymbolNameConstraint())
     body = region_def("single_block")
 
     traits = traits_def(NoTerminator(), HasParent(DialectOp), SymbolOpInterface())
@@ -287,7 +288,7 @@ class OperationOp(IRDLOperation):
 
     name = "irdl.operation"
 
-    sym_name = attr_def(StringAttr)
+    sym_name = attr_def(SymbolNameConstraint())
     body = region_def("single_block")
 
     traits = traits_def(NoTerminator(), HasParent(DialectOp), SymbolOpInterface())

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -17,6 +17,7 @@ from xdsl.dialects.builtin import (
     IntegerType,
     NoneAttr,
     StringAttr,
+    SymbolNameConstraint,
     SymbolRefAttr,
     UnitAttr,
     i1,
@@ -1350,7 +1351,7 @@ class GlobalOp(IRDLOperation):
 
     global_type = prop_def(Attribute)
     constant = opt_prop_def(UnitAttr)
-    sym_name = prop_def(StringAttr)
+    sym_name = prop_def(SymbolNameConstraint())
     linkage = prop_def(LinkageAttr)
     dso_local = opt_prop_def(UnitAttr)
     thread_local_ = opt_prop_def(UnitAttr)
@@ -1506,7 +1507,7 @@ class FuncOp(IRDLOperation):
     name = "llvm.func"
 
     body = region_def()
-    sym_name = prop_def(StringAttr)
+    sym_name = prop_def(SymbolNameConstraint())
     function_type = prop_def(LLVMFunctionType)
     CConv = prop_def(CallingConventionAttr)
     linkage = prop_def(LinkageAttr)

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -23,6 +23,7 @@ from xdsl.dialects.builtin import (
     SignlessIntegerConstraint,
     StridedLayoutAttr,
     StringAttr,
+    SymbolNameConstraint,
     SymbolRefAttr,
     UnitAttr,
     UnrankedMemRefType,
@@ -403,7 +404,7 @@ class GetGlobalOp(IRDLOperation):
 class GlobalOp(IRDLOperation):
     name = "memref.global"
 
-    sym_name = prop_def(StringAttr)
+    sym_name = prop_def(SymbolNameConstraint())
     sym_visibility = prop_def(StringAttr)
     type = prop_def(MemRefType)
     initial_value = prop_def(UnitAttr | DenseIntOrFPElementsAttr)

--- a/xdsl/dialects/ml_program.py
+++ b/xdsl/dialects/ml_program.py
@@ -5,6 +5,7 @@ from typing_extensions import Self
 from xdsl.dialects.builtin import (
     NoneType,
     StringAttr,
+    SymbolNameConstraint,
     SymbolRefAttr,
     UnitAttr,
 )
@@ -38,7 +39,7 @@ class GlobalOp(IRDLOperation):
 
     name = "ml_program.global"
 
-    sym_name = attr_def(StringAttr)
+    sym_name = attr_def(SymbolNameConstraint())
     type = attr_def(TypeAttribute)
     is_mutable = opt_attr_def(UnitAttr)
     value = opt_attr_def(Attribute)

--- a/xdsl/dialects/pdl_interp.py
+++ b/xdsl/dialects/pdl_interp.py
@@ -21,6 +21,7 @@ from xdsl.dialects.builtin import (
     IntegerAttr,
     IntegerType,
     StringAttr,
+    SymbolNameConstraint,
     SymbolRefAttr,
     UnitAttr,
 )
@@ -813,7 +814,7 @@ class FuncOp(IRDLOperation):
     """
 
     name = "pdl_interp.func"
-    sym_name = prop_def(StringAttr)
+    sym_name = prop_def(SymbolNameConstraint())
     function_type = prop_def(FunctionType)
     arg_attrs = opt_prop_def(ArrayAttr[DictionaryAttr])
     res_attrs = opt_prop_def(ArrayAttr[DictionaryAttr])

--- a/xdsl/dialects/riscv_func.py
+++ b/xdsl/dialects/riscv_func.py
@@ -11,6 +11,7 @@ from xdsl.dialects.builtin import (
     IntegerAttr,
     IntegerType,
     StringAttr,
+    SymbolNameConstraint,
     SymbolRefAttr,
     i8,
 )
@@ -152,7 +153,7 @@ class FuncOp(IRDLOperation, AssemblyPrintable):
     """RISC-V function definition operation"""
 
     name = "riscv_func.func"
-    sym_name = attr_def(StringAttr)
+    sym_name = attr_def(SymbolNameConstraint())
     body = region_def()
     function_type = attr_def(FunctionType)
     sym_visibility = opt_attr_def(StringAttr)

--- a/xdsl/dialects/transform.py
+++ b/xdsl/dialects/transform.py
@@ -12,6 +12,7 @@ from xdsl.dialects.builtin import (
     IntegerAttr,
     IntegerType,
     StringAttr,
+    SymbolNameConstraint,
     SymbolRefAttr,
     UnitAttr,
     i1,
@@ -745,7 +746,7 @@ class NamedSequenceOp(IRDLOperation):
 
     name = "transform.named_sequence"
 
-    sym_name = prop_def(StringAttr)
+    sym_name = prop_def(SymbolNameConstraint())
     function_type = prop_def(FunctionType)
     sym_visibility = opt_prop_def(StringAttr)
     arg_attrs = opt_prop_def(ArrayAttr[DictionaryAttr])

--- a/xdsl/dialects/x86_func.py
+++ b/xdsl/dialects/x86_func.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 
-from xdsl.dialects.builtin import FunctionType, StringAttr
+from xdsl.dialects.builtin import FunctionType, StringAttr, SymbolNameConstraint
 from xdsl.dialects.utils import (
     parse_func_op_like,
     print_func_op_like,
@@ -49,7 +49,7 @@ class FuncOp(X86AsmOperation):
     """x86 function definition operation"""
 
     name = "x86_func.func"
-    sym_name = attr_def(StringAttr)
+    sym_name = attr_def(SymbolNameConstraint())
     body = region_def()
     function_type = attr_def(FunctionType)
     sym_visibility = opt_attr_def(StringAttr)


### PR DESCRIPTION
Actually use the new `SymbolNameConstraint` for things called `sym_name`. In all these cases there's no functional difference as they don't use assembly format, but I personally believes this conveys intent better.

I did not change `symref.declare` as this would actually cause functionality change. I'm not sure who this dialects "belongs" to, but would be good to get their input.