### PR TITLE
interactive: display pass spec in gui always

### DIFF
--- a/tests/interactive/test_app.py
+++ b/tests/interactive/test_app.py
@@ -316,7 +316,6 @@ async def test_rewrites():
         await pilot.click("#condense_button")
 
         addi_pass = AvailablePass(
-            display_name="AddiOp(%res = arith.addi %n, %c0 : i32):arith.addi:SignlessIntegerBinaryOperationZeroOrUnitRight",
             module_pass=individual_rewrite.ApplyIndividualRewritePass(
                 3, "arith.addi", "SignlessIntegerBinaryOperationZeroOrUnitRight"
             ),

--- a/tests/interactive/test_get_all_available_passes.py
+++ b/tests/interactive/test_get_all_available_passes.py
@@ -79,17 +79,8 @@ def test_get_all_available_passes():
 
     assert res == tuple(
         (
-            AvailablePass(
-                display_name="bc",
-                module_pass=BCPass(),
-            ),
-            AvailablePass(
-                display_name="bd",
-                module_pass=BDPass(),
-            ),
-            AvailablePass(
-                display_name='TestOp("test.op"() {key = "b"} : () -> ()):test.op:be',
-                module_pass=ApplyIndividualRewritePass(1, "test.op", "be"),
-            ),
+            AvailablePass(module_pass=BCPass()),
+            AvailablePass(module_pass=BDPass()),
+            AvailablePass(module_pass=ApplyIndividualRewritePass(1, "test.op", "be")),
         )
     )

--- a/tests/interactive/test_get_all_available_passes.py
+++ b/tests/interactive/test_get_all_available_passes.py
@@ -77,10 +77,8 @@ def test_get_all_available_passes():
         },
     )
 
-    assert res == tuple(
-        (
-            AvailablePass(module_pass=BCPass()),
-            AvailablePass(module_pass=BDPass()),
-            AvailablePass(module_pass=ApplyIndividualRewritePass(1, "test.op", "be")),
-        )
+    assert res == (
+        AvailablePass(BCPass()),
+        AvailablePass(BDPass()),
+        AvailablePass(ApplyIndividualRewritePass(1, "test.op", "be")),
     )

--- a/tests/interactive/test_rewrites.py
+++ b/tests/interactive/test_rewrites.py
@@ -42,12 +42,10 @@ def test_get_all_possible_rewrite():
 
     expected_res = [
         AvailablePass(
-            display_name='TestOp("test.op"() {label = "a"} : () -> ()):test.op:TestRewrite',
-            module_pass=ApplyIndividualRewritePass(1, "test.op", "TestRewrite"),
+            module_pass=ApplyIndividualRewritePass(1, "test.op", "TestRewrite")
         ),
         AvailablePass(
-            display_name='TestOp("test.op"() {label = "a"} : () -> ()):test.op:TestRewrite',
-            module_pass=ApplyIndividualRewritePass(2, "test.op", "TestRewrite"),
+            module_pass=ApplyIndividualRewritePass(2, "test.op", "TestRewrite")
         ),
     ]
 

--- a/xdsl/interactive/app.py
+++ b/xdsl/interactive/app.py
@@ -250,7 +250,7 @@ class InputApp(App[None]):
         """
         match self.current_module:
             case None:
-                return tuple(AvailablePass(p.name, p) for _, p in self.all_passes)
+                return tuple(AvailablePass(p) for _, p in self.all_passes)
             case Exception():
                 return ()
             case ModuleOp():
@@ -339,10 +339,10 @@ class InputApp(App[None]):
         # remove potential children nodes in case expand node has been clicked multiple times on the same node
         expanded_pass.remove_children()
 
-        for pass_name, value in child_pass_list:
+        for value in child_pass_list:
             expanded_pass.add(
-                label=pass_name,
-                data=value,
+                label=str(value),
+                data=value.module_pass,
             )
 
     def update_root_of_passes_tree(self) -> None:

--- a/xdsl/interactive/get_all_available_passes.py
+++ b/xdsl/interactive/get_all_available_passes.py
@@ -38,5 +38,5 @@ def get_available_pass_list(
     if condense_mode:
         pass_list = get_condensed_pass_list(current_module, all_passes)
     else:
-        pass_list = tuple(AvailablePass(p.name, p) for _, p in all_passes)
+        pass_list = tuple(AvailablePass(p) for _, p in all_passes)
     return pass_list + tuple(individual_rewrites)

--- a/xdsl/interactive/passes.py
+++ b/xdsl/interactive/passes.py
@@ -14,8 +14,14 @@ class AvailablePass(NamedTuple):
     pass, the module pass and pass spec.
     """
 
-    display_name: str
     module_pass: type[ModulePass] | ModulePass
+
+    def __str__(self) -> str:
+        module_pass = self.module_pass
+        if isinstance(module_pass, ModulePass):
+            return str(module_pass.pipeline_pass_spec())
+        else:
+            return module_pass.name
 
 
 def get_new_registered_context(
@@ -42,7 +48,7 @@ def iter_condensed_passes(
     for _, pass_type in all_passes:
         if pass_type is MLIROptPass:
             # Always keep MLIROptPass as an option in condensed list
-            yield AvailablePass(pass_type.name, pass_type), None
+            yield AvailablePass(pass_type)
             continue
         cloned_module = input.clone()
         cloned_ctx = ctx.clone()
@@ -53,7 +59,7 @@ def iter_condensed_passes(
                 continue
         except Exception:
             continue
-        yield AvailablePass(pass_type.name, pass_instance), cloned_module
+        yield AvailablePass(pass_instance)
 
 
 def get_condensed_pass_list(
@@ -64,4 +70,4 @@ def get_condensed_pass_list(
     Function that returns the condensed pass list for a given ModuleOp, i.e. the passes that
     change the ModuleOp.
     """
-    return tuple(ap for ap, _ in iter_condensed_passes(input, all_passes))
+    return tuple(iter_condensed_passes(input, all_passes))

--- a/xdsl/interactive/rewrites.py
+++ b/xdsl/interactive/rewrites.py
@@ -35,7 +35,6 @@ def get_all_possible_rewrites(
             if rewriter.has_done_action:
                 res.append(
                     AvailablePass(
-                        f"{cloned_op}:{cloned_op.name}:{pattern_name}",
                         individual_rewrite.ApplyIndividualRewritePass(
                             op_idx, cloned_op.name, pattern_name
                         ),


### PR DESCRIPTION
Currently our individual rewrites are displayed differently, but I'm not sure that the extra logic is pulling its weight, especially since they are printed differently once they are clicked on and added to the pass pipeline.
