### PR TITLE
transformations: (convert-memref-to-ptr) replace op list with builder

### DIFF
--- a/tests/filecheck/transforms/convert_memref_to_ptr.mlir
+++ b/tests/filecheck/transforms/convert_memref_to_ptr.mlir
@@ -73,11 +73,11 @@ memref.store %fv, %farr[%idx] {"nontemporal" = false} : memref<10xf64>
 // CHECK-NEXT:  %idx3, %offsetmem = "test.op"() : () -> (index, memref<16xf64, strided<[1], offset: 4>>
 // CHECK-NEXT:  %offsetmem_1 = ptr_xdsl.to_ptr %offsetmem : memref<16xf64, strided<[1], offset: 4>> -> !ptr_xdsl.ptr
 // CHECK-NEXT:  %memref_base_offset = arith.constant 4 : index
-// CHECK-NEXT:  %flv3 = arith.addi %idx3, %memref_base_offset : index
+// CHECK-NEXT:  %pointer_with_offset = arith.addi %idx3, %memref_base_offset : index
 // CHECK-NEXT:  %bytes_per_element_6 = ptr_xdsl.type_offset f64 : index
-// CHECK-NEXT:  %scaled_pointer_offset_6 = arith.muli %flv3, %bytes_per_element_6 : index
+// CHECK-NEXT:  %scaled_pointer_offset_6 = arith.muli %pointer_with_offset, %bytes_per_element_6 : index
 // CHECK-NEXT:  %offset_pointer_6 = ptr_xdsl.ptradd %offsetmem_1, %scaled_pointer_offset_6 : (!ptr_xdsl.ptr, index) -> !ptr_xdsl.ptr
-// CHECK-NEXT:  %flv3_1 = ptr_xdsl.load %offset_pointer_6 : !ptr_xdsl.ptr -> f64
+// CHECK-NEXT:  %flv3 = ptr_xdsl.load %offset_pointer_6 : !ptr_xdsl.ptr -> f64
 
 // -----
 

--- a/xdsl/transforms/convert_memref_to_ptr.py
+++ b/xdsl/transforms/convert_memref_to_ptr.py
@@ -2,6 +2,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import cast
 
+from xdsl.builder import Builder
 from xdsl.context import Context
 from xdsl.dialects import arith, builtin, func, memref, ptr
 from xdsl.ir import Operation, SSAValue
@@ -23,16 +24,17 @@ def get_target_ptr(
     target_memref: SSAValue,
     memref_type: memref.MemRefType[Any],
     indices: Iterable[SSAValue],
-) -> tuple[list[Operation], SSAValue]:
+    builder: Builder,
+) -> SSAValue:
     """
     Get operations returning a pointer to an element of a memref referenced by indices.
     """
 
-    ops: list[Operation] = [memref_ptr := ptr.ToPtrOp(target_memref)]
+    memref_ptr = builder.insert_op(ptr.ToPtrOp(target_memref))
     memref_ptr.res.name_hint = target_memref.name_hint
 
     if not indices:
-        return ops, memref_ptr.res
+        return memref_ptr.res
 
     match memref_type.layout:
         case builtin.NoneAttr():
