### PR TITLE
misc: (dlti) add `allow-unregistered-dialect` to test

### DIFF
--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/dlti/attrs.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/dlti/attrs.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s | mlir-opt --mlir-print-op-generic | filecheck %s
+// RUN: xdsl-opt %s | mlir-opt --mlir-print-op-generic --allow-unregistered-dialect | filecheck %s
 
 // CHECK: entry1 = #dlti.dl_entry<"str", i32>
 // CHECK: entry2 = #dlti.dl_entry<i32, i32>


### PR DESCRIPTION
My tests are failing locally without this, unsure why CI and presumably everyone elses is fine.