### PR TITLE
dialects: (vector) deprecate get methods

### DIFF
--- a/tests/dialects/test_vector.py
+++ b/tests/dialects/test_vector.py
@@ -102,7 +102,7 @@ def test_vectorType_with_scalable_dims():
 
 def test_vector_load_i32():
     memref_ssa_value = get_MemRef_SSAVal(i32, [1])
-    load = LoadOp.get(memref_ssa_value, [])
+    load = LoadOp(memref_ssa_value, [], VectorType(i32, ()))
 
     assert type(load.results[0]) is OpResult
     assert type(load.results[0].type) is VectorType
@@ -113,7 +113,7 @@ def test_vector_load_i32_with_dimensions():
     memref_ssa_value = get_MemRef_SSAVal(i32, [2, 3])
     index1 = create_ssa_value(IndexType())
     index2 = create_ssa_value(IndexType())
-    load = LoadOp.get(memref_ssa_value, [index1, index2])
+    load = LoadOp(memref_ssa_value, [index1, index2], VectorType(i32, (3,)))
 
     assert type(load.results[0]) is OpResult
     assert type(load.results[0].type) is VectorType
@@ -137,7 +137,7 @@ def test_vector_load_verify_type_matching():
 def test_vector_load_verify_indexing_exception():
     memref_ssa_value = get_MemRef_SSAVal(i32, [2, 3])
 
-    load = LoadOp.get(memref_ssa_value, [])
+    load = LoadOp(memref_ssa_value, [], VectorType(i32, ()))
 
     with pytest.raises(Exception, match="Expected an index for each dimension."):
         load.verify()
@@ -147,7 +147,7 @@ def test_vector_store_i32():
     vector_ssa_value = get_Vector_SSAVal(i32, [1])
     memref_ssa_value = get_MemRef_SSAVal(i32, [1])
 
-    store = StoreOp.get(vector_ssa_value, memref_ssa_value, [])
+    store = StoreOp(vector_ssa_value, memref_ssa_value, [])
 
     assert store.base is memref_ssa_value
     assert store.vector is vector_ssa_value
@@ -160,7 +160,7 @@ def test_vector_store_i32_with_dimensions():
 
     index1 = create_ssa_value(IndexType())
     index2 = create_ssa_value(IndexType())
-    store = StoreOp.get(vector_ssa_value, memref_ssa_value, [index1, index2])
+    store = StoreOp(vector_ssa_value, memref_ssa_value, [index1, index2])
 
     assert store.base is memref_ssa_value
     assert store.vector is vector_ssa_value
@@ -172,7 +172,7 @@ def test_vector_store_verify_type_matching():
     vector_ssa_value = get_Vector_SSAVal(i64, [2, 3])
     memref_ssa_value = get_MemRef_SSAVal(i32, [4, 5])
 
