### PR TITLE
transformations: (eqsat) don't apply eqsat rewrite patterns recursively

### DIFF
--- a/xdsl/transforms/apply_eqsat_pdl.py
+++ b/xdsl/transforms/apply_eqsat_pdl.py
@@ -55,7 +55,7 @@ class ApplyEqsatPDLPass(ModulePass):
         listener.operation_modification_handler.append(
             implementations.modification_handler
         )
-        walker = PatternRewriteWalker(rewrite_pattern)
+        walker = PatternRewriteWalker(rewrite_pattern, apply_recursively=False)
         walker.listener = listener
 
         for _i in range(self.max_iterations):

--- a/xdsl/transforms/apply_eqsat_pdl_interp.py
+++ b/xdsl/transforms/apply_eqsat_pdl_interp.py
@@ -47,7 +47,7 @@ class ApplyEqsatPDLInterpPass(ModulePass):
         listener.operation_modification_handler.append(
             implementations.modification_handler
         )
-        walker = PatternRewriteWalker(rewrite_pattern)
+        walker = PatternRewriteWalker(rewrite_pattern, apply_recursively=False)
         walker.listener = listener
 
         for _i in range(self.max_iterations):


### PR DESCRIPTION
We already do a number of iterations in the pass, so no need for recursion in the walker.