### PR TITLE
backend: raise OutOfRegisters if we have to spill during regalloc

### DIFF
--- a/docs/Toy/toy/compiler.py
+++ b/docs/Toy/toy/compiler.py
@@ -122,7 +122,7 @@ def transform(
     if target == "riscv-opt":
         return
 
-    RISCVRegisterAllocation().apply(ctx, module_op)
+    RISCVRegisterAllocation(allow_infinite=True).apply(ctx, module_op)
 
     module_op.verify()
 

--- a/tests/backend/riscv/test_register_allocation.py
+++ b/tests/backend/riscv/test_register_allocation.py
@@ -17,7 +17,7 @@ from xdsl.utils.exceptions import DiagnosticException
 
 
 def test_default_reserved_registers():
-    available_registers = RiscvRegisterStack()
+    available_registers = RiscvRegisterStack(allow_infinite=True)
 
     unallocated = riscv.Registers.UNALLOCATED_INT
 
@@ -96,7 +96,7 @@ def test_allocate_with_inout_constraints():
                 (self.rs0,), (self.rd0,), ((self.rs1, self.rd1),)
             )
 
-    available_registers = RiscvRegisterStack()
+    available_registers = RiscvRegisterStack(allow_infinite=True)
     register_allocator = RegisterAllocatorLivenessBlockNaive(available_registers)
 
     # All new registers. The result register is reused by the allocator for the operand.

--- a/tests/backend/test_register_allocation.py
+++ b/tests/backend/test_register_allocation.py
@@ -11,7 +11,7 @@ from xdsl.backend.register_allocatable import (
     RegisterConstraints,
 )
 from xdsl.backend.register_allocator import ValueAllocator
-from xdsl.backend.register_stack import RegisterStack
+from xdsl.backend.register_stack import OutOfRegisters, RegisterStack
 from xdsl.backend.register_type import RegisterType
 from xdsl.builder import Builder
 from xdsl.ir import Attribute, Block, SSAValue
@@ -178,7 +178,7 @@ def test_allocate_value():
     a1 = TestRegister.from_name("a1")
     y0 = TestRegister.from_name("y0")
 
-    register_stack = RegisterStack.get((a0, a1))
+    register_stack = RegisterStack.get((a0, a1), allow_infinite=True)
     allocator = ValueAllocator(register_stack, TestRegister)
 
     op0 = op((), u, u, u, u)
@@ -371,3 +371,9 @@ def test_fail_error_message():
   ---------------------
 """
     ]
+
+
+def test_out_of_registers():
+    register_stack = RegisterStack()
+    with pytest.raises(OutOfRegisters, match="Out of registers."):
+        register_stack.pop(TestRegister)

--- a/xdsl/transforms/riscv_register_allocation.py
+++ b/xdsl/transforms/riscv_register_allocation.py
@@ -23,6 +23,11 @@ class RISCVRegisterAllocation(ModulePass):
     Inserts a comment with register allocation info in the IR.
     """
 
+    allow_infinite: bool = False
+    """
+    Whether to allow using infinite registers during register allocation.
+    """
+
     def apply(self, ctx: Context, op: ModuleOp) -> None:
         allocator_strategies = {
             "LivenessBlockNaive": RegisterAllocatorLivenessBlockNaive,
@@ -36,7 +41,9 @@ class RISCVRegisterAllocation(ModulePass):
 
         for inner_op in op.walk():
             if isinstance(inner_op, riscv_func.FuncOp):
-                register_stack = RiscvRegisterStack.get()
+                register_stack = RiscvRegisterStack.get(
+                    allow_infinite=self.allow_infinite
+                )
                 allocator = allocator_strategies[self.allocation_strategy](
                     register_stack
                 )


### PR DESCRIPTION
There are cases where we want an explicit failure if the regalloc doesn't succeed, instead of dipping into the infinite/spilled registers.