### PR TITLE
dialects: (dlti) add mapattr

### DIFF
--- a/tests/filecheck/dialects/dlti/attrs.mlir
+++ b/tests/filecheck/dialects/dlti/attrs.mlir
@@ -182,3 +182,53 @@ module attributes {
     "CPU" = #dlti.target_device_spec<"L1_cache_size_in_bytes" = 4096 : ui32>,
     "GPU" = #dlti.target_device_spec<"max_vector_op_width" = 128>
   >} {}
+
+// -----
+
+// CHECK:      module attributes {
+// CHECK-SAME:   dlti.map = #dlti.map<
+// CHECK-SAME:     "magic_num" = 42 : i32,
+// CHECK-SAME:     "magic_num_float" = 4.242000e+01 : f32,
+// CHECK-SAME:     "magic_type" = i32,
+// CHECK-SAME:     i32 = #dlti.map<"bitwidth" = 32 : i32>
+// CHECK:        >} {
+// CHECK:      }
+module attributes {
+  dlti.map = #dlti.map<"magic_num" = 42 : i32,
+                       "magic_num_float" = 42.42 : f32,
+                       "magic_type" = i32,
+                        i32 = #dlti.map<"bitwidth" = 32 : i32>>
+  } {}
+
+// -----
+
+// CHECK:      module attributes {
+// CHECK-SAME:   dlti.map = #dlti.map<
+// CHECK-SAME:     "CPU" = #dlti.map<"L1_cache_size_in_bytes" = 4096 : i32>,
+// CHECK-SAME:     "GPU" = #dlti.map<"max_vector_op_width" = 128 : i32>
+// CHECK-SAME:   >} {
+// CHECK:      }
+module attributes {
+  dlti.map = #dlti.map<
+    "CPU" = #dlti.map<"L1_cache_size_in_bytes" = 4096 : i32>,
+    "GPU" = #dlti.map<"max_vector_op_width" = 128 : i32>
+  >} {}
+
+// -----
+
+// CHECK:      module attributes {
+// CHECK-SAME:   dlti.target_system_spec = #dlti.target_system_spec<
+// CHECK-SAME:     "CPU" = #dlti.target_device_spec<
+// CHECK-SAME:       "key" = #dlti.map<"V1" = 22 : i32, "V2" = 100 : i32,
+// CHECK-SAME:                          "V3" = 22 : i32>>,
+// CHECK-SAME:     "GPU" = #dlti.target_device_spec<
+// CHECK-SAME:       "key" = #dlti.map<"V1" = 24 : i32, "V2" = 16 : i32,
+// CHECK-SAME:                          "V3" = 9.920000e+01 : f32>>
+// CHECK-SAME:   >} {
+// CHECK:      }
+
+module attributes {
+  dlti.target_system_spec = #dlti.target_system_spec<
+    "CPU" = #dlti.target_device_spec<"key" = #dlti.map<"V1" = 22 : i32, "V2" = 100 : i32, "V3" = 22 : i32>>,
+    "GPU" = #dlti.target_device_spec<"key" = #dlti.map<"V1" = 24 : i32, "V2" = 16 : i32, "V3" = 99.2 : f32>>
+  >} {}

--- a/tests/filecheck/dialects/dlti/attrs_invalid.mlir
+++ b/tests/filecheck/dialects/dlti/attrs_invalid.mlir
@@ -36,9 +36,18 @@ module attributes {
 // -----
 
 // CHECK: duplicate DLTI entry key
-
 module attributes {
   dlti.target_system_spec = #dlti.target_system_spec<
     "CPU" = #dlti.target_device_spec<"L1_cache_size_in_bytes" = 4096,
                                      "L1_cache_size_in_bytes" = 8192>
   >} {}
+
+// -----
+
+// CHECK: empty string as DLTI key is not allowed
+"test.op"() { test.unknown_attr = #dlti.map<"" = 42> } : () -> ()
+
+// -----
+// CHECK: duplicate DLTI entry key
+"test.op"() { test.unknown_attr = #dlti.map<
+  i32 = 42, i32 = 19> } : () -> ()

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/dlti/attrs.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/dlti/attrs.mlir
@@ -29,3 +29,17 @@ module attributes {
     "GPU" = #dlti.target_device_spec<
       "dlti.max_vector_op_width" = 128 : ui32>
   >} {}
+
+// CHECK: "builtin.module"() ({
+// CHECK:   ^bb0:
+// CHECK:   }) {
+// CHECK:   dlti.map = #dlti.map<
+// CHECK:          "CPU" = #dlti.map<
+// CHECK:                   "L1_cache_size_in_bytes" = 4096 : i32>,
+// CHECK:          "GPU" = #dlti.map<
+// CHECK:                   "max_vector_op_width" = 128 : i32>>} : () -> ()
+module attributes {
+  dlti.map = #dlti.map<
+    "CPU" = #dlti.map<"L1_cache_size_in_bytes" = 4096 : i32>,
+    "GPU" = #dlti.map<"max_vector_op_width" = 128 : i32>
+  >} {}

--- a/xdsl/dialects/dlti.py
+++ b/xdsl/dialects/dlti.py
@@ -33,6 +33,8 @@ class DataLayoutEntryAttr(ParametrizedAttribute):
     def verify(self) -> None:
         if not isinstance(self.key, StringAttr | TypeAttribute):
             raise VerifyException("key must be a string or a type attribute")
+        if isinstance(self.key, StringAttr) and not self.key.data:
+            raise VerifyException("empty string as DLTI key is not allowed")
 
 
 class DLTIEntryMap(ParametrizedAttribute, ABC):
@@ -118,12 +120,27 @@ class TargetSystemSpecAttr(DLTIEntryMap):
     name = "dlti.target_system_spec"
 
 
+@irdl_attr_definition
+class MapAttr(DLTIEntryMap):
+    """
+    A mapping of DLTI-information by way of key-value pairs
+
+    A Data Layout and Target Information map is a list of entries effectively
+    encoding a dictionary, mapping DLTI-related keys to DLTI-related values.
+
+    https://mlir.llvm.org/docs/Dialects/DLTIDialect/#mapattr
+    """
+
+    name = "dlti.map"
+
+
 DLTI = Dialect(
     "dlti",
     [],
     [
         DataLayoutEntryAttr,
         DataLayoutSpecAttr,
+        MapAttr,
         TargetDeviceSpecAttr,
         TargetSystemSpecAttr,
     ],


### PR DESCRIPTION
Added MapAttr to the DLTI dialect. Also added verification check that DataLayoutEntryAttr key is not an empty string (which conforms to MLIR behaviour)
