### PR TITLE
dialects: (dlti) Add getitems to entry map attributes 

### DIFF
--- a/tests/dialects/test_dlti.py
+++ b/tests/dialects/test_dlti.py
@@ -123,10 +123,8 @@ def test_duplicate_data_layout_map_entries(
 def test_not_found_map_entry_lookup(
     cls: type[DLTIEntryMap],
 ):
-    with pytest.raises(IndexError):
-        attr = cls(
-            ArrayAttr(
-                [DataLayoutEntryAttr("key1", "v"), DataLayoutEntryAttr("key2", 12)]
-            )
-        )
+    attr = cls(
+        ArrayAttr([DataLayoutEntryAttr("key1", "v"), DataLayoutEntryAttr("key2", 12)])
+    )
+    with pytest.raises(KeyError):
         attr["key3"]

--- a/xdsl/dialects/dlti.py
+++ b/xdsl/dialects/dlti.py
@@ -105,7 +105,7 @@ class DLTIEntryMap(ParametrizedAttribute, ABC):
             if entry.key == key:
                 return entry.value
 
-        raise IndexError
+        raise KeyError
 
     @classmethod
     def parse_parameters(


### PR DESCRIPTION
Add getitems to entry map attributes in DLTI dialect to provide convenience when retrieving elements that are held in the map
