### PR TITLE
misc: (utils) move `is_const_classvar` to utils

### DIFF
--- a/tests/dialects/test_irdl.py
+++ b/tests/dialects/test_irdl.py
@@ -19,7 +19,7 @@ from xdsl.dialects.irdl import (
 )
 from xdsl.ir import Block, Region
 from xdsl.irdl import IRDLOperation, irdl_op_definition
-from xdsl.utils.exceptions import PyRDLOpDefinitionError
+from xdsl.utils.exceptions import PyRDLError
 from xdsl.utils.test_value import create_ssa_value
 
 
@@ -147,7 +147,9 @@ def test_class_var_on_op():
 
 
 def test_class_var_on_op_invalid():
-    with pytest.raises(PyRDLOpDefinitionError, match="is neither a"):
+    with pytest.raises(
+        PyRDLError, match='Invalid ClassVar name "var", must be uppercase'
+    ):
         irdl_op_definition(MyOpWithClassVarInvalid)
 
 

--- a/tests/dialects/test_irdl.py
+++ b/tests/dialects/test_irdl.py
@@ -19,7 +19,7 @@ from xdsl.dialects.irdl import (
 )
 from xdsl.ir import Block, Region
 from xdsl.irdl import IRDLOperation, irdl_op_definition
-from xdsl.utils.exceptions import PyRDLError
+from xdsl.utils.exceptions import PyRDLOpDefinitionError
 from xdsl.utils.test_value import create_ssa_value
 
 
@@ -148,7 +148,7 @@ def test_class_var_on_op():
 
 def test_class_var_on_op_invalid():
     with pytest.raises(
-        PyRDLError, match='Invalid ClassVar name "var", must be uppercase'
+        PyRDLOpDefinitionError, match='Invalid ClassVar name "var", must be uppercase'
     ):
         irdl_op_definition(MyOpWithClassVarInvalid)
 

--- a/tests/dialects/test_irdl_with_annotations.py
+++ b/tests/dialects/test_irdl_with_annotations.py
@@ -6,7 +6,7 @@ from typing import ClassVar
 import pytest
 
 from xdsl.irdl import IRDLOperation, irdl_op_definition
-from xdsl.utils.exceptions import PyRDLError
+from xdsl.utils.exceptions import PyRDLOpDefinitionError
 
 
 class MyOpWithClassVar(IRDLOperation):
@@ -27,7 +27,7 @@ def test_class_var_on_op():
 
 def test_class_var_on_op_invalid():
     with pytest.raises(
-        PyRDLError, match='Invalid ClassVar name "var", must be uppercase'
+        PyRDLOpDefinitionError, match='Invalid ClassVar name "var", must be uppercase'
     ):
         irdl_op_definition(MyOpWithClassVarInvalid)
 

--- a/tests/dialects/test_irdl_with_annotations.py
+++ b/tests/dialects/test_irdl_with_annotations.py
@@ -6,7 +6,7 @@ from typing import ClassVar
 import pytest
 
 from xdsl.irdl import IRDLOperation, irdl_op_definition
-from xdsl.utils.exceptions import PyRDLOpDefinitionError
+from xdsl.utils.exceptions import PyRDLError
 
 
 class MyOpWithClassVar(IRDLOperation):
@@ -26,7 +26,9 @@ def test_class_var_on_op():
 
 
 def test_class_var_on_op_invalid():
-    with pytest.raises(PyRDLOpDefinitionError, match="is neither a"):
+    with pytest.raises(
+        PyRDLError, match='Invalid ClassVar name "var", must be uppercase'
+    ):
         irdl_op_definition(MyOpWithClassVarInvalid)
 
 

--- a/tests/irdl/test_attribute_definition.py
+++ b/tests/irdl/test_attribute_definition.py
@@ -57,10 +57,7 @@ from xdsl.irdl import (
 )
 from xdsl.parser import AttrParser, Parser
 from xdsl.printer import Printer
-from xdsl.utils.exceptions import (
-    PyRDLAttrDefinitionError,
-    VerifyException,
-)
+from xdsl.utils.exceptions import PyRDLAttrDefinitionError, VerifyException
 from xdsl.utils.hints import isa
 
 

--- a/tests/irdl/test_attribute_definition.py
+++ b/tests/irdl/test_attribute_definition.py
@@ -57,7 +57,7 @@ from xdsl.irdl import (
 )
 from xdsl.parser import AttrParser, Parser
 from xdsl.printer import Printer
