### PR TITLE
misc: (Assembly Format) miscellaneous cleanups

### DIFF
--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -3769,10 +3769,7 @@ class Hello(CustomDirective):
         return True
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
-        if state.should_emit_space or not state.last_was_punctuation:
-            printer.print_string(" ")
-        state.last_was_punctuation = False
-        state.should_emit_space = True
+        state.print_whitespace(printer)
         printer.print_string("hello")
 
 
@@ -3820,11 +3817,8 @@ class Bars(CustomDirective):
         operands = self.var.get(op)
         if not operands:
             return
-        if state.should_emit_space or not state.last_was_punctuation:
-            printer.print_string(" ")
+        state.print_whitespace(printer)
         printer.print_list(operands, printer.print_ssa_value, delimiter=" | ")
-        state.last_was_punctuation = False
-        state.should_emit_space = True
 
 
 @irdl_op_definition

--- a/xdsl/dialects/utils/dynamic_index_list.py
+++ b/xdsl/dialects/utils/dynamic_index_list.py
@@ -239,8 +239,8 @@ class DynamicIndexList(CustomDirective):
         return True
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
-        state.should_emit_space = True
-        state.last_was_punctuation = True
+        state.print_whitespace(printer)
+
         dynamic = self.dynamic_position.get(op)
         static = self.static_position.get(op)
         assert isa(static, DenseArrayBase[IntegerType])


### PR DESCRIPTION
Some cleanup which trying to check that the whitespace printing is exactly the same as MLIR

I'm not sure all the logic around default values is correct in the new AttributeVariable hierarchy, but I guess we can fix issues as we find them.