### PR TITLE
core: add special handling of DenseArrayBase in assembly format

### DIFF
--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -1261,7 +1261,7 @@ class DenseArrayAttributeVariable(AttributeVariable):
         assert isa(attr, DenseArrayBase), attr
         with printer.in_square_brackets():
             if isa(attr, DenseArrayBase[IntegerType]):
-                printer.print_list(attr.get_values(), printer.print_int)
+                printer.print_list(attr.iter_values(), printer.print_int)
             elif isa(attr, DenseArrayBase[AnyFloat]):
                 printer.print_list(
                     attr.iter_values(),

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -1258,7 +1258,6 @@ class DenseArrayAttributeVariable(AttributeVariable):
             )
 
     def print_attr(self, printer: Printer, attr: Attribute) -> None:
-        assert isa(attr, DenseArrayBase), attr
         with printer.in_square_brackets():
             if isa(attr, DenseArrayBase[IntegerType]):
                 printer.print_list(attr.iter_values(), printer.print_int)

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -13,7 +13,14 @@ from typing import Any, Literal, cast
 
 from typing_extensions import TypeVar
 
-from xdsl.dialects.builtin import StringAttr, UnitAttr
+from xdsl.dialects.builtin import (
+    AnyFloat,
+    BytesAttr,
+    DenseArrayBase,
+    IntegerType,
+    StringAttr,
+    UnitAttr,
+)
 from xdsl.ir import (
     Attribute,
     Data,
@@ -33,6 +40,7 @@ from xdsl.irdl import (
 )
 from xdsl.parser import Parser, UnresolvedOperand
 from xdsl.printer import Printer
+from xdsl.utils.hints import isa
 from xdsl.utils.mlir_lexer import PunctuationSpelling
 
 
@@ -1213,6 +1221,52 @@ class TypedAttributeVariable(UniqueBaseAttributeVariable):
     def print_attr(self, printer: Printer, attr: Attribute) -> None:
         assert isinstance(attr, TypedAttribute)
         return attr.print_without_type(printer)
+
+
+@dataclass(frozen=True)
+class DenseArrayAttributeVariable(AttributeVariable):
+    elt_type: IntegerType | AnyFloat
+
+    def parse_attr(self, parser: Parser) -> Attribute | None:
+        if isinstance(self.elt_type, IntegerType):
+            if self.is_optional:
+                elements = parser.parse_optional_comma_separated_list(
+                    parser.Delimiter.SQUARE, parser.parse_integer
+                )
+                if elements is None:
+                    return None
+            else:
+                elements = parser.parse_comma_separated_list(
+                    parser.Delimiter.SQUARE, parser.parse_integer
+                )
+            return DenseArrayBase(
+                self.elt_type, BytesAttr(self.elt_type.pack(elements))
+            )
+        else:
+            if self.is_optional:
+                elements = parser.parse_optional_comma_separated_list(
+                    parser.Delimiter.SQUARE, parser.parse_float
+                )
+                if elements is None:
+                    return None
+            else:
+                elements = parser.parse_comma_separated_list(
+                    parser.Delimiter.SQUARE, parser.parse_float
+                )
+            return DenseArrayBase(
+                self.elt_type, BytesAttr(self.elt_type.pack(elements))
+            )
+
+    def print_attr(self, printer: Printer, attr: Attribute) -> None:
+        assert isa(attr, DenseArrayBase), attr
+        with printer.in_square_brackets():
+            if isa(attr, DenseArrayBase[IntegerType]):
+                printer.print_list(attr.get_values(), printer.print_int)
+            elif isa(attr, DenseArrayBase[AnyFloat]):
+                printer.print_list(
+                    attr.iter_values(),
+                    lambda value: printer.print_float(value, attr.elt_type),
+                )
 
 
 class SymbolNameAttributeVariable(AttributeVariable):


### PR DESCRIPTION
Adds functionality present in MLIR, where the special assembly format for DenseArrayBase of a specific subclass is printed prettily.