-from xdsl.utils.exceptions import PyRDLAttrDefinitionError, VerifyException
+from xdsl.utils.exceptions import PyRDLAttrDefinitionError, PyRDLError, VerifyException
 from xdsl.utils.hints import isa
 
 
@@ -1087,10 +1087,8 @@ def test_class_var_pass():
 def test_class_var_fail():
     """Test that lowercase ClassVar fields are not allowed."""
     with pytest.raises(
-        PyRDLAttrDefinitionError,
-        match=re.escape(
-            "Invalid field type typing.ClassVar[int] for field name constant."
-        ),
+        PyRDLError,
+        match='Invalid ClassVar name "constant", must be uppercase.',
     ):
 
         @irdl_attr_definition

--- a/tests/irdl/test_attribute_definition.py
+++ b/tests/irdl/test_attribute_definition.py
@@ -1088,7 +1088,9 @@ def test_class_var_fail():
     """Test that lowercase ClassVar fields are not allowed."""
     with pytest.raises(
         PyRDLAttrDefinitionError,
-        match='Invalid ClassVar name "constant", must be uppercase.',
+        match=re.escape(
+            "Invalid field type typing.ClassVar[int] for field name constant."
+        ),
     ):
 
         @irdl_attr_definition

--- a/tests/irdl/test_attribute_definition.py
+++ b/tests/irdl/test_attribute_definition.py
@@ -57,7 +57,10 @@ from xdsl.irdl import (
 )
 from xdsl.parser import AttrParser, Parser
 from xdsl.printer import Printer
-from xdsl.utils.exceptions import PyRDLAttrDefinitionError, PyRDLError, VerifyException
+from xdsl.utils.exceptions import (
+    PyRDLAttrDefinitionError,
+    VerifyException,
+)
 from xdsl.utils.hints import isa
 
 
@@ -1087,7 +1090,7 @@ def test_class_var_pass():
 def test_class_var_fail():
     """Test that lowercase ClassVar fields are not allowed."""
     with pytest.raises(
-        PyRDLError,
+        PyRDLAttrDefinitionError,
         match='Invalid ClassVar name "constant", must be uppercase.',
     ):
 

--- a/xdsl/irdl/attributes.py
+++ b/xdsl/irdl/attributes.py
@@ -220,7 +220,7 @@ class ParamAttrDef:
         parameters: dict[str, ParamDef] = {}
 
         for field_name, field_type in field_types.items():
-            if is_const_classvar(field_name, field_type):
+            if is_const_classvar(field_name, field_type, PyRDLAttrDefinitionError):
                 field_values.pop(field_name, None)
                 continue
             try:

--- a/xdsl/irdl/operations.py
+++ b/xdsl/irdl/operations.py
@@ -33,6 +33,7 @@ from xdsl.ir import (
     SSAValue,
 )
 from xdsl.traits import OpTrait
