### PR TITLE
misc: return verified attribute/range from `verify`

### DIFF
--- a/tests/irdl/test_range_constraint.py
+++ b/tests/irdl/test_range_constraint.py
@@ -25,8 +25,8 @@ class AnyRangeConstraint(RangeConstraint):
 
     def verify(
         self, attrs: Sequence[Attribute], constraint_context: ConstraintContext
-    ) -> None:
-        return
+    ) -> Sequence[Attribute]:
+        return attrs
 
     def verify_length(self, length: int, constraint_context: ConstraintContext) -> None:
         return

--- a/tests/test_pyrdl.py
+++ b/tests/test_pyrdl.py
@@ -154,11 +154,12 @@ class LessThan(AttrConstraint):
         self,
         attr: Attribute,
         constraint_context: ConstraintContext,
-    ) -> None:
+    ) -> Attribute:
         if not isinstance(attr, IntData):
             raise VerifyException(f"{attr} should be of base attribute {IntData.name}")
         if attr.data >= self.bound:
             raise VerifyException(f"{attr} should hold a value less than {self.bound}")
+        return attr
 
     def mapping_type_vars(
         self, type_var_mapping: dict[TypeVar, AttrConstraint]
@@ -170,13 +171,16 @@ class LessThan(AttrConstraint):
 class GreaterThan(AttrConstraint):
     bound: int
 
-    def verify(self, attr: Attribute, constraint_context: ConstraintContext) -> None:
+    def verify(
+        self, attr: Attribute, constraint_context: ConstraintContext
+    ) -> Attribute:
         if not isinstance(attr, IntData):
             raise VerifyException(f"{attr} should be of base attribute {IntData.name}")
         if attr.data <= self.bound:
             raise VerifyException(
                 f"{attr} should hold a value greater than {self.bound}"
             )
+        return attr
 
     def mapping_type_vars(
         self, type_var_mapping: dict[TypeVar, AttrConstraint]

--- a/xdsl/dialects/bufferization.py
+++ b/xdsl/dialects/bufferization.py
@@ -76,14 +76,17 @@ class TensorFromMemRefConstraint(
         memref_type = self.memref_constraint.infer(context)
         return self.memref_to_tensor(memref_type)
 
-    def verify(self, attr: Attribute, constraint_context: ConstraintContext) -> None:
+    def verify(
+        self, attr: Attribute, constraint_context: ConstraintContext
+    ) -> TensorType[Attribute] | UnrankedTensorType[Attribute]:
         if isa(attr, TensorType | UnrankedTensorType):
             memref_type = self.tensor_to_memref(attr)
         else:
             raise VerifyException(
                 f"Expected tensor or unranked tensor type, got {attr}"
             )
-        return self.memref_constraint.verify(memref_type, constraint_context)
+        self.memref_constraint.verify(memref_type, constraint_context)
+        return attr
 
     def get_bases(self) -> set[type[Attribute]] | None:
         return {TensorType, UnrankedTensorType}

--- a/xdsl/dialects/pdl_interp.py
+++ b/xdsl/dialects/pdl_interp.py
@@ -536,7 +536,9 @@ class ValueConstrFromResultConstr(AttrConstraint[ValueType | RangeType[ValueType
             return RangeType(ValueType())
         return ValueType()
 
-    def verify(self, attr: Attribute, constraint_context: ConstraintContext) -> None:
+    def verify(
+        self, attr: Attribute, constraint_context: ConstraintContext
+    ) -> ValueType | RangeType[ValueType]:
         if isa(attr, RangeType[ValueType]):
             result_type = RangeType(TypeType())
         elif isa(attr, ValueType):
@@ -545,7 +547,8 @@ class ValueConstrFromResultConstr(AttrConstraint[ValueType | RangeType[ValueType
             raise VerifyException(
                 f"Expected an attribute of type ValueType or RangeType[ValueType], but got {attr}"
             )
-        return self.result_constr.verify(result_type, constraint_context)
+        self.result_constr.verify(result_type, constraint_context)
+        return attr
 
     def mapping_type_vars(
         self, type_var_mapping: dict[TypeVar, AttrConstraint]

--- a/xdsl/dialects/stencil.py
+++ b/xdsl/dialects/stencil.py
@@ -1208,7 +1208,9 @@ class TensorIgnoreSizeConstraint(VarConstraint[Attribute]):
             and attr.get_element_type() == other.get_element_type()
         )
 
-    def verify(self, attr: Attribute, constraint_context: ConstraintContext) -> None:
+    def verify(
+        self, attr: Attribute, constraint_context: ConstraintContext
+    ) -> Attribute:
         ctx_attr = constraint_context.get_variable(self.name)
         if ctx_attr is not None:
             if isa(
@@ -1216,8 +1218,8 @@ class TensorIgnoreSizeConstraint(VarConstraint[Attribute]):
             ) and TensorIgnoreSizeConstraint.ranks_and_element_types_match(
                 attr, ctx_attr
             ):
-                return
-        super().verify(attr, constraint_context)
+                return attr
+        return super().verify(attr, constraint_context)
 
 
 @irdl_op_definition

--- a/xdsl/dialects/utils/reshape_ops_utils.py
+++ b/xdsl/dialects/utils/reshape_ops_utils.py
@@ -5,7 +5,6 @@ for more details.
 """
 
 from dataclasses import dataclass
-from typing import cast
 
 from typing_extensions import TypeVar
 
@@ -41,11 +40,12 @@ class ContiguousArrayOfIntArray(AttrConstraint[ArrayOfIntArrayAttr]):
     An empty inner array is considered contiguous.
     """
 
-    def verify(self, attr: Attribute, constraint_context: ConstraintContext) -> None:
-        _CONTIGUOUS_ARRAY_TYPE_CONSTRAINT.verify(
+    def verify(
+        self, attr: Attribute, constraint_context: ConstraintContext
+    ) -> ArrayOfIntArrayAttr:
+        attr = _CONTIGUOUS_ARRAY_TYPE_CONSTRAINT.verify(
             attr, constraint_context=constraint_context
         )
-        attr = cast(ArrayOfIntArrayAttr, attr)
 
         # Flatten all integer values from all inner arrays
         flat_values = [e.value.data for inner in attr.data for e in inner.data]
@@ -53,6 +53,7 @@ class ContiguousArrayOfIntArray(AttrConstraint[ArrayOfIntArrayAttr]):
         for prev, curr in zip(flat_values, flat_values[1:]):
             if curr != prev + 1:
                 raise VerifyException(f"All inner arrays must be contiguous: {attr}")
+        return attr
 
     def mapping_type_vars(
         self, type_var_mapping: dict[TypeVar, AttrConstraint]


### PR DESCRIPTION
I occasionally have to do many stages of verification, and we don't have a nice way of doing that today. This PR unlocks a new pattern where you can use the verified attribute with the narrowed type without casting after verification.