### PR TITLE
core: Remove __len__ from IRUses

### DIFF
--- a/docs/Toy/toy/rewrites/inline_toy.py
+++ b/docs/Toy/toy/rewrites/inline_toy.py
@@ -50,7 +50,7 @@ class InlineFunctions(RewritePattern):
 
         # remove block args
         while len(impl_block.args):
-            assert not len(impl_block.args[-1].uses)
+            assert not impl_block.args[-1].uses
             rewriter.erase_block_argument(impl_block.args[-1])
 
         # Inline function definition before matched op

--- a/docs/marimo/xdsl_introduction.py
+++ b/docs/marimo/xdsl_introduction.py
@@ -780,7 +780,7 @@ def _(
     class DeadConstantElim(RewritePattern):
         @op_type_rewrite_pattern
         def match_and_rewrite(self, op: arith.ConstantOp, rewriter: PatternRewriter):
-            if len(op.result.uses) == 0:
+            if not op.result.uses:
                 rewriter.erase_matched_op()
 
 

--- a/tests/dialects/test_llvm.py
+++ b/tests/dialects/test_llvm.py
@@ -109,7 +109,7 @@ def test_llvm_pointer_ops():
 
     module.verify()
 
-    assert len(alloc_ptr.res.uses) == 1
+    assert alloc_ptr.res.has_one_use()
     assert ptr.size is idx.result
     assert isinstance(ptr.res.type, llvm.LLVMPointerType)
     assert ptr.res.type.type == builtin.i32

--- a/tests/interpreters/test_eqsat_pdl_interp_interpreter.py
+++ b/tests/interpreters/test_eqsat_pdl_interp_interpreter.py
@@ -461,7 +461,7 @@ def test_run_create_operation_existing_operation_not_in_use():
 
     # Verify the existing operation has no uses
     assert len(existing_op.results) > 0, "Existing operation must have results"
-    assert len(existing_op.results[0].uses) == 0, (
+    assert not existing_op.results[0].uses, (
         "Existing operation result should have no uses"
     )
 

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -161,8 +161,8 @@ def test_op_operands_assign():
     op.operands = [val2, val1]
     op.verify()
 
-    assert len(val1.uses) == 1
-    assert len(val2.uses) == 1
+    assert val1.has_one_use()
+    assert val2.has_one_use()
     assert tuple(op.operands) == (val2, val1)
 
 
@@ -180,8 +180,8 @@ def test_op_operands_indexing():
     op.operands[0] = val2
     op.verify()
 
-    assert len(val1.uses) == 0
-    assert len(val2.uses) == 2
+    assert not list(val1.uses)
+    assert len(list(val2.uses)) == 2
     assert tuple(op.operands) == (val2, val2)
 
 

--- a/xdsl/dialects/accfg.py
+++ b/xdsl/dialects/accfg.py
@@ -168,9 +168,7 @@ class LaunchOp(IRDLOperation):
             )
 
         # that the token is used
-        if len(self.token.uses) != 1 or not isinstance(
-            next(iter(self.token.uses)).operation, AwaitOp
-        ):
+        if not isinstance(self.token.get_user_of_unique_use(), AwaitOp):
             raise VerifyException("Launch token must be used by exactly one await op")
 
         # that len(values) == len(param_names)

--- a/xdsl/dialects/eqsat.py
+++ b/xdsl/dialects/eqsat.py
@@ -77,7 +77,7 @@ class EClassOp(IRDLOperation):
                     "another eclass."
                 )
 
