### PR TITLE
dialects: (memref) Add missing traits to operations

### DIFF
--- a/tests/filecheck/dce.mlir
+++ b/tests/filecheck/dce.mlir
@@ -16,4 +16,27 @@
   // CHECK-NEXT:  %1 = "test.op"() : () -> i32
   // CHECK-NOT: addi
   // CHECK-NEXT:  "test.op"(%0) : (i32) -> ()
+
+  %10 = "memref.alloc"() <{operandSegmentSizes = array<i32: 0, 0>}> : () -> memref<memref<?xf32>>
+  %11 = memref.load %10[] : memref<memref<?xf32>>
+  %12 = arith.constant 1 : index
+  %13 = "memref.dim"(%11, %12) : (memref<?xf32>, index) -> index
+
+  // CHECK:       %2 = memref.alloc() : memref<memref<?xf32>>
+  // CHECK-NOT: memref.load
+  // CHECK-NOT: arith.constant
+  // CHECK-NOT: memref.dim
+
+  %20 = "memref.alloc"() <{operandSegmentSizes = array<i32: 0, 0>}> : () -> memref<memref<?xf32>>
+  %21 = memref.load %20[] : memref<memref<?xf32>>
+  %22 = arith.constant 0 : index
+  %23 = arith.constant 9.1 : f32
+  memref.store %23, %21[%22] : memref<?xf32>
+
+  // CHECK:       %3 = memref.alloc() : memref<memref<?xf32>>
+  // CHECK-NEXT:  %4 = memref.load %3[] : memref<memref<?xf32>>
+  // CHECK-NEXT:  %5 = arith.constant 0 : index
+  // CHECK-NEXT:  %6 = arith.constant 9.100000e+00 : f32
+  // CHECK-NEXT:  memref.store %6, %4[%5] : memref<?xf32>
+
 }) : () -> ()

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -66,12 +66,12 @@ from xdsl.traits import (
     HasCanonicalizationPatternsTrait,
     HasParent,
     IsTerminator,
+    MemoryAllocEffect,
+    MemoryFreeEffect,
+    MemoryReadEffect,
+    MemoryWriteEffect,
     NoMemoryEffect,
     SymbolOpInterface,
-    MemoryReadEffect,
-    MemoryAllocEffect,
-    MemoryWriteEffect,
-    MemoryFreeEffect,
 )
 from xdsl.utils.bitwise_casts import is_power_of_two
 from xdsl.utils.exceptions import VerifyException


### PR DESCRIPTION
Added traits to operations in the memref dialect where they were missing from, to set the memory effect for operations which is then leveraged by transformation passes so is beneficial to have them provided
