### PR TITLE
dialects: (dlti) Add initialisation convenience from dictionary and python types

### DIFF
--- a/tests/dialects/test_dlti.py
+++ b/tests/dialects/test_dlti.py
@@ -31,131 +31,73 @@ DictValueType: TypeAlias = Mapping[
 def test_data_layout_entry():
     # Test passing strings for key and value
     entry = DataLayoutEntryAttr("test", "V")
-    assert isinstance(entry.key, StringAttr)
-    assert isinstance(entry.value, StringAttr)
-    assert entry.key.data == "test"
-    assert entry.value.data == "V"
+    assert entry.key == StringAttr("test")
+    assert entry.value == StringAttr("V")
 
     # Test passing string for key and int for value
     entry = DataLayoutEntryAttr("test2", 12)
-    assert isinstance(entry.key, StringAttr)
-    assert entry.key.data == "test2"
-    assert isinstance(entry.value, IntAttr)
-    assert entry.value.data == 12
+    assert entry.key == StringAttr("test2")
+    assert entry.value == IntAttr(12)
 
     # Test passing string for key and float for value
     entry = DataLayoutEntryAttr("test3", FloatAttr(99.45, Float32Type()))
-    assert isinstance(entry.key, StringAttr)
-    assert isinstance(entry.value, FloatAttr)
-    assert entry.key.data == "test3"
-    assert round(entry.value.value.data, 2) == 99.45  # pyright: ignore
+    assert entry.key == StringAttr("test3")
+    assert entry.value == FloatAttr(99.45, Float32Type())
 
     # Test passing type for key and string for value
     entry = DataLayoutEntryAttr(i32, "test")
-    assert isinstance(entry.key, TypeAttribute)
-    assert isinstance(entry.value, StringAttr)
     assert entry.key == i32
-    assert entry.value.data == "test"
+    assert entry.value == StringAttr("test")
 
     # Test passing StringAttr for key and value
     entry = DataLayoutEntryAttr(StringAttr("k"), StringAttr("v"))
-    assert isinstance(entry.key, StringAttr)
-    assert isinstance(entry.value, StringAttr)
-    assert entry.key.data == "k"
-    assert entry.value.data == "v"
+    assert entry.key == StringAttr("k")
+    assert entry.value == StringAttr("v")
 
 
 def test_incorrect_data_layout_entry():
     with pytest.raises(VerifyException):
-        entry = DataLayoutEntryAttr("", "V")
-        entry.verify()
-
-
-def generic_test_entry_equals_defn(
-    dlti_entry: DataLayoutEntryAttr,
-    comparison_entry: tuple[
-        StringAttr | TypeAttribute | str, Attribute | str | int | DictValueType
-    ],
-):
-    assert isinstance(dlti_entry, DataLayoutEntryAttr)
-
-    comparison_entry_key = comparison_entry[0]
-    comparison_entry_value = comparison_entry[1]
-
-    dlti_entry_key = dlti_entry.key
-    dlti_entry_value = dlti_entry.value
-
-    if isinstance(comparison_entry_key, str) or isinstance(
-        comparison_entry_key, StringAttr
-    ):
-        assert isinstance(dlti_entry_key, StringAttr)
-        assert (
-            dlti_entry_key.data == comparison_entry_key.data
-            if isinstance(comparison_entry_key, StringAttr)
-            else comparison_entry_key
-        )
-    else:
-        assert isinstance(dlti_entry_key, TypeAttribute)
-        assert dlti_entry_key == comparison_entry_key
-
-    if isinstance(comparison_entry_value, str) or isinstance(
-        comparison_entry_value, StringAttr
-    ):
-        assert isinstance(dlti_entry_value, StringAttr)
-        assert (
-            dlti_entry_value.data == dlti_entry_value.data
-            if isinstance(comparison_entry_value, StringAttr)
-            else comparison_entry_value
-        )
-    elif isinstance(comparison_entry_value, int) or isinstance(
-        comparison_entry_value, IntAttr
-    ):
-        assert isinstance(dlti_entry_value, IntAttr)
-        assert (
-            dlti_entry_value.data == dlti_entry_value.data
-            if isinstance(comparison_entry_value, IntAttr)
-            else comparison_entry_value
-        )
-    elif isinstance(comparison_entry_value, FloatAttr):
-        assert isinstance(dlti_entry_value, FloatAttr)
-        assert dlti_entry_value.value.data == dlti_entry_value.value.data
-    else:
-        pytest.fail("Unknown comparison type")
+        DataLayoutEntryAttr("", "V")
 
 
 def generic_specification_test(
     dlti_class: type[DLTIEntryMap],
     contents: ArrayAttr[DataLayoutEntryAttr] | DictValueType,
-    comparison_entries: list[
-        tuple[StringAttr | TypeAttribute | str, Attribute | str | int]
-    ],
+    comparison_entries: list[Attribute],
 ):
     spec = dlti_class(contents)
     assert isa(spec.entries, ArrayAttr[DataLayoutEntryAttr])
     assert len(spec.entries) == len(comparison_entries)
 
-    for dlti_entry, comparison in zip(spec.entries.data, comparison_entries):
-        generic_test_entry_equals_defn(dlti_entry, comparison)
+    for idx, (dlti_entry, comparison_entry) in enumerate(
+        zip(spec.entries.data, comparison_entries)
+    ):
+        assert dlti_entry.key == StringAttr("key_" + str(idx))
+        assert dlti_entry.value == comparison_entry
 
 
 @pytest.mark.parametrize(
     "entries",
     [
-        [("key1", "value1"), ("key2", 23), (i32, 43)],
-        [("k", IntAttr(23)), (i32, FloatAttr(2.4, Float32Type()))],
+        [StringAttr("value1"), IntAttr(23), IntAttr(43)],
+        [IntAttr(23), FloatAttr(2.4, Float32Type())],
     ],
 )
 def test_data_layout_spec(
-    entries: list[tuple[StringAttr | TypeAttribute | str, Attribute | str | int]],
+    entries: list[Attribute],
 ):
     # Test initialisation from a dictionary
     generic_specification_test(
-        DataLayoutSpecAttr, {e[0]: e[1] for e in entries}, entries
+        DataLayoutSpecAttr,
+        {"key_" + str(idx): e for idx, e in enumerate(entries)},
+        entries,
     )
     # Test initialisation from an array attribute of data layout entries
     generic_specification_test(
         DataLayoutSpecAttr,
-        ArrayAttr([DataLayoutEntryAttr(e[0], e[1]) for e in entries]),
+        ArrayAttr(
+            [DataLayoutEntryAttr("key_" + str(idx), e) for idx, e in enumerate(entries)]
+        ),
         entries,
     )
 
@@ -163,21 +105,25 @@ def test_data_layout_spec(
 @pytest.mark.parametrize(
     "entries",
     [
-        [("key1", "value1"), ("key2", 23), (i32, FloatAttr(9.3, Float32Type()))],
-        [("k", IntAttr(23)), (i32, FloatAttr(2.4, Float32Type()))],
+        [StringAttr("value1"), IntAttr(23), IntAttr(43)],
+        [IntAttr(23), FloatAttr(2.4, Float32Type())],
     ],
 )
 def test_target_device_spec(
-    entries: list[tuple[StringAttr | TypeAttribute | str, Attribute | str | int]],
+    entries: list[Attribute],
 ):
     # Test initialisation from a dictionary
     generic_specification_test(
-        TargetDeviceSpecAttr, {e[0]: e[1] for e in entries}, entries
+        TargetDeviceSpecAttr,
+        {"key_" + str(idx): e for idx, e in enumerate(entries)},
+        entries,
     )
     # Test initialisation from an array attribute of data layout entries
     generic_specification_test(
         TargetDeviceSpecAttr,
-        ArrayAttr([DataLayoutEntryAttr(e[0], e[1]) for e in entries]),
+        ArrayAttr(
+            [DataLayoutEntryAttr("key_" + str(idx), e) for idx, e in enumerate(entries)]
+        ),
         entries,
     )
 
@@ -185,21 +131,25 @@ def test_target_device_spec(
 @pytest.mark.parametrize(
     "entries",
     [
-        [("key1", "value1"), ("key2", 23), (i32, "test")],
-        [("k", IntAttr(23)), (i32, FloatAttr(2.4, Float32Type()))],
+        [StringAttr("value1"), IntAttr(23), IntAttr(43)],
+        [IntAttr(23), FloatAttr(2.4, Float32Type())],
     ],
 )
 def test_target_system_spec(
-    entries: list[tuple[StringAttr | TypeAttribute | str, Attribute | str | int]],
+    entries: list[Attribute],
 ):
     # Test initialisation from a dictionary
     generic_specification_test(
-        TargetSystemSpecAttr, {e[0]: e[1] for e in entries}, entries
+        TargetSystemSpecAttr,
+        {"key_" + str(idx): e for idx, e in enumerate(entries)},
+        entries,
     )
     # Test initialisation from an array attribute of data layout entries
     generic_specification_test(
         TargetSystemSpecAttr,
-        ArrayAttr([DataLayoutEntryAttr(e[0], e[1]) for e in entries]),
+        ArrayAttr(
+            [DataLayoutEntryAttr("key_" + str(idx), e) for idx, e in enumerate(entries)]
+        ),
         entries,
     )
 
@@ -207,24 +157,29 @@ def test_target_system_spec(
 @pytest.mark.parametrize(
     "entries",
     [
-        [("key1", "value1"), ("key2", 23), (i32, 17)],
-        [("k", IntAttr(23)), (i32, FloatAttr(2.4, Float32Type()))],
+        [StringAttr("value1"), IntAttr(23), IntAttr(43)],
+        [IntAttr(23), FloatAttr(2.4, Float32Type())],
     ],
 )
 def test_map_attr(
-    entries: list[tuple[StringAttr | TypeAttribute | str, Attribute | str | int]],
+    entries: list[Attribute],
 ):
     # Test initialisation from a dictionary
-    generic_specification_test(MapAttr, {e[0]: e[1] for e in entries}, entries)
+    generic_specification_test(
+        MapAttr, {"key_" + str(idx): e for idx, e in enumerate(entries)}, entries
+    )
     # Test initialisation from an array attribute of data layout entries
     generic_specification_test(
-        MapAttr, ArrayAttr([DataLayoutEntryAttr(e[0], e[1]) for e in entries]), entries
+        MapAttr,
+        ArrayAttr(
+            [DataLayoutEntryAttr("key_" + str(idx), e) for idx, e in enumerate(entries)]
+        ),
+        entries,
     )
 
 
 def test_map_attr_embedded_dict():
     m = MapAttr({"key": {"key": {"key": "value"}}})
-    m.verify()
     assert isinstance(m.entries.data[0].value, MapAttr)
     assert isinstance(m.entries.data[0].value.entries.data[0].value, MapAttr)
     embedded_contents = m.entries.data[0].value.entries.data[0].value
@@ -234,31 +189,27 @@ def test_map_attr_embedded_dict():
 
 def test_duplicate_data_layout_spec_entries():
     with pytest.raises(VerifyException):
-        entry = DataLayoutSpecAttr(
+        DataLayoutSpecAttr(
             ArrayAttr([DataLayoutEntryAttr("k", "v"), DataLayoutEntryAttr("k", 12)])
         )
-        entry.verify()
 
 
 def test_duplicate_target_device_spec_entries():
     with pytest.raises(VerifyException):
-        entry = TargetDeviceSpecAttr(
+        TargetDeviceSpecAttr(
             ArrayAttr([DataLayoutEntryAttr("k", "v"), DataLayoutEntryAttr("k", 12)])
         )
-        entry.verify()
 
 
 def test_duplicate_system_spec_entries():
     with pytest.raises(VerifyException):
-        entry = TargetSystemSpecAttr(
+        TargetSystemSpecAttr(
             ArrayAttr([DataLayoutEntryAttr("k", "v"), DataLayoutEntryAttr("k", 12)])
         )
-        entry.verify()
 
 
 def test_duplicate_map_attr_entries():
     with pytest.raises(VerifyException):
-        entry = MapAttr(
+        MapAttr(
             ArrayAttr([DataLayoutEntryAttr("k", "v"), DataLayoutEntryAttr("k", 12)])
         )
-        entry.verify()

--- a/tests/dialects/test_dlti.py
+++ b/tests/dialects/test_dlti.py
@@ -59,89 +59,42 @@ def test_incorrect_data_layout_entry():
         DataLayoutEntryAttr("", "V")
 
 
-def generic_specification_test(
-    dlti_class: type[DLTIEntryMap],
-    comparison_entries: list[Attribute],
+@pytest.mark.parametrize(
+    "cls", [DataLayoutSpecAttr, TargetDeviceSpecAttr, TargetSystemSpecAttr, MapAttr]
+)
+@pytest.mark.parametrize(
+    "entries",
+    [
+        [StringAttr("value1"), IntAttr(23), IntAttr(43)],
+        [IntAttr(23), FloatAttr(2.4, Float32Type())],
+    ],
+)
+def test_entry_maps(
+    cls: type[DLTIEntryMap],
+    entries: list[Attribute],
 ):
     # Comparison
-    comparison_attr = dlti_class.new(
+    comparison_attr = cls.new(
         (
             ArrayAttr(
                 [
                     DataLayoutEntryAttr("key_" + str(idx), e)
-                    for idx, e in enumerate(comparison_entries)
+                    for idx, e in enumerate(entries)
                 ]
             ),
         )
     )
 
     # Test initialisation from a dictionary
-    attr_one = dlti_class(
-        {"key_" + str(idx): e for idx, e in enumerate(comparison_entries)}
-    )
+    attr_one = cls({"key_" + str(idx): e for idx, e in enumerate(entries)})
     assert comparison_attr == attr_one
     # Test initialisation from an array attribute of data layout entries
-    attr_two = dlti_class(
+    attr_two = cls(
         ArrayAttr(
-            [
-                DataLayoutEntryAttr("key_" + str(idx), e)
-                for idx, e in enumerate(comparison_entries)
-            ]
+            [DataLayoutEntryAttr("key_" + str(idx), e) for idx, e in enumerate(entries)]
         )
     )
     assert comparison_attr == attr_two
-
-
-@pytest.mark.parametrize(
-    "entries",
-    [
-        [StringAttr("value1"), IntAttr(23), IntAttr(43)],
-        [IntAttr(23), FloatAttr(2.4, Float32Type())],
-    ],
-)
-def test_data_layout_spec(
-    entries: list[Attribute],
-):
-    generic_specification_test(DataLayoutSpecAttr, entries)
-
-
-@pytest.mark.parametrize(
-    "entries",
-    [
-        [StringAttr("value1"), IntAttr(23), IntAttr(43)],
-        [IntAttr(23), FloatAttr(2.4, Float32Type())],
-    ],
-)
-def test_target_device_spec(
-    entries: list[Attribute],
-):
-    generic_specification_test(TargetDeviceSpecAttr, entries)
-
-
-@pytest.mark.parametrize(
-    "entries",
-    [
-        [StringAttr("value1"), IntAttr(23), IntAttr(43)],
-        [IntAttr(23), FloatAttr(2.4, Float32Type())],
-    ],
-)
-def test_target_system_spec(
-    entries: list[Attribute],
-):
-    generic_specification_test(TargetSystemSpecAttr, entries)
-
-
-@pytest.mark.parametrize(
-    "entries",
-    [
-        [StringAttr("value1"), IntAttr(23), IntAttr(43)],
-        [IntAttr(23), FloatAttr(2.4, Float32Type())],
-    ],
-)
-def test_map_attr(
-    entries: list[Attribute],
-):
-    generic_specification_test(MapAttr, entries)
 
 
 def test_map_attr_embedded_dict():
@@ -153,29 +106,11 @@ def test_map_attr_embedded_dict():
     assert isinstance(embedded_contents.entries.data[0].value, StringAttr)
 
 
-def test_duplicate_data_layout_spec_entries():
+@pytest.mark.parametrize(
+    "cls", [DataLayoutSpecAttr, TargetDeviceSpecAttr, TargetSystemSpecAttr, MapAttr]
+)
+def test_duplicate_data_layout_map_entries(
+    cls: type[DLTIEntryMap],
+):
     with pytest.raises(VerifyException):
-        DataLayoutSpecAttr(
-            ArrayAttr([DataLayoutEntryAttr("k", "v"), DataLayoutEntryAttr("k", 12)])
-        )
-
-
-def test_duplicate_target_device_spec_entries():
-    with pytest.raises(VerifyException):
-        TargetDeviceSpecAttr(
-            ArrayAttr([DataLayoutEntryAttr("k", "v"), DataLayoutEntryAttr("k", 12)])
-        )
-
-
-def test_duplicate_system_spec_entries():
-    with pytest.raises(VerifyException):
-        TargetSystemSpecAttr(
-            ArrayAttr([DataLayoutEntryAttr("k", "v"), DataLayoutEntryAttr("k", 12)])
-        )
-
-
-def test_duplicate_map_attr_entries():
-    with pytest.raises(VerifyException):
-        MapAttr(
-            ArrayAttr([DataLayoutEntryAttr("k", "v"), DataLayoutEntryAttr("k", 12)])
-        )
+        cls(ArrayAttr([DataLayoutEntryAttr("k", "v"), DataLayoutEntryAttr("k", 12)]))

--- a/tests/dialects/test_dlti.py
+++ b/tests/dialects/test_dlti.py
@@ -1,12 +1,12 @@
 import pytest
 
 from xdsl.dialects.builtin import (
-    StringAttr,
-    IntegerAttr,
-    FloatAttr,
     ArrayAttr,
-    i32,
     Float32Type,
+    FloatAttr,
+    IntegerAttr,
+    StringAttr,
+    i32,
 )
 from xdsl.dialects.dlti import (
     DataLayoutEntryAttr,
@@ -16,7 +16,7 @@ from xdsl.dialects.dlti import (
     TargetDeviceSpecAttr,
     TargetSystemSpecAttr,
 )
-from xdsl.ir import TypeAttribute, Attribute
+from xdsl.ir import Attribute, TypeAttribute
 from xdsl.utils.exceptions import VerifyException
 
 
@@ -120,7 +120,7 @@ def generic_test_entry_equals_defn(
             else comparison_entry_value
         )
     else:
-        pytest.fail()
+        pytest.fail("Unknown comparison type")
 
 
 def generic_specification_test(

--- a/tests/dialects/test_dlti.py
+++ b/tests/dialects/test_dlti.py
@@ -1,5 +1,6 @@
-import pytest
 from typing import TypeAlias
+
+import pytest
 
 from xdsl.dialects.builtin import (
     ArrayAttr,

--- a/tests/dialects/test_dlti.py
+++ b/tests/dialects/test_dlti.py
@@ -21,7 +21,6 @@ from xdsl.dialects.dlti import (
 )
 from xdsl.ir import Attribute, TypeAttribute
 from xdsl.utils.exceptions import VerifyException
-from xdsl.utils.hints import isa
 
 DictValueType: TypeAlias = Mapping[
     StringAttr | TypeAttribute | str, "Attribute | str | int | DictValueType"
@@ -62,18 +61,35 @@ def test_incorrect_data_layout_entry():
 
 def generic_specification_test(
     dlti_class: type[DLTIEntryMap],
-    contents: ArrayAttr[DataLayoutEntryAttr] | DictValueType,
     comparison_entries: list[Attribute],
 ):
-    spec = dlti_class(contents)
-    assert isa(spec.entries, ArrayAttr[DataLayoutEntryAttr])
-    assert len(spec.entries) == len(comparison_entries)
+    # Comparison
+    comparison_attr = dlti_class.new(
+        (
+            ArrayAttr(
+                [
+                    DataLayoutEntryAttr("key_" + str(idx), e)
+                    for idx, e in enumerate(comparison_entries)
+                ]
+            ),
+        )
+    )
 
-    for idx, (dlti_entry, comparison_entry) in enumerate(
-        zip(spec.entries.data, comparison_entries)
-    ):
-        assert dlti_entry.key == StringAttr("key_" + str(idx))
-        assert dlti_entry.value == comparison_entry
+    # Test initialisation from a dictionary
+    attr_one = dlti_class(
+        {"key_" + str(idx): e for idx, e in enumerate(comparison_entries)}
+    )
+    assert comparison_attr == attr_one
+    # Test initialisation from an array attribute of data layout entries
+    attr_two = dlti_class(
+        ArrayAttr(
+            [
+                DataLayoutEntryAttr("key_" + str(idx), e)
+                for idx, e in enumerate(comparison_entries)
+            ]
+        )
+    )
+    assert comparison_attr == attr_two
 
 
 @pytest.mark.parametrize(
@@ -86,20 +102,7 @@ def generic_specification_test(
 def test_data_layout_spec(
     entries: list[Attribute],
 ):
-    # Test initialisation from a dictionary
-    generic_specification_test(
-        DataLayoutSpecAttr,
-        {"key_" + str(idx): e for idx, e in enumerate(entries)},
-        entries,
-    )
-    # Test initialisation from an array attribute of data layout entries
-    generic_specification_test(
-        DataLayoutSpecAttr,
-        ArrayAttr(
-            [DataLayoutEntryAttr("key_" + str(idx), e) for idx, e in enumerate(entries)]
-        ),
-        entries,
-    )
+    generic_specification_test(DataLayoutSpecAttr, entries)
 
 
 @pytest.mark.parametrize(
@@ -112,20 +115,7 @@ def test_data_layout_spec(
 def test_target_device_spec(
     entries: list[Attribute],
 ):
-    # Test initialisation from a dictionary
-    generic_specification_test(
-        TargetDeviceSpecAttr,
-        {"key_" + str(idx): e for idx, e in enumerate(entries)},
-        entries,
-    )
-    # Test initialisation from an array attribute of data layout entries
-    generic_specification_test(
-        TargetDeviceSpecAttr,
-        ArrayAttr(
-            [DataLayoutEntryAttr("key_" + str(idx), e) for idx, e in enumerate(entries)]
-        ),
-        entries,
-    )
+    generic_specification_test(TargetDeviceSpecAttr, entries)
 
 
 @pytest.mark.parametrize(
@@ -138,20 +128,7 @@ def test_target_device_spec(
 def test_target_system_spec(
     entries: list[Attribute],
 ):
-    # Test initialisation from a dictionary
-    generic_specification_test(
-        TargetSystemSpecAttr,
-        {"key_" + str(idx): e for idx, e in enumerate(entries)},
-        entries,
-    )
-    # Test initialisation from an array attribute of data layout entries
-    generic_specification_test(
-        TargetSystemSpecAttr,
-        ArrayAttr(
-            [DataLayoutEntryAttr("key_" + str(idx), e) for idx, e in enumerate(entries)]
-        ),
-        entries,
-    )
+    generic_specification_test(TargetSystemSpecAttr, entries)
 
 
 @pytest.mark.parametrize(
@@ -164,18 +141,7 @@ def test_target_system_spec(
 def test_map_attr(
     entries: list[Attribute],
 ):
-    # Test initialisation from a dictionary
-    generic_specification_test(
-        MapAttr, {"key_" + str(idx): e for idx, e in enumerate(entries)}, entries
-    )
-    # Test initialisation from an array attribute of data layout entries
-    generic_specification_test(
-        MapAttr,
-        ArrayAttr(
-            [DataLayoutEntryAttr("key_" + str(idx), e) for idx, e in enumerate(entries)]
-        ),
-        entries,
-    )
+    generic_specification_test(MapAttr, entries)
 
 
 def test_map_attr_embedded_dict():

--- a/tests/dialects/test_dlti.py
+++ b/tests/dialects/test_dlti.py
@@ -1,0 +1,271 @@
+import pytest
+
+from xdsl.dialects.dlti import (
+    DataLayoutEntryAttr,
+    DataLayoutSpecAttr,
+    DLTIEntryMap,
+    TargetDeviceSpecAttr,
+    TargetSystemSpecAttr,
+    MapAttr,
+)
+from xdsl.dialects.builtin import (
+    StringAttr,
+    IntegerAttr,
+    FloatAttr,
+    ArrayAttr,
+    i32,
+    Float32Type,
+)
+from xdsl.ir import TypeAttribute, Attribute
+from typing import Type
+from xdsl.utils.exceptions import VerifyException
+
+
+def test_data_layout_entry():
+    # Test passing strings for key and value
+    entry = DataLayoutEntryAttr("test", "V")
+    assert isinstance(entry.key, StringAttr)
+    assert isinstance(entry.value, StringAttr)
+    assert entry.key.data == "test"
+    assert entry.value.data == "V"
+
+    # Test passing string for key and int for value
+    entry = DataLayoutEntryAttr("test2", 12)
+    assert isinstance(entry.key, StringAttr)
+    assert entry.key.data == "test2"
+    assert isinstance(entry.value, IntegerAttr)
+    assert entry.value.value.data == 12  # pyright: ignore
+
+    # Test passing string for key and float for value
+    entry = DataLayoutEntryAttr("test3", 99.45)
+    assert isinstance(entry.key, StringAttr)
+    assert isinstance(entry.value, FloatAttr)
+    assert entry.key.data == "test3"
+    assert round(entry.value.value.data, 2) == 99.45  # pyright: ignore
+
+    # Test passing type for key and string for value
+    entry = DataLayoutEntryAttr(i32, "test")
+    assert isinstance(entry.key, TypeAttribute)
+    assert isinstance(entry.value, StringAttr)
+    assert entry.key == i32
+    assert entry.value.data == "test"
+
+    # Test passing StringAttr for key and value
+    entry = DataLayoutEntryAttr(StringAttr("k"), StringAttr("v"))
+    assert isinstance(entry.key, StringAttr)
+    assert isinstance(entry.value, StringAttr)
+    assert entry.key.data == "k"
+    assert entry.value.data == "v"
+
+
+def test_incorrect_data_layout_entry():
+    with pytest.raises(VerifyException):
+        entry = DataLayoutEntryAttr(12, "V")  # pyright: ignore
+        entry.verify()
+        entry = DataLayoutEntryAttr("", "V")
+        entry.verify()
+
+
+def generic_test_entry_equals_defn(
+    dlti_entry: DataLayoutEntryAttr,
+    comparison_entry: tuple[
+        StringAttr | TypeAttribute | str, Attribute | str | int | float
+    ],
+):
+    assert isinstance(dlti_entry, DataLayoutEntryAttr)
+
+    comparison_entry_key = comparison_entry[0]
+    comparison_entry_value = comparison_entry[1]
+
+    dlti_entry_key = dlti_entry.key
+    dlti_entry_value = dlti_entry.value
+
+    if isinstance(comparison_entry_key, str) or isinstance(
+        comparison_entry_key, StringAttr
+    ):
+        assert isinstance(dlti_entry_key, StringAttr)
+        assert (
+            dlti_entry_key.data == comparison_entry_key.data
+            if isinstance(comparison_entry_key, StringAttr)
+            else comparison_entry_key
+        )
+    else:
+        assert isinstance(dlti_entry_key, TypeAttribute)
+        assert dlti_entry_key == comparison_entry_key
+
+    if isinstance(comparison_entry_value, str) or isinstance(
+        comparison_entry_value, StringAttr
+    ):
+        assert isinstance(dlti_entry_value, StringAttr)
+        assert (
+            dlti_entry_value.data == dlti_entry_value.data
+            if isinstance(comparison_entry_value, StringAttr)
+            else comparison_entry_value
+        )
+    elif isinstance(comparison_entry_value, int) or isinstance(
+        comparison_entry_value, IntegerAttr
+    ):
+        assert isinstance(dlti_entry_value, IntegerAttr)
+        assert (
+            dlti_entry_value.value.data == dlti_entry_value.value.data
+            if isinstance(comparison_entry_value, IntegerAttr)
+            else comparison_entry_value
+        )
+    elif isinstance(comparison_entry_value, float) or isinstance(
+        comparison_entry_value, FloatAttr
+    ):
+        assert isinstance(dlti_entry_value, FloatAttr)
+        assert (
+            dlti_entry_value.value.data == dlti_entry_value.value.data
+            if isinstance(comparison_entry_value, FloatAttr)
+            else comparison_entry_value
+        )
+    else:
+        assert False
+
+
+def generic_specification_test(
+    dlti_class: Type[DLTIEntryMap],
+    contents: ArrayAttr
+    | list[DataLayoutEntryAttr]
+    | dict[StringAttr | TypeAttribute | str, Attribute | str | int | float],
+    comparison_entries: list[
+        tuple[StringAttr | TypeAttribute | str, Attribute | str | int | float]
+    ],
+):
+    spec = dlti_class(contents)
+    assert isinstance(spec.entries, ArrayAttr)
+    assert len(spec.entries) == len(comparison_entries)
+
+    for dlti_entry, comparison in zip(spec.entries.data, comparison_entries):
+        generic_test_entry_equals_defn(dlti_entry, comparison)
+
+
+@pytest.mark.parametrize(
+    "entries",
+    [
+        [("key1", "value1"), ("key2", 23), (i32, 9.4)],
+        [("k", IntegerAttr(23, i32)), (i32, FloatAttr(2.4, Float32Type()))],
+    ],
+)
+def test_data_layout_spec(
+    entries: list[
+        tuple[StringAttr | TypeAttribute | str, Attribute | str | int | float]
+    ],
+):
+    # Test initialisation from a dictionary
+    generic_specification_test(
+        DataLayoutSpecAttr, {e[0]: e[1] for e in entries}, entries
+    )
+    # Test initialisation from a list of data layout entries
+    generic_specification_test(
+        DataLayoutSpecAttr, [DataLayoutEntryAttr(e[0], e[1]) for e in entries], entries
+    )
+    # Test initialisation from an array attribute of data layout entries
+    generic_specification_test(
+        DataLayoutSpecAttr,
+        ArrayAttr([DataLayoutEntryAttr(e[0], e[1]) for e in entries]),
+        entries,
+    )
+
+
+@pytest.mark.parametrize(
+    "entries",
+    [
+        [("key1", "value1"), ("key2", 23), (i32, 9.4)],
+        [("k", IntegerAttr(23, i32)), (i32, FloatAttr(2.4, Float32Type()))],
+    ],
+)
+def test_target_device_spec(
+    entries: list[
+        tuple[StringAttr | TypeAttribute | str, Attribute | str | int | float]
+    ],
+):
+    # Test initialisation from a dictionary
+    generic_specification_test(
+        TargetDeviceSpecAttr, {e[0]: e[1] for e in entries}, entries
+    )
+    # Test initialisation from a list of data layout entries
+    generic_specification_test(
+        TargetDeviceSpecAttr,
+        [DataLayoutEntryAttr(e[0], e[1]) for e in entries],
+        entries,
+    )
+    # Test initialisation from an array attribute of data layout entries
+    generic_specification_test(
+        TargetDeviceSpecAttr,
+        ArrayAttr([DataLayoutEntryAttr(e[0], e[1]) for e in entries]),
+        entries,
+    )
+
+
+@pytest.mark.parametrize(
+    "entries",
+    [
+        [("key1", "value1"), ("key2", 23), (i32, 9.4)],
+        [("k", IntegerAttr(23, i32)), (i32, FloatAttr(2.4, Float32Type()))],
+    ],
+)
+def test_target_system_spec(
+    entries: list[
+        tuple[StringAttr | TypeAttribute | str, Attribute | str | int | float]
+    ],
+):
+    # Test initialisation from a dictionary
+    generic_specification_test(
+        TargetSystemSpecAttr, {e[0]: e[1] for e in entries}, entries
+    )
+    # Test initialisation from a list of data layout entries
+    generic_specification_test(
+        TargetSystemSpecAttr,
+        [DataLayoutEntryAttr(e[0], e[1]) for e in entries],
+        entries,
+    )
+    # Test initialisation from an array attribute of data layout entries
+    generic_specification_test(
+        TargetSystemSpecAttr,
+        ArrayAttr([DataLayoutEntryAttr(e[0], e[1]) for e in entries]),
+        entries,
+    )
+
+
+@pytest.mark.parametrize(
+    "entries",
+    [
+        [("key1", "value1"), ("key2", 23), (i32, 9.4)],
+        [("k", IntegerAttr(23, i32)), (i32, FloatAttr(2.4, Float32Type()))],
+    ],
+)
+def test_map_attr(
+    entries: list[
+        tuple[StringAttr | TypeAttribute | str, Attribute | str | int | float]
+    ],
+):
+    # Test initialisation from a dictionary
+    generic_specification_test(MapAttr, {e[0]: e[1] for e in entries}, entries)
+    # Test initialisation from a list of data layout entries
+    generic_specification_test(
+        MapAttr, [DataLayoutEntryAttr(e[0], e[1]) for e in entries], entries
+    )
+    # Test initialisation from an array attribute of data layout entries
+    generic_specification_test(
+        MapAttr, ArrayAttr([DataLayoutEntryAttr(e[0], e[1]) for e in entries]), entries
+    )
+
+
+def test_duplicate_spec_entries():
+    with pytest.raises(VerifyException):
+        entry = DataLayoutSpecAttr(
+            [DataLayoutEntryAttr("k", "v"), DataLayoutEntryAttr("k", 12)]  # pyright: ignore
+        )
+        entry.verify()
+        entry = TargetDeviceSpecAttr(
+            [DataLayoutEntryAttr("k", "v"), DataLayoutEntryAttr("k", 12)]  # pyright: ignore
+        )
+        entry.verify()
+        entry = TargetSystemSpecAttr(
+            [DataLayoutEntryAttr("k", "v"), DataLayoutEntryAttr("k", 12)]  # pyright: ignore
+        )
+        entry.verify()
+        entry = MapAttr([DataLayoutEntryAttr("k", "v"), DataLayoutEntryAttr("k", 12)])  # pyright: ignore
+        entry.verify()

--- a/tests/dialects/test_dlti.py
+++ b/tests/dialects/test_dlti.py
@@ -1,13 +1,5 @@
 import pytest
 
-from xdsl.dialects.dlti import (
-    DataLayoutEntryAttr,
-    DataLayoutSpecAttr,
-    DLTIEntryMap,
-    TargetDeviceSpecAttr,
-    TargetSystemSpecAttr,
-    MapAttr,
-)
 from xdsl.dialects.builtin import (
     StringAttr,
     IntegerAttr,
@@ -16,8 +8,15 @@ from xdsl.dialects.builtin import (
     i32,
     Float32Type,
 )
+from xdsl.dialects.dlti import (
+    DataLayoutEntryAttr,
+    DataLayoutSpecAttr,
+    DLTIEntryMap,
+    MapAttr,
+    TargetDeviceSpecAttr,
+    TargetSystemSpecAttr,
+)
 from xdsl.ir import TypeAttribute, Attribute
-from typing import Type
 from xdsl.utils.exceptions import VerifyException
 
 
@@ -121,11 +120,11 @@ def generic_test_entry_equals_defn(
             else comparison_entry_value
         )
     else:
-        assert False
+        pytest.fail()
 
 
 def generic_specification_test(
-    dlti_class: Type[DLTIEntryMap],
+    dlti_class: type[DLTIEntryMap],
     contents: ArrayAttr
     | list[DataLayoutEntryAttr]
     | dict[StringAttr | TypeAttribute | str, Attribute | str | int | float],

--- a/tests/filecheck/dialects/dlti/attrs_invalid.mlir
+++ b/tests/filecheck/dialects/dlti/attrs_invalid.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --verify-diagnostics --split-input-file | filecheck %s --strict-whitespace
+// RUN: xdsl-opt %s --parsing-diagnostics --verify-diagnostics --split-input-file | filecheck %s --strict-whitespace
 
 // CHECK: key must be a string or a type attribute
 "test.op"() {

--- a/tests/filecheck/dialects/dlti/attrs_invalid.mlir
+++ b/tests/filecheck/dialects/dlti/attrs_invalid.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --parsing-diagnostics --verify-diagnostics --split-input-file | filecheck %s --strict-whitespace
+// RUN: xdsl-opt %s --verify-diagnostics --split-input-file | filecheck %s --strict-whitespace
 
 // CHECK: key must be a string or a type attribute
 "test.op"() {

--- a/xdsl/dialects/dlti.py
+++ b/xdsl/dialects/dlti.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from abc import ABC
 from collections.abc import Mapping
+from dataclasses import dataclass
 from typing import TypeAlias
 
 from xdsl.dialects.builtin import (
@@ -65,6 +66,7 @@ class DataLayoutEntryAttr(ParametrizedAttribute):
             raise VerifyException("empty string as DLTI key is not allowed")
 
 
+@dataclass(frozen=True)
 class DLTIEntryMap(ParametrizedAttribute, ABC):
     """
     Many DLTI dialect operations contain arrays of DataLayoutEntryInterface,
@@ -115,7 +117,7 @@ class DLTIEntryMap(ParametrizedAttribute, ABC):
             raise VerifyException("duplicate DLTI entry key")
 
 
-@irdl_attr_definition
+@irdl_attr_definition(init=False)
 class DataLayoutSpecAttr(DLTIEntryMap):
     """
     An attribute to represent a data layout specification.
@@ -129,14 +131,8 @@ class DataLayoutSpecAttr(DLTIEntryMap):
 
     name = "dlti.dl_spec"
 
-    def __init__(
-        self,
-        contents: ArrayAttr[DataLayoutEntryAttr] | DictValueType,
-    ):
-        return super().__init__(contents)
 
-
-@irdl_attr_definition
+@irdl_attr_definition(init=False)
 class TargetDeviceSpecAttr(DLTIEntryMap):
     """
     An attribute to represent target device specification.
@@ -150,14 +146,8 @@ class TargetDeviceSpecAttr(DLTIEntryMap):
 
     name = "dlti.target_device_spec"
 
-    def __init__(
-        self,
-        contents: ArrayAttr[DataLayoutEntryAttr] | DictValueType,
-    ):
-        return super().__init__(contents)
 
-
-@irdl_attr_definition
+@irdl_attr_definition(init=False)
 class TargetSystemSpecAttr(DLTIEntryMap):
     """
     An attribute to represent target system specification.
@@ -171,14 +161,8 @@ class TargetSystemSpecAttr(DLTIEntryMap):
 
     name = "dlti.target_system_spec"
 
-    def __init__(
-        self,
-        contents: ArrayAttr[DataLayoutEntryAttr] | DictValueType,
-    ):
-        return super().__init__(contents)
 
-
-@irdl_attr_definition
+@irdl_attr_definition(init=False)
 class MapAttr(DLTIEntryMap):
     """
     A mapping of DLTI-information by way of key-value pairs
@@ -190,12 +174,6 @@ class MapAttr(DLTIEntryMap):
     """
 
     name = "dlti.map"
-
-    def __init__(
-        self,
-        contents: ArrayAttr[DataLayoutEntryAttr] | DictValueType,
-    ):
-        return super().__init__(contents)
 
 
 DLTI = Dialect(

--- a/xdsl/dialects/dlti.py
+++ b/xdsl/dialects/dlti.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 from abc import ABC
 from collections.abc import Mapping
-from dataclasses import dataclass
 from typing import TypeAlias
 
 from xdsl.dialects.builtin import (
@@ -87,7 +86,6 @@ class DataLayoutEntryAttr(ParametrizedAttribute):
             raise VerifyException("empty string as DLTI key is not allowed")
 
 
-@dataclass(frozen=True)
 class DLTIEntryMap(ParametrizedAttribute, ABC):
     """
     Many DLTI dialect operations contain arrays of DataLayoutEntryInterface,
@@ -99,12 +97,6 @@ class DLTIEntryMap(ParametrizedAttribute, ABC):
     entries: ArrayAttr[DataLayoutEntryAttr] = param_def(
         converter=DLTITypeConverters.convert_entry_map_type
     )
-
-    def __init__(
-        self,
-        contents: ArrayAttr[DataLayoutEntryAttr] | DictValueType,
-    ):
-        super().__init__(contents)
 
     @classmethod
     def parse_parameters(

--- a/xdsl/dialects/dlti.py
+++ b/xdsl/dialects/dlti.py
@@ -9,6 +9,7 @@ https://mlir.llvm.org/docs/Dialects/DLTIDialect/
 from __future__ import annotations
 
 from abc import ABC
+from collections.abc import Mapping
 from typing import TypeAlias, cast
 
 from xdsl.dialects.builtin import (
@@ -24,8 +25,9 @@ from xdsl.irdl import irdl_attr_definition
 from xdsl.parser import AttrParser
 from xdsl.printer import Printer
 from xdsl.utils.exceptions import VerifyException
+from xdsl.utils.hints import isa
 
-DictValueType: TypeAlias = dict[
+DictValueType: TypeAlias = Mapping[
     StringAttr | TypeAttribute | str, "Attribute | str | int | float | DictValueType"
 ]
 
@@ -80,16 +82,13 @@ class DLTIEntryMap(ParametrizedAttribute, ABC):
 
     def __init__(
         self,
-        contents: ArrayAttr | list[DataLayoutEntryAttr] | DictValueType,
+        contents: ArrayAttr[DataLayoutEntryAttr] | DictValueType,
     ):
-        if isinstance(contents, dict):
+        if not isa(contents, ArrayAttr[DataLayoutEntryAttr]):
+            assert isinstance(contents, Mapping)
             contents = ArrayAttr(
                 [DataLayoutEntryAttr(k, v) for k, v in contents.items()]
             )
-        elif isinstance(contents, list):
-            contents = ArrayAttr(contents)
-
-        assert isinstance(contents, ArrayAttr)
 
         super().__init__(contents)
 
@@ -138,7 +137,7 @@ class DataLayoutSpecAttr(DLTIEntryMap):
 
     def __init__(
         self,
-        contents: ArrayAttr | list[DataLayoutEntryAttr] | DictValueType,
+        contents: ArrayAttr[DataLayoutEntryAttr] | DictValueType,
     ):
         return super().__init__(contents)
 
@@ -159,7 +158,7 @@ class TargetDeviceSpecAttr(DLTIEntryMap):
 
     def __init__(
         self,
-        contents: ArrayAttr | list[DataLayoutEntryAttr] | DictValueType,
+        contents: ArrayAttr[DataLayoutEntryAttr] | DictValueType,
     ):
         return super().__init__(contents)
 
@@ -180,7 +179,7 @@ class TargetSystemSpecAttr(DLTIEntryMap):
 
     def __init__(
         self,
-        contents: ArrayAttr | list[DataLayoutEntryAttr] | DictValueType,
+        contents: ArrayAttr[DataLayoutEntryAttr] | DictValueType,
     ):
         return super().__init__(contents)
 
@@ -200,7 +199,7 @@ class MapAttr(DLTIEntryMap):
 
     def __init__(
         self,
-        contents: ArrayAttr | list[DataLayoutEntryAttr] | DictValueType,
+        contents: ArrayAttr[DataLayoutEntryAttr] | DictValueType,
     ):
         return super().__init__(contents)
 

--- a/xdsl/dialects/dlti.py
+++ b/xdsl/dialects/dlti.py
@@ -9,7 +9,7 @@ https://mlir.llvm.org/docs/Dialects/DLTIDialect/
 from __future__ import annotations
 
 from abc import ABC
-from typing import cast, TypeAlias
+from typing import TypeAlias, cast
 
 from xdsl.dialects.builtin import (
     ArrayAttr,

--- a/xdsl/dialects/dlti.py
+++ b/xdsl/dialects/dlti.py
@@ -14,11 +14,8 @@ from typing import TypeAlias, cast
 
 from xdsl.dialects.builtin import (
     ArrayAttr,
-    Float32Type,
-    FloatAttr,
-    IntegerAttr,
+    IntAttr,
     StringAttr,
-    i32,
 )
 from xdsl.ir import Attribute, Dialect, ParametrizedAttribute, TypeAttribute
 from xdsl.irdl import irdl_attr_definition
@@ -28,7 +25,7 @@ from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.hints import isa
 
 DictValueType: TypeAlias = Mapping[
-    StringAttr | TypeAttribute | str, "Attribute | str | int | float | DictValueType"
+    StringAttr | TypeAttribute | str, "Attribute | str | int | DictValueType"
 ]
 
 
@@ -47,7 +44,7 @@ class DataLayoutEntryAttr(ParametrizedAttribute):
     def __init__(
         self,
         key: StringAttr | TypeAttribute | str,
-        value: Attribute | str | int | float | DictValueType,
+        value: Attribute | str | int | DictValueType,
     ):
         if isinstance(key, str):
             key = StringAttr(key)
@@ -55,9 +52,7 @@ class DataLayoutEntryAttr(ParametrizedAttribute):
         if isinstance(value, str):
             value = StringAttr(value)
         elif isinstance(value, int):
-            value = IntegerAttr(value, i32)
-        elif isinstance(value, float):
-            value = FloatAttr(value, Float32Type())
+            value = IntAttr(value)
         elif isinstance(value, dict):
             value = MapAttr(value)
 

--- a/xdsl/dialects/dlti.py
+++ b/xdsl/dialects/dlti.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from abc import ABC
 from collections.abc import Mapping
-from typing import TypeAlias, cast
+from typing import TypeAlias
 
 from xdsl.dialects.builtin import (
     ArrayAttr,
@@ -93,10 +93,9 @@ class DLTIEntryMap(ParametrizedAttribute, ABC):
     ) -> tuple[ArrayAttr[DataLayoutEntryAttr]]:
         def parse_entry() -> DataLayoutEntryAttr:
             entry = parser.parse_attribute()
-            entry = cast(StringAttr | TypeAttribute, entry)
             parser.parse_punctuation("=")
             value = parser.parse_attribute()
-            return DataLayoutEntryAttr(entry, value)
+            return DataLayoutEntryAttr.new((entry, value))
 
         entries = parser.parse_comma_separated_list(parser.Delimiter.ANGLE, parse_entry)
 

--- a/xdsl/dialects/dlti.py
+++ b/xdsl/dialects/dlti.py
@@ -23,7 +23,6 @@ from xdsl.irdl import irdl_attr_definition
 from xdsl.parser import AttrParser
 from xdsl.printer import Printer
 from xdsl.utils.exceptions import VerifyException
-from xdsl.utils.hints import isa
 
 DictValueType: TypeAlias = Mapping[
     StringAttr | TypeAttribute | str, "Attribute | str | int | DictValueType"
@@ -54,7 +53,7 @@ class DataLayoutEntryAttr(ParametrizedAttribute):
             value = StringAttr(value)
         elif isinstance(value, int):
             value = IntAttr(value)
-        elif isinstance(value, dict):
+        elif isinstance(value, Mapping):
             value = MapAttr(value)
 
         super().__init__(key, value)
@@ -81,8 +80,7 @@ class DLTIEntryMap(ParametrizedAttribute, ABC):
         self,
         contents: ArrayAttr[DataLayoutEntryAttr] | DictValueType,
     ):
-        if not isa(contents, ArrayAttr[DataLayoutEntryAttr]):
-            assert isinstance(contents, Mapping)
+        if isinstance(contents, Mapping):
             contents = ArrayAttr(
                 [DataLayoutEntryAttr(k, v) for k, v in contents.items()]
             )

--- a/xdsl/dialects/dlti.py
+++ b/xdsl/dialects/dlti.py
@@ -12,8 +12,8 @@ from abc import ABC
 
 from xdsl.dialects.builtin import (
     ArrayAttr,
-    FloatAttr,
     Float32Type,
+    FloatAttr,
     IntegerAttr,
     StringAttr,
     i32,

--- a/xdsl/dialects/dlti.py
+++ b/xdsl/dialects/dlti.py
@@ -12,11 +12,11 @@ from abc import ABC
 
 from xdsl.dialects.builtin import (
     ArrayAttr,
-    StringAttr,
-    IntegerAttr,
-    i32,
     FloatAttr,
     Float32Type,
+    IntegerAttr,
+    StringAttr,
+    i32,
 )
 from xdsl.ir import Attribute, Dialect, ParametrizedAttribute, TypeAttribute
 from xdsl.irdl import irdl_attr_definition
@@ -93,14 +93,19 @@ class DLTIEntryMap(ParametrizedAttribute, ABC):
         cls, parser: AttrParser
     ) -> tuple[ArrayAttr[DataLayoutEntryAttr]]:
         def parse_entry() -> DataLayoutEntryAttr:
+            pos = parser.pos
             entry = parser.parse_attribute()
-            parser.parse_punctuation("=")
-            value = parser.parse_attribute()
-            assert (
+            end_pos = parser.pos
+            if not (
                 isinstance(entry, str)
                 or isinstance(entry, StringAttr)
                 or isinstance(entry, TypeAttribute)
-            )
+            ):
+                parser.raise_error(
+                    "key must be a string or a type attribute", pos, end_pos
+                )
+            parser.parse_punctuation("=")
+            value = parser.parse_attribute()
             return DataLayoutEntryAttr(entry, value)
 
         entries = parser.parse_comma_separated_list(parser.Delimiter.ANGLE, parse_entry)

--- a/xdsl/dialects/dlti.py
+++ b/xdsl/dialects/dlti.py
@@ -80,13 +80,6 @@ class DataLayoutEntryAttr(ParametrizedAttribute):
         converter=DLTITypeConverters.convert_entry_attr_value_type
     )
 
-    def __init__(
-        self,
-        key: StringAttr | TypeAttribute | str,
-        value: Attribute | str | int | DictValueType,
-    ):
-        super().__init__(key, value)
-
     def verify(self) -> None:
         if not isinstance(self.key, StringAttr | TypeAttribute):
             raise VerifyException("key must be a string or a type attribute")


### PR DESCRIPTION
DLTI dialect initialises the entry map operations based on a dictionary or list, and the entries themselves are initialised based on str or attribute (for key), and attribute, str, int or float for value. This is for convenience when creating these in code.

Pyright test added for this, along with testing verification of aspects in the dialect too