### PR TITLE
transformations: (convert-memref-to-ptr) ignore offset when indexing

### DIFF
--- a/tests/filecheck/transforms/convert_memref_to_ptr.mlir
+++ b/tests/filecheck/transforms/convert_memref_to_ptr.mlir
@@ -72,12 +72,20 @@ memref.store %fv, %farr[%idx] {"nontemporal" = false} : memref<10xf64>
 
 // CHECK-NEXT:  %idx3, %offsetmem = "test.op"() : () -> (index, memref<16xf64, strided<[1], offset: 4>>
 // CHECK-NEXT:  %offsetmem_1 = ptr_xdsl.to_ptr %offsetmem : memref<16xf64, strided<[1], offset: 4>> -> !ptr_xdsl.ptr
-// CHECK-NEXT:  %memref_base_offset = arith.constant 4 : index
-// CHECK-NEXT:  %pointer_with_offset = arith.addi %idx3, %memref_base_offset : index
 // CHECK-NEXT:  %bytes_per_element_6 = ptr_xdsl.type_offset f64 : index
-// CHECK-NEXT:  %scaled_pointer_offset_6 = arith.muli %pointer_with_offset, %bytes_per_element_6 : index
+// CHECK-NEXT:  %scaled_pointer_offset_6 = arith.muli %idx3, %bytes_per_element_6 : index
 // CHECK-NEXT:  %offset_pointer_6 = ptr_xdsl.ptradd %offsetmem_1, %scaled_pointer_offset_6 : (!ptr_xdsl.ptr, index) -> !ptr_xdsl.ptr
 // CHECK-NEXT:  %flv3 = ptr_xdsl.load %offset_pointer_6 : !ptr_xdsl.ptr -> f64
+
+%fv4, %idx4, %mstr4 = "test.op"() : () -> (f32, index, memref<2xf32, strided<[1], offset: ?>>)
+memref.store %fv4, %mstr4[%idx4] {"nontemporal" = false} : memref<2xf32, strided<[1], offset: ?>>
+
+// CHECK-NEXT:    %fv4, %idx4, %mstr4 = "test.op"() : () -> (f32, index, memref<2xf32, strided<[1], offset: ?>>)
+// CHECK-NEXT:    %mstr4_1 = ptr_xdsl.to_ptr %mstr4 : memref<2xf32, strided<[1], offset: ?>> -> !ptr_xdsl.ptr
+// CHECK-NEXT:    %bytes_per_element_7 = ptr_xdsl.type_offset f32 : index
+// CHECK-NEXT:    %scaled_pointer_offset_7 = arith.muli %idx4, %bytes_per_element_7 : index
+// CHECK-NEXT:    %offset_pointer_7 = ptr_xdsl.ptradd %mstr4_1, %scaled_pointer_offset_7 : (!ptr_xdsl.ptr, index) -> !ptr_xdsl.ptr
+// CHECK-NEXT:    ptr_xdsl.store %fv4, %offset_pointer_7 : f32, !ptr_xdsl.ptr
 
 // -----
 
@@ -92,10 +100,3 @@ memref.store %fv, %mstr[%idx] {"nontemporal" = false} : memref<2xf64, strided<[?
 memref.store %fv, %mstr[%idx] {"nontemporal" = false} : memref<2xf64, affine_map<(d0) -> (d0 * 10)>>
 
 // CHECK: Unsupported layout type affine_map<(d0) -> ((d0 * 10))>
-
-// -----
-
-%fv, %idx, %mstr = "test.op"() : () -> (f32, index, memref<2xf32, strided<[1], offset: ?>>)
-memref.store %fv, %mstr[%idx] {"nontemporal" = false} : memref<2xf32, strided<[1], offset: ?>>
-
-// CHECK: Unsupported layout with dynamic offset strided<[1], offset: ?>


### PR DESCRIPTION
The idea is to apply the offset when lowering ops that affect the
memref, such as subview and reinterpret_cast.