### PR TITLE
documentation: add back autogenerated documentation to nav

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,9 +43,9 @@ extra_css:
 
 plugins:
 - search
-# - gen-files:
-#     scripts:
-#     - scripts/gen_ref_pages.py
+- gen-files:
+    scripts:
+    - scripts/gen_ref_pages.py
 - awesome-nav
 - mkdocstrings:
     handlers:


### PR DESCRIPTION
The documentation website style PR commented out the auto-generation of code documentation and jupyter notebooks to speed up development. This was accidentally merged, with this PR uncommenting them to add them back