### PR TITLE
dialects: (tosa) implement trig operations

### DIFF
--- a/tests/filecheck/dialects/tosa/ops.mlir
+++ b/tests/filecheck/dialects/tosa/ops.mlir
@@ -10,6 +10,9 @@
 %7 = tosa.sub %0, %1 : (tensor<12x34xi32>, tensor<1x1xi32>) -> tensor<12x34xi32>
 %8 = tosa.mul %0, %0 : (tensor<12x34xi32>, tensor<12x34xi32>) -> tensor<12x34xi32>
 %9 = tosa.mul %0, %1 : (tensor<12x34xi32>, tensor<1x1xi32>) -> tensor<12x34xi32>
+%10 = "test.op"() : () -> tensor<12x13xf32>
+%11 = tosa.sin %10 : (tensor<12x13xf32>) -> tensor<12x13xf32>
+%12 = tosa.cos %10 : (tensor<12x13xf32>) -> tensor<12x13xf32>
 
 
 // CHECK: builtin.module {
@@ -23,4 +26,7 @@
 // CHECK-NEXT:   %7 = tosa.sub %0, %1 : (tensor<12x34xi32>, tensor<1x1xi32>) -> tensor<12x34xi32>
 // CHECK-NEXT:   %8 = tosa.mul %0, %0 : (tensor<12x34xi32>, tensor<12x34xi32>) -> tensor<12x34xi32>
 // CHECK-NEXT:   %9 = tosa.mul %0, %1 : (tensor<12x34xi32>, tensor<1x1xi32>) -> tensor<12x34xi32>
+// CHECK-NEXT:   %10 = "test.op"() : () -> tensor<12x13xf32>
+// CHECK-NEXT:   %11 = tosa.sin %10 : (tensor<12x13xf32>) -> tensor<12x13xf32>
+// CHECK-NEXT:   %12 = tosa.cos %10 : (tensor<12x13xf32>) -> tensor<12x13xf32>
 // CHECK-NEXT: }

--- a/xdsl/dialects/tosa.py
+++ b/xdsl/dialects/tosa.py
@@ -5,6 +5,7 @@ from xdsl.dialects.builtin import (
     I32,
     I64,
     AnyAttr,
+    AnyFloatConstr,
     BoolAttr,
     DenseArrayBase,
     FloatAttr,
@@ -181,6 +182,45 @@ class MulOp(ElementwiseBinaryOperation):
     )
 
 