@@ -64,14 +66,10 @@ def get_target_ptr(
             case _:
                 # Otherwise, multiply the stride (which by definition is the number of
                 # elements required to be skipped when incrementing that dimension).
-                ops.extend(
-                    (
-                        stride_op := arith.ConstantOp.from_int_and_width(
-                            stride, builtin.IndexType()
-                        ),
-                        offset_op := arith.MuliOp(increment, stride_op),
-                    )
+                stride_op = builder.insert_op(
+                    arith.ConstantOp.from_int_and_width(stride, builtin.IndexType())
                 )
+                offset_op = builder.insert_op(arith.MuliOp(increment, stride_op))
                 stride_op.result.name_hint = "pointer_dim_stride"
                 offset_op.result.name_hint = "pointer_dim_offset"
 
@@ -83,31 +81,28 @@ def get_target_ptr(
             continue
 
         # Otherwise sum up the products.
-        add_op = arith.AddiOp(head, increment)
+        add_op = builder.insert_op(arith.AddiOp(head, increment))
         add_op.result.name_hint = "pointer_dim_stride"
-        ops.append(add_op)
         head = add_op.result
 
     if offset:
-        ops.append(
-            memref_offset_op := arith.ConstantOp.from_int_and_width(
-                offset, builtin.IndexType()
-            )
+        memref_offset_op = builder.insert_op(
+            arith.ConstantOp.from_int_and_width(offset, builtin.IndexType())
         )
+
         memref_offset_op.result.name_hint = "memref_base_offset"
         if head is not None:
-            ops.append(add_op := arith.AddiOp(head, memref_offset_op.result))
+            add_op = builder.insert_op(arith.AddiOp(head, memref_offset_op.result))
+            add_op.result.name_hint = "pointer_with_offset"
             head = add_op.result
 
     if head is not None:
-        ops.extend(
-            [
-                bytes_per_element_op := ptr.TypeOffsetOp(
-                    memref_type.element_type, builtin.IndexType()
-                ),
-                final_offset := arith.MuliOp(head, bytes_per_element_op),
-                target_ptr := ptr.PtrAddOp(memref_ptr.res, final_offset.result),
-            ]
+        bytes_per_element_op = builder.insert_op(
+            ptr.TypeOffsetOp(memref_type.element_type, builtin.IndexType())
+        )
+        final_offset = builder.insert_op(arith.MuliOp(head, bytes_per_element_op))
+        target_ptr = builder.insert_op(
+            ptr.PtrAddOp(memref_ptr.res, final_offset.result)
         )
 
         bytes_per_element_op.offset.name_hint = "bytes_per_element"
@@ -117,7 +112,7 @@ def get_target_ptr(
     else:
         pointer = memref_ptr.res
 
-    return ops, pointer
+    return pointer
 
 
 @dataclass
@@ -125,11 +120,8 @@ class ConvertStoreOp(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: memref.StoreOp, rewriter: PatternRewriter, /):
         assert isa(memref_type := op.memref.type, memref.MemRefType)
-
-        ops, target_ptr = get_target_ptr(op.memref, memref_type, op.indices)
-        ops.append(ptr.StoreOp(target_ptr, op.value))
-
-        rewriter.replace_matched_op(ops)
+        target_ptr = get_target_ptr(op.memref, memref_type, op.indices, rewriter)
+        rewriter.replace_matched_op(ptr.StoreOp(target_ptr, op.value))
 
 
 @dataclass
@@ -137,9 +129,8 @@ class ConvertLoadOp(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: memref.LoadOp, rewriter: PatternRewriter, /):
         assert isa(memref_type := op.memref.type, memref.MemRefType)
-        ops, target_ptr = get_target_ptr(op.memref, memref_type, op.indices)
-        ops.append(load_result := ptr.LoadOp(target_ptr, memref_type.element_type))
-        rewriter.replace_matched_op(ops, new_results=[load_result.res])
+        target_ptr = get_target_ptr(op.memref, memref_type, op.indices, rewriter)
+        rewriter.replace_matched_op(ptr.LoadOp(target_ptr, memref_type.element_type))
 
 
 @dataclass

--- a/xdsl/transforms/convert_vector_to_ptr.py
+++ b/xdsl/transforms/convert_vector_to_ptr.py
@@ -19,9 +19,8 @@ class VectorStoreToPtr(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: vector.StoreOp, rewriter: PatternRewriter):
         assert isa(memref_type := op.base.type, memref.MemRefType)
-        ops, target_ptr = get_target_ptr(op.base, memref_type, op.indices)
-        ops.append(ptr.StoreOp(addr=target_ptr, value=op.vector))
-        rewriter.replace_matched_op(ops)
+        target_ptr = get_target_ptr(op.base, memref_type, op.indices, rewriter)
+        rewriter.replace_matched_op(ptr.StoreOp(addr=target_ptr, value=op.vector))
 
 
 @dataclass
@@ -29,9 +28,8 @@ class VectorLoadToPtr(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: vector.LoadOp, rewriter: PatternRewriter):
         assert isa(memref_type := op.base.type, memref.MemRefType)
-        ops, target_ptr = get_target_ptr(op.base, memref_type, op.indices)
-        ops.append(ptr.LoadOp(target_ptr, op.result.type))
-        rewriter.replace_matched_op(ops)
+        target_ptr = get_target_ptr(op.base, memref_type, op.indices, rewriter)
+        rewriter.replace_matched_op(ptr.LoadOp(target_ptr, op.result.type))
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
We have nicer builder APIs since we wrote this lowering. I'd like to add some functionality to these files so I thought I'd do a quick refactor here.