### PR TITLE
bench: incorporate benchmark proposed in #4834

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -71,7 +71,9 @@ uv run benchmarks/lexer.py Lexer.empty_program dis
         importlib.reload(xdsl.dialects.newdialect)
     ```
 
-2. Associate the method with a name in the main code at the bottom of the file
+2. If the test operates on an xDSL operation or other workload which needs to be set up, this is best added in `benchmarks/workloads.py` as a new class method on `WorkloadBuilder`.
+
+3. Associate the method with a name in the main code at the bottom of the file
    
    For example, to add this new method, you might write
 

--- a/benchmarks/parser.py
+++ b/benchmarks/parser.py
@@ -5,11 +5,13 @@ from benchmarks.workloads import WorkloadBuilder
 from xdsl.context import Context
 from xdsl.dialects.arith import Arith
 from xdsl.dialects.builtin import Builtin
+from xdsl.dialects.func import Func
 from xdsl.parser import Parser as XdslParser
 
 CTX = Context(allow_unregistered=True)
 CTX.load_dialect(Arith)
 CTX.load_dialect(Builtin)
+CTX.load_dialect(Func)
 
 
 class Parser:
@@ -19,22 +21,29 @@ class Parser:
     WORKLOAD_CONSTANT_1000 = WorkloadBuilder.constant_folding(1000)
     WORKLOAD_LARGE_DENSE_ATTR = WorkloadBuilder.large_dense_attr()
     WORKLOAD_LARGE_DENSE_ATTR_HEX = WorkloadBuilder.large_dense_attr_hex()
+    WORKLOAD_LARGE_CONSTANT_TENSOR = str(
+        WorkloadBuilder.large_constant_tensor((1, 3, 1080, 1080))
+    )
 
     def time_constant_100(self) -> None:
-        """Time lexing constant folding for 100 items."""
+        """Time parsing constant folding for 100 items."""
         XdslParser(CTX, Parser.WORKLOAD_CONSTANT_100).parse_module()
 
     def time_constant_1000(self) -> None:
-        """Time lexing constant folding for 1000 items."""
+        """Time parsing constant folding for 1000 items."""
         XdslParser(CTX, Parser.WORKLOAD_CONSTANT_1000).parse_module()
 
     def ignore_time_dense_attr(self) -> None:
-        """Time lexing a 1024x1024xi8 dense attribute."""
+        """Time parsing a 1024x1024xi8 dense attribute."""
         XdslParser(CTX, Parser.WORKLOAD_LARGE_DENSE_ATTR).parse_module()
 
     def ignore_time_dense_attr_hex(self) -> None:
-        """Time lexing a 1024x1024xi8 dense attribute given as a hex string."""
+        """Time parsing a 1024x1024xi8 dense attribute given as a hex string."""
         XdslParser(CTX, Parser.WORKLOAD_LARGE_DENSE_ATTR_HEX).parse_module()
+
+    def time_large_constant_tensor(self) -> None:
+        """Time parsing a large constant tensor."""
+        XdslParser(CTX, Parser.WORKLOAD_LARGE_CONSTANT_TENSOR).parse_module()
 
 
 if __name__ == "__main__":
@@ -47,5 +56,8 @@ if __name__ == "__main__":
             "Parser.constant_1000": Benchmark(PARSER.time_constant_1000),
             "Parser.dense_attr": Benchmark(PARSER.ignore_time_dense_attr),
             "Parser.dense_attr_hex": Benchmark(PARSER.ignore_time_dense_attr_hex),
+            "Parser.large_constant_tensor": Benchmark(
+                PARSER.time_large_constant_tensor
+            ),
         }
     )

--- a/benchmarks/workloads.py
+++ b/benchmarks/workloads.py
@@ -153,6 +153,8 @@ class WorkloadBuilder:
         Returns:
             The created module containing the function with addition operations.
         """
+        assert num_add_ops >= 0
+        random.seed(RANDOM_SEED)
         tensor_type = TensorType(shape=tensor_shape, element_type=Float32Type())
         function_type = FunctionType.from_lists(
             inputs=[tensor_type], outputs=[tensor_type]

--- a/benchmarks/workloads.py
+++ b/benchmarks/workloads.py
@@ -2,16 +2,20 @@
 """Workloads for benchmarking xDSL."""
 
 import random
+from math import prod
 
-from xdsl.dialects.arith import AddiOp, ConstantOp
+from xdsl.dialects.arith import AddfOp, AddiOp, ConstantOp
 from xdsl.dialects.builtin import (
     DenseIntOrFPElementsAttr,
+    Float32Type,
+    FunctionType,
     IntegerAttr,
     ModuleOp,
     TensorType,
     i8,
     i32,
 )
+from xdsl.dialects.func import FuncOp, ReturnOp
 from xdsl.dialects.test import TestOp
 from xdsl.ir import Operation
 
@@ -133,3 +137,54 @@ class WorkloadBuilder:
             )
         ]
         return WorkloadBuilder.wrap_module(ops)
+
+    @classmethod
+    def large_constant_tensor(
+        cls,
+        tensor_shape: tuple[int, ...],
+        num_add_ops: int = 10,
+    ) -> ModuleOp:
+        """Create a module with a function that adds multiple large constant tensors.
+
+        Args:
+            tensor_shape: The shape of the constant tensors to be created.
+            num_add_ops: The number of addition operations to perform with the constant tensors.
+
+        Returns:
+            The created module containing the function with addition operations.
+        """
+        tensor_type = TensorType(shape=tensor_shape, element_type=Float32Type())
+        function_type = FunctionType.from_lists(
+            inputs=[tensor_type], outputs=[tensor_type]
+        )
+
+        func_op = FuncOp(name="main", function_type=function_type)
+
+        input_val = func_op.args[0]
+        output_val = input_val
+
+        for _ in range(num_add_ops):
+            # Create a constant tensor with random values
+            dense_elements_attr = DenseIntOrFPElementsAttr.from_list(
+                type=tensor_type,
+                data=[random.random() for _ in range(prod(tensor_shape))],
+            )
+            const_op = ConstantOp(value=dense_elements_attr, value_type=tensor_type)
+            func_op.body.block.add_op(const_op)
+
+            # Add the constant to the input value
+            add_op = AddfOp(
+                operand1=input_val, operand2=const_op, result_type=tensor_type
+            )
+            func_op.body.block.add_op(add_op)
+
+            # Update input_val to the result of the addition
+            input_val = add_op.result
+            output_val = add_op.result
+
+        return_op = ReturnOp(output_val)
+        func_op.body.block.add_op(return_op)
+
+        module_op = ModuleOp([func_op])
+        module_op.verify()
+        return module_op


### PR DESCRIPTION
#4834 discusses speeding up parsing by improving the way byte contents of strings are retrieved. This PR incorporates the benchmark proposed in the PR into the benchmarking suite for xDSL