### PR TITLE
core: Abstract `uses` field from `IRWithUses`

### DIFF
--- a/tests/test_use.py
+++ b/tests/test_use.py
@@ -24,8 +24,8 @@ def test_main():
     assert isinstance(module, ModuleOp)
 
     op1, op2 = list(module.ops)
-    assert op1.results[0].uses == {Use(op2, 0), Use(op2, 1)}
-    assert op2.results[0].uses == set()
+    assert set(op1.results[0].uses) == {Use(op2, 0), Use(op2, 1)}
+    assert not op2.results[0].uses
 
     print("Done")
 

--- a/xdsl/transforms/experimental/dmp/stencil_global_to_local.py
+++ b/xdsl/transforms/experimental/dmp/stencil_global_to_local.py
@@ -57,7 +57,7 @@ class AddHaloExchangeOps(RewritePattern):
         swap_op = dmp.SwapOp.get(op.res, self.strategy)
         assert swap_op.swapped_values
         rewriter.insert_op_after_matched_op(swap_op)
-        for use in op.res.uses.copy():
+        for use in tuple(op.res.uses):
             if use.operation is swap_op:
                 continue
             use.operation.operands[use.index] = swap_op.swapped_values

--- a/xdsl/transforms/stencil_bufferize.py
+++ b/xdsl/transforms/stencil_bufferize.py
@@ -198,7 +198,7 @@ class LoadBufferFoldPattern(RewritePattern):
 
         # TODO: further analysis
         # For now, only handle usages in the same block
-        uses = op.res.uses.copy()
+        uses = tuple(op.res.uses)
         block = op.parent
         if not block or any(use.operation.parent is not block for use in uses):
             return

--- a/xdsl/transforms/test_constant_folding.py
+++ b/xdsl/transforms/test_constant_folding.py
@@ -165,13 +165,13 @@ class TestSpecialisedConstantFoldingPass(ModulePass):
                     ## We know there is only one result, so can elide the loop
                     old_result = old_op.results[0]
                     ## There are no callbacks, so can elide `self.handle_operation_modification(use.operation)`
-                    for use in old_result.uses.copy():
+                    for use in tuple(old_result.uses):
                         ## Inline `use.operation.operands.__setitem__(...)`
                         operands = use.operation._operands  # pyright: ignore[reportPrivateUsage]
                         ## Inline `operands[use.index].remove_use(Use(use.operation, use.index))`
-                        operands[use.index].uses.remove(use)
+                        operands[use.index]._uses.remove(use)  # pyright: ignore[reportPrivateUsage]
                         ## Inline `new_result.add_use(Use(use.operation, use.index))`
-                        new_result.uses.add(use)
+                        new_result._uses.add(use)  # pyright: ignore[reportPrivateUsage]
                         new_operands = (
                             *operands[: use.index],
                             new_result,
@@ -213,7 +213,7 @@ class TestSpecialisedConstantFoldingPass(ModulePass):
                     old_op.parent = None
                     for idx, operand in enumerate(old_op._operands):  # pyright: ignore[reportPrivateUsage]
                         ## Inline `operand.remove_use(Use(old_op, idx))`
-                        operand.uses.remove(Use(old_op, idx))
+                        operand._uses.remove(Use(old_op, idx))  # pyright: ignore[reportPrivateUsage]
                     ## This application has no regions, so no recursive drops
 
                     for result in old_op.results:


### PR DESCRIPTION
Stacked PRs:
 * #4909
 * #4908
 * #4907
 * __->__#4906


--- --- ---

### core: Abstract `uses` field from `IRWithUses`


This is a refactor which will make it easier to make `IRWithUses` use
a linked list.
