### PR TITLE
core: (attr/prop-def) add default argument

### DIFF
--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -281,7 +281,7 @@ def test_attr_dict_prop_fallback(program: str, generic_program: str):
     @irdl_op_definition
     class PropOp(IRDLOperation):
         name = "test.prop"
-        prop = opt_prop_def(Attribute)
+        prop = opt_prop_def()
         irdl_options = [ParsePropInAttrDict()]
         assembly_format = "attr-dict"
 
@@ -309,8 +309,8 @@ def test_partial_attr_dict_prop_fallback(program: str, generic_program: str):
     @irdl_op_definition
     class PropOp(IRDLOperation):
         name = "test.prop"
-        prop1 = prop_def(Attribute)
-        prop2 = opt_prop_def(Attribute)
+        prop1 = prop_def()
+        prop2 = opt_prop_def()
         irdl_options = [ParsePropInAttrDict()]
         assembly_format = "$prop1 attr-dict"
 
@@ -330,7 +330,7 @@ def test_partial_attr_dict_prop_fallback(program: str, generic_program: str):
 class OpWithAttrOp(IRDLOperation):
     name = "test.one_attr"
 
-    attr = attr_def(Attribute)
+    attr = attr_def()
     assembly_format = "$attr attr-dict"
 
 
@@ -431,8 +431,8 @@ def test_missing_property_error():
     class MissingPropOp(IRDLOperation):
         name = "test.missing_prop"
 
