### PR TITLE
bench: shrink the #4834 benchmark size to run efficiently in CI

### DIFF
--- a/benchmarks/parser.py
+++ b/benchmarks/parser.py
@@ -22,7 +22,7 @@ class Parser:
     WORKLOAD_LARGE_DENSE_ATTR = WorkloadBuilder.large_dense_attr()
     WORKLOAD_LARGE_DENSE_ATTR_HEX = WorkloadBuilder.large_dense_attr_hex()
     WORKLOAD_LARGE_CONSTANT_TENSOR = str(
-        WorkloadBuilder.large_constant_tensor((1, 3, 1080, 1080))
+        WorkloadBuilder.large_constant_tensor((500, 500))
     )
 
     def time_constant_100(self) -> None:


### PR DESCRIPTION
Currently, the benchmark proposed in https://github.com/xdslproject/xdsl/pull/4840 takes 10s to run -- meaning it may timeout in CI when measurements are repeated. This PR reduces the tensor size to bring the time down to ~0.7s to avoid this issue.