### PR TITLE
core: add support for string types in Pass definitions

### DIFF
--- a/tests/test_pass_from_spec.py
+++ b/tests/test_pass_from_spec.py
@@ -28,6 +28,8 @@ class CustomPass(ModulePass):
 
     optional_bool: bool = False
 
+    annotation: "str" = "default_value"
+
     def apply(self, ctx: Context, op: builtin.ModuleOp) -> None:
         pass
 
@@ -61,6 +63,7 @@ def test_pass_instantiation():
                 "str-thing": ("hello world",),
                 "literal": ("maybe",),
                 # "optional" was left out here, as it is optional
+                "annotation": ("other_value",),
             },
         )
     )

--- a/xdsl/passes.py
+++ b/xdsl/passes.py
@@ -101,9 +101,13 @@ class ModulePass(ABC):
                 raise ValueError(f'Pass {cls.name} requires argument "{op_field.name}"')
 
             # convert pass arg to the correct type:
+            field_type = op_field.type
+            if isinstance(field_type, str):
+                # If the type was provided as a string, eval the string to get the type
+                field_type = eval(field_type, None)
             arg_dict[op_field.name] = _convert_pass_arg_to_type(
                 spec_arguments_dict.pop(op_field.name),
-                op_field.type,
+                field_type,
             )
             # we use .pop here to also remove the arg from the dict
 


### PR DESCRIPTION
When we import `annotations` from `__future__`, the types are turned to strings, and our current pass validation code breaks. This PR proposes to just eval the strings when checking the type.