### PR TITLE
dialects: (ptr) canonicalize PtrAdd with zero

### DIFF
--- a/xdsl/dialects/ptr.py
+++ b/xdsl/dialects/ptr.py
@@ -43,6 +43,14 @@ class PtrType(ParametrizedAttribute, TypeAttribute):
         super().__init__()
 
 
+class PtrAddOpHasCanonicalizationPatterns(HasCanonicalizationPatternsTrait):
+    @classmethod
+    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+        from xdsl.transforms.canonicalization_patterns import ptr
+
+        return (ptr.PtrAddZero(),)
+
+
 @irdl_op_definition
 class PtrAddOp(IRDLOperation):
     name = "ptr_xdsl.ptradd"
@@ -52,6 +60,8 @@ class PtrAddOp(IRDLOperation):
     result = result_def(PtrType)
 
     assembly_format = "$addr `,` $offset attr-dict `:` `(` type($addr) `,` type($offset) `)` `->` type($result)"
+
+    traits = traits_def(PtrAddOpHasCanonicalizationPatterns())
 
     def __init__(self, addr: SSAValue, offset: SSAValue):
         super().__init__(operands=(addr, offset), result_types=(PtrType(),))

--- a/xdsl/transforms/canonicalization_patterns/ptr.py
+++ b/xdsl/transforms/canonicalization_patterns/ptr.py
@@ -1,4 +1,5 @@
-from xdsl.dialects import ptr
+from xdsl.dialects import arith, ptr
+from xdsl.dialects.builtin import IntegerAttr
 from xdsl.pattern_rewriter import (
     PatternRewriter,
     RewritePattern,
@@ -24,3 +25,14 @@ class RedundantToPtr(RewritePattern):
 
         if origin.source.type == op.res.type:
             rewriter.replace_matched_op((), (origin.source,))
+
+
+class PtrAddZero(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: ptr.PtrAddOp, rewriter: PatternRewriter, /):
+        if (
+            (isinstance(offset_op := op.offset.owner, arith.ConstantOp))
+            and isinstance(offset_op.value, IntegerAttr)
+            and offset_op.value.value.data == 0
+        ):
+            rewriter.replace_matched_op((), (op.addr,))


### PR DESCRIPTION
Removes the redundant addition of 0 to a pointer.