### PR TITLE
API: add EqIntConstraint

### DIFF
--- a/tests/irdl/test_int_constraint.py
+++ b/tests/irdl/test_int_constraint.py
@@ -2,7 +2,7 @@ import re
 
 import pytest
 
-from xdsl.irdl import AtLeast, ConstraintContext
+from xdsl.irdl import AtLeast, ConstraintContext, EqIntConstraint
 from xdsl.utils.exceptions import VerifyException
 
 
@@ -28,3 +28,9 @@ def test_at_least():
         AtLeast(2).verify(1, ConstraintContext())
     with pytest.raises(VerifyException):
         AtLeast(2).verify(0, ConstraintContext())
+
+
+def test_eq():
+    EqIntConstraint(1).verify(1, ConstraintContext())
+    with pytest.raises(VerifyException):
+        EqIntConstraint(2).verify(3, ConstraintContext())

--- a/xdsl/irdl/constraints.py
+++ b/xdsl/irdl/constraints.py
@@ -813,6 +813,27 @@ class AnyInt(IntConstraint):
 
 
 @dataclass(frozen=True)
+class EqIntConstraint(IntConstraint):
+    """Constrain an integer to a value."""
+
+    value: int
+
+    def verify(
+        self,
+        i: int,
+        constraint_context: ConstraintContext,
+    ) -> None:
+        if self.value != i:
+            raise VerifyException(f"Invalid value {i}, expected {self.value}")
+
+    def can_infer(self, var_constraint_names: AbstractSet[str]) -> bool:
+        return True
+
+    def infer(self, context: ConstraintContext) -> int:
+        return self.value
+
+
+@dataclass(frozen=True)
 class AtLeast(IntConstraint):
     """Constrain an integer to be at least a given value."""
 


### PR DESCRIPTION
I'm still not sure which way we'll go on the int constraint front, but if we get rid of IntConstraint then we can replace this trivially, and if we don't then it'll be useful.