### PR TITLE
CI: use --allow-unregistered-dialect in LLVM attrs test

### DIFF
--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/attrs.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/attrs.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt %s --mlir-print-op-generic | xdsl-opt --print-op-generic | filecheck %s
+// RUN: mlir-opt %s --mlir-print-op-generic --allow-unregistered-dialect | xdsl-opt --print-op-generic | filecheck %s
 
 // CHECK: frame_all = #llvm.framePointerKind<all>
 // CHECK: frame_non_leaf = #llvm.framePointerKind<"non-leaf">


### PR DESCRIPTION
I can't figure out hoew go get the CI to catch this.