### PR TITLE
dialects: (linalg) Broadcast and transpose op init methods take sequence of result types

### DIFF
--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/linalg/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/linalg/ops.mlir
@@ -121,6 +121,14 @@ linalg.matmul {id} ins(%18, %19 : memref<64x9216xf32>, memref<9216x4096xf32>) ou
 %copy = linalg.copy ins(%3 : tensor<2x3xf32>) outs(%2 : tensor<2x3xf32>) -> tensor<2x3xf32>
 linalg.copy ins(%1 : memref<1x256xf32>) outs(%1 : memref<1x256xf32>)
 
+%48 = "test.op"() : () -> (memref<f32>)
+
+linalg.broadcast ins(%48 : memref<f32>) outs(%1 : memref<1x256xf32>) dimensions = [0,1]
+
+%49, %50 = "test.op"() : () -> (memref<16x64xf32>, memref<64x16xf32>)
+
+linalg.transpose ins(%49 : memref<16x64xf32>) outs(%50 : memref<64x16xf32>) permutation = [1, 0]
+
 // CHECK-NEXT:  #map = affine_map<(d0, d1) -> ()>
 // CHECK-NEXT:  #map1 = affine_map<(d0, d1) -> (d0, d1)>
 // CHECK-NEXT:  module {
@@ -186,4 +194,8 @@ linalg.copy ins(%1 : memref<1x256xf32>) outs(%1 : memref<1x256xf32>)
 // CHECK-NEXT:    %36 = linalg.conv_2d_ngchw_fgchw {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%35#0, %35#1 : tensor<1x8x9x18x18xi8>, tensor<7x8x9x3x3xi8>) outs(%35#2 : tensor<1x8x7x16x16xi32>) -> tensor<1x8x7x16x16xi32>
 // CHECK-NEXT:    %{{.*}} = linalg.copy ins(%1#1 : tensor<2x3xf32>) outs(%1#0 : tensor<2x3xf32>) -> tensor<2x3xf32>
 // CHECK-NEXT:    linalg.copy ins(%0#1 : memref<1x256xf32>) outs(%0#1 : memref<1x256xf32>)
+// CHECK-NEXT:    %38 = "test.op"() : () -> memref<f32>
+// CHECK-NEXT:    linalg.broadcast ins(%38 : memref<f32>) outs(%0#1 : memref<1x256xf32>) dimensions = [0, 1]
+// CHECK-NEXT:    %39:2 = "test.op"() : () -> (memref<16x64xf32>, memref<64x16xf32>)
+// CHECK-NEXT:    linalg.transpose ins(%39#0 : memref<16x64xf32>) outs(%39#1 : memref<64x16xf32>) permutation = [1, 0]
 // CHECK-NEXT:  }

--- a/tests/interpreters/test_linalg_interpreter.py
+++ b/tests/interpreters/test_linalg_interpreter.py
@@ -237,7 +237,7 @@ def test_linalg_transpose():
         create_ssa_value(TensorType(f32, [3, 2])),
         create_ssa_value(TensorType(f32, [2, 3])),
         DenseArrayBase.from_list(i64, [1, 0]),
-        (TensorType(f32, [2, 3]),),
+        TensorType(f32, [2, 3]),
     )
 
     a = ShapedArray(TypedPtr.new_float32([3.0, 5.0, 6.0, 7.0, 8.0, 9.0]), [3, 2])

--- a/tests/interpreters/test_linalg_interpreter.py
+++ b/tests/interpreters/test_linalg_interpreter.py
@@ -237,7 +237,7 @@ def test_linalg_transpose():
         create_ssa_value(TensorType(f32, [3, 2])),
         create_ssa_value(TensorType(f32, [2, 3])),
         DenseArrayBase.from_list(i64, [1, 0]),
-        TensorType(f32, [2, 3]),
+        (TensorType(f32, [2, 3]),),
     )
 
     a = ShapedArray(TypedPtr.new_float32([3.0, 5.0, 6.0, 7.0, 8.0, 9.0]), [3, 2])

--- a/xdsl/dialects/linalg.py
+++ b/xdsl/dialects/linalg.py
@@ -936,8 +936,14 @@ class TransposeOp(IRDLOperation):
         input: SSAValue,
         init: SSAValue,
         permutation: Attribute,
