### PR TITLE
dialects: (linalg) add reduction operation to linalg dialect

### DIFF
--- a/tests/filecheck/dialects/linalg/invalid.mlir
+++ b/tests/filecheck/dialects/linalg/invalid.mlir
@@ -1,5 +1,38 @@
-// RUN: xdsl-opt --verify-diagnostics %s | filecheck %s
+// RUN: xdsl-opt %s --verify-diagnostics --split-input-file | filecheck %s
 
 %0 = linalg.index 3 : index
 
 // CHECK: Operation does not verify: 'linalg.index' expects parent op 'linalg.generic'
+
+// -----
+
+%1, %2 = "test.op"() : () -> (tensor<12x20xf32>, tensor<20xi32>)
+linalg.reduce ins(%1:tensor<12x20xf32>) outs(%2:tensor<20xi32>) dimensions = [0]
+(%3 : f32, %4 : f32) {
+    %5 = arith.addf %3, %4 : f32
+    linalg.yield %5 : f32
+}
+
+// CHECK: Operation does not verify: Reduction element types must be equal, but input is f32 and init is i32
+
+// -----
+
+%1, %2 = "test.op"() : () -> (tensor<12x20xf32>, tensor<10xf32>)
+linalg.reduce ins(%1:tensor<12x20xf32>) outs(%2:tensor<10xf32>) dimensions = [0]
+(%3 : f32, %4 : f32) {
+    %5 = arith.addf %3, %4 : f32
+    linalg.yield %5 : f32
+}
+
+// CHECK: Operation does not verify: Non-reduced input dimension 1 must equal output dimension 0
+
+// -----
+
+%1, %2 = "test.op"() : () -> (memref<12x20xf32>, memref<20xf32>)
+linalg.reduce ins(%1:memref<12x20xf32>) outs(%2:memref<20xf32>) dimensions = [0, 1]
+(%3 : f32, %4 : f32) {
+    %5 = arith.addf %3, %4 : f32
+    linalg.yield %5 : f32
+}
+
+// CHECK: Operation does not verify: Output rank must equal input rank minus number of dimensions being reduced over

