### PR TITLE
transformations: add split-load-extract for manual optimization

### DIFF
--- a/tests/filecheck/transforms/vector-split-load-extract.mlir
+++ b/tests/filecheck/transforms/vector-split-load-extract.mlir
@@ -1,0 +1,34 @@
+// RUN: xdsl-opt -p vector-split-load-extract %s | filecheck %s
+
+// CHECK-LABEL: @do_split
+func.func @do_split(%ptr : !ptr_xdsl.ptr) {
+// CHECK-NEXT:      %vector = arith.constant 12 : index
+// CHECK-NEXT:      %vector_1 = ptr_xdsl.ptradd %ptr, %vector : (!ptr_xdsl.ptr, index) -> !ptr_xdsl.ptr
+// CHECK-NEXT:      %vector_2 = ptr_xdsl.load %vector_1 : !ptr_xdsl.ptr -> f32
+// CHECK-NEXT:      %vector_3 = arith.constant 8 : index
+// CHECK-NEXT:      %vector_4 = ptr_xdsl.ptradd %ptr, %vector_3 : (!ptr_xdsl.ptr, index) -> !ptr_xdsl.ptr
+// CHECK-NEXT:      %vector_5 = ptr_xdsl.load %vector_4 : !ptr_xdsl.ptr -> f32
+// CHECK-NEXT:      %vector_6 = arith.constant 4 : index
+// CHECK-NEXT:      %vector_7 = ptr_xdsl.ptradd %ptr, %vector_6 : (!ptr_xdsl.ptr, index) -> !ptr_xdsl.ptr
+// CHECK-NEXT:      %vector_8 = ptr_xdsl.load %vector_7 : !ptr_xdsl.ptr -> f32
+    %vector = ptr_xdsl.load %ptr : !ptr_xdsl.ptr -> vector<4xf32>
+    %f0 = vector.extract %vector[1] : f32 from vector<4xf32>
+    %f1 = vector.extract %vector[2] : f32 from vector<4xf32>
+    %f2 = vector.extract %vector[3] : f32 from vector<4xf32>
+
+// CHECK-NEXT:      "test.op"(%vector_8, %vector_5, %vector_2) : (f32, f32, f32) -> ()
+    "test.op"(%f0, %f1, %f2) : (f32, f32, f32) -> ()
+    return
+}
+
+// CHECK-LABEL: @do_not_split
+func.func @do_not_split(%ptr : !ptr_xdsl.ptr) {
+// CHECK-NEXT:      %vector = ptr_xdsl.load %ptr : !ptr_xdsl.ptr -> vector<4xf32>
+// CHECK-NEXT:      %f0 = vector.extract %vector[1] : f32 from vector<4xf32>
+    %vector = ptr_xdsl.load %ptr : !ptr_xdsl.ptr -> vector<4xf32>
+    %f0 = vector.extract %vector[1] : f32 from vector<4xf32>
+
+// CHECK-NEXT:      "test.op"(%f0, %vector) : (f32, vector<4xf32>) -> ()
+    "test.op"(%f0, %vector) : (f32, vector<4xf32>) -> ()
+    return
+}

--- a/xdsl/transforms/__init__.py
+++ b/xdsl/transforms/__init__.py
@@ -565,6 +565,11 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
 
         return varith_transformations.VarithFuseRepeatedOperandsPass
 
+    def get_vector_split_load_extract():
+        from xdsl.transforms import vector_split_load_extract
+
+        return vector_split_load_extract.VectorSplitLoadExtractPass
+
     def get_x86_allocate_registers():
         from xdsl.transforms import x86_allocate_registers
 
@@ -684,5 +689,6 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
         "test-transform-dialect-erase-schedule": get_test_transform_dialect_erase_schedule,
         "transform-interpreter": get_transform_interpreter,
         "varith-fuse-repeated-operands": get_varith_fuse_repeated_operands,
+        "vector-split-load-extract": get_vector_split_load_extract,
         "x86-allocate-registers": get_x86_allocate_registers,
     }

--- a/xdsl/transforms/vector_split_load_extract.py
+++ b/xdsl/transforms/vector_split_load_extract.py
@@ -1,0 +1,78 @@
+from dataclasses import dataclass
+from typing import cast
+
+from xdsl.context import Context
+from xdsl.dialects import arith, ptr, vector
+from xdsl.dialects.builtin import (
+    CompileTimeFixedBitwidthType,
+    IndexType,
+    IntegerAttr,
+    ModuleOp,
+    VectorType,
+)
+from xdsl.passes import ModulePass
+from xdsl.pattern_rewriter import (
+    PatternRewriter,
+    PatternRewriteWalker,
+    RewritePattern,
+    op_type_rewrite_pattern,
+)
+
+
+class VectorSplitLoadExtract(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: ptr.LoadOp, rewriter: PatternRewriter) -> None:
+        if not all(
+            isinstance(use.operation, vector.ExtractOp)
+            and not use.operation.dynamic_position
+            for use in op.res.uses
+        ):
+            return
+
+        vector_type = cast(VectorType, op.res.type)
+        element_type = vector_type.element_type
+        if not isinstance(element_type, CompileTimeFixedBitwidthType):
+            raise NotImplementedError
+
+        if len(vector_type.shape) != 1:
+            raise NotImplementedError
+
+        element_size = element_type.compile_time_size
+        name_hint = op.res.name_hint
+
+        for use in op.res.uses:
+            user = cast(vector.ExtractOp, use.operation)
+            indices = user.static_position.get_values()
+            assert len(indices) == 1
+            (element_index,) = indices
+            rewriter.insert_op_before_matched_op(
+                (
+                    constant_op := arith.ConstantOp(
+                        IntegerAttr(element_size * element_index, IndexType())
+                    ),
+                    add_op := ptr.PtrAddOp(op.addr, constant_op.result),
+                    load_op := ptr.LoadOp(add_op.result, element_type),
+                )
+            )
+            rewriter.replace_all_uses_with(user.result, load_op.res)
+            rewriter.erase_op(user)
+            constant_op.result.name_hint = name_hint
+            add_op.result.name_hint = name_hint
+            load_op.res.name_hint = name_hint
+
+        rewriter.erase_matched_op()
+
+
+@dataclass(frozen=True)
+class VectorSplitLoadExtractPass(ModulePass):
+    """
+    Rewrites a vector load followed only by extracts with scalar loads.
+    """
+
+    name = "vector-split-load-extract"
+
+    def apply(self, ctx: Context, op: ModuleOp) -> None:
+        PatternRewriteWalker(
+            VectorSplitLoadExtract(),
+            apply_recursively=False,
+        ).rewrite_module(op)


### PR DESCRIPTION
This transformation doesn't always make sense to perform, but it does in the case of vectorisation of matmul for NEON and AVX. it feels like this might make sense eventually as a transform thing but until then I propose we add a pass.