-        result: Sequence[Attribute] | None = [],
+        result: Attribute | None = None,
     ):
+        if result is None:
+            if isa(input.type, TensorType):
+                result = (input.type,)
+            else:
+                result = ()
+
         arg_types = NamedOperation.body_arg_types((input, init))
 
         @Builder.implicit_region(arg_types)
@@ -1021,7 +1027,7 @@ class TransposeOp(IRDLOperation):
             input,
             init,
             DenseArrayBase.from_list(i64, permutation),
-            [result] if isa(result, TensorType) else [],
+            (result,) if isa(result, TensorType) else None,
         )
         return transpose
 
@@ -1302,8 +1308,14 @@ class BroadcastOp(IRDLOperation):
         input: SSAValue,
         init: SSAValue,
         dimensions: Attribute,
-        result: Sequence[Attribute] | None = [],
+        result: Attribute | None = None,
     ):
+        if result is None:
+            if isa(input.type, TensorType):
+                result = (input.type,)
+            else:
+                result = ()
+
         arg_types = NamedOperation.body_arg_types((input, init))
 
         @Builder.implicit_region(arg_types)
@@ -1392,7 +1404,7 @@ class BroadcastOp(IRDLOperation):
             input,
             init,
             DenseArrayBase.from_list(i64, dimensions),
-            [result] if isa(result, TensorType) else [],
+            (result,) if isa(result, TensorType) else None,
         )
         return broadcast
 

--- a/xdsl/dialects/linalg.py
+++ b/xdsl/dialects/linalg.py
@@ -1018,7 +1018,7 @@ class TransposeOp(IRDLOperation):
         parser.parse_punctuation("(")
         init = parser.parse_operand()
         parser.parse_punctuation(":")
-        result = parser.parse_type()
+        parser.parse_type()
         parser.parse_punctuation(")")
         parser.parse_keyword("permutation")
         parser.parse_punctuation("=")
@@ -1029,7 +1029,6 @@ class TransposeOp(IRDLOperation):
             input,
             init,
             DenseArrayBase.from_list(i64, permutation),
-            result if isa(result, TensorType) else None,
         )
         return transpose
 
@@ -1397,7 +1396,7 @@ class BroadcastOp(IRDLOperation):
         parser.parse_punctuation("(")
         init = parser.parse_operand()
         parser.parse_punctuation(":")
-        result = parser.parse_type()
+        parser.parse_type()
         parser.parse_punctuation(")")
         parser.parse_keyword("dimensions")
         parser.parse_punctuation("=")
@@ -1408,7 +1407,6 @@ class BroadcastOp(IRDLOperation):
             input,
             init,
             DenseArrayBase.from_list(i64, dimensions),
-            result if isa(result, TensorType) else None,
         )
         return broadcast
 

--- a/xdsl/dialects/linalg.py
+++ b/xdsl/dialects/linalg.py
@@ -943,6 +943,8 @@ class TransposeOp(IRDLOperation):
                 results = (input.type,)
             else:
                 results = ()
+        else:
+            results = (result,)
 
         arg_types = NamedOperation.body_arg_types((input, init))
 
@@ -1027,7 +1029,7 @@ class TransposeOp(IRDLOperation):
             input,
             init,
             DenseArrayBase.from_list(i64, permutation),
-            (result,) if isa(result, TensorType) else None,
+            result if isa(result, TensorType) else None,
         )
         return transpose
 
@@ -1315,6 +1317,8 @@ class BroadcastOp(IRDLOperation):
                 results = (input.type,)
             else:
                 results = ()
+        else:
+            results = (result,)
 
         arg_types = NamedOperation.body_arg_types((input, init))
 
@@ -1404,7 +1408,7 @@ class BroadcastOp(IRDLOperation):
             input,
             init,
             DenseArrayBase.from_list(i64, dimensions),
-            (result,) if isa(result, TensorType) else None,
+            result if isa(result, TensorType) else None,
         )
         return broadcast
 

--- a/xdsl/dialects/linalg.py
+++ b/xdsl/dialects/linalg.py
@@ -1021,7 +1021,7 @@ class TransposeOp(IRDLOperation):
             input,
             init,
             DenseArrayBase.from_list(i64, permutation),
