### PR TITLE
[RFC] core: (assembly-format) custom directives

### DIFF
--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import textwrap
 from collections.abc import Callable
+from dataclasses import dataclass
 from io import StringIO
 from typing import Annotated, ClassVar, Generic
 
@@ -74,11 +75,15 @@ from xdsl.irdl import (
 )
 from xdsl.irdl.declarative_assembly_format import (
     AttrDictDirective,
+    FormatDirective,
     FormatProgram,
     OperandsDirective,
+    ParsingState,
+    PrintingState,
     PunctuationDirective,
     ResultsDirective,
     TypeDirective,
+    VariadicOperandVariable,
 )
 from xdsl.parser import Parser
 from xdsl.printer import Printer
@@ -3614,3 +3619,97 @@ def test_qualified_attr():
     op = parser.parse_operation()
     assert isinstance(op, QualifiedAttrOp)
     assert op.attr == MyAttr(StringAttr("test"))
+
+
+################################################################################
+#                             Custom directives                                #
+################################################################################
+
+
+@irdl_op_definition
+class CustomDirectiveOp(IRDLOperation):
+    name = "test.custom"
+
+    class Hello(FormatDirective):
+        def parse(self, parser: Parser, state: ParsingState) -> bool:
+            parser.parse_keyword("hello")
+            return True
+
+        def print(
+            self, printer: Printer, state: PrintingState, op: IRDLOperation
+        ) -> None:
+            if state.should_emit_space or not state.last_was_punctuation:
+                printer.print_string(" ")
+            state.last_was_punctuation = False
+            state.should_emit_space = True
+            printer.print_string("hello")
+
+    assembly_format = "custom<Hello>() attr-dict"
+
+
+@pytest.mark.parametrize(
+    "program",
+    [
+        "test.custom hello",
+        "test.custom hello {attr = 1 : i32}",
+    ],
+)
+def test_custom_directive(program: str):
+    ctx = Context()
+    ctx.load_op(CustomDirectiveOp)
+    ctx.load_dialect(Test)
+    check_roundtrip(program, ctx)
+
+
+@irdl_op_definition
+class CustomDirectiveWithParamOp(IRDLOperation):
+    name = "test.custom_param"
+
+    ops = var_operand_def()
+
+    @dataclass(frozen=True)
+    class Bars(FormatDirective):
+        """We print the operands with bars between, because why not."""
+
+        var: VariadicOperandVariable
+
+        def parse(self, parser: Parser, state: ParsingState) -> bool:
+            first = parser.parse_optional_unresolved_operand()
+            if first is None:
+                operands = []
+            else:
+                operands = [first]
+                while parser.parse_optional_punctuation("|"):
+                    operands.append(parser.parse_unresolved_operand())
+            state.operands[self.var.index] = operands
+            return bool(operands)
+
+        def print(
+            self, printer: Printer, state: PrintingState, op: IRDLOperation
+        ) -> None:
+            operand = getattr(op, self.var.name)
+            if not operand:
+                return
+            if state.should_emit_space or not state.last_was_punctuation:
+                printer.print_string(" ")
+            printer.print_list(operand, printer.print_ssa_value, delimiter=" | ")
+            state.last_was_punctuation = False
+            state.should_emit_space = True
+
+    assembly_format = "custom<Bars>($ops) (`:` type($ops)^)? attr-dict"
+
+
+@pytest.mark.parametrize(
+    "program",
+    [
+        "test.custom_param",
+        "test.custom_param %0 : i32",
+        "test.custom_param %0 | %1 : i32, i32",
+        "test.custom_param %0 | %1 | %2 : i32, i32, i32",
+    ],
+)
+def test_custom_directive_param(program: str):
+    ctx = Context()
+    ctx.load_op(CustomDirectiveWithParamOp)
+    ctx.load_dialect(Test)
+    check_roundtrip(program, ctx)

--- a/xdsl/irdl/declarative_assembly_format_parser.py
+++ b/xdsl/irdl/declarative_assembly_format_parser.py
@@ -5,6 +5,7 @@ https://mlir.llvm.org/docs/DefiningDialects/Operations/#declarative-assembly-for
 
 from __future__ import annotations
 
+import inspect
 import re
 from collections.abc import Set as AbstractSet
 from dataclasses import dataclass
@@ -705,6 +706,39 @@ class FormatParser(BaseParser):
             return variable
         self.raise_error(f"unexpected token '{self._current_token.text}'")
 
+    def parse_custom_directive(self) -> FormatDirective:
+        """
+        Parse a custom directive, with the following format:
+          custom-directive ::= custom<bare-ident>((directive (`,` directive)*)?)
+        Assumes the keyword "custom" has already been parsed.
+        """
+
+        with self.in_angle_brackets():
+            name = self.parse_identifier()
+            if name not in self.op_def.custom_directives:
+                self.raise_error(f"Custom directive {name} cannot be found.")
+        directive = self.op_def.custom_directives[name]
+        if not issubclass(directive, FormatDirective):
+            self.raise_error(f"{name} is not a format directive.")
+        param_types = inspect.get_annotations(directive, eval_str=True)
+        params = list[FormatDirective]()
+        with self.in_parens():
+            self.parse_comma_separated_list
+            for i, (field, ty) in enumerate(param_types.items()):
+                if i:
+                    self.parse_punctuation(",")
+                if not issubclass(ty, FormatDirective):
+                    self.raise_error(
+                        f"Custom directive {name} has parameter {field} which is not a format directive."
+                    )
+                param = self.parse_format_directive()
+                if not isinstance(param, ty):
+                    self.raise_error(
+                        f"{name}.{field} was expected to be of type {ty}, but got {param}"
+                    )
+                params.append(param)
+        return directive(*params)
+
     def parse_format_directive(self) -> FormatDirective:
         """
         Parse a format directive, with the following format:
@@ -726,6 +760,8 @@ class FormatParser(BaseParser):
             return self.parse_functional_type_directive()
         if self.parse_optional_keyword("qualified"):
             return self.parse_qualified_directive()
+        if self.parse_optional_keyword("custom"):
+            return self.parse_custom_directive()
         if self._current_token.text == "`":
             return self.parse_keyword_or_punctuation()
         if self.parse_optional_punctuation("("):


### PR DESCRIPTION
Prototype implementation of custom assembly format directives.
Feel I've been procrastinating a while with trying to find a "perfect" way to do this, when realistically we would benefit a lot from a half decent way of doing this.

Thought I'd see what people think of this sort of interface. Will need a few more tests for multiple parameters/all the errors.