-    store = StoreOp.get(vector_ssa_value, memref_ssa_value, [])
+    store = StoreOp(vector_ssa_value, memref_ssa_value, [])
 
     with pytest.raises(
         Exception, match="MemRef element type should match the Vector element type."
@@ -184,7 +184,7 @@ def test_vector_store_verify_indexing_exception():
     vector_ssa_value = get_Vector_SSAVal(i32, [2, 3])
     memref_ssa_value = get_MemRef_SSAVal(i32, [4, 5])
 
-    store = StoreOp.get(vector_ssa_value, memref_ssa_value, [])
+    store = StoreOp(vector_ssa_value, memref_ssa_value, [])
 
     with pytest.raises(Exception, match="Expected an index for each dimension."):
         store.verify()
@@ -192,7 +192,7 @@ def test_vector_store_verify_indexing_exception():
 
 def test_vector_broadcast():
     index1 = create_ssa_value(IndexType())
-    broadcast = BroadcastOp.get(index1)
+    broadcast = BroadcastOp(index1, VectorType(IndexType(), ()))
 
     assert type(broadcast.results[0]) is OpResult
     assert type(broadcast.results[0].type) is VectorType
@@ -219,7 +219,7 @@ def test_vector_fma():
     rhs_vector_ssa_value = create_ssa_value(i32_vector_type)
     acc_vector_ssa_value = create_ssa_value(i32_vector_type)
 
-    fma = FMAOp.get(lhs_vector_ssa_value, rhs_vector_ssa_value, acc_vector_ssa_value)
+    fma = FMAOp(lhs_vector_ssa_value, rhs_vector_ssa_value, acc_vector_ssa_value)
 
     assert type(fma.results[0]) is OpResult
     assert type(fma.results[0].type) is VectorType
@@ -235,7 +235,7 @@ def test_vector_fma_with_dimensions():
     rhs_vector_ssa_value = create_ssa_value(i32_vector_type)
     acc_vector_ssa_value = create_ssa_value(i32_vector_type)
 
-    fma = FMAOp.get(lhs_vector_ssa_value, rhs_vector_ssa_value, acc_vector_ssa_value)
+    fma = FMAOp(lhs_vector_ssa_value, rhs_vector_ssa_value, acc_vector_ssa_value)
 
     assert type(fma.results[0]) is OpResult
     assert type(fma.results[0].type) is VectorType
@@ -249,7 +249,7 @@ def test_vector_masked_load():
     mask_vector_ssa_value = get_Vector_SSAVal(i1, [1])
     passthrough_vector_ssa_value = get_Vector_SSAVal(i32, [1])
 
-    maskedload = MaskedLoadOp.get(
+    maskedload = MaskedLoadOp(
         memref_ssa_value, [], mask_vector_ssa_value, passthrough_vector_ssa_value
     )
 
@@ -266,7 +266,7 @@ def test_vector_masked_load_with_dimensions():
     index1 = create_ssa_value(IndexType())
     index2 = create_ssa_value(IndexType())
 
-    maskedload = MaskedLoadOp.get(
+    maskedload = MaskedLoadOp(
         memref_ssa_value,
         [index1, index2],
         mask_vector_ssa_value,
@@ -335,7 +335,7 @@ def test_vector_masked_load_verify_indexing_exception():
     mask_vector_ssa_value = get_Vector_SSAVal(i1, [2])
     passthrough_vector_ssa_value = get_Vector_SSAVal(i32, [1])
 
-    maskedload = MaskedLoadOp.get(
+    maskedload = MaskedLoadOp(
         memref_ssa_value, [], mask_vector_ssa_value, passthrough_vector_ssa_value
     )
 
@@ -348,7 +348,7 @@ def test_vector_masked_store():
     mask_vector_ssa_value = get_Vector_SSAVal(i1, [1])
     value_to_store_vector_ssa_value = get_Vector_SSAVal(i32, [1])
 
-    maskedstore = MaskedStoreOp.get(
+    maskedstore = MaskedStoreOp(
         memref_ssa_value, [], mask_vector_ssa_value, value_to_store_vector_ssa_value
     )
 
@@ -366,7 +366,7 @@ def test_vector_masked_store_with_dimensions():
     index1 = create_ssa_value(IndexType())
     index2 = create_ssa_value(IndexType())
 
-    maskedstore = MaskedStoreOp.get(
+    maskedstore = MaskedStoreOp(
         memref_ssa_value,
         [index1, index2],
         mask_vector_ssa_value,
@@ -385,7 +385,7 @@ def test_vector_masked_store_verify_memref_value_to_store_type_matching():
     mask_vector_ssa_value = get_Vector_SSAVal(i1, [1])
     value_to_store_vector_ssa_value = get_Vector_SSAVal(i64, [1])
 
-    maskedstore = MaskedStoreOp.get(
+    maskedstore = MaskedStoreOp(
         memref_ssa_value, [], mask_vector_ssa_value, value_to_store_vector_ssa_value
     )
 
@@ -402,7 +402,7 @@ def test_vector_masked_store_verify_indexing_exception():
     mask_vector_ssa_value = get_Vector_SSAVal(i1, [2])
     value_to_store_vector_ssa_value = get_Vector_SSAVal(i32, [1])
 
-    maskedstore = MaskedStoreOp.get(
+    maskedstore = MaskedStoreOp(
         memref_ssa_value, [], mask_vector_ssa_value, value_to_store_vector_ssa_value
     )
 
@@ -413,13 +413,13 @@ def test_vector_masked_store_verify_indexing_exception():
 def test_vector_print():
     vector_ssa_value = get_Vector_SSAVal(i32, [1])
 
-    print = PrintOp.get(vector_ssa_value)
+    print = PrintOp(vector_ssa_value)
 
     assert print.source is vector_ssa_value
 
 
 def test_vector_create_mask():
-    create_mask = CreateMaskOp.get([])
+    create_mask = CreateMaskOp([], VectorType(i1, []))
 
     assert type(create_mask.results[0]) is OpResult
     assert type(create_mask.results[0].type) is VectorType
@@ -430,7 +430,7 @@ def test_vector_create_mask_with_dimensions():
     index1 = create_ssa_value(IndexType())
     index2 = create_ssa_value(IndexType())
 
-    create_mask = CreateMaskOp.get([index1, index2])
+    create_mask = CreateMaskOp([index1, index2], VectorType(i1, [2]))
 
     assert type(create_mask.results[0]) is OpResult
     assert type(create_mask.results[0].type) is VectorType

--- a/xdsl/dialects/vector.py
+++ b/xdsl/dialects/vector.py
@@ -4,6 +4,8 @@ from abc import ABC
 from collections.abc import Sequence
 from typing import ClassVar, cast
 
+from typing_extensions import deprecated
+
 from xdsl.dialects.builtin import (
     I1,
     AffineMapAttr,
@@ -72,6 +74,17 @@ class LoadOp(IRDLOperation):
         "$base `[` $indices `]` attr-dict `:` type($base) `,` type($result)"
     )
 
+    def __init__(
+        self,
+        ref: SSAValue | Operation,
+        indices: Sequence[SSAValue | Operation],
+        result_type: VectorType,
+    ):
+        super().__init__(
+            operands=(ref, indices),
+            result_types=(result_type,),
+        )
+
     def verify_(self):
         assert isa(self.base.type, MemRefType)
         assert isa(self.result.type, VectorType[Attribute])
@@ -84,16 +97,13 @@ class LoadOp(IRDLOperation):
         if self.base.type.get_num_dims() != len(self.indices):
             raise VerifyException("Expected an index for each dimension.")
 
+    @deprecated("Please use vector.LoadOp(ref, indices, result_type)")
     @staticmethod
     def get(
         ref: SSAValue | Operation, indices: Sequence[SSAValue | Operation]
     ) -> LoadOp:
         ref = SSAValue.get(ref, type=MemRefType)
-
-        return LoadOp.build(
-            operands=[ref, indices],
-            result_types=[VectorType(ref.type.element_type, [1])],
-        )
+        return LoadOp(ref, indices, VectorType(ref.type.element_type, [1]))
 
 
 @irdl_op_definition
@@ -109,6 +119,18 @@ class StoreOp(IRDLOperation):
         "$vector `,` $base `[` $indices `]` attr-dict `:` type($base) `,` type($vector)"
     )
 
+    def __init__(
+        self,
+        vector: SSAValue | Operation,
+        base: SSAValue | Operation,
+        indices: Sequence[SSAValue | Operation],
+        nontemporal: BoolAttr | None = None,
+    ):
+        super().__init__(
+            operands=[vector, base, indices],
+            properties={"nontemporal": nontemporal},
+        )
+
     def verify_(self):
         assert isa(self.base.type, MemRefType)
         assert isa(self.vector.type, VectorType[Attribute])
@@ -121,13 +143,14 @@ class StoreOp(IRDLOperation):
         if self.base.type.get_num_dims() != len(self.indices):
             raise VerifyException("Expected an index for each dimension.")
 
+    @deprecated("Please use vector.StoreOp(vector, ref, indices)")
     @staticmethod
     def get(
         vector: Operation | SSAValue,
         ref: Operation | SSAValue,
         indices: Sequence[Operation | SSAValue],
     ) -> StoreOp:
-        return StoreOp.build(operands=[vector, ref, indices])
+        return StoreOp(vector, ref, indices)
 
 
 @irdl_op_definition
@@ -143,6 +166,9 @@ class BroadcastOp(IRDLOperation):
 
     assembly_format = "$source attr-dict `:` type($source) `to` type($vector)"
 
+    def __init__(self, source: Operation | SSAValue, result_type: VectorType):
+        super().__init__(operands=(source,), result_types=(result_type,))
+
     def verify_(self):
         if isa(self.source.type, VectorType):
             element_type = self.source.type.element_type
@@ -154,12 +180,10 @@ class BroadcastOp(IRDLOperation):
                 "Source operand and result vector must have the same element type."
             )
 
+    @deprecated("Please use vector.BroadcastOp(source, result_type)")
     @staticmethod
     def get(source: Operation | SSAValue) -> BroadcastOp:
-        return BroadcastOp.build(
-            operands=[source],
-            result_types=[VectorType(SSAValue.get(source).type, [1])],
-        )
+        return BroadcastOp(source, VectorType(SSAValue.get(source).type, [1]))
 
 
 @irdl_op_definition
@@ -176,16 +200,21 @@ class FMAOp(IRDLOperation):
 
     assembly_format = "$lhs `,` $rhs `,` $acc attr-dict `:` type($lhs)"
 
+    def __init__(
+        self,
+        lhs: Operation | SSAValue,
+        rhs: Operation | SSAValue,
+        acc: Operation | SSAValue,
+    ):
+        acc = SSAValue.get(acc)
+        super().__init__(operands=(lhs, rhs, acc), result_types=(acc.type,))
+
+    @deprecated("Please use vector.FMAOp(lhs, rhs, acc)")
     @staticmethod
     def get(
         lhs: Operation | SSAValue, rhs: Operation | SSAValue, acc: Operation | SSAValue
     ) -> FMAOp:
-        lhs = SSAValue.get(lhs, type=VectorType)
-
-        return FMAOp.build(
-            operands=[lhs, rhs, acc],
-            result_types=[VectorType(lhs.type.element_type, [1])],
-        )
+        return FMAOp(lhs, rhs, acc)
 
 
 @irdl_op_definition
@@ -198,6 +227,22 @@ class MaskedLoadOp(IRDLOperation):
     result = result_def(VectorRankConstraint(1))
 
     assembly_format = "$base `[` $indices `]` `,` $mask `,` $pass_thru attr-dict `:` type($base) `,` type($mask) `,` type($pass_thru) `into` type($result)"  # noqa: E501
+
+    def __init__(
+        self,
+        base: SSAValue | Operation,
+        indices: Sequence[SSAValue | Operation],
+        mask: SSAValue | Operation,
+        pass_thru: SSAValue | Operation,
+        result_type: VectorType | None = None,
+    ):
+        pass_thru = SSAValue.get(pass_thru, type=VectorType)
+        if result_type is None:
+            result_type = pass_thru.type
+        super().__init__(
+            operands=[base, indices, mask, pass_thru],
+            result_types=[result_type],
+        )
 
     def verify_(self):
         memref_type = self.base.type
@@ -226,6 +271,9 @@ class MaskedLoadOp(IRDLOperation):
         if memref_type.get_num_dims() != len(self.indices):
             raise VerifyException("Expected an index for each memref dimension.")
 
+    @deprecated(
+        "Please use vector.MaskedLoadOp(memref, indices, mask, passthrough, result_type)"
+    )
     @staticmethod
     def get(
         memref: SSAValue | Operation,
@@ -275,6 +323,18 @@ class MaskedStoreOp(IRDLOperation):
         if memref_type.get_num_dims() != len(self.indices):
             raise VerifyException("Expected an index for each memref dimension.")
 
+    def __init__(
+        self,
+        memref: SSAValue | Operation,
+        indices: Sequence[SSAValue | Operation],
+        mask: SSAValue | Operation,
+        value_to_store: SSAValue | Operation,
+    ):
+        super().__init__(operands=[memref, indices, mask, value_to_store])
+
+    @deprecated(
+        "Please use vector.MaskedStoreOp(memref, indices, mask, value_to_store)"
+    )
     @staticmethod
     def get(
         memref: SSAValue | Operation,
@@ -282,7 +342,7 @@ class MaskedStoreOp(IRDLOperation):
         mask: SSAValue | Operation,
         value_to_store: SSAValue | Operation,
     ) -> MaskedStoreOp:
-        return MaskedStoreOp.build(operands=[memref, indices, mask, value_to_store])
+        return MaskedStoreOp(memref, indices, mask, value_to_store)
 
 
 @irdl_op_definition
@@ -290,9 +350,13 @@ class PrintOp(IRDLOperation):
     name = "vector.print"
     source = operand_def()
 
+    def __init__(self, source: SSAValue | Operation):
+        super().__init__(operands=[SSAValue.get(source)])
+
+    @deprecated("Please use vector.PrintOp(source)")
     @staticmethod
     def get(source: Operation | SSAValue) -> PrintOp:
-        return PrintOp.build(operands=[source])
+        return PrintOp(source)
 
 
 @irdl_op_definition
@@ -303,6 +367,11 @@ class CreateMaskOp(IRDLOperation):
 
     assembly_format = "$mask_dim_sizes attr-dict `:` type(results)"
 
+    def __init__(
+        self, mask_operands: list[Operation | SSAValue], result_type: VectorType
+    ):
+        super().__init__(operands=(mask_operands,), result_types=(result_type,))
+
     def verify_(self):
         assert isa(self.mask_vector.type, VectorType[Attribute])
         if self.mask_vector.type.get_num_dims() != len(self.mask_dim_sizes):
@@ -310,6 +379,7 @@ class CreateMaskOp(IRDLOperation):
                 "Expected an operand value for each dimension of resultant mask."
             )
 
+    @deprecated("Please use vector.CreateMaskOp(mask_operands, result_type)")
     @staticmethod
     def get(mask_operands: list[Operation | SSAValue]) -> CreateMaskOp:
         return CreateMaskOp.build(


### PR DESCRIPTION
The current get methods don't allow you to specify return types in places where it cannot be inferred, so I thought I'd migrate the dialect to use inits and to fix the functionality.