--- a/tests/filecheck/dialects/linalg/linalg_ops.mlir
+++ b/tests/filecheck/dialects/linalg/linalg_ops.mlir
@@ -265,13 +265,13 @@ linalg.generic {indexing_maps = [affine_map<(d0, d1) -> ()>, affine_map<(d0, d1)
 // CHECK-GENERIC-NEXT:    }) : (tensor<4x16xf32>, tensor<4x16xf32>, tensor<4x16xf32>) -> tensor<4x16xf32>
 // CHECK-GENERIC-NEXT:    %{{.*}}, %{{.*}} = "test.op"() : () -> (memref<64x10xi32>, memref<i32>)
 // CHECK-GENERIC-NEXT:    "linalg.reduce"(%{{.*}}, %{{.*}}) <{dimensions = array<i64: 0, 1>, operandSegmentSizes = array<i32: 1, 1>}> ({
-// CHECK-GENERIC-NEXT:    ^%{{.*}}(%{{.*}} : i32, %{{.*}} : i32):
+// CHECK-GENERIC-NEXT:    ^{{.*}}(%{{.*}} : i32, %{{.*}} : i32):
 // CHECK-GENERIC-NEXT:      %{{.*}} = "arith.addi"(%{{.*}}, %{{.*}}) <{overflowFlags = #arith.overflow<none>}> : (i32, i32) -> i32
 // CHECK-GENERIC-NEXT:      "linalg.yield"(%{{.*}}) : (i32) -> ()
 // CHECK-GENERIC-NEXT:    }) : (memref<64x10xi32>, memref<i32>) -> ()
 // CHECK-GENERIC-NEXT:    %{{.*}}, %{{.*}} = "test.op"() : () -> (tensor<12x20xf32>, tensor<20xf32>)
 // CHECK-GENERIC-NEXT:    %{{.*}} = "linalg.reduce"(%{{.*}}, %{{.*}}) <{dimensions = array<i64: 0>, operandSegmentSizes = array<i32: 1, 1>}> ({
-// CHECK-GENERIC-NEXT:    ^%{{.*}}(%{{.*}} : f32, %{{.*}} : f32):
+// CHECK-GENERIC-NEXT:    ^{{.*}}(%{{.*}} : f32, %{{.*}} : f32):
 // CHECK-GENERIC-NEXT:      %{{.*}} = "arith.addf"(%{{.*}}, %{{.*}}) <{fastmath = #arith.fastmath<none>}> : (f32, f32) -> f32
 // CHECK-GENERIC-NEXT:      "linalg.yield"(%{{.*}}) : (f32) -> ()
 // CHECK-GENERIC-NEXT:    }) : (tensor<12x20xf32>, tensor<20xf32>) -> tensor<20xf32>

--- a/tests/filecheck/dialects/linalg/linalg_ops.mlir
+++ b/tests/filecheck/dialects/linalg/linalg_ops.mlir
@@ -65,6 +65,21 @@ linalg.generic {indexing_maps = [affine_map<(d0, d1) -> ()>, affine_map<(d0, d1)
  %11 = linalg.max ins(%t1, %t2 : tensor<4x16xf32>, tensor<4x16xf32>) outs(%t1 : tensor<4x16xf32>) -> tensor<4x16xf32>
  %12 = linalg.min ins(%t1, %t2 : tensor<4x16xf32>, tensor<4x16xf32>) outs(%t1 : tensor<4x16xf32>) -> tensor<4x16xf32>
 
+ %13, %14 = "test.op"() : () -> (memref<64x10xi32>, memref<i32>)
+ linalg.reduce ins(%13:memref<64x10xi32>) outs(%14:memref<i32>) dimensions = [0, 1]
+ (%15 : i32, %16 : i32) {
+     %17 = arith.addi %15, %16 : i32
+     linalg.yield %17 : i32
+ }
+
+ %18, %19 = "test.op"() : () -> (tensor<12x20xf32>, tensor<20xf32>)
+ linalg.reduce ins(%18:tensor<12x20xf32>) outs(%19:tensor<20xf32>) dimensions = [0]
+ (%20 : f32, %21 : f32) {
+     %22 = arith.addf %20, %21 : f32
+     linalg.yield %22 : f32
+ }
+
+
 // CHECK:        module {
 // CHECK-NEXT:    %{{.*}} %{{.*}} = "test.op"() : () -> (f32, memref<1x256xf32>)
 // CHECK-NEXT:    linalg.generic {indexing_maps = [affine_map<(d0, d1) -> ()>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%{{.*}} : f32) outs(%{{.*}} : memref<1x256xf32>) {
@@ -113,6 +128,18 @@ linalg.generic {indexing_maps = [affine_map<(d0, d1) -> ()>, affine_map<(d0, d1)
 // CHECK-NEXT:    "test.op"(%11) : (tensor<4x16xf32>) -> ()
 // CHECK-NEXT:    %12 = linalg.max ins(%t1, %t2 : tensor<4x16xf32>, tensor<4x16xf32>) outs(%t1 : tensor<4x16xf32>) -> tensor<4x16xf32>
 // CHECK-NEXT:    %13 = linalg.min ins(%t1, %t2 : tensor<4x16xf32>, tensor<4x16xf32>) outs(%t1 : tensor<4x16xf32>) -> tensor<4x16xf32>
+// CHECK-NEXT:    %14, %15 = "test.op"() : () -> (memref<64x10xi32>, memref<i32>)
+// CHECK-NEXT:    linalg.reduce ins(%14:memref<64x10xi32>) outs(%15:memref<i32>) dimensions = [0, 1]
+// CHECK-NEXT:    (%16 : i32, %17 : i32) {
+// CHECK-NEXT:        %18 = arith.addi %16, %17 : i32
+// CHECK-NEXT:        linalg.yield %18 : i32
+// CHECK-NEXT:    }
+// CHECK-NEXT:    %19, %20 = "test.op"() : () -> (tensor<12x20xf32>, tensor<20xf32>)
+// CHECK-NEXT:    %21 = linalg.reduce ins(%19:tensor<12x20xf32>) outs(%20:tensor<20xf32>) dimensions = [0]
+// CHECK-NEXT:    (%22 : f32, %23 : f32) {
+// CHECK-NEXT:        %24 = arith.addf %22, %23 : f32
+// CHECK-NEXT:        linalg.yield %24 : f32
+// CHECK-NEXT:    }
 // CHECK-NEXT:    }
 
 // CHECK-GENERIC:       "linalg.generic"(%{{.*}}, %{{.*}}) <{indexing_maps = [affine_map<(d0, d1) -> ()>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>], operandSegmentSizes = array<i32: 1, 1>}> ({
@@ -236,3 +263,15 @@ linalg.generic {indexing_maps = [affine_map<(d0, d1) -> ()>, affine_map<(d0, d1)
 // CHECK-GENERIC-NEXT:      %{{.*}} = "arith.minimumf"(%{{.*}}, %{{.*}}) <{fastmath = #arith.fastmath<none>}> : (f32, f32) -> f32
 // CHECK-GENERIC-NEXT:      "linalg.yield"(%{{.*}}) : (f32) -> ()
 // CHECK-GENERIC-NEXT:    }) : (tensor<4x16xf32>, tensor<4x16xf32>, tensor<4x16xf32>) -> tensor<4x16xf32>
+// CHECK-GENERIC-NEXT:    %{{.*}}, %{{.*}} = "test.op"() : () -> (memref<64x10xi32>, memref<i32>)
+// CHECK-GENERIC-NEXT:    "linalg.reduce"(%{{.*}}, %{{.*}}) <{dimensions = array<i64: 0, 1>, operandSegmentSizes = array<i32: 1, 1>}> ({
+// CHECK-GENERIC-NEXT:    ^%{{.*}}(%{{.*}} : i32, %{{.*}} : i32):
+// CHECK-GENERIC-NEXT:      %{{.*}} = "arith.addi"(%{{.*}}, %{{.*}}) <{overflowFlags = #arith.overflow<none>}> : (i32, i32) -> i32
+// CHECK-GENERIC-NEXT:      "linalg.yield"(%{{.*}}) : (i32) -> ()
+// CHECK-GENERIC-NEXT:    }) : (memref<64x10xi32>, memref<i32>) -> ()
+// CHECK-GENERIC-NEXT:    %{{.*}}, %{{.*}} = "test.op"() : () -> (tensor<12x20xf32>, tensor<20xf32>)
+// CHECK-GENERIC-NEXT:    %{{.*}} = "linalg.reduce"(%{{.*}}, %{{.*}}) <{dimensions = array<i64: 0>, operandSegmentSizes = array<i32: 1, 1>}> ({
+// CHECK-GENERIC-NEXT:    ^%{{.*}}(%{{.*}} : f32, %{{.*}} : f32):
+// CHECK-GENERIC-NEXT:      %{{.*}} = "arith.addf"(%{{.*}}, %{{.*}}) <{fastmath = #arith.fastmath<none>}> : (f32, f32) -> f32
+// CHECK-GENERIC-NEXT:      "linalg.yield"(%{{.*}}) : (f32) -> ()
+// CHECK-GENERIC-NEXT:    }) : (tensor<12x20xf32>, tensor<20xf32>) -> tensor<20xf32>

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/linalg/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/linalg/ops.mlir
@@ -129,6 +129,22 @@ linalg.broadcast ins(%48 : memref<f32>) outs(%1 : memref<1x256xf32>) dimensions 
 
 linalg.transpose ins(%49 : memref<16x64xf32>) outs(%50 : memref<64x16xf32>) permutation = [1, 0]
 
+%51 = "test.op"() : () -> (memref<16xf32>)
+
+linalg.reduce ins(%49:memref<16x64xf32>) outs(%51:memref<16xf32>) dimensions = [1]
+(%52 : f32, %53 : f32) {
+    %54 = arith.addf %52, %53 : f32
+    linalg.yield %54 : f32
+}
+
+%55, %56 = "test.op"(): () ->  (tensor<100x50xi32>, tensor<i32>)
+
+%reduced = linalg.reduce ins(%55:tensor<100x50xi32>) outs(%56:tensor<i32>) dimensions = [0, 1]
+(%57 : i32, %58 : i32) {
+    %59 = arith.addi %57, %58 : i32
+    linalg.yield %59 : i32
+}
+
 // CHECK-NEXT:  #map = affine_map<(d0, d1) -> ()>
 // CHECK-NEXT:  #map1 = affine_map<(d0, d1) -> (d0, d1)>
 // CHECK-NEXT:  module {
@@ -198,4 +214,16 @@ linalg.transpose ins(%49 : memref<16x64xf32>) outs(%50 : memref<64x16xf32>) perm
 // CHECK-NEXT:    linalg.broadcast ins(%38 : memref<f32>) outs(%0#1 : memref<1x256xf32>) dimensions = [0, 1]
 // CHECK-NEXT:    %39:2 = "test.op"() : () -> (memref<16x64xf32>, memref<64x16xf32>)
 // CHECK-NEXT:    linalg.transpose ins(%39#0 : memref<16x64xf32>) outs(%39#1 : memref<64x16xf32>) permutation = [1, 0]
+// CHECK-NEXT:    %40 = "test.op"() : () -> memref<16xf32>
+// CHECK-NEXT:    linalg.reduce ins(%39#0 : memref<16x64xf32>) outs(%40 : memref<16xf32>) dimensions = [1]
+// CHECK-NEXT:    (%in: f32, %init: f32) {
+// CHECK-NEXT:        %42 = arith.addf %in, %init : f32
+// CHECK-NEXT:        linalg.yield %42 : f32
+// CHECK-NEXT:    }
+// CHECK-NEXT:    %41:2 = "test.op"() : () -> (tensor<100x50xi32>, tensor<i32>)
+// CHECK-NEXT:    %reduced = linalg.reduce ins(%41#0 : tensor<100x50xi32>) outs(%41#1 : tensor<i32>) dimensions = [0, 1]
+// CHECK-NEXT:    (%in: i32, %init: i32) {
+// CHECK-NEXT:        %42 = arith.addi %in, %init : i32
+// CHECK-NEXT:        linalg.yield %42 : i32
+// CHECK-NEXT:    }
 // CHECK-NEXT:  }

--- a/xdsl/dialects/linalg.py
+++ b/xdsl/dialects/linalg.py
@@ -1452,7 +1452,8 @@ class ReduceOp(IRDLOperation):
 
         if input_type.get_element_type() != init_type.get_element_type():
             raise VerifyException(
-                f"Reduction element types must be equal, but input is {input_type.get_element_type()} and init is {init_type.get_element_type()}"
+                f"Reduction element types must be equal, but input is {input_type.get_element_type()} "
+                f"and init is {init_type.get_element_type()}"
             )
 
         dimensions_shape = self.dimensions.get_values()

--- a/xdsl/dialects/linalg.py
+++ b/xdsl/dialects/linalg.py
@@ -1411,6 +1411,120 @@ class BroadcastOp(IRDLOperation):
         return broadcast
 
 
+@irdl_op_definition
+class ReduceOp(IRDLOperation):
+    name = "linalg.reduce"
+
+    input = operand_def(base(MemRefType) | base(AnyTensorType))
+    init = operand_def(base(MemRefType) | base(AnyTensorType))
+    result = var_result_def(AnyTensorType)
+
+    region: Region = region_def("single_block")
+
+    dimensions = prop_def(DenseArrayBase.constr(i64))
+
+    irdl_options = [AttrSizedOperandSegments(as_property=True)]
+
+    def __init__(
+        self,
+        input: SSAValue,
+        init: SSAValue,
+        dimensions: Attribute,
+        region: Region,
+    ):
+        if isa(init.type, TensorType):
+            result = (init.type,)
+        else:
+            result = ()
+
+        super().__init__(
+            properties={
+                "dimensions": dimensions,
+            },
+            operands=(input, init),
+            regions=[region],
+            result_types=[result],
+        )
+
+    def verify_(self) -> None:
+        assert isinstance(input_type := self.input.type, TensorType | MemRefType)
+        assert isinstance(init_type := self.init.type, TensorType | MemRefType)
+
+        if input_type.get_element_type() != init_type.get_element_type():
+            raise VerifyException(
+                f"Reduction element types must be equal, but input is {input_type.get_element_type()} and init is {init_type.get_element_type()}"
+            )
+
+        dimensions_shape = self.dimensions.get_values()
+        input_shape = input_type.get_shape()
+        init_shape = init_type.get_shape()
+
+        if len(init_shape) != len(input_shape) - len(dimensions_shape):
+            raise VerifyException(
+                "Output rank must equal input rank minus number of dimensions being reduced over"
+            )
+
+        init_index = 0
+        for input_index in range(len(input_shape)):
+            if input_index not in dimensions_shape:
+                if input_shape[input_index] != init_shape[init_index]:
+                    raise VerifyException(
+                        f"Non-reduced input dimension {input_index} must equal output dimension {init_index}"
+                    )
+                init_index += 1
+
+    def print(self, printer: Printer):
+        printer.print_string(" ins")
+        with printer.in_parens():
+            printer.print_ssa_value(self.input)
+            printer.print_string(":")
+            printer.print_attribute(self.input.type)
+        printer.print_string(" outs")
+        with printer.in_parens():
+            printer.print_ssa_value(self.init)
+            printer.print_string(":")
+            printer.print_attribute(self.init.type)
+        printer.print_string(" dimensions = ")
+        with printer.in_square_brackets():
+            printer.print_list(self.dimensions.get_values(), printer.print_int)
+        printer.print_string("\n")
+        with printer.in_parens():
+            printer.print_list(self.region.blocks[0].args, printer.print_block_argument)
+        printer.print_string(" ")
+        printer.print_region(self.region, print_entry_block_args=False)
+
+    @classmethod
+    def parse(cls, parser: Parser) -> Self:
+        parser.parse_characters("ins")
+        parser.parse_punctuation("(")
+        input = parser.parse_operand()
+        parser.parse_punctuation(":")
+        parser.parse_type()
+        parser.parse_punctuation(")")
+        parser.parse_characters("outs")
+        parser.parse_punctuation("(")
+        init = parser.parse_operand()
+        parser.parse_punctuation(":")
+        parser.parse_type()
+        parser.parse_punctuation(")")
+        parser.parse_keyword("dimensions")
+        parser.parse_punctuation("=")
+        dimensions = parser.parse_comma_separated_list(
+            parser.Delimiter.SQUARE, parser.parse_integer
+        )
+        entry_args = parser.parse_comma_separated_list(
+            parser.Delimiter.PAREN, parser.parse_argument
+        )
+        region = parser.parse_region(entry_args)
+        reduction = cls(
+            input,
+            init,
+            DenseArrayBase.from_list(i64, dimensions),
+            region,
+        )
+        return reduction
+
+
 Linalg = Dialect(
     "linalg",
     [
@@ -1436,6 +1550,7 @@ Linalg = Dialect(
         Conv2DNgchwFgchwOp,
         Conv2DNhwc_FhwcOp,
         BroadcastOp,
+        ReduceOp,
     ],
     [
         IteratorTypeAttr,


### PR DESCRIPTION
The linalg.reduce operation which applies body of calculation on an element by element basis to one or more dimensions of a tensor or memref 
