### PR TITLE
interactive: pass context to iter_condensed_passes

### DIFF
--- a/tests/interactive/test_app.py
+++ b/tests/interactive/test_app.py
@@ -19,7 +19,11 @@ from xdsl.dialects.builtin import (
 from xdsl.interactive import _pasteboard
 from xdsl.interactive.add_arguments_screen import AddArguments
 from xdsl.interactive.app import InputApp
-from xdsl.interactive.passes import AvailablePass, get_condensed_pass_list
+from xdsl.interactive.passes import (
+    AvailablePass,
+    get_condensed_pass_list,
+    get_new_registered_context,
+)
 from xdsl.interactive.rewrites import get_all_possible_rewrites
 from xdsl.ir import Block, Region
 from xdsl.transforms import (
@@ -278,7 +282,9 @@ builtin.module {
             individual_rewrite.INDIVIDUAL_REWRITE_PATTERNS_BY_NAME,
         )
         assert app.available_pass_list == get_condensed_pass_list(
-            expected_module, app.all_passes
+            get_new_registered_context(app.all_dialects),
+            expected_module,
+            app.all_passes,
         ) + tuple(rewrites)
 
         # press "Uncondense" button
@@ -325,9 +331,11 @@ async def test_rewrites():
         # assert after "Condense Button" is clicked that the state and get_condensed_pass list change accordingly
         assert app.condense_mode is True
         assert isinstance(app.current_module, ModuleOp)
-        condensed_list = get_condensed_pass_list(app.current_module, app.all_passes) + (
-            addi_pass,
-        )
+        condensed_list = get_condensed_pass_list(
+            get_new_registered_context(app.all_dialects),
+            app.current_module,
+            app.all_passes,
+        ) + (addi_pass,)
         assert app.available_pass_list == condensed_list
 
         # Select a rewrite

--- a/xdsl/interactive/get_all_available_passes.py
+++ b/xdsl/interactive/get_all_available_passes.py
@@ -31,7 +31,7 @@ def get_available_pass_list(
 
     # merge rewrite passes with "other" pass list
     if condense_mode:
-        pass_list = get_condensed_pass_list(current_module, all_passes)
+        pass_list = get_condensed_pass_list(ctx, current_module, all_passes)
         # get all individual rewrites
         individual_rewrites = get_all_possible_rewrites(
             current_module,

--- a/xdsl/interactive/passes.py
+++ b/xdsl/interactive/passes.py
@@ -2,7 +2,7 @@ from collections.abc import Callable
 from typing import NamedTuple
 
 from xdsl.context import Context
-from xdsl.dialects import builtin, get_all_dialects
+from xdsl.dialects import builtin
 from xdsl.ir import Dialect
 from xdsl.passes import ModulePass
 from xdsl.transforms.mlir_opt import MLIROptPass
@@ -37,14 +37,10 @@ def get_new_registered_context(
 
 
 def iter_condensed_passes(
+    ctx: Context,
     input: builtin.ModuleOp,
     all_passes: tuple[tuple[str, type[ModulePass]], ...],
 ):
-    ctx = Context(True)
-
-    for dialect_name, dialect_factory in get_all_dialects().items():
-        ctx.register_dialect(dialect_name, dialect_factory)
-
     for _, pass_type in all_passes:
         if pass_type is MLIROptPass:
             # Always keep MLIROptPass as an option in condensed list
@@ -63,6 +59,7 @@ def iter_condensed_passes(
 
 
 def get_condensed_pass_list(
+    ctx: Context,
     input: builtin.ModuleOp,
     all_passes: tuple[tuple[str, type[ModulePass]], ...],
 ) -> tuple[AvailablePass, ...]:
@@ -70,4 +67,4 @@ def get_condensed_pass_list(
     Function that returns the condensed pass list for a given ModuleOp, i.e. the passes that
     change the ModuleOp.
     """
-    return tuple(iter_condensed_passes(input, all_passes))
+    return tuple(iter_condensed_passes(ctx, input, all_passes))


### PR DESCRIPTION
No need to create a new context every time, and lets the user choose the dialects to look for. Importantly, it removes the dependency on get_all_dialects in iter_condensed_passes, which currently prevents the app from accessing dialects not in core xDSL.