### PR TITLE
core: (AnyOf) allow variable inference and use for arith.constant

### DIFF
--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -31,9 +31,8 @@ from xdsl.ir import Attribute, BitEnumAttribute, Dialect, Operation, SSAValue
 from xdsl.irdl import (
     AnyAttr,
     AnyOf,
-    BaseAttr,
     IRDLOperation,
-    TypedAttributeConstraint,
+    ParamAttrConstraint,
     VarConstraint,
     base,
     irdl_attr_definition,
@@ -133,13 +132,12 @@ class ConstantOp(IRDLOperation):
     _T: ClassVar = VarConstraint("T", AnyAttr())
     result = result_def(_T)
     value = prop_def(
-        TypedAttributeConstraint(
-            IntegerAttr.constr(SignlessIntegerConstraint | IndexTypeConstr)
-            | BaseAttr(FloatAttr)
-            | BaseAttr(DenseIntOrFPElementsAttr)
-            | BaseAttr(DenseResourceAttr),
-            _T,
+        ParamAttrConstraint(
+            IntegerAttr, (AnyAttr(), _T & (SignlessIntegerConstraint | IndexTypeConstr))
         )
+        | ParamAttrConstraint(FloatAttr, (AnyAttr(), _T))
+        | ParamAttrConstraint(DenseIntOrFPElementsAttr, (_T, AnyAttr()))
+        | ParamAttrConstraint(DenseResourceAttr, (AnyAttr(), _T))
     )
 
     traits = traits_def(ConstantLike(), Pure())

--- a/xdsl/irdl/constraints.py
+++ b/xdsl/irdl/constraints.py
@@ -519,7 +519,7 @@ class AnyOf(Generic[AttributeCovT], GenericAttrConstraint[AttributeCovT]):
         return AnyOf((*self.attr_constrs, value))
 
     def variables(self) -> set[str]:
-        if len(self.attr_constrs) == 0:
+        if not self.attr_constrs:
             return set()
         variables = self.attr_constrs[0].variables()
         for constr in self.attr_constrs[1:]:

--- a/xdsl/irdl/constraints.py
+++ b/xdsl/irdl/constraints.py
@@ -519,10 +519,12 @@ class AnyOf(Generic[AttributeCovT], GenericAttrConstraint[AttributeCovT]):
         return AnyOf((*self.attr_constrs, value))
 
     def variables(self) -> set[str]:
-        if len(self.attr_constrs) == 1:
-            return self.attr_constrs[0].variables()
-        else:
+        if len(self.attr_constrs) == 0:
             return set()
+        variables = self.attr_constrs[0].variables()
+        for constr in self.attr_constrs[1:]:
+            variables &= constr.variables()
+        return variables
 
     def get_bases(self) -> set[type[Attribute]] | None:
         bases = set[type[Attribute]]()


### PR DESCRIPTION
With the new(ish) `AnyOf` mechanisms/restrictions, we can now infer variables from "any of" constraints when that variable appears in all branches. 

This can be used in arith.constant in place of `TypedAttributeConstraint` (which I intend to deprecate)

If wanted, I can split this into two PRs:
- Change AnyOf (finding a suitable test to add)
- Change arith.constant