+from xdsl.utils.classvar import is_const_classvar
 from xdsl.utils.exceptions import (
     ParseError,
     PyRDLOpDefinitionError,
@@ -44,7 +45,6 @@ from .attributes import (  # noqa: TID251
     IRDLAttrConstraint,
     irdl_list_to_attr_constraint,
     irdl_to_attr_constraint,
-    is_classvar,
     range_constr_coercion,
     single_range_constr_coercion,
 )
@@ -870,19 +870,6 @@ def lazy_traits_def(future_traits: Callable[[], tuple[OpTrait, ...]]):
 _OPERATION_DICT_KEYS = {key for cls in Operation.mro()[:-1] for key in cls.__dict__}
 
 
-def _is_const_classvar(field_name: str, annotation: Any) -> bool:
-    """
-    Operation definitions may only have `*_def` fields or constant class variables,
-    where the constness is defined by convention with an UPPER_CASE name and enforced by
-    pyright.
-    The type annotation can be one of
-     * `ClassVar[MyType]`,
-     * `ClassVar`, or
-     * `"ClassVar[MyType]"`.
-    """
-    return field_name.isupper() and is_classvar(annotation)
-
-
 @dataclass(kw_only=True)
 class OpDef:
     """The internal IRDL definition of an operation."""
@@ -962,7 +949,7 @@ class OpDef:
             annotations = parent_cls.__annotations__
 
             for field_name in annotations:
-                if _is_const_classvar(field_name, annotations[field_name]):
+                if is_const_classvar(field_name, annotations[field_name]):
                     continue
                 if field_name not in clsdict:
                     raise wrong_field_exception(field_name)
@@ -976,7 +963,7 @@ class OpDef:
                 if field_name in field_names:
                     # already registered value for field name
                     continue
-                if field_name in annotations and _is_const_classvar(
+                if field_name in annotations and is_const_classvar(
                     field_name, annotations[field_name]
                 ):
                     continue

--- a/xdsl/irdl/operations.py
+++ b/xdsl/irdl/operations.py
@@ -949,9 +949,9 @@ class OpDef:
             annotations = parent_cls.__annotations__
 
             for field_name in annotations:
-                if is_const_classvar(field_name, annotations[field_name]):
-                    continue
                 if field_name not in clsdict:
+                    if is_const_classvar(field_name, annotations[field_name]):
+                        continue
                     raise wrong_field_exception(field_name)
 
             for field_name in clsdict:

--- a/xdsl/irdl/operations.py
+++ b/xdsl/irdl/operations.py
@@ -950,7 +950,9 @@ class OpDef:
 
             for field_name in annotations:
                 if field_name not in clsdict:
-                    if is_const_classvar(field_name, annotations[field_name]):
+                    if is_const_classvar(
+                        field_name, annotations[field_name], PyRDLOpDefinitionError
+                    ):
                         continue
                     raise wrong_field_exception(field_name)
 
@@ -964,7 +966,7 @@ class OpDef:
                     # already registered value for field name
                     continue
                 if field_name in annotations and is_const_classvar(
-                    field_name, annotations[field_name]
+                    field_name, annotations[field_name], PyRDLOpDefinitionError
                 ):
                     continue
 

--- a/xdsl/utils/classvar.py
+++ b/xdsl/utils/classvar.py
@@ -1,5 +1,7 @@
 from typing import Any, ClassVar, get_origin
 
+from xdsl.utils.exceptions import PyRDLError
+
 
 def is_classvar(annotation: Any) -> bool:
     """
@@ -24,5 +26,10 @@ def is_const_classvar(field_name: str, annotation: Any) -> bool:
      * `ClassVar[MyType]`,
      * `ClassVar`, or
      * `"ClassVar[MyType]"`.
+    This function throws an exception on a non UPPER_CASE class variable.
     """
-    return field_name.isupper() and is_classvar(annotation)
+    if not is_classvar(annotation):
+        return False
+    if not field_name.isupper():
+        raise PyRDLError(f'Invalid ClassVar name "{field_name}", must be uppercase.')
+    return True

--- a/xdsl/utils/classvar.py
+++ b/xdsl/utils/classvar.py
@@ -17,7 +17,9 @@ def is_classvar(annotation: Any) -> bool:
     )
 
 
-def is_const_classvar(field_name: str, annotation: Any) -> bool:
+def is_const_classvar(
+    field_name: str, annotation: Any, error_type: type[PyRDLError]
+) -> bool:
     """
     Operation definitions may only have `*_def` fields or constant class variables,
     where the constness is defined by convention with an UPPER_CASE name and enforced by
@@ -31,5 +33,5 @@ def is_const_classvar(field_name: str, annotation: Any) -> bool:
     if not is_classvar(annotation):
         return False
     if not field_name.isupper():
-        raise PyRDLError(f'Invalid ClassVar name "{field_name}", must be uppercase.')
+        raise error_type(f'Invalid ClassVar name "{field_name}", must be uppercase.')
     return True

--- a/xdsl/utils/classvar.py
+++ b/xdsl/utils/classvar.py
@@ -1,0 +1,28 @@
+from typing import Any, ClassVar, get_origin
+
+
+def is_classvar(annotation: Any) -> bool:
+    """
+    The type annotation can be one of
+     * `ClassVar[MyType]`,
+     * `ClassVar`, or
+     * `"ClassVar[MyType]"`.
+    """
+    return (
+        get_origin(annotation) is ClassVar
+        or annotation is ClassVar
+        or (isinstance(annotation, str) and annotation.startswith("ClassVar"))
+    )
+
+
+def is_const_classvar(field_name: str, annotation: Any) -> bool:
+    """
+    Operation definitions may only have `*_def` fields or constant class variables,
+    where the constness is defined by convention with an UPPER_CASE name and enforced by
+    pyright.
+    The type annotation can be one of
+     * `ClassVar[MyType]`,
+     * `ClassVar`, or
+     * `"ClassVar[MyType]"`.
+    """
+    return field_name.isupper() and is_classvar(annotation)


### PR DESCRIPTION
Makes the error message slightly worse but makes things a bit more consistent.