+class ElementwiseTrigOperation(IRDLOperation, ABC):
+    """
+    Abstract base class for elementwise trig operations on tensors of floating-point types
+    """
+
+    T: ClassVar = VarConstraint("T", AnyFloatConstr)
+
+    input1 = operand_def(TensorType.constr(T))
+    result = result_def(TensorType.constr(T))
+
+    traits = traits_def(
+        Pure(),
+    )
+
+    assembly_format = "operands attr-dict `:` functional-type(operands, results)"
+
+
+@irdl_op_definition
+class SinOp(ElementwiseTrigOperation):
+    """
+    TOSA dialect operation computing sin(x) for each element in a tensor
+
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/TOSA/#tosasin-mlirtosasinop)
+    """
+
+    name = "tosa.sin"
+
+
+@irdl_op_definition
+class CosOp(ElementwiseTrigOperation):
+    """
+    TOSA dialect operation computing cos(x) for each element in a tensor
+
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/TOSA/#tosacos-mlirtosacosop)
+    """
+
+    name = "tosa.cos"
+
+
 TOSA = Dialect(
     "tosa",
     [
@@ -189,6 +229,8 @@ TOSA = Dialect(
         AddOp,
         SubOp,
         MulOp,
+        SinOp,
+        CosOp,
     ],
     [],
 )

--- a/xdsl/dialects/tosa.py
+++ b/xdsl/dialects/tosa.py
@@ -112,7 +112,19 @@ class RescaleOp(IRDLOperation):
     assembly_format = "$input attr-dict `:` `(` type($input) `)` `->` type($output)"
 
 
-class ElementwiseBinaryOperation(IRDLOperation, ABC):
+class ElementwiseOperation(IRDLOperation, ABC):
+    """
+    Abstract superclass for elementwise TOSA operations
+    """
+
+    assembly_format = "operands attr-dict `:` functional-type(operands, results)"
+
+    traits = traits_def(
+        Pure(),
+    )
+
+
+class ElementwiseBinaryOperation(ElementwiseOperation):
     """
     Abstract superclass for elementwise, binary TOSA operations.
     """
@@ -122,12 +134,6 @@ class ElementwiseBinaryOperation(IRDLOperation, ABC):
     input1 = operand_def(TensorType.constr(T))
     input2 = operand_def(TensorType.constr(T))
     output = result_def(TensorType.constr(T))
-
-    assembly_format = "operands attr-dict `:` functional-type(operands, results)"
-
-    traits = traits_def(
-        Pure(),
-    )
 
     def verify_(self) -> None:
         t1 = self.input1.type
@@ -177,14 +183,13 @@ class MulOp(ElementwiseBinaryOperation):
     name = "tosa.mul"
 
     traits = traits_def(
-        Pure(),
         Commutative(),
     )
 
 
-class ElementwiseTrigOperation(IRDLOperation, ABC):
+class ElementwiseUnaryOperation(ElementwiseOperation):
     """
-    Abstract base class for elementwise trig operations on tensors of floating-point types
+    Abstract base class for elementwise unary operations on tensors of floating-point types
     """
 
     T: ClassVar = VarConstraint("T", AnyFloatConstr)
@@ -200,7 +205,7 @@ class ElementwiseTrigOperation(IRDLOperation, ABC):
 
 
 @irdl_op_definition
-class SinOp(ElementwiseTrigOperation):
+class SinOp(ElementwiseUnaryOperation):
     """
     TOSA dialect operation computing sin(x) for each element in a tensor
 
@@ -211,7 +216,7 @@ class SinOp(ElementwiseTrigOperation):
 
 
 @irdl_op_definition
-class CosOp(ElementwiseTrigOperation):
+class CosOp(ElementwiseUnaryOperation):
     """
     TOSA dialect operation computing cos(x) for each element in a tensor
 

--- a/xdsl/dialects/tosa.py
+++ b/xdsl/dialects/tosa.py
@@ -1,5 +1,6 @@
 from abc import ABC
 from typing import ClassVar, Generic
+
 from typing_extensions import TypeVar
 
 from xdsl.dialects.builtin import (

--- a/xdsl/dialects/tosa.py
+++ b/xdsl/dialects/tosa.py
@@ -200,12 +200,6 @@ class ElementwiseUnaryOperation(Generic[TInv], ElementwiseOperation):
     input1 = operand_def(TInv)
     result = result_def(TInv)
 
-    traits = traits_def(
-        Pure(),
-    )
-
-    assembly_format = "operands attr-dict `:` functional-type(operands, results)"
-
 
 @irdl_op_definition
 class SinOp(ElementwiseUnaryOperation[TensorType[AnyFloat]]):

--- a/xdsl/dialects/tosa.py
+++ b/xdsl/dialects/tosa.py
@@ -1,11 +1,12 @@
 from abc import ABC
-from typing import ClassVar
+from typing import ClassVar, Generic
+from typing_extensions import TypeVar
 
 from xdsl.dialects.builtin import (
     I32,
     I64,
     AnyAttr,
-    AnyFloatConstr,
+    AnyFloat,
     BoolAttr,
     DenseArrayBase,
     FloatAttr,
@@ -187,15 +188,16 @@ class MulOp(ElementwiseBinaryOperation):
     )
 
 
-class ElementwiseUnaryOperation(ElementwiseOperation):
+TInv = TypeVar("TInv", bound=TensorType)
+
+
+class ElementwiseUnaryOperation(Generic[TInv], ElementwiseOperation):
     """
     Abstract base class for elementwise unary operations on tensors of floating-point types
     """
 
-    T: ClassVar = VarConstraint("T", AnyFloatConstr)
-
-    input1 = operand_def(TensorType.constr(T))
-    result = result_def(TensorType.constr(T))
+    input1 = operand_def(TInv)
+    result = result_def(TInv)
 
     traits = traits_def(
         Pure(),
@@ -205,7 +207,7 @@ class ElementwiseUnaryOperation(ElementwiseOperation):
 
 
 @irdl_op_definition
-class SinOp(ElementwiseUnaryOperation):
+class SinOp(ElementwiseUnaryOperation[TensorType[AnyFloat]]):
     """
     TOSA dialect operation computing sin(x) for each element in a tensor
 
@@ -216,7 +218,7 @@ class SinOp(ElementwiseUnaryOperation):
 
 
 @irdl_op_definition
-class CosOp(ElementwiseUnaryOperation):
+class CosOp(ElementwiseUnaryOperation[TensorType[AnyFloat]]):
     """
     TOSA dialect operation computing cos(x) for each element in a tensor
 


### PR DESCRIPTION
Adds operations for `tosa.cos` and `tosa.sin` and a positive roundtrip test case