-        prop1 = prop_def(Attribute)
-        prop2 = prop_def(Attribute)
+        prop1 = prop_def()
+        prop2 = prop_def()
         assembly_format = "$prop1 attr-dict"
 
     with pytest.raises(
@@ -457,7 +457,7 @@ def test_standard_prop_directive(program: str, generic_program: str):
     class PropOp(IRDLOperation):
         name = "test.one_prop"
 
-        prop = prop_def(Attribute)
+        prop = prop_def()
         assembly_format = "$prop attr-dict"
 
     ctx = Context()
@@ -511,7 +511,7 @@ def test_optional_property(program: str, generic_program: str):
     @irdl_op_definition
     class OptionalPropertyOp(IRDLOperation):
         name = "test.optional_property"
-        prop = opt_prop_def(Attribute)
+        prop = opt_prop_def()
 
         assembly_format = "(`prop` $prop^)? attr-dict"
 
@@ -542,7 +542,7 @@ def test_optional_qualified_property(program: str, generic_program: str):
     @irdl_op_definition
     class OptionalPropertyOp(IRDLOperation):
         name = "test.optional_property"
-        prop = opt_prop_def(Attribute)
+        prop = opt_prop_def()
 
         assembly_format = "($prop^)? attr-dict"
 
@@ -573,7 +573,7 @@ def test_optional_property_with_whitespace(program: str, generic_program: str):
     @irdl_op_definition
     class OptionalPropertyOp(IRDLOperation):
         name = "test.optional_property"
-        prop = opt_prop_def(Attribute)
+        prop = opt_prop_def()
 
         assembly_format = "`(` (` ` `prop` $prop^ ` `)? `)` attr-dict"
 
@@ -666,7 +666,7 @@ def test_optional_attribute(program: str, generic_program: str):
     @irdl_op_definition
     class OptionalAttributeOp(IRDLOperation):
         name = "test.optional_attribute"
-        attr = opt_attr_def(Attribute)
+        attr = opt_attr_def()
 
         assembly_format = "(`attr` $attr^)? attr-dict"
 

--- a/tests/irdl/test_operation_definition.py
+++ b/tests/irdl/test_operation_definition.py
@@ -17,7 +17,7 @@ from xdsl.dialects.builtin import (
     i64,
 )
 from xdsl.dialects.test import TestType
-from xdsl.ir import Attribute, Block, Region
+from xdsl.ir import Block, Region
 from xdsl.irdl import (
     AnyAttr,
     AnyInt,
@@ -78,8 +78,8 @@ class OpDefTestOp(IRDLOperation):
 
     operand = operand_def()
     result = result_def()
-    prop = prop_def(Attribute)
-    attr = attr_def(Attribute)
+    prop = prop_def()
+    attr = attr_def()
     region = region_def()
 
     # Check that we can define methods in operation definitions
@@ -452,7 +452,7 @@ def test_same_length_op():
 class WithoutPropOp(IRDLOperation):
     name = "test.op_without_prop"
 
-    prop1 = prop_def(Attribute)
+    prop1 = prop_def()
 
 
 # Check that an operation cannot accept properties that are not defined
@@ -860,7 +860,7 @@ def test_generic_op(cls: type[StringFooOp | StringFoo2Op]):
 
 
 class OtherParentOp(IRDLOperation):
-    other_attr = attr_def(Attribute)
+    other_attr = attr_def()
 
 
 @irdl_op_definition

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -18,7 +18,6 @@ from xdsl.dialects.builtin import (
 from xdsl.dialects.cf import Cf
 from xdsl.dialects.func import Func
 from xdsl.ir import (
-    Attribute,
     Block,
     ErasedSSAValue,
     Operation,
@@ -41,7 +40,7 @@ from xdsl.utils.test_value import create_ssa_value
 class TestWithPropOp(IRDLOperation):
     name = "test.op_with_prop"
 
-    prop = prop_def(Attribute)
+    prop = prop_def()
 
 
 def test_ops_accessor():

--- a/xdsl/dialects/experimental/fir.py
+++ b/xdsl/dialects/experimental/fir.py
@@ -583,7 +583,7 @@ class AllocmemOp(IRDLOperation):
     """
 
     name = "fir.allocmem"
-    in_type = prop_def(Attribute)
+    in_type = prop_def()
     uniq_name = opt_prop_def(StringAttr)
     bindc_name = opt_prop_def(StringAttr)
     typeparams = var_operand_def()
@@ -659,7 +659,7 @@ class AllocaOp(IRDLOperation):
     """
 
     name = "fir.alloca"
-    in_type = prop_def(Attribute)
+    in_type = prop_def()
     uniq_name = opt_prop_def(StringAttr)
     bindc_name = opt_prop_def(StringAttr)
     typeparams = var_operand_def()
@@ -1107,7 +1107,7 @@ class BoxOffsetOp(IRDLOperation):
     """
 
     name = "fir.box_offset"
-    field = prop_def(Attribute)
+    field = prop_def()
     val = operand_def()
     result_0 = result_def()
 
@@ -1178,7 +1178,7 @@ class CallOp(IRDLOperation):
     """
 
     name = "fir.call"
-    callee = prop_def(Attribute)
+    callee = prop_def()
     fastmath = opt_prop_def(FastMathFlagsAttr)
     result_0 = opt_result_def()
     args = var_operand_def()
@@ -1281,7 +1281,7 @@ class CoordinateOfOp(IRDLOperation):
     """
 
     name = "fir.coordinate_of"
-    baseType = prop_def(Attribute)
+    baseType = prop_def()
     ref = operand_def()
     coor = var_operand_def()
     result_0 = result_def()
@@ -1432,7 +1432,7 @@ class DoLoopOp(IRDLOperation):
     step = operand_def()
     reduceOperands = var_operand_def()
     initArgs = var_operand_def()
-    finalValue = opt_prop_def(Attribute)
+    finalValue = opt_prop_def()
     initArgs = opt_operand_def()
     _results = var_result_def()
     regs = var_region_def()
@@ -1626,7 +1626,7 @@ class ExtractValueOp(IRDLOperation):
 
     name = "fir.extract_value"
     adt = operand_def()
-    coor = opt_prop_def(Attribute)
+    coor = opt_prop_def()
     res = result_def()
     regs = var_region_def()
 
@@ -1743,12 +1743,12 @@ class GlobalOp(IRDLOperation):
     regs = var_region_def()
     sym_name = prop_def(SymbolNameConstraint())
     symref = prop_def(SymbolRefAttr)
-    type = prop_def(Attribute)
-    initVal = opt_prop_def(Attribute)
+    type = prop_def()
+    initVal = opt_prop_def()
     constant = opt_prop_def(UnitAttr)
     target = opt_prop_def(UnitAttr)
     linkName = opt_prop_def(StringAttr)
-    data_attr = opt_prop_def(Attribute)
+    data_attr = opt_prop_def()
     alignment = opt_prop_def(IntegerAttr)
 
     traits = traits_def(SymbolOpInterface())
@@ -1845,7 +1845,7 @@ class InsertValueOp(IRDLOperation):
     name = "fir.insert_value"
     adt = operand_def()
     val = operand_def()
-    coor = opt_prop_def(Attribute)
+    coor = opt_prop_def()
     result_0 = result_def()
     regs = var_region_def()
 

--- a/xdsl/dialects/experimental/hls.py
+++ b/xdsl/dialects/experimental/hls.py
@@ -70,7 +70,7 @@ class PragmaDataflowOp(IRDLOperation):
 class PragmaArrayPartitionOp(IRDLOperation):
     name = "hls.array_partition"
     variable = opt_attr_def(StringAttr)
-    array_type = opt_attr_def(Attribute)  # look at memref.Global
+    array_type = opt_attr_def()  # look at memref.Global
     factor = operand_def()
     dim = operand_def()
 
@@ -97,7 +97,7 @@ class HLSStreamType(ParametrizedAttribute, TypeAttribute):
 @irdl_op_definition
 class HLSStreamOp(IRDLOperation):
     name = "hls.stream"
-    elem_type = attr_def(Attribute)
+    elem_type = attr_def()
     result = result_def(HLSStreamType)  # This should be changed to HLSStreamType
 
     @staticmethod

--- a/xdsl/dialects/fsm.py
+++ b/xdsl/dialects/fsm.py
@@ -323,7 +323,7 @@ class VariableOp(IRDLOperation):
 
     name = "fsm.variable"
 
-    initValue = attr_def(Attribute)
+    initValue = attr_def()
     name_var = opt_attr_def(StringAttr)
 
     result = var_result_def(Attribute)

--- a/xdsl/dialects/irdl/irdl.py
+++ b/xdsl/dialects/irdl/irdl.py
@@ -561,7 +561,7 @@ class IsOp(IRDLOperation):
 
     name = "irdl.is"
 
-    expected = attr_def(Attribute)
+    expected = attr_def()
     output = result_def(AttributeType)
 
     def __init__(self, expected: Attribute):

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -988,7 +988,7 @@ class GEPOp(IRDLOperation):
 
     ptr = operand_def(LLVMPointerType)
     ssa_indices = var_operand_def(IntegerType)
-    elem_type = opt_prop_def(Attribute)
+    elem_type = opt_prop_def()
 
     result = result_def(LLVMPointerType)
 
@@ -1080,7 +1080,7 @@ class AllocaOp(IRDLOperation):
     size = operand_def(IntegerType)
 
     alignment = opt_prop_def(IntegerAttr)
-    elem_type = opt_prop_def(Attribute)
+    elem_type = opt_prop_def()
 
     res = result_def()
 
@@ -1349,14 +1349,14 @@ class UndefOp(IRDLOperation):
 class GlobalOp(IRDLOperation):
     name = "llvm.mlir.global"
 
-    global_type = prop_def(Attribute)
+    global_type = prop_def()
     constant = opt_prop_def(UnitAttr)
     sym_name = prop_def(SymbolNameConstraint())
     linkage = prop_def(LinkageAttr)
     dso_local = opt_prop_def(UnitAttr)
     thread_local_ = opt_prop_def(UnitAttr)
     visibility_ = opt_prop_def(IntegerAttr[IntegerType])
-    value = opt_prop_def(Attribute)
+    value = opt_prop_def()
     alignment = opt_prop_def(IntegerAttr)
     addr_space = prop_def(IntegerAttr)
     unnamed_addr = opt_prop_def(IntegerAttr)
@@ -1566,7 +1566,7 @@ class ReturnOp(IRDLOperation):
 class ConstantOp(IRDLOperation):
     name = "llvm.mlir.constant"
     result = result_def(Attribute)
-    value = prop_def(Attribute)
+    value = prop_def()
 
     traits = traits_def(NoMemoryEffect())
 

--- a/xdsl/dialects/ml_program.py
+++ b/xdsl/dialects/ml_program.py
@@ -42,7 +42,7 @@ class GlobalOp(IRDLOperation):
     sym_name = attr_def(SymbolNameConstraint())
     type = attr_def(TypeAttribute)
     is_mutable = opt_attr_def(UnitAttr)
-    value = opt_attr_def(Attribute)
+    value = opt_attr_def()
     sym_visibility = attr_def(StringAttr)
 
     traits = traits_def(SymbolOpInterface())

--- a/xdsl/dialects/mpi.py
+++ b/xdsl/dialects/mpi.py
@@ -695,7 +695,7 @@ class GetDtypeOp(MPIBaseOp):
 
     name = "mpi.get_dtype"
 
-    dtype = attr_def(Attribute)
+    dtype = attr_def()
 
     result = result_def(DataType)
 

--- a/xdsl/dialects/pdl.py
+++ b/xdsl/dialects/pdl.py
@@ -259,7 +259,7 @@ class AttributeOp(IRDLOperation):
     """
 
     name = "pdl.attribute"
-    value = opt_prop_def(Attribute)
+    value = opt_prop_def()
     value_type = opt_operand_def(TypeType)
     output = result_def(AttributeType)
 
@@ -853,7 +853,7 @@ class TypeOp(IRDLOperation):
     """
 
     name = "pdl.type"
-    constantType = opt_prop_def(Attribute)
+    constantType = opt_prop_def()
     result = result_def(TypeType)
 
     assembly_format = "attr-dict (`:` $constantType^)?"

--- a/xdsl/dialects/pdl_interp.py
+++ b/xdsl/dialects/pdl_interp.py
@@ -345,7 +345,7 @@ class CheckAttributeOp(IRDLOperation):
 
     name = "pdl_interp.check_attribute"
     traits = traits_def(IsTerminator())
-    constantValue = prop_def(Attribute)
+    constantValue = prop_def()
     attribute = operand_def(AttributeType)
     true_dest = successor_def()
     false_dest = successor_def()

--- a/xdsl/dialects/test.py
+++ b/xdsl/dialects/test.py
@@ -44,9 +44,9 @@ class TestOp(IRDLOperation):
     ops = var_operand_def()
     regs = var_region_def()
 
-    prop1 = opt_prop_def(Attribute)
-    prop2 = opt_prop_def(Attribute)
-    prop3 = opt_prop_def(Attribute)
+    prop1 = opt_prop_def()
+    prop2 = opt_prop_def()
+    prop3 = opt_prop_def()
 
     def __init__(
         self,
@@ -83,9 +83,9 @@ class TestTermOp(IRDLOperation):
     regs = var_region_def()
     successor = var_successor_def()
 
-    prop1 = opt_prop_def(Attribute)
-    prop2 = opt_prop_def(Attribute)
-    prop3 = opt_prop_def(Attribute)
+    prop1 = opt_prop_def()
+    prop2 = opt_prop_def()
+    prop3 = opt_prop_def()
 
     traits = traits_def(IsTerminator())
 
@@ -126,9 +126,9 @@ class TestPureOp(IRDLOperation):
     regs = var_region_def()
     successor = var_successor_def()
 
-    prop1 = opt_prop_def(Attribute)
-    prop2 = opt_prop_def(Attribute)
-    prop3 = opt_prop_def(Attribute)
+    prop1 = opt_prop_def()
+    prop2 = opt_prop_def()
+    prop3 = opt_prop_def()
 
     traits = traits_def(Pure())
 
@@ -169,9 +169,9 @@ class TestReadOp(IRDLOperation):
     regs = var_region_def()
     successor = var_successor_def()
 
-    prop1 = opt_prop_def(Attribute)
-    prop2 = opt_prop_def(Attribute)
-    prop3 = opt_prop_def(Attribute)
+    prop1 = opt_prop_def()
+    prop2 = opt_prop_def()
+    prop3 = opt_prop_def()
 
     traits = traits_def(MemoryReadEffect())
 
@@ -212,9 +212,9 @@ class TestWriteOp(IRDLOperation):
     regs = var_region_def()
     successor = var_successor_def()
 
-    prop1 = opt_prop_def(Attribute)
-    prop2 = opt_prop_def(Attribute)
-    prop3 = opt_prop_def(Attribute)
+    prop1 = opt_prop_def()
+    prop2 = opt_prop_def()
+    prop3 = opt_prop_def()
 
     traits = traits_def(MemoryWriteEffect())
 

--- a/xdsl/dialects/transform.py
+++ b/xdsl/dialects/transform.py
@@ -364,7 +364,7 @@ class IncludeOp(IRDLOperation):
     name = "transform.include"
 
     target = prop_def(SymbolRefAttr)
-    failure_propagation_mode = prop_def(Attribute)
+    failure_propagation_mode = prop_def()
     operands_input = var_operand_def(TransformHandleType)
     result = var_result_def(TransformHandleType)
 
@@ -484,7 +484,7 @@ class ParamConstantOp(IRDLOperation):
 
     name = "transform.param.constant"
 
-    value = prop_def(Attribute)
+    value = prop_def()
     param = result_def(ParamType)
 
     def __init__(self, value: Attribute, param_type: TypeAttribute):
@@ -564,7 +564,7 @@ class SequenceOp(IRDLOperation):
     name = "transform.sequence"
 
     body = region_def("single_block")
-    failure_propagation_mode = prop_def(Attribute)
+    failure_propagation_mode = prop_def()
     root = var_operand_def(AnyOpType)
     extra_bindings = var_operand_def(TransformHandleType)
 

--- a/xdsl/irdl/operations.py
+++ b/xdsl/irdl/operations.py
@@ -613,7 +613,7 @@ def opt_result_def(
 
 
 def prop_def(
-    constraint: IRDLAttrConstraint[AttributeInvT],
+    constraint: IRDLAttrConstraint[AttributeInvT] = Attribute,
     default_value: Attribute | None = None,
     *,
     prop_name: str | None = None,
@@ -631,18 +631,6 @@ def prop_def(
 @overload
 def opt_prop_def(
     constraint: IRDLAttrConstraint[AttributeInvT],
-    default_value: None = None,
-    *,
-    prop_name: str | None = None,
-    default: None = None,
-    resolver: None = None,
-    init: Literal[False] = False,
-) -> AttributeInvT | None: ...
-
-
-@overload
-def opt_prop_def(
-    constraint: IRDLAttrConstraint[AttributeInvT],
     default_value: Attribute,
     *,
     prop_name: str | None = None,
@@ -652,8 +640,20 @@ def opt_prop_def(
 ) -> AttributeInvT: ...
 
 
+@overload
 def opt_prop_def(
-    constraint: IRDLAttrConstraint[AttributeInvT],
+    constraint: IRDLAttrConstraint[AttributeInvT] = Attribute,
+    default_value: Attribute | None = None,
+    *,
+    prop_name: str | None = None,
+    default: None = None,
+    resolver: None = None,
+    init: Literal[False] = False,
+) -> AttributeInvT | None: ...
+
+
+def opt_prop_def(
+    constraint: IRDLAttrConstraint[AttributeInvT] = Attribute,
     default_value: Attribute | None = None,
     *,
     prop_name: str | None = None,
@@ -669,7 +669,7 @@ def opt_prop_def(
 
 
 def attr_def(
-    constraint: IRDLAttrConstraint[AttributeInvT],
+    constraint: IRDLAttrConstraint[AttributeInvT] = Attribute,
     default_value: Attribute | None = None,
     *,
     attr_name: str | None = None,
@@ -689,18 +689,6 @@ def attr_def(
 @overload
 def opt_attr_def(
     constraint: IRDLAttrConstraint[AttributeInvT],
-    default_value: None = None,
-    *,
-    attr_name: str | None = None,
-    default: None = None,
-    resolver: None = None,
-    init: Literal[False] = False,
-) -> AttributeInvT | None: ...
-
-
-@overload
-def opt_attr_def(
-    constraint: IRDLAttrConstraint[AttributeInvT],
     default_value: Attribute,
     *,
     attr_name: str | None = None,
@@ -710,8 +698,20 @@ def opt_attr_def(
 ) -> AttributeInvT: ...
 
 
+@overload
 def opt_attr_def(
-    constraint: IRDLAttrConstraint[AttributeInvT],
+    constraint: IRDLAttrConstraint[AttributeInvT] = Attribute,
+    default_value: Attribute | None = None,
+    *,
+    attr_name: str | None = None,
+    default: None = None,
+    resolver: None = None,
+    init: Literal[False] = False,
+) -> AttributeInvT | None: ...
+
+
+def opt_attr_def(
+    constraint: IRDLAttrConstraint[AttributeInvT] = Attribute,
     default_value: Attribute | None = None,
     *,
     attr_name: str | None = None,


### PR DESCRIPTION
`(opt_)?(attr|prop)_def` had no default argument for the constraint compared to `(operand|result)_def`. I don't see a reason for the inconsistency so this PR adds the default argument of `Attribute`