### PR TITLE
core: speed up checking for uses

### DIFF
--- a/xdsl/interpreters/eqsat_pdl_interp.py
+++ b/xdsl/interpreters/eqsat_pdl_interp.py
@@ -151,7 +151,7 @@ class EqsatPDLInterpFunctions(PDLInterpFunctions):
         if result.has_one_use():
             if isinstance(eclass_op := result.get_user_of_unique_use(), eqsat.EClassOp):
                 result = eclass_op.result
-        elif result.uses:  # multiple uses
+        else:
             for use in result.uses:
                 if isinstance(use.operation, eqsat.EClassOp):
                     raise InterpretationError(
@@ -183,7 +183,7 @@ class EqsatPDLInterpFunctions(PDLInterpFunctions):
                 ):
                     assert len(eclass_op.results) == 1
                     result = eclass_op.results[0]
-            elif result.uses:  # multiple uses
+            else:
                 for use in result.uses:
                     if isinstance(use.operation, eqsat.EClassOp):
                         raise InterpretationError(
@@ -308,7 +308,7 @@ class EqsatPDLInterpFunctions(PDLInterpFunctions):
         # Check if an identical operation already exists in our known_ops map
         if existing_op := self.known_ops.get(new_op):
             # CSE can have removed the existing operation, here we check if it is still in use:
-            if existing_op.results and existing_op.results[0].uses:
+            if existing_op.results and existing_op.results[0].first_use is not None:
                 self.rewriter.erase_op(new_op)
                 self.rewriter.has_done_action = has_done_action_checkpoint
                 return (existing_op,)

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -723,7 +723,7 @@ class SSAValue(Generic[AttributeCovT], IRWithUses, ABC):
         # carry over name if possible
         if value.name_hint is None:
             value.name_hint = self.name_hint
-        assert not self.uses, "unexpected error in xdsl"
+        assert self.first_use is None, "unexpected error in xdsl"
 
     def replace_by_if(self, value: SSAValue, test: Callable[[Use], bool]):
         """
@@ -743,7 +743,7 @@ class SSAValue(Generic[AttributeCovT], IRWithUses, ABC):
         If safe_erase is True, then check that no operations use the value anymore.
         If safe_erase is False, then replace its uses by an ErasedSSAValue.
         """
-        if safe_erase and self.uses:
+        if safe_erase and self.first_use is not None:
             raise ValueError(
                 "Attempting to delete SSA value that still has uses of result "
                 f"of operation:\n{self.owner}"

--- a/xdsl/transforms/dead_code_elimination.py
+++ b/xdsl/transforms/dead_code_elimination.py
@@ -34,7 +34,9 @@ def is_trivially_dead(op: Operation):
     """
     Returns if the operation has no observable effect.
     """
-    return all(not result.uses for result in op.results) and would_be_trivially_dead(op)
+    return all(
+        result.first_use is None for result in op.results
+    ) and would_be_trivially_dead(op)
 
 
 def result_only_effects(rootOp: Operation) -> bool:


### PR DESCRIPTION
Before:

```
❯ python benchmarks/rewriting.py RemoveUnused.is_trivially_dead dis
===========================================
 Events recorded: 58
 Opcodes recorded: 40
 Uninstrumented: 350.35 ns
 Uninstrumented per opcode: 8.76 ns/op
 Instrumented: 11895.62 ns
 Instrumented per opcode: 297.39 ns/op
 Elapsed: 4825.74 ns
 Elapsed per opcode: 120.64 ns/op
 Opcode overhead: 0.00 ns/op
 Tracing overhead per opcode: 111.88 ns/op
===========================================
```

After:

```
❯ python benchmarks/rewriting.py RemoveUnused.is_trivially_dead dis ===========================================
 Events recorded: 39
 Opcodes recorded: 27
 Uninstrumented: 220.84 ns
 Uninstrumented per opcode: 8.18 ns/op
 Instrumented: 7753.91 ns
 Instrumented per opcode: 287.18 ns/op
 Elapsed: 2951.75 ns
 Elapsed per opcode: 109.32 ns/op
 Opcode overhead: 0.00 ns/op
 Tracing overhead per opcode: 101.15 ns/op
===========================================
```