-            if len(operand.uses) != 1:
+            if not operand.has_one_use():
                 if len(set(use.operation for use in operand.uses)) == 1:
                     raise VerifyException(
                         "Eclass operands must only be used once by the eclass."

--- a/xdsl/interpreters/eqsat_pdl_interp.py
+++ b/xdsl/interpreters/eqsat_pdl_interp.py
@@ -148,10 +148,8 @@ class EqsatPDLInterpFunctions(PDLInterpFunctions):
         if result is None:
             return (None,)
 
-        if len(result.uses) == 1:
-            if isinstance(
-                eclass_op := next(iter(result.uses)).operation, eqsat.EClassOp
-            ):
+        if result.has_one_use():
+            if isinstance(eclass_op := result.get_user_of_unique_use(), eqsat.EClassOp):
                 result = eclass_op.result
         elif result.uses:  # multiple uses
             for use in result.uses:
@@ -179,9 +177,9 @@ class EqsatPDLInterpFunctions(PDLInterpFunctions):
 
         results: list[OpResult] = []
         for result in src_op.results:
-            if len(result.uses) == 1:
+            if result.has_one_use():
                 if isinstance(
-                    eclass_op := next(iter(result.uses)).operation, eqsat.EClassOp
+                    eclass_op := result.get_user_of_unique_use(), eqsat.EClassOp
                 ):
                     assert len(eclass_op.results) == 1
                     result = eclass_op.results[0]
@@ -356,7 +354,9 @@ class EqsatPDLInterpFunctions(PDLInterpFunctions):
                 self.backtrack_stack.pop()
             else:
                 backtrack_point.index += 1
-                interpreter._ctx = backtrack_point.scope  # pyright: ignore[reportPrivateUsage]
+                interpreter._ctx = (  # pyright: ignore[reportPrivateUsage]
+                    backtrack_point.scope
+                )
                 self.visited = False
                 return Successor(backtrack_point.block, backtrack_point.block_args), ()
         return ReturnedValues(()), ()

--- a/xdsl/interpreters/irdl.py
+++ b/xdsl/interpreters/irdl.py
@@ -120,7 +120,7 @@ class IRDLFunctions(InterpreterFunctions):
     @impl(irdl.IsOp)
     def run_is(self, interpreter: Interpreter, op: irdl.IsOp, args: PythonValues):
         constr = EqAttrConstraint(op.expected)
-        if len(op.output.uses) > 1:
+        if op.output.has_more_than_one_use():
             constr = self.variable_wrap(interpreter, constr)
         return (constr,)
 
@@ -129,14 +129,14 @@ class IRDLFunctions(InterpreterFunctions):
         self, interpreter: Interpreter, op: irdl.AnyOfOp, args: PythonValues
     ):
         constr = AnyOf[Attribute](args)
-        if len(op.output.uses) > 1:
+        if op.output.has_more_than_one_use():
             constr = self.variable_wrap(interpreter, constr)
         return (constr,)
 
     @impl(irdl.AnyOp)
     def run_any(self, interpreter: Interpreter, op: irdl.AnyOp, args: PythonValues):
         constr = AnyAttr()
-        if len(op.output.uses) > 1:
+        if op.output.has_more_than_one_use():
             constr = self.variable_wrap(interpreter, constr)
         return (constr,)
 
@@ -151,7 +151,7 @@ class IRDLFunctions(InterpreterFunctions):
             )
         base_type = self.get_attr(interpreter, base_attr_op.qualified_name)
         constr = ParamAttrConstraint(base_type, args)
-        if len(op.output.uses) > 1:
+        if op.output.has_more_than_one_use():
             constr = self.variable_wrap(interpreter, constr)
         return (constr,)
 

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -547,9 +547,6 @@ class IRUses(Iterable[Use]):
     def __iter__(self):
         return self.ir._uses.__iter__()  # pyright: ignore[reportPrivateUsage]
 
