### PR TITLE
core: move out KIND_BY_PUNCTUATION_SPELLING in MLIR lexer

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -33,7 +33,11 @@ from xdsl.irdl import (
 from xdsl.parser import Parser
 from xdsl.printer import Printer
 from xdsl.utils.exceptions import ParseError
-from xdsl.utils.mlir_lexer import MLIRTokenKind, PunctuationSpelling
+from xdsl.utils.mlir_lexer import (
+    KIND_BY_PUNCTUATION_SPELLING,
+    MLIRTokenKind,
+    PunctuationSpelling,
+)
 from xdsl.utils.str_enum import StrEnum
 
 # pyright: reportPrivateUsage=false
@@ -588,9 +592,7 @@ def test_parse_comma_separated_list_error_delimiters(
     assert e.value.span.text == "5"
 
 
-@pytest.mark.parametrize(
-    "punctuation", list(MLIRTokenKind.get_punctuation_spelling_to_kind_dict().values())
-)
+@pytest.mark.parametrize("punctuation", list(KIND_BY_PUNCTUATION_SPELLING.values()))
 def test_is_punctuation_true(punctuation: MLIRTokenKind):
     assert punctuation.is_punctuation()
 
@@ -603,9 +605,7 @@ def test_is_punctuation_false(punctuation: MLIRTokenKind):
     assert not punctuation.is_punctuation()
 
 
-@pytest.mark.parametrize(
-    "punctuation", list(MLIRTokenKind.get_punctuation_spelling_to_kind_dict().values())
-)
+@pytest.mark.parametrize("punctuation", list(KIND_BY_PUNCTUATION_SPELLING.values()))
 def test_is_spelling_of_punctuation_true(punctuation: MLIRTokenKind):
     value = cast(PunctuationSpelling, punctuation.value)
     assert MLIRTokenKind.is_spelling_of_punctuation(value)
@@ -616,17 +616,13 @@ def test_is_spelling_of_punctuation_false(punctuation: str):
     assert not MLIRTokenKind.is_spelling_of_punctuation(punctuation)
 
 
-@pytest.mark.parametrize(
-    "punctuation", list(MLIRTokenKind.get_punctuation_spelling_to_kind_dict().values())
-)
+@pytest.mark.parametrize("punctuation", list(KIND_BY_PUNCTUATION_SPELLING.values()))
 def test_get_punctuation_kind(punctuation: MLIRTokenKind):
     value = cast(PunctuationSpelling, punctuation.value)
     assert punctuation.get_punctuation_kind_from_name(value) == punctuation
 
 
-@pytest.mark.parametrize(
-    "punctuation", list(MLIRTokenKind.get_punctuation_spelling_to_kind_dict().keys())
-)
+@pytest.mark.parametrize("punctuation", list(KIND_BY_PUNCTUATION_SPELLING.keys()))
 def test_parse_punctuation(punctuation: PunctuationSpelling):
     parser = Parser(Context(), punctuation)
 
@@ -635,9 +631,7 @@ def test_parse_punctuation(punctuation: PunctuationSpelling):
     assert parser._parse_token(MLIRTokenKind.EOF, "").kind == MLIRTokenKind.EOF
 
 
-@pytest.mark.parametrize(
-    "punctuation", list(MLIRTokenKind.get_punctuation_spelling_to_kind_dict().keys())
-)
+@pytest.mark.parametrize("punctuation", list(KIND_BY_PUNCTUATION_SPELLING.keys()))
 def test_parse_punctuation_fail(punctuation: PunctuationSpelling):
     parser = Parser(Context(), "e +")
     with pytest.raises(ParseError) as e:
@@ -646,9 +640,7 @@ def test_parse_punctuation_fail(punctuation: PunctuationSpelling):
     assert e.value.msg == "Expected '" + punctuation + "' in test"
 
 
-@pytest.mark.parametrize(
-    "punctuation", list(MLIRTokenKind.get_punctuation_spelling_to_kind_dict().keys())
-)
+@pytest.mark.parametrize("punctuation", list(KIND_BY_PUNCTUATION_SPELLING.keys()))
 def test_parse_optional_punctuation(punctuation: PunctuationSpelling):
     parser = Parser(Context(), punctuation)
     res = parser.parse_optional_punctuation(punctuation)
@@ -656,9 +648,7 @@ def test_parse_optional_punctuation(punctuation: PunctuationSpelling):
     assert parser._parse_token(MLIRTokenKind.EOF, "").kind == MLIRTokenKind.EOF
 
 
-@pytest.mark.parametrize(
-    "punctuation", list(MLIRTokenKind.get_punctuation_spelling_to_kind_dict().keys())
-)
+@pytest.mark.parametrize("punctuation", list(KIND_BY_PUNCTUATION_SPELLING.keys()))
 def test_parse_optional_punctuation_fail(punctuation: PunctuationSpelling):
     parser = Parser(Context(), "e +")
     assert parser.parse_optional_punctuation(punctuation) is None

--- a/xdsl/utils/mlir_lexer.py
+++ b/xdsl/utils/mlir_lexer.py
@@ -170,41 +170,14 @@ class MLIRTokenKind(Enum):
     FILE_METADATA_BEGIN = "{-#"
     FILE_METADATA_END = "#-}"
 
-    @staticmethod
-    def get_punctuation_spelling_to_kind_dict() -> dict[str, MLIRTokenKind]:
-        return {
-            "->": MLIRTokenKind.ARROW,
-            ":": MLIRTokenKind.COLON,
-            ",": MLIRTokenKind.COMMA,
-            "...": MLIRTokenKind.ELLIPSIS,
-            "=": MLIRTokenKind.EQUAL,
-            ">": MLIRTokenKind.GREATER,
-            "{": MLIRTokenKind.L_BRACE,
-            "(": MLIRTokenKind.L_PAREN,
-            "[": MLIRTokenKind.L_SQUARE,
-            "<": MLIRTokenKind.LESS,
-            "-": MLIRTokenKind.MINUS,
-            "+": MLIRTokenKind.PLUS,
-            "?": MLIRTokenKind.QUESTION,
-            "}": MLIRTokenKind.R_BRACE,
-            ")": MLIRTokenKind.R_PAREN,
-            "]": MLIRTokenKind.R_SQUARE,
-            "*": MLIRTokenKind.STAR,
-            "|": MLIRTokenKind.VERTICAL_BAR,
-            "{-#": MLIRTokenKind.FILE_METADATA_BEGIN,
-            "#-}": MLIRTokenKind.FILE_METADATA_END,
-        }
-
     def is_punctuation(self) -> bool:
-        punctuation_dict = MLIRTokenKind.get_punctuation_spelling_to_kind_dict()
-        return self in punctuation_dict.values()
+        return self in KIND_BY_PUNCTUATION_SPELLING.values()
 
     @staticmethod
     def is_spelling_of_punctuation(
         spelling: str,
     ) -> TypeGuard[PunctuationSpelling]:
-        punctuation_dict = MLIRTokenKind.get_punctuation_spelling_to_kind_dict()
-        return spelling in punctuation_dict.keys()
+        return spelling in KIND_BY_PUNCTUATION_SPELLING.keys()
 
     @staticmethod
     def get_punctuation_kind_from_name(
@@ -214,7 +187,7 @@ class MLIRTokenKind(Enum):
             "Kind.get_punctuation_kind_from_name: spelling is not a "
             "valid punctuation spelling!"
         )
-        return MLIRTokenKind.get_punctuation_spelling_to_kind_dict()[spelling]
+        return KIND_BY_PUNCTUATION_SPELLING[spelling]
 
     def get_int_value(self, span: Span):
         """
@@ -248,6 +221,30 @@ class MLIRTokenKind(Enum):
         if self != MLIRTokenKind.STRING_LIT:
             raise ValueError("Token is not a string literal!")
         return StringLiteral.from_span(span).string_contents
+
+
+KIND_BY_PUNCTUATION_SPELLING = {
+    "->": MLIRTokenKind.ARROW,
+    ":": MLIRTokenKind.COLON,
+    ",": MLIRTokenKind.COMMA,
+    "...": MLIRTokenKind.ELLIPSIS,
+    "=": MLIRTokenKind.EQUAL,
+    ">": MLIRTokenKind.GREATER,
+    "{": MLIRTokenKind.L_BRACE,
+    "(": MLIRTokenKind.L_PAREN,
+    "[": MLIRTokenKind.L_SQUARE,
+    "<": MLIRTokenKind.LESS,
+    "-": MLIRTokenKind.MINUS,
+    "+": MLIRTokenKind.PLUS,
+    "?": MLIRTokenKind.QUESTION,
+    "}": MLIRTokenKind.R_BRACE,
+    ")": MLIRTokenKind.R_PAREN,
+    "]": MLIRTokenKind.R_SQUARE,
+    "*": MLIRTokenKind.STAR,
+    "|": MLIRTokenKind.VERTICAL_BAR,
+    "{-#": MLIRTokenKind.FILE_METADATA_BEGIN,
+    "#-}": MLIRTokenKind.FILE_METADATA_END,
+}
 
 
 MLIRToken = Token[MLIRTokenKind]


### PR DESCRIPTION
Saves 6% = 1-0.782s/0.834s when loading arith
