### PR TITLE
transformations: (eqsat) eqsat-create-egraphs

### DIFF
--- a/tests/filecheck/transforms/eqsat-create-egraphs.mlir
+++ b/tests/filecheck/transforms/eqsat-create-egraphs.mlir
@@ -1,0 +1,19 @@
+// RUN: xdsl-opt -p eqsat-create-egraphs %s | filecheck %s
+
+func.func @test(%x : index) -> (index) {
+  %c2 = arith.constant 2 : index
+  %res = arith.muli %x, %c2 : index
+  func.return %res : index
+}
+
+// CHECK:      func.func @test(%x : index) -> index {
+// CHECK-NEXT:   %res = eqsat.egraph -> index {
+// CHECK-NEXT:     %x_1 = eqsat.eclass %x : index
+// CHECK-NEXT:     %c2 = arith.constant 2 : index
+// CHECK-NEXT:     %c2_1 = eqsat.eclass %c2 : index
+// CHECK-NEXT:     %res_1 = arith.muli %x_1, %c2_1 : index
+// CHECK-NEXT:     %res_2 = eqsat.eclass %res_1 : index
+// CHECK-NEXT:     eqsat.yield %res_2 : index
+// CHECK-NEXT:   }
+// CHECK-NEXT:   func.return %res : index
+// CHECK-NEXT: }

--- a/xdsl/transforms/__init__.py
+++ b/xdsl/transforms/__init__.py
@@ -278,6 +278,11 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
 
         return eqsat_create_eclasses.EqsatCreateEclassesPass
 
+    def get_eqsat_create_egraphs():
+        from xdsl.transforms import eqsat_create_egraphs
+
+        return eqsat_create_egraphs.EqsatCreateEgraphsPass
+
     def get_eqsat_serialize_egraph():
         from xdsl.transforms import eqsat_serialize_egraph
 
@@ -637,6 +642,7 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
         "empty-tensor-to-alloc-tensor": get_empty_tensor_to_alloc_tensor,
         "eqsat-add-costs": get_eqsat_add_costs,
         "eqsat-create-eclasses": get_eqsat_create_eclasses,
+        "eqsat-create-egraphs": get_eqsat_create_egraphs,
         "eqsat-serialize-egraph": get_eqsat_serialize_egraph,
         "eqsat-extract": get_eqsat_extract,
         "frontend-desymrefy": get_frontend_desymrefy,

--- a/xdsl/transforms/eqsat_create_egraphs.py
+++ b/xdsl/transforms/eqsat_create_egraphs.py
@@ -1,0 +1,99 @@
+from ordered_set import OrderedSet
+
+from xdsl.context import Context
+from xdsl.dialects import builtin, eqsat, func
+from xdsl.ir import Block, OpResult, Region, SSAValue
+from xdsl.passes import ModulePass
+
+
+class EqsatCreateEgraphsPass(ModulePass):
+    """
+    Create an egraph from a function by inserting an `eqsat.egraph` operation.
+
+    Input example:
+    ```
+    func.func @test(%a : index, %b : index) -> (index) {
+        %c = arith.addi %a, %b : index
+        func.return %c : index
+    }
+    ```
+    Output example:
+    ```
+    func.func @test(%a : index, %b : index) -> index {
+        %c = eqsat.egraph -> index {
+            %a_1 = eqsat.eclass %a : index
+            %b_1 = eqsat.eclass %b : index
+            %c_1 = arith.addi %a_1, %b_1 : index
+            %c_2 = eqsat.eclass %c_1 : index
+            eqsat.yield %c_2 : index
+        }
+        func.return %c : index
+    }
+    ```
+    """
+
+    name = "eqsat-create-egraphs"
+
+    def apply(self, ctx: Context, op: builtin.ModuleOp) -> None:
+        for f in op.body.block.ops:
+            if isinstance(f, func.FuncOp):
+                insert_egraph_op(f)
+
+
+def insert_egraph_op(f: func.FuncOp):
+    egraph_block = Block()
+    egraph_body = Region(egraph_block)
+    egraph_values: OrderedSet[OpResult] = OrderedSet(())
+
+    def create_eclass(val: SSAValue):
+        eclass_op = eqsat.EClassOp(val)
+        egraph_block.add_op(eclass_op)
+        new_val = eclass_op.results[0]
+        egraph_values.add(new_val)
+        val.replace_by_if(new_val, lambda u: u.operation != eclass_op)
+        return new_val
+
+    for arg in f.body.block.args:
+        create_eclass(arg)
+
+    # we don't walk recursively over all operations, but only
+    # the top-level operations in the function body:
+    for op in f.body.block.ops:
+        if isinstance(op, func.ReturnOp) or not all(
+            operand in egraph_values for operand in op.operands
+        ):
+            continue
+        op.detach()
+        egraph_block.add_op(op)
+        for res in op.results:
+            assert res not in egraph_values
+            create_eclass(res)
+
+    # Find values that have uses outside the egraph body
+    values_to_yield: list[SSAValue] = []
+    for val in egraph_values:
+        has_external_use = False
+        for use in val.uses:
+            # Check if the use is outside the egraph block
+            if use.operation.parent != egraph_block:
+                has_external_use = True
+                break
+        if has_external_use:
+            values_to_yield.append(val)
+
+    # Each value in the egraph block that has a use outside the egraph body should be yielded by the egraph op.
+    # Next, these outside uses need to be replaced by the results of the egraph op.
+    egraph_block.add_op(eqsat.YieldOp(*values_to_yield))
+
+    # Create the egraph operation with the types of yielded values
+    yielded_types = [val.type for val in values_to_yield]
+    egraph_op = eqsat.EGraphOp(yielded_types, egraph_body)
+
+    for i, val in enumerate(values_to_yield):
+        val.replace_by_if(
+            egraph_op.results[i], lambda u: u.operation.parent != egraph_block
+        )
+
+    # Insert the egraph operation at the beginning of the function body
+    assert f.body.block.first_op is not None, "Function body block is empty"
+    f.body.block.insert_op_before(egraph_op, f.body.block.first_op)


### PR DESCRIPTION
This pass creates an `eqsat.egraph` operation for each function. The egraph contains eclasses wrapping the function arguments as well as all other operations that only depend on eclasses (except `func.return`).