-    def __len__(self):
-        return len(self.ir._uses)  # pyright: ignore[reportPrivateUsage]
-
     def __bool__(self) -> bool:
         """Returns `True` if there are operations in this block."""
         return bool(self.ir._uses)  # pyright: ignore[reportPrivateUsage]

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -648,7 +648,7 @@ class PatternRewriteWalker:
         """
         for operand in operands:
             if (
-                len(operand.uses) == 1
+                operand.has_one_use()
                 and not isinstance(operand, ErasedSSAValue)
                 and isinstance((op := operand.owner), Operation)
             ):

--- a/xdsl/transforms/canonicalization_patterns/arith.py
+++ b/xdsl/transforms/canonicalization_patterns/arith.py
@@ -117,8 +117,7 @@ class FoldConstsByReassociation(RewritePattern):
 
         if (
             not isinstance(const1, arith.ConstantOp)
-            or len(op.result.uses) != 1
-            or not isinstance(u := list(op.result.uses)[0].operation, type(op))
+            or not isinstance(u := op.result.get_user_of_unique_use(), type(op))
             or not isinstance(
                 const2 := u.lhs.owner if u.rhs == op.result else u.rhs.owner,
                 arith.ConstantOp,

--- a/xdsl/transforms/canonicalization_patterns/cf.py
+++ b/xdsl/transforms/canonicalization_patterns/cf.py
@@ -516,10 +516,8 @@ class SimplifySwitchFromSwitchOnSameCondition(RewritePattern):
         block = op.parent_block()
         if block is None:
             return
-        preds = block.uses
-        if len(preds) != 1:
+        if (pred := block.get_unique_use()) is None:
             return
-        pred = next(iter(preds))
         switch = pred.operation
         if not isinstance(switch, cf.SwitchOp):
             return

--- a/xdsl/transforms/canonicalization_patterns/csl.py
+++ b/xdsl/transforms/canonicalization_patterns/csl.py
@@ -22,8 +22,8 @@ class GetDsdAndOffsetFolding(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: csl.GetMemDsdOp, rewriter: PatternRewriter) -> None:
         # single use that is `@increment_dsd_offset`
-        if len(op.result.uses) != 1 or not isinstance(
-            offset_op := next(iter(op.result.uses)).operation, csl.IncrementDsdOffsetOp
+        if not isinstance(
+            offset_op := op.result.get_user_of_unique_use(), csl.IncrementDsdOffsetOp
         ):
             return
         # only works on 1d
@@ -62,8 +62,8 @@ class GetDsdAndLengthFolding(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: csl.GetMemDsdOp, rewriter: PatternRewriter) -> None:
         # single use that is `@set_dsd_length`
-        if len(op.result.uses) != 1 or not isinstance(
-            size_op := next(iter(op.result.uses)).operation, csl.SetDsdLengthOp
+        if not isinstance(
+            size_op := op.result.get_user_of_unique_use(), csl.SetDsdLengthOp
         ):
             return
         # only works on 1d
@@ -89,8 +89,8 @@ class GetDsdAndStrideFolding(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: csl.GetMemDsdOp, rewriter: PatternRewriter) -> None:
         # single use that is `@set_dsd_stride`
-        if len(op.result.uses) != 1 or not isinstance(
-            stride_op := next(iter(op.result.uses)).operation, csl.SetDsdStrideOp
+        if not isinstance(
+            stride_op := op.result.get_user_of_unique_use(), csl.SetDsdStrideOp
         ):
             return
         # only works on 1d and default (unspecified) tensor_access
@@ -129,8 +129,8 @@ class ChainedDsdOffsetFolding(RewritePattern):
         self, op: csl.IncrementDsdOffsetOp, rewriter: PatternRewriter
     ) -> None:
         # single use that is `@increment_dsd_offset`
-        if len(op.result.uses) != 1 or not isinstance(
-            next_op := next(iter(op.result.uses)).operation, csl.IncrementDsdOffsetOp
+        if not isinstance(
+            next_op := op.result.get_user_of_unique_use(), csl.IncrementDsdOffsetOp
         ):
             return
 
@@ -160,8 +160,8 @@ class ChainedDsdLengthFolding(RewritePattern):
         self, op: csl.SetDsdLengthOp, rewriter: PatternRewriter
     ) -> None:
         # single use that is `@set_dsd_length`
-        if len(op.result.uses) != 1 or not isinstance(
-            next_op := next(iter(op.result.uses)).operation, csl.SetDsdLengthOp
+        if not isinstance(
+            next_op := op.result.get_user_of_unique_use(), csl.SetDsdLengthOp
         ):
             return
 
@@ -186,8 +186,8 @@ class ChainedDsdStrideFolding(RewritePattern):
         self, op: csl.SetDsdStrideOp, rewriter: PatternRewriter
     ) -> None:
         # single use that is `@set_dsd_stride`
-        if len(op.result.uses) != 1 or not isinstance(
-            next_op := next(iter(op.result.uses)).operation, csl.SetDsdStrideOp
+        if not isinstance(
+            next_op := op.result.get_user_of_unique_use(), csl.SetDsdStrideOp
         ):
             return
 

--- a/xdsl/transforms/canonicalization_patterns/csl_stencil.py
+++ b/xdsl/transforms/canonicalization_patterns/csl_stencil.py
@@ -18,14 +18,14 @@ class RedundantAccumulatorInitialisation(RewritePattern):
     def match_and_rewrite(
         self, op: csl_stencil.ApplyOp, rewriter: PatternRewriter
     ) -> None:
-        if len(op.accumulator.uses) > 1:
+        if op.accumulator.has_more_than_one_use():
             return
 
         next_apply = op
         while (next_apply := next_apply.next_op) is not None:
             if (
                 isinstance(next_apply, csl_stencil.ApplyOp)
-                and len(next_apply.accumulator.uses) == 1
+                and next_apply.accumulator.has_one_use()
                 and isinstance(next_apply.accumulator, OpResult)
                 and isinstance(next_apply.accumulator.op, tensor.EmptyOp)
                 and op.accumulator.type == next_apply.accumulator.type

--- a/xdsl/transforms/canonicalization_patterns/memref.py
+++ b/xdsl/transforms/canonicalization_patterns/memref.py
@@ -72,8 +72,6 @@ class MemRefSubviewOfSubviewFolding(RewritePattern):
 class ElideUnusedAlloc(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: memref.AllocOp, rewriter: PatternRewriter, /):
-        if len(op.memref.uses) == 1 and isinstance(
-            only_use := tuple(op.memref.uses)[0].operation, memref.DeallocOp
-        ):
+        if isinstance(only_use := op.memref.get_user_of_unique_use(), memref.DeallocOp):
             rewriter.erase_op(only_use)
             rewriter.erase_matched_op()

--- a/xdsl/transforms/canonicalization_patterns/riscv.py
+++ b/xdsl/transforms/canonicalization_patterns/riscv.py
@@ -395,13 +395,13 @@ class FuseMultiplyAddD(RewritePattern):
         if (
             isinstance(mul := op.rs2.owner, riscv.FMulDOp)
             and _has_contract_flag(mul)
-            and len(mul.rd.uses) == 1
+            and mul.rd.has_one_use()
         ):
             addend = op.rs1
         elif (
             isinstance(mul := op.rs1.owner, riscv.FMulDOp)
             and _has_contract_flag(mul)
-            and len(mul.rd.uses) == 1
+            and mul.rd.has_one_use()
         ):
             addend = op.rs2
         else:

--- a/xdsl/transforms/canonicalization_patterns/stencil.py
+++ b/xdsl/transforms/canonicalization_patterns/stencil.py
@@ -79,7 +79,7 @@ class ApplyUnusedResults(RewritePattern):
 
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: stencil.ApplyOp, rewriter: PatternRewriter) -> None:
-        unused = [i for i, r in enumerate(op.res) if len(r.uses) == 0]
+        unused = [i for i, r in enumerate(op.res) if not r.uses]
 
         if not unused:
             return

--- a/xdsl/transforms/convert_memref_stream_to_snitch_stream.py
+++ b/xdsl/transforms/convert_memref_stream_to_snitch_stream.py
@@ -79,7 +79,7 @@ class ReadOpLowering(RewritePattern):
             (op.stream,), (snitch.ReadableStreamType(register_type),)
         )
         new_op = riscv_snitch.ReadOp(new_stream.results[0])
-        if len(op.res.uses) == 1:
+        if op.res.has_one_use():
             new_mv = ()
             new_vals = (new_op.res,)
         else:

--- a/xdsl/transforms/csl_stencil_bufferize.py
+++ b/xdsl/transforms/csl_stencil_bufferize.py
@@ -428,7 +428,7 @@ class InjectApplyOutsIntoLinalgOuts(RewritePattern):
                 new_yield_args.append(yld_arg)
                 continue
             additional_args.append(arg)
-            if len(yld_arg.uses) == 1:
+            if yld_arg.has_one_use():
                 to_remove.append(yld_arg.op)
 
             arg = op.done_exchange.block.insert_arg(
@@ -514,7 +514,7 @@ class ReselectLinalgOutsFromInputs(RewritePattern):
 
         for arg in op.inputs:
             # reselect outs that has no later use to avoid read-after-write conflicts
-            if len(arg.uses) == 1:
+            if arg.has_one_use():
                 # check for a `writable` input with no later uses and break immediately
                 if self.is_writable(arg):
                     out = arg

--- a/xdsl/transforms/desymref.py
+++ b/xdsl/transforms/desymref.py
@@ -298,7 +298,7 @@ class Desymrefier:
 
     def _prune_unused_reads(self, block: Block):
         def is_unused_read(op: Operation) -> bool:
-            return isinstance(op, symref.FetchOp) and len(op.results[0].uses) == 0
+            return isinstance(op, symref.FetchOp) and not op.results[0].uses
 
         unused_reads = [op for op in block.ops if is_unused_read(op)]
         for read in unused_reads:

--- a/xdsl/transforms/eqsat_serialize_egraph.py
+++ b/xdsl/transforms/eqsat_serialize_egraph.py
@@ -44,9 +44,7 @@ def serialize_to_egraph(mod: builtin.ModuleOp):
                     assert len(op.results) == 1, (
                         "Only single result operations are supported"
                     )
-                    assert len(res.uses) == 1, (
-                        "Only single use operations are supported"
-                    )
+                    assert res.has_one_use(), "Only single use operations are supported"
                     eclass_id = eclass_to_id[use.operation]
         if eclass_id is None:
             continue

--- a/xdsl/transforms/experimental/convert_stencil_to_ll_mlir.py
+++ b/xdsl/transforms/experimental/convert_stencil_to_ll_mlir.py
@@ -612,15 +612,11 @@ def _get_use_target(use: Use) -> SSAValue | None:
                 temp = store.results[use.index - len(store.lower) - len(store.lowerext)]
                 # If it's the nth upperext arg, the combined temp is the
                 # (lower+lowerext+n)th combined.
-            temp_uses = temp.uses
-            match len(temp_uses):
-                case 0:
-                    return None
-                case 1:
-                    target = _get_use_target(list(temp_uses)[0])
-                    return target
-                case _:
-                    raise ValueError("Each stencil result should be stored only once.")
+            if not temp.uses:
+                return None
+            if (temp_use := temp.get_unique_use()) is not None:
+                return _get_use_target(temp_use)
+            raise ValueError("Each stencil result should be stored only once.")
         case _:
             # Should be unreachable
             raise ValueError(f"Unexpected store type {store}")

--- a/xdsl/transforms/linalg_transformations.py
+++ b/xdsl/transforms/linalg_transformations.py
@@ -79,7 +79,7 @@ class FuseMultiplyAddPass(RewritePattern):
 
             # replace in position of the add op
             rewriter.replace_op(add, fma)
-            if len(mul.res[0].uses) == 0:
+            if not mul.res[0].uses:
                 rewriter.erase_matched_op()
 
     @staticmethod

--- a/xdsl/transforms/lower_csl_stencil.py
+++ b/xdsl/transforms/lower_csl_stencil.py
@@ -340,7 +340,7 @@ class FullStencilAccessImmediateReductionOptimization(RewritePattern):
         reduction_ops = cast(set[csl.BuiltinDsdOp], reduction_ops)
 
         # check: only apply rewrite if each access has exactly one use
-        if any(len(a.result.uses) != 1 for a in access_ops):
+        if any(not a.result.has_one_use() for a in access_ops):
             return
 
         # check: only apply rewrite if reduction ops use `access` ops only (plus one other, checked below)

--- a/xdsl/transforms/riscv_scf_loop_range_folding.py
+++ b/xdsl/transforms/riscv_scf_loop_range_folding.py
@@ -17,7 +17,7 @@ class HoistIndexTimesConstantOp(RewritePattern):
 
         # Fold until a fixed point is reached
         while True:
-            if len(index.uses) != 1:
+            if not index.has_one_use():
                 # If the induction variable is used more than once, we can't fold its
                 # arith ops into the loop range
                 return

--- a/xdsl/transforms/scf_for_loop_flatten.py
+++ b/xdsl/transforms/scf_for_loop_flatten.py
@@ -94,7 +94,7 @@ class FlattenNestedLoopsPattern(RewritePattern):
                 return
 
             # If either induction variable is used, we can only fold if used exactly once
-            if len(outer_index.uses) != 1 or len(inner_index.uses) != 1:
+            if not outer_index.has_one_use() or not inner_index.has_one_use():
                 return
 
             outer_user = next(iter(outer_index.uses)).operation

--- a/xdsl/transforms/scf_for_loop_range_folding.py
+++ b/xdsl/transforms/scf_for_loop_range_folding.py
@@ -21,7 +21,7 @@ class ScfForLoopRangeFolding(RewritePattern):
 
         # Fold until a fixed point is reached
         while True:
-            if len(index.uses) != 1:
+            if not index.has_one_use():
                 # If the induction variable is used more than once, we can't fold its
                 # arith ops into the loop range
                 return

--- a/xdsl/transforms/stencil_bufferize.py
+++ b/xdsl/transforms/stencil_bufferize.py
@@ -438,7 +438,7 @@ class CombineStoreFold(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: CombineOp, rewriter: PatternRewriter):
         for i, r in enumerate(op.results):
-            if len(r.uses) != 1:
+            if not r.has_one_use():
                 continue
             store = next(iter(r.uses)).operation
             if not isinstance(store, StoreOp):

--- a/xdsl/transforms/varith_transformations.py
+++ b/xdsl/transforms/varith_transformations.py
@@ -1,6 +1,6 @@
 import collections
 from dataclasses import dataclass
-from typing import Literal
+from typing import Literal, cast
 
 from xdsl.context import Context
 from xdsl.dialects import arith, builtin, varith
@@ -42,13 +42,13 @@ class ArithToVarithPattern(RewritePattern):
     ):
         dest_type = ARITH_TO_VARITH_TYPE_MAP[type(op)]
 
-        if len(op.result.uses) != 1:
-            return
-        if type(use_op := list(op.result.uses)[0].operation) not in (
+        if type(use_op := op.result.get_user_of_unique_use()) not in (
             type(op),
             dest_type,
         ):
             return
+        # pyright does not understand that `use_op` cannot be None here
+        use_op = cast(Operation, use_op)
 
         other_operands = [o for o in use_op.operands if o != op.result]
         rewriter.replace_op(
@@ -165,7 +165,7 @@ class MergeVarithOpsPattern(RewritePattern):
 
         # check all ops that may be erased later:
         for old_op in possibly_erased_ops:
-            if len(old_op.results[-1].uses) == 0:
+            if not old_op.results[-1].uses:
                 rewriter.erase_op(old_op)
 
 


### PR DESCRIPTION
Stacked PRs:
 * #4909
 * __->__#4908
 * #4907


--- --- ---

### core: Remove __len__ from IRUses


__len__ is costly to compute (since it will be moved to a linked list),
so it should not be easy to call.
