### PR TITLE
core: (Operation) Use deletion on descriptors

### DIFF
--- a/xdsl/irdl/operations.py
+++ b/xdsl/irdl/operations.py
@@ -2066,10 +2066,10 @@ class OptionalAttributeAccessor:
         return obj.attributes.get(self.attribute_name, self.default_value)
 
     def __set__(self, obj: IRDLOperation, value):
-        if value is None:
-            obj.attributes.pop(self.attribute_name, None)
-        else:
-            obj.attributes[self.attribute_name] = value
+        obj.attributes[self.attribute_name] = value
+
+    def __delete__(self, obj: IRDLOperation):
+        obj.attributes.pop(self.attribute_name, None)
 
 
 @dataclass(frozen=True)
@@ -2096,10 +2096,10 @@ class OptionalPropertyAccessor:
         return obj.properties.get(self.property_name, self.default_value)
 
     def __set__(self, obj: IRDLOperation, value):
-        if value is None:
-            obj.properties.pop(self.property_name, None)
-        else:
-            obj.properties[self.property_name] = value
+        obj.properties[self.property_name] = value
+
+    def __delete__(self, obj: IRDLOperation):
+        obj.properties.pop(self.property_name, None)
 
 
 @dataclass(frozen=True)

--- a/xdsl/transforms/csl_stencil_set_global_coeffs.py
+++ b/xdsl/transforms/csl_stencil_set_global_coeffs.py
@@ -174,7 +174,7 @@ class GenerateCoeffAPICalls(RewritePattern):
 
         # delete coefficients from apply ops
         for apply in applies:
-            apply.coeffs = None
+            del apply.coeffs
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Less sure about this one but descriptors seem to have `delete` functionality, which would avoid a check in attribute setting. Unsure whether this is worth it as we probably use `op.attr = None` in other places.