### PR TITLE
dialects: (x86) add MemoryReadEffect to DM_Operation

### DIFF
--- a/tests/filecheck/dialects/x86/canonicalize.mlir
+++ b/tests/filecheck/dialects/x86/canonicalize.mlir
@@ -35,4 +35,7 @@ x86.ms.mov %offset_ptr, %rm_mov, 8 : (!x86.reg<rdi>, !x86.reg<rax>) -> ()
 %avx = x86.dm.vmovupd %offset_ptr, 32 : (!x86.reg<rdi>) -> !x86.avx2reg<ymm1>
 x86.ms.vmovapd %offset_ptr, %avx, 32 : (!x86.reg<rdi>, !x86.avx2reg<ymm1>) -> ()
 
+// Unused memory reads get eliminated
+%unused_read = x86.dm.mov %i0, 8 : (!x86.reg<rdi>) -> !x86.reg<rax>
+
 // CHECK-NEXT:  }

--- a/xdsl/dialects/x86/ops.py
+++ b/xdsl/dialects/x86/ops.py
@@ -69,7 +69,12 @@ from xdsl.irdl import (
 from xdsl.parser import Parser, UnresolvedOperand
 from xdsl.pattern_rewriter import RewritePattern
 from xdsl.printer import Printer
-from xdsl.traits import HasCanonicalizationPatternsTrait, IsTerminator, Pure
+from xdsl.traits import (
+    HasCanonicalizationPatternsTrait,
+    IsTerminator,
+    MemoryReadEffect,
+    Pure,
+)
 from xdsl.utils.exceptions import VerifyException
 
 from .assembly import (
@@ -436,7 +441,10 @@ class DM_Operation(
     memory = operand_def(R2InvT)
     memory_offset = attr_def(IntegerAttr, default_value=IntegerAttr(0, 64))
 
-    traits = traits_def(DM_OperationHasCanonicalizationPatterns())
+    traits = traits_def(
+        DM_OperationHasCanonicalizationPatterns(),
+        MemoryReadEffect(),
+    )
 
     def __init__(
         self,


### PR DESCRIPTION
This allows unused reads to get optimised out.