### PR TITLE
misc: (ParametrizedAttribute) remove deprecated init

### DIFF
--- a/tests/irdl/test_attribute_definition.py
+++ b/tests/irdl/test_attribute_definition.py
@@ -797,13 +797,6 @@ def test_irdl_definition():
     )
 
 
-def test_deprecated_tuple_init():
-    with pytest.deprecated_call():
-        assert ParamAttrDefAttr(StringData(""), BoolData(True)) == ParamAttrDefAttr(
-            (StringData(""), BoolData(True))  # pyright: ignore[reportCallIssue]
-        )
-
-
 @irdl_attr_definition
 class ParamAttrDefAttr2(ParametrizedAttribute):
     name = "test.param_attr_def_attr"

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -430,17 +430,6 @@ class ParametrizedAttribute(Attribute):
     """An attribute parametrized by other attributes."""
 
     def __init__(self, *parameters: Attribute):
-        if len(parameters) == 1 and isinstance(parameters[0], tuple):
-            import warnings
-
-            warnings.warn(
-                "Passing a tuple as a single argument to ParametrizedAttribute.__init__ is deprecated. "
-                "Pass the tuple elements as separate arguments instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            parameters = parameters[0]
-
         for (f, _), param in zip(
             self.get_irdl_definition().parameters, parameters, strict=True
         ):


### PR DESCRIPTION
Removes the deprecated `__init__` and test