### PR TITLE
dialects: (x86) fix constant offset canonicalization

### DIFF
--- a/tests/filecheck/dialects/x86/canonicalize.mlir
+++ b/tests/filecheck/dialects/x86/canonicalize.mlir
@@ -18,22 +18,24 @@
 %c0_0 = x86.ds.mov %c0 : (!x86.reg) -> !x86.reg
 %c32 = x86.di.mov 32 : () -> !x86.reg
 
-// CHECK-NEXT:    "test.op"(%i0) : (!x86.reg<rdi>) -> ()
-%add_immediate_zero_reg = x86.rs.add %i0, %c0 : (!x86.reg<rdi>, !x86.reg) -> !x86.reg<rdi>
-"test.op"(%add_immediate_zero_reg) : (!x86.reg<rdi>) -> ()
+// CHECK-NEXT:    %moved_i = x86.ds.mov %i0 : (!x86.reg<rdi>) -> !x86.reg<rbx>
+// CHECK-NEXT:    "test.op"(%moved_i) : (!x86.reg<rbx>) -> ()
+%moved_i = x86.ds.mov %i0 : (!x86.reg<rdi>) -> !x86.reg<rbx>
+%add_immediate_zero_reg = x86.rs.add %moved_i, %c0 : (!x86.reg<rbx>, !x86.reg) -> !x86.reg<rbx>
+"test.op"(%add_immediate_zero_reg) : (!x86.reg<rbx>) -> ()
 
 // Constant memory offsets get optimized out
-%offset_ptr = x86.rs.add %i0, %c32 : (!x86.reg<rdi>, !x86.reg) -> !x86.reg<rdi>
+%offset_ptr = x86.rs.add %moved_i, %c32 : (!x86.reg<rbx>, !x86.reg) -> !x86.reg<rbx>
 
 // CHECK-NEXT:     %rm_mov = x86.dm.mov %i0, 40 : (!x86.reg<rdi>) -> !x86.reg<rax>
 // CHECK-NEXT:     x86.ms.mov %i0, %rm_mov, 40 : (!x86.reg<rdi>, !x86.reg<rax>) -> ()
-%rm_mov = x86.dm.mov %offset_ptr, 8 : (!x86.reg<rdi>) -> !x86.reg<rax>
-x86.ms.mov %offset_ptr, %rm_mov, 8 : (!x86.reg<rdi>, !x86.reg<rax>) -> ()
+%rm_mov = x86.dm.mov %offset_ptr, 8 : (!x86.reg<rbx>) -> !x86.reg<rax>
+x86.ms.mov %offset_ptr, %rm_mov, 8 : (!x86.reg<rbx>, !x86.reg<rax>) -> ()
 
 // CHECK-NEXT:     %avx = x86.dm.vmovupd %i0, 64 : (!x86.reg<rdi>) -> !x86.avx2reg<ymm1>
 // CHECK-NEXT:     x86.ms.vmovapd %i0, %avx, 64 : (!x86.reg<rdi>, !x86.avx2reg<ymm1>) -> ()
-%avx = x86.dm.vmovupd %offset_ptr, 32 : (!x86.reg<rdi>) -> !x86.avx2reg<ymm1>
-x86.ms.vmovapd %offset_ptr, %avx, 32 : (!x86.reg<rdi>, !x86.avx2reg<ymm1>) -> ()
+%avx = x86.dm.vmovupd %offset_ptr, 32 : (!x86.reg<rbx>) -> !x86.avx2reg<ymm1>
+x86.ms.vmovapd %offset_ptr, %avx, 32 : (!x86.reg<rbx>, !x86.avx2reg<ymm1>) -> ()
 
 // Unused memory reads get eliminated
 %unused_read = x86.dm.mov %i0, 8 : (!x86.reg<rdi>) -> !x86.reg<rax>

--- a/xdsl/transforms/canonicalization_patterns/x86.py
+++ b/xdsl/transforms/canonicalization_patterns/x86.py
@@ -34,12 +34,12 @@ class MS_Operation_ConstantOffset(RewritePattern):
             isinstance(op, x86.ops.MS_Operation)
             and isinstance(add_op := op.memory.owner, x86.RS_AddOp)
             and ((value := get_constant_value(add_op.source)) is not None)
+            # The addition is in-place, so we have to get the original value
+            and isinstance(mov_op := add_op.register_in.owner, x86.DS_MovOp)
         ):
             op = cast(x86.ops.MS_Operation[X86RegisterType, X86RegisterType], op)
             new_offset = op.memory_offset.value.data + value.value.data
-            rewriter.replace_matched_op(
-                type(op)(add_op.register_in, op.source, new_offset)
-            )
+            rewriter.replace_matched_op(type(op)(mov_op.source, op.source, new_offset))
 
 
 class DM_Operation_ConstantOffset(RewritePattern):
@@ -48,13 +48,13 @@ class DM_Operation_ConstantOffset(RewritePattern):
             isinstance(op, x86.ops.DM_Operation)
             and isinstance(add_op := op.memory.owner, x86.RS_AddOp)
             and ((value := get_constant_value(add_op.source)) is not None)
+            # The addition is in-place, so we have to get the original value
+            and isinstance(mov_op := add_op.register_in.owner, x86.DS_MovOp)
         ):
             op = cast(x86.ops.DM_Operation[X86RegisterType, X86RegisterType], op)
             new_offset = op.memory_offset.value.data + value.value.data
             rewriter.replace_matched_op(
-                type(op)(
-                    add_op.register_in, new_offset, destination=op.destination.type
-                )
+                type(op)(mov_op.source, new_offset, destination=op.destination.type)
             )
 
 


### PR DESCRIPTION
I added the linearity constraints to catch this case, but our traits are currently not inherited in the way that I expected, which I'll fix in an upcoming PR.

This PR changes the canonicalization of constant offsets to use the original value, as opposed to the copy that's intended to only be used by the add op, which modifies it in-place.