### PR TITLE
frontend: (pyast): add support for expr AST node

### DIFF
--- a/xdsl/frontend/pyast/code_generation.py
+++ b/xdsl/frontend/pyast/code_generation.py
@@ -340,6 +340,9 @@ class CodeGenerationVisitor(ast.NodeVisitor):
             f"which does not overload '{python_op}'.",
         )
 
+    def visit_Expr(self, node: ast.Expr):
+        self.visit(node.value)
+
     def _generate_affine_loop_bounds(
         self, args: list[ast.expr]
     ) -> tuple[int, int, int]:


### PR DESCRIPTION
This PR adds support for the expr ast node by passing through walking its value. This is required for building out the PDL rewrite frontend and peeled off #4859