-            result if isa(result, TensorType) else [],
+            [result] if isa(result, TensorType) else [],
         )
         return transpose
 
@@ -1392,7 +1392,7 @@ class BroadcastOp(IRDLOperation):
             input,
             init,
             DenseArrayBase.from_list(i64, dimensions),
-            result if isa(result, TensorType) else [],
+            [result] if isa(result, TensorType) else [],
         )
         return broadcast
 

--- a/xdsl/dialects/linalg.py
+++ b/xdsl/dialects/linalg.py
@@ -940,9 +940,9 @@ class TransposeOp(IRDLOperation):
     ):
         if result is None:
             if isa(input.type, TensorType):
-                result = (input.type,)
+                results = (input.type,)
             else:
-                result = ()
+                results = ()
 
         arg_types = NamedOperation.body_arg_types((input, init))
 
@@ -955,7 +955,7 @@ class TransposeOp(IRDLOperation):
                 "permutation": permutation,
             },
             operands=(input, init),
-            result_types=(result,),
+            result_types=(results,),
             regions=(hidden_region,),
         )
 
@@ -1312,9 +1312,9 @@ class BroadcastOp(IRDLOperation):
     ):
         if result is None:
             if isa(input.type, TensorType):
-                result = (input.type,)
+                results = (input.type,)
             else:
-                result = ()
+                results = ()
 
         arg_types = NamedOperation.body_arg_types((input, init))
 
@@ -1327,7 +1327,7 @@ class BroadcastOp(IRDLOperation):
                 "dimensions": dimensions,
             },
             operands=(input, init),
-            result_types=(result,),
+            result_types=(results,),
             regions=(hidden_region,),
         )
 

--- a/xdsl/dialects/linalg.py
+++ b/xdsl/dialects/linalg.py
@@ -936,7 +936,7 @@ class TransposeOp(IRDLOperation):
         input: SSAValue,
         init: SSAValue,
         permutation: Attribute,
-        result: Attribute | None = None,
+        result: Sequence[Attribute] | None = [],
     ):
         arg_types = NamedOperation.body_arg_types((input, init))
 
@@ -1021,7 +1021,7 @@ class TransposeOp(IRDLOperation):
             input,
             init,
             DenseArrayBase.from_list(i64, permutation),
-            result,
+            result if isa(result, TensorType) else [],
         )
         return transpose
 
@@ -1302,7 +1302,7 @@ class BroadcastOp(IRDLOperation):
         input: SSAValue,
         init: SSAValue,
         dimensions: Attribute,
-        result: Attribute | None = None,
+        result: Sequence[Attribute] | None = [],
     ):
         arg_types = NamedOperation.body_arg_types((input, init))
 
@@ -1392,7 +1392,7 @@ class BroadcastOp(IRDLOperation):
             input,
             init,
             DenseArrayBase.from_list(i64, dimensions),
-            result,
+            result if isa(result, TensorType) else [],
         )
         return broadcast
 

--- a/xdsl/dialects/linalg.py
+++ b/xdsl/dialects/linalg.py
@@ -939,8 +939,8 @@ class TransposeOp(IRDLOperation):
         result: Attribute | None = None,
     ):
         if result is None:
-            if isa(input.type, TensorType):
-                results = (input.type,)
+            if isa(init.type, TensorType):
+                results = (init.type,)
             else:
                 results = ()
         else:
@@ -1312,8 +1312,8 @@ class BroadcastOp(IRDLOperation):
         result: Attribute | None = None,
     ):
         if result is None:
-            if isa(input.type, TensorType):
-                results = (input.type,)
+            if isa(init.type, TensorType):
+                results = (init.type,)
             else:
                 results = ()
         else:


### PR DESCRIPTION
This is a bug fix for the broadcast and transpose linalg methods, where the result type is varadic but the default result init method is None, which results in an error. This therefore fixes that by defaulting to an empty list.

This also ensures these two operations match MLIR behaviour which is when the outs type is a tensor then the result type of the operation is a tensor, otherwise if the outs type is a memref then there is no result type. The parsing routing did not handle this, so this nuance is now added (the verification already picked this up, as the only result type can be a tensor). This meant we could not use memrefs as output from these operations when passed to MLIR, which we can now.

I have updated the filecheck test to include no result type with memref as outs type
