### PR TITLE
[WIP] core: allow results directive with SameVariadicResultSize option

### DIFF
--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -93,6 +93,7 @@ from xdsl.irdl.declarative_assembly_format import (
     VariadicOperandVariable,
     irdl_custom_directive,
 )
+from xdsl.irdl.operations import SameVariadicResultSize
 from xdsl.parser import Parser
 from xdsl.printer import Printer
 from xdsl.utils.exceptions import (
@@ -1822,6 +1823,31 @@ def test_results_directive_fails_with_two_var():
             irdl_options = [AttrSizedResultSegments()]
 
             assembly_format = "attr-dict `:` type(results)"
+
+
+def test_results_directive_works_with_two_var_and_option():
+    """
+    Test results directive can be used with two variadic results as long as they have
+    the same length.
+    """
+
+    @irdl_op_definition
+    class TwoVarOp(IRDLOperation):
+        name = "test.two_var_op"
+
+        res1 = var_result_def()
+        res2 = var_result_def()
+
+        irdl_options = [SameVariadicResultSize()]
+
+        assembly_format = "attr-dict `:` type(results)"
+
+    ctx = Context()
+    ctx.load_op(TwoVarOp)
+    ctx.load_dialect(Test)
+
+    check_roundtrip("%0, %1 = test.two_var_op : i32, i32", ctx)
+    check_roundtrip("%0, %1, %2, %3 = test.two_var_op : i32, i32, i32, i32", ctx)
 
 
 def test_results_directive_fails_with_no_results():

--- a/xdsl/irdl/declarative_assembly_format_parser.py
+++ b/xdsl/irdl/declarative_assembly_format_parser.py
@@ -33,6 +33,7 @@ from xdsl.irdl import (
     OptSuccessorDef,
     ParamAttrConstraint,
     ParsePropInAttrDict,
+    SameVariadicResultSize,
     VarConstraint,
     VariadicDef,
     VarOperandDef,
@@ -881,7 +882,7 @@ class FormatParser(BaseParser):
             for i, (_, o) in enumerate(self.op_def.results)
             if isinstance(o, VarResultDef)
         )
-        if len(variadics) > 1:
+        if len(variadics) > 1 and SameVariadicResultSize() not in self.op_def.options:
             self.raise_error("'results' is ambiguous with multiple variadic results")
         if not inside_ref:
             self.seen_result_types = [True] * len(self.seen_result_types)


### PR DESCRIPTION
@alexarice do you have any pointers wrt how to fix this? MLIR supports this for [memref.extract_strided_metadata](https://mlir.llvm.org/docs/Dialects/MemRef/#memrefextract_strided_metadata-memrefextractstridedmetadataop)