### PR TITLE
transformations: (eqsat-add-costs) add default cost

### DIFF
--- a/tests/filecheck/transforms/eqsat-add-costs-with-default.mlir
+++ b/tests/filecheck/transforms/eqsat-add-costs-with-default.mlir
@@ -1,10 +1,10 @@
 // RUN: xdsl-opt -p eqsat-add-costs{default=1000} --verify-diagnostics --split-input-file %s | filecheck %s
 
 //      CHECK:    func.func @recursive(%a : index) -> index {
-// CHECK-NEXT:      %a_eq = eqsat.eclass %a, %b : index {min_cost_index = #builtin.int<0>}
+// CHECK-NEXT:      %a_eq = eqsat.eclass %a, %b {min_cost_index = #builtin.int<0>} : index
 // CHECK-NEXT:      %one = arith.constant {eqsat_cost = #builtin.int<1>} 1 : index
 // CHECK-NEXT:      %one_eq = eqsat.eclass %one {min_cost_index = #builtin.int<0>} : index
-// CHECK-NEXT:      %b = arith.muli %a_eq, %one_eq : index {eqsat_cost = #builtin.int<2>}
+// CHECK-NEXT:      %b = arith.muli %a_eq, %one_eq {eqsat_cost = #builtin.int<2>} : index
 // CHECK-NEXT:      func.return %a_eq : index
 // CHECK-NEXT:    }
 

--- a/tests/filecheck/transforms/eqsat-add-costs-with-default.mlir
+++ b/tests/filecheck/transforms/eqsat-add-costs-with-default.mlir
@@ -1,0 +1,17 @@
+// RUN: xdsl-opt -p eqsat-add-costs{default=1000} --verify-diagnostics --split-input-file %s | filecheck %s
+
+//      CHECK:    func.func @recursive(%a : index) -> index {
+// CHECK-NEXT:      %a_eq = eqsat.eclass %a, %b : index {min_cost_index = #builtin.int<0>}
+// CHECK-NEXT:      %one = arith.constant {eqsat_cost = #builtin.int<1>} 1 : index
+// CHECK-NEXT:      %one_eq = eqsat.eclass %one {min_cost_index = #builtin.int<0>} : index
+// CHECK-NEXT:      %b = arith.muli %a_eq, %one_eq : index {eqsat_cost = #builtin.int<2>}
+// CHECK-NEXT:      func.return %a_eq : index
+// CHECK-NEXT:    }
+
+func.func @recursive(%a : index) -> (index) {
+    %a_eq = eqsat.eclass %a, %b : index
+    %one = arith.constant 1 : index
+    %one_eq = eqsat.eclass %one : index
+    %b = arith.muli %a_eq, %one_eq : index
+    return %a_eq : index
+}

--- a/tests/filecheck/transforms/eqsat-add-costs.mlir
+++ b/tests/filecheck/transforms/eqsat-add-costs.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -p eqsat-add-costs{default=1000} --verify-diagnostics --split-input-file %s | filecheck %s
+// RUN: xdsl-opt -p eqsat-add-costs --verify-diagnostics --split-input-file %s | filecheck %s
 
 // CHECK:         func.func @trivial_arithmetic(%a : index, %b : index) -> index {
 // CHECK-NEXT:      %a_eq = eqsat.eclass %a {min_cost_index = #builtin.int<0>} : index

--- a/tests/filecheck/transforms/eqsat-add-costs.mlir
+++ b/tests/filecheck/transforms/eqsat-add-costs.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -p eqsat-add-costs --verify-diagnostics --split-input-file %s | filecheck %s
+// RUN: xdsl-opt -p eqsat-add-costs{default=1000} --verify-diagnostics --split-input-file %s | filecheck %s
 
 // CHECK:         func.func @trivial_arithmetic(%a : index, %b : index) -> index {
 // CHECK-NEXT:      %a_eq = eqsat.eclass %a {min_cost_index = #builtin.int<0>} : index
@@ -56,6 +56,24 @@ func.func @existing_cost(%a : index, %b : index) -> (index) {
     %a_times_two = arith.muli %a_eq, %two_eq : index
     %res_eq = eqsat.eclass %a_shift_one, %a_times_two : index
     func.return %res_eq : index
+}
+
+// -----
+
+//      CHECK:    func.func @recursive(%a : index) -> index {
+// CHECK-NEXT:      %a_eq = eqsat.eclass %a, %b : index
+// CHECK-NEXT:      %one = arith.constant {eqsat_cost = #builtin.int<1>} 1 : index
+// CHECK-NEXT:      %one_eq = eqsat.eclass %one {min_cost_index = #builtin.int<0>} : index
+// CHECK-NEXT:      %b = arith.muli %a_eq, %one_eq : index
+// CHECK-NEXT:      func.return %a_eq : index
+// CHECK-NEXT:    }
+
+func.func @recursive(%a : index) -> (index) {
+    %a_eq = eqsat.eclass %a, %b : index
+    %one = arith.constant 1 : index
+    %one_eq = eqsat.eclass %one : index
+    %b = arith.muli %a_eq, %one_eq : index
+    return %a_eq : index
 }
 
 // -----

