### PR TITLE
dialects: (fir) FIR compatibility with Flang 20.7.1

### DIFF
--- a/xdsl/dialects/experimental/fir.py
+++ b/xdsl/dialects/experimental/fir.py
@@ -1744,7 +1744,7 @@ class GlobalOp(IRDLOperation):
     sym_name = prop_def(SymbolNameConstraint())
     symref = prop_def(SymbolRefAttr)
     type = prop_def(Attribute)
-    initVal = opt_prop_def(Attribute)
+    initVal = opt_prop_def()
     constant = opt_prop_def(UnitAttr)
     target = opt_prop_def(UnitAttr)
     linkName = opt_prop_def(StringAttr)

--- a/xdsl/dialects/experimental/fir.py
+++ b/xdsl/dialects/experimental/fir.py
@@ -1744,11 +1744,11 @@ class GlobalOp(IRDLOperation):
     sym_name = prop_def(SymbolNameConstraint())
     symref = prop_def(SymbolRefAttr)
     type = prop_def(Attribute)
-    initVal = opt_prop_def()
+    initVal = opt_prop_def(Attribute)
     constant = opt_prop_def(UnitAttr)
     target = opt_prop_def(UnitAttr)
     linkName = opt_prop_def(StringAttr)
-    data_attr = opt_prop_def()
+    data_attr = opt_prop_def(Attribute)
     alignment = opt_prop_def(IntegerAttr)
 
     traits = traits_def(SymbolOpInterface())

--- a/xdsl/dialects/experimental/fir.py
+++ b/xdsl/dialects/experimental/fir.py
@@ -1748,7 +1748,7 @@ class GlobalOp(IRDLOperation):
     constant = opt_prop_def(UnitAttr)
     target = opt_prop_def(UnitAttr)
     linkName = opt_prop_def(StringAttr)
-    data_attr = opt_prop_def(Attribute)
+    data_attr = opt_prop_def()
     alignment = opt_prop_def(IntegerAttr)
 
     traits = traits_def(SymbolOpInterface())

--- a/xdsl/dialects/experimental/fir.py
+++ b/xdsl/dialects/experimental/fir.py
@@ -75,6 +75,7 @@ class FortranVariableFlags(Enum):
     VALUE = "value"
     VOLATILE = "volatile"
     HOSTASSOC = "host_assoc"
+    INTERNALASSOC = "internal_assoc"
 
     @staticmethod
     def try_parse(parser: AttrParser) -> set[FortranVariableFlags] | None:
@@ -1743,8 +1744,12 @@ class GlobalOp(IRDLOperation):
     sym_name = prop_def(SymbolNameConstraint())
     symref = prop_def(SymbolRefAttr)
     type = prop_def(Attribute)
-    linkName = opt_prop_def(StringAttr)
+    initVal = opt_prop_def(Attribute)
     constant = opt_prop_def(UnitAttr)
+    target = opt_prop_def(UnitAttr)
+    linkName = opt_prop_def(StringAttr)
+    data_attr = opt_prop_def(Attribute)
+    alignment = opt_prop_def(IntegerAttr)
 
     traits = traits_def(SymbolOpInterface())
 


### PR DESCRIPTION
An additional fortran variable flag and optional properties in the global operation that are present in Flang 20.7.1 but were missing in our FIR dialect
