### PR TITLE
bench: update docs and docstrings for benchmarks, peeled from #4840

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -71,7 +71,9 @@ uv run benchmarks/lexer.py Lexer.empty_program dis
         importlib.reload(xdsl.dialects.newdialect)
     ```
 
-2. Associate the method with a name in the main code at the bottom of the file
+2. If the test operates on an xDSL operation or other workload which needs to be set up, this is best added in `benchmarks/workloads.py` as a new class method on `WorkloadBuilder`.
+
+3. Associate the method with a name in the main code at the bottom of the file
    
    For example, to add this new method, you might write
 

--- a/benchmarks/parser.py
+++ b/benchmarks/parser.py
@@ -21,19 +21,19 @@ class Parser:
     WORKLOAD_LARGE_DENSE_ATTR_HEX = WorkloadBuilder.large_dense_attr_hex()
 
     def time_constant_100(self) -> None:
-        """Time lexing constant folding for 100 items."""
+        """Time parsing constant folding for 100 items."""
         XdslParser(CTX, Parser.WORKLOAD_CONSTANT_100).parse_module()
 
     def time_constant_1000(self) -> None:
-        """Time lexing constant folding for 1000 items."""
+        """Time parsing constant folding for 1000 items."""
         XdslParser(CTX, Parser.WORKLOAD_CONSTANT_1000).parse_module()
 
     def ignore_time_dense_attr(self) -> None:
-        """Time lexing a 1024x1024xi8 dense attribute."""
+        """Time parsing a 1024x1024xi8 dense attribute."""
         XdslParser(CTX, Parser.WORKLOAD_LARGE_DENSE_ATTR).parse_module()
 
     def ignore_time_dense_attr_hex(self) -> None:
-        """Time lexing a 1024x1024xi8 dense attribute given as a hex string."""
+        """Time parsing a 1024x1024xi8 dense attribute given as a hex string."""
         XdslParser(CTX, Parser.WORKLOAD_LARGE_DENSE_ATTR_HEX).parse_module()
 
 


### PR DESCRIPTION
Update docs and docstrings for benchmarks, peeled from #4840