--- a/xdsl/transforms/eqsat_add_costs.py
+++ b/xdsl/transforms/eqsat_add_costs.py
@@ -1,3 +1,7 @@
+from dataclasses import dataclass, field
+
+from typing_extensions import TypeVar
+
 from xdsl.context import Context
 from xdsl.dialects import builtin, eqsat
 from xdsl.dialects.builtin import IntAttr
@@ -5,16 +9,30 @@ from xdsl.ir import Block, OpResult, SSAValue
 from xdsl.passes import ModulePass
 from xdsl.utils.exceptions import DiagnosticException
 
+_DefaultCostT = TypeVar("_DefaultCostT", bound=int | None)
 
-def get_eqsat_cost(value: SSAValue) -> int | None:
+
+def get_eqsat_cost(
+    value: SSAValue, *, default: _DefaultCostT = None
+) -> int | _DefaultCostT:
+    """
+    Calculate or fetch the cost of computing a value.
+
+    If it's a block argument, return 0.
+    If it's an eclass op, take the minimal cost of its arguments.
+    If the cost is none, then return the default value provided, which is `None` by
+    default.
+    """
     if not isinstance(value, OpResult):
         return 0
     if isinstance(value.op, eqsat.EClassOp):
         if (min_cost_index := value.op.min_cost_index) is not None:
-            return get_eqsat_cost(value.op.operands[min_cost_index.data])
+            return get_eqsat_cost(
+                value.op.operands[min_cost_index.data], default=default
+            )
     cost_attribute = value.op.attributes.get(eqsat.EQSAT_COST_LABEL)
     if cost_attribute is None:
-        return None
+        return default
     if not isinstance(cost_attribute, IntAttr):
         raise DiagnosticException(
             f"Unexpected value {cost_attribute} for key {eqsat.EQSAT_COST_LABEL} in {value.op}"
@@ -22,7 +40,7 @@ def get_eqsat_cost(value: SSAValue) -> int | None:
     return cost_attribute.data
 
 
-def add_eqsat_costs(block: Block):
+def add_eqsat_costs(block: Block, default: int | None):
     for op in block.ops:
         if not op.results:
             # No need to annotate ops without results
@@ -37,7 +55,7 @@ def add_eqsat_costs(block: Block):
                 f"results: {op}"
             )
 
-        costs = tuple(get_eqsat_cost(value) for value in op.operands)
+        costs = tuple(get_eqsat_cost(value, default=default) for value in op.operands)
         if None in costs:
             continue
 
@@ -51,6 +69,7 @@ def add_eqsat_costs(block: Block):
             op.attributes[eqsat.EQSAT_COST_LABEL] = IntAttr(cost)
 
 
+@dataclass(frozen=True)
 class EqsatAddCostsPass(ModulePass):
     """
     Add costs to all operations in blocks that contain eqsat.eclass ops.
@@ -60,9 +79,15 @@ class EqsatAddCostsPass(ModulePass):
     operations of the operands + 1, if these are all non-`None`, and `None` otherwise.
     The cost is stored as an `IntAttr`, and cannot be computed for operations with
     multiple results.
+
+    If the cost cannot be calculated, the default value can be provided with the
+    `default` optional parameter.
     """
 
     name = "eqsat-add-costs"
+
+    default: int | None = field(default=None)
+    "Default cost to assign if it cannot be calculated."
 
     def apply(self, ctx: Context, op: builtin.ModuleOp) -> None:
         eclass_parent_blocks = set(
@@ -71,4 +96,4 @@ class EqsatAddCostsPass(ModulePass):
             if o.parent is not None and isinstance(o, eqsat.EClassOp)
         )
         for block in eclass_parent_blocks:
-            add_eqsat_costs(block)
+            add_eqsat_costs(block, default=self.default)


### PR DESCRIPTION
In the presence of cycles, our toy cost model falls over, as we calculate costs top to bottom. This PR adds a parameter to both the helper functions and the pass to provide a default value when it cannot be computed. The default behaviour is unchanged, but we now have an escape hatch to guarantee that we can extract something out of nothing (even if the order and dominance aren't guaranteed to be preserved).