### PR TITLE
dialects: (x86) print `.intel_syntax noprefix` in assembly

### DIFF
--- a/tests/filecheck/dialects/x86/x86_assembly_emission.mlir
+++ b/tests/filecheck/dialects/x86/x86_assembly_emission.mlir
@@ -1,5 +1,7 @@
 // RUN: xdsl-opt -t x86-asm %s | filecheck %s
 
+// CHECK-NEXT: .intel_syntax noprefix
+
 %0 = x86.get_register : () -> !x86.reg<rax>
 %1 = x86.get_register : () -> !x86.reg<rdx>
 %2 = x86.get_register : () -> !x86.reg<rcx>
@@ -7,7 +9,7 @@
 %rax = x86.get_register : () -> !x86.reg<rax>
 
 %rr_add = x86.rs.add %0, %1 : (!x86.reg<rax>, !x86.reg<rdx>) -> !x86.reg<rax>
-// CHECK: add rax, rdx
+// CHECK-NEXT: add rax, rdx
 %rr_sub = x86.rs.sub %0, %1 : (!x86.reg<rax>, !x86.reg<rdx>) -> !x86.reg<rax>
 // CHECK-NEXT: sub rax, rdx
 %rr_imul = x86.rs.imul %0, %1 : (!x86.reg<rax>, !x86.reg<rdx>) -> !x86.reg<rax>

--- a/xdsl/dialects/x86/ops.py
+++ b/xdsl/dialects/x86/ops.py
@@ -3012,6 +3012,7 @@ class GetAVXRegisterOp(GetAnyRegisterOperation[X86VectorRegisterType]):
 
 def print_assembly(module: ModuleOp, output: IO[str]) -> None:
     printer = AssemblyPrinter(stream=output)
+    print(".intel_syntax noprefix", file=output)
     printer.print_module(module)
 
 


### PR DESCRIPTION
Clang's assembler on linux is not happy without this being explicitly stated, as it assumes AT&T.