### PR TITLE
tool: (xdsl-opt) Disable attribute verify on `--disable-verify`

### DIFF
--- a/xdsl/xdsl_opt_main.py
+++ b/xdsl/xdsl_opt_main.py
@@ -19,6 +19,10 @@ from xdsl.utils.lexer import Span
 
 
 def _empty_post_init(self: Attribute):
+    """
+    An empty 'post_init' function.
+    Used to replace the default 'post_init' on 'Attribute' when verification is disabled.
+    """
     pass
 
 

--- a/xdsl/xdsl_opt_main.py
+++ b/xdsl/xdsl_opt_main.py
@@ -9,12 +9,17 @@ from typing import IO, Any
 
 from xdsl.context import Context
 from xdsl.dialects.builtin import ModuleOp
+from xdsl.ir import Attribute
 from xdsl.passes import ModulePass, PassPipeline
 from xdsl.printer import Printer
 from xdsl.tools.command_line_tool import CommandLineTool
 from xdsl.transforms import get_all_passes
 from xdsl.utils.exceptions import DiagnosticException, ParseError, ShrinkException
 from xdsl.utils.lexer import Span
+
+
+def _empty_post_init(self: Attribute):
+    pass
 
 
 class xDSLOptMain(CommandLineTool):
@@ -53,6 +58,9 @@ class xDSLOptMain(CommandLineTool):
         self.args = arg_parser.parse_args(args=args)
 
         self.ctx.allow_unregistered = self.args.allow_unregistered_dialect
+
+        if self.args.disable_verify:
+            Attribute.__post_init__ = _empty_post_init
 
         self.setup_pipeline()
 


### PR DESCRIPTION
I'm guessing that verification is run on Attribute post_init instead of being recursively called from operation verifications as Attributes should be immutable? 

It would be nice to have these not run when `--disable-verify` is on, and this is the best way I could think of doing it. This does feel a bit hacky though, and It won't effect benchmarking. I wonder if it's just worth taking the hit and recursively activating the attribute verification.