### PR TITLE
transformations: add test-vectorize-matmul

### DIFF
--- a/tests/filecheck/projects/libxsmm/integration_test_matmul.mlir
+++ b/tests/filecheck/projects/libxsmm/integration_test_matmul.mlir
@@ -1,60 +1,11 @@
-// RUN: xdsl-opt -p convert-vector-to-ptr,convert-memref-to-ptr{lower_func=true},convert-ptr-type-offsets,canonicalize,convert-func-to-x86-func,convert-vector-to-x86{arch=avx2},convert-ptr-to-x86{arch=avx2},convert-arith-to-x86,reconcile-unrealized-casts,canonicalize,x86-infer-broadcast,x86-allocate-registers,canonicalize -t x86-asm %s | filecheck %s
+// RUN: xdsl-opt -p test-vectorize-matmul,convert-vector-to-ptr,convert-memref-to-ptr{lower_func=true},convert-ptr-type-offsets,canonicalize,convert-func-to-x86-func,convert-vector-to-x86{arch=avx2},convert-ptr-to-x86{arch=avx2},convert-arith-to-x86,reconcile-unrealized-casts,canonicalize,x86-infer-broadcast,x86-allocate-registers,canonicalize -t x86-asm %s | filecheck %s
 
 func.func @matmul(
   %A: memref<2x4xf64>,
   %B: memref<4x4xf64>,
   %C: memref<2x4xf64>
 ) {
-  %i0 = arith.constant 0: index
-  %i1 = arith.constant 1: index
-  %j0 = arith.constant 0: index
-  %k0 = arith.constant 0: index
-  %k1 = arith.constant 1: index
-  %k2 = arith.constant 2: index
-  %k3 = arith.constant 3: index
-
-  // Load C lines
-  %c_line0 = vector.load %C[%i0,%j0]: memref<2x4xf64>, vector<4xf64>
-  %c_line1 = vector.load %C[%i1,%j0]: memref<2x4xf64>, vector<4xf64>
-  // Load B lines
-  %b_line0 = vector.load %B[%k0,%j0]: memref<4x4xf64>, vector<4xf64>
-  %b_line1 = vector.load %B[%k1,%j0]: memref<4x4xf64>, vector<4xf64>
-  %b_line2 = vector.load %B[%k2,%j0]: memref<4x4xf64>, vector<4xf64>
-  %b_line3 = vector.load %B[%k3,%j0]: memref<4x4xf64>, vector<4xf64>
-
-  // Load column 0 of A
-  %a_00_scal = memref.load %A[%i0, %k0] : memref<2x4xf64>
-  %a_01_scal = memref.load %A[%i0, %k1] : memref<2x4xf64>
-  %a_02_scal = memref.load %A[%i0, %k2] : memref<2x4xf64>
-  %a_03_scal = memref.load %A[%i0, %k3] : memref<2x4xf64>
-  %a_00 = vector.broadcast %a_00_scal: f64 to vector<4xf64>
-  %a_01 = vector.broadcast %a_01_scal: f64 to vector<4xf64>
-  %a_02 = vector.broadcast %a_02_scal: f64 to vector<4xf64>
-  %a_03 = vector.broadcast %a_03_scal: f64 to vector<4xf64>
-  // Perform the reduction
-  %c_line0_acc0 = vector.fma %a_00, %b_line0, %c_line0: vector<4xf64>
-  %c_line0_acc1 = vector.fma %a_01, %b_line1, %c_line0_acc0: vector<4xf64>
-  %c_line0_acc2 = vector.fma %a_02, %b_line2, %c_line0_acc1: vector<4xf64>
-  %c_line0_acc3 = vector.fma %a_03, %b_line3, %c_line0_acc2: vector<4xf64>
-
-  // Load column 1 of A
-  %a_10_scal = memref.load %A[%i1, %k0] : memref<2x4xf64>
-  %a_11_scal = memref.load %A[%i1, %k1] : memref<2x4xf64>
-  %a_12_scal = memref.load %A[%i1, %k2] : memref<2x4xf64>
-  %a_13_scal = memref.load %A[%i1, %k3] : memref<2x4xf64>
-  %a_10 = vector.broadcast %a_10_scal: f64 to vector<4xf64>
-  %a_11 = vector.broadcast %a_11_scal: f64 to vector<4xf64>
-  %a_12 = vector.broadcast %a_12_scal: f64 to vector<4xf64>
-  %a_13 = vector.broadcast %a_13_scal: f64 to vector<4xf64>
-  // Perform the reduction
-  %c_line1_acc4 = vector.fma %a_10, %b_line0, %c_line1: vector<4xf64>
-  %c_line1_acc5 = vector.fma %a_11, %b_line1, %c_line1_acc4: vector<4xf64>
-  %c_line1_acc6 = vector.fma %a_12, %b_line2, %c_line1_acc5: vector<4xf64>
-  %c_line1_acc7 = vector.fma %a_13, %b_line3, %c_line1_acc6: vector<4xf64>
-
-  vector.store %c_line0_acc3, %C[%i0,%j0]: memref<2x4xf64>, vector<4xf64>
-  vector.store %c_line1_acc7, %C[%i1,%j0]: memref<2x4xf64>, vector<4xf64>
-
+  linalg.matmul ins(%A, %B: memref<2x4xf64>, memref<4x4xf64>) outs(%C: memref<2x4xf64>)
   return
 }
 // CHECK:       .intel_syntax noprefix

--- a/tests/filecheck/transforms/test-vectorize-matmul.mlir
+++ b/tests/filecheck/transforms/test-vectorize-matmul.mlir
@@ -1,0 +1,45 @@
+// RUN: xdsl-opt -p test-vectorize-matmul %s | filecheck %s
+
+func.func @matmul(
+  %A: memref<2x3xf64>,
+  %B: memref<3x4xf64>,
+  %C: memref<2x4xf64>
+) {
+  linalg.matmul ins(%A, %B: memref<2x3xf64>, memref<3x4xf64>) outs(%C: memref<2x4xf64>)
+  return
+}
+
+// CHECK:       builtin.module {
+// CHECK-NEXT:    func.func @matmul(%A : memref<2x3xf64>, %B : memref<3x4xf64>, %C : memref<2x4xf64>) {
+// CHECK-NEXT:      %0 = arith.constant 0 : index
+// CHECK-NEXT:      %1 = arith.constant 1 : index
+// CHECK-NEXT:      %2 = arith.constant 2 : index
+// CHECK-NEXT:      %3 = arith.constant 3 : index
+// CHECK-NEXT:      %4 = vector.load %C[%0, %0] : memref<2x4xf64>, vector<4xf64>
+// CHECK-NEXT:      %5 = vector.load %C[%1, %0] : memref<2x4xf64>, vector<4xf64>
+// CHECK-NEXT:      %6 = vector.load %B[%0, %0] : memref<3x4xf64>, vector<4xf64>
+// CHECK-NEXT:      %7 = vector.load %B[%1, %0] : memref<3x4xf64>, vector<4xf64>
+// CHECK-NEXT:      %8 = vector.load %B[%2, %0] : memref<3x4xf64>, vector<4xf64>
+// CHECK-NEXT:      %9 = memref.load %A[%0, %0] : memref<2x3xf64>
+// CHECK-NEXT:      %10 = memref.load %A[%0, %1] : memref<2x3xf64>
+// CHECK-NEXT:      %11 = memref.load %A[%0, %2] : memref<2x3xf64>
+// CHECK-NEXT:      %12 = vector.broadcast %9 : f64 to vector<4xf64>
+// CHECK-NEXT:      %13 = vector.broadcast %10 : f64 to vector<4xf64>
+// CHECK-NEXT:      %14 = vector.broadcast %11 : f64 to vector<4xf64>
+// CHECK-NEXT:      %15 = vector.fma %12, %6, %4 : vector<4xf64>
+// CHECK-NEXT:      %16 = vector.fma %13, %7, %15 : vector<4xf64>
+// CHECK-NEXT:      %17 = vector.fma %14, %8, %16 : vector<4xf64>
+// CHECK-NEXT:      %18 = memref.load %A[%1, %0] : memref<2x3xf64>
+// CHECK-NEXT:      %19 = memref.load %A[%1, %1] : memref<2x3xf64>
+// CHECK-NEXT:      %20 = memref.load %A[%1, %2] : memref<2x3xf64>
+// CHECK-NEXT:      %21 = vector.broadcast %18 : f64 to vector<4xf64>
+// CHECK-NEXT:      %22 = vector.broadcast %19 : f64 to vector<4xf64>
+// CHECK-NEXT:      %23 = vector.broadcast %20 : f64 to vector<4xf64>
+// CHECK-NEXT:      %24 = vector.fma %21, %6, %5 : vector<4xf64>
+// CHECK-NEXT:      %25 = vector.fma %22, %7, %24 : vector<4xf64>
+// CHECK-NEXT:      %26 = vector.fma %23, %8, %25 : vector<4xf64>
+// CHECK-NEXT:      vector.store %17, %C[%0, %0] : memref<2x4xf64>, vector<4xf64>
+// CHECK-NEXT:      vector.store %26, %C[%1, %0] : memref<2x4xf64>, vector<4xf64>
+// CHECK-NEXT:      func.return
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/xdsl/transforms/__init__.py
+++ b/xdsl/transforms/__init__.py
@@ -548,15 +548,15 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
 
         return test_constant_folding.TestConstantFoldingPass
 
-    def get_test_specialised_constant_folding():
-        from xdsl.transforms import test_constant_folding
-
-        return test_constant_folding.TestSpecialisedConstantFoldingPass
-
     def get_test_lower_linalg_to_snitch():
         from xdsl.transforms import test_lower_linalg_to_snitch
 
         return test_lower_linalg_to_snitch.TestLowerLinalgToSnitchPass
+
+    def get_test_specialised_constant_folding():
+        from xdsl.transforms import test_constant_folding
+
+        return test_constant_folding.TestSpecialisedConstantFoldingPass
 
     def get_test_transform_dialect_erase_schedule():
         from xdsl.transforms import test_transform_dialect_erase_schedule
@@ -564,6 +564,11 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
         return (
             test_transform_dialect_erase_schedule.TestTransformDialectEraseSchedulePass
         )
+
+    def get_test_vectorize_matmul():
+        from xdsl.transforms import test_vectorize_matmul
+
+        return test_vectorize_matmul.TestVectorizeMatmulPass
 
     def get_transform_interpreter():
         from xdsl.transforms import transform_interpreter
@@ -701,9 +706,10 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
         "stencil-unroll": get_stencil_unroll,
         "test-add-timers-to-top-level-funcs": get_test_add_timers_to_top_level_funcs,
         "test-constant-folding": get_test_constant_folding,
-        "test-specialised-constant-folding": get_test_specialised_constant_folding,
         "test-lower-linalg-to-snitch": get_test_lower_linalg_to_snitch,
+        "test-specialised-constant-folding": get_test_specialised_constant_folding,
         "test-transform-dialect-erase-schedule": get_test_transform_dialect_erase_schedule,
+        "test-vectorize-matmul": get_test_vectorize_matmul,
         "transform-interpreter": get_transform_interpreter,
         "varith-fuse-repeated-operands": get_varith_fuse_repeated_operands,
         "vector-split-load-extract": get_vector_split_load_extract,

--- a/xdsl/transforms/test_vectorize_matmul.py
+++ b/xdsl/transforms/test_vectorize_matmul.py
@@ -1,0 +1,112 @@
+from dataclasses import dataclass
+
+from xdsl.builder import ImplicitBuilder
+from xdsl.context import Context
+from xdsl.dialects import arith, builtin, linalg, memref, vector
+from xdsl.passes import ModulePass
+from xdsl.pattern_rewriter import (
+    PatternRewriter,
+    PatternRewriteWalker,
+    RewritePattern,
+    op_type_rewrite_pattern,
+)
+from xdsl.utils.exceptions import DiagnosticException
+from xdsl.utils.hints import isa
+
+_index_type = builtin.IndexType()
+
+
+@dataclass
+class VectorizeMatmulOp(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: linalg.MatmulOp, rewriter: PatternRewriter, /):
+        # C += A * B
+        # C: M x N, A: M x K, B: K x N
+
+        a, b = op.inputs
+        c = op.outputs[0]
+
+        a_type = a.type
+        b_type = b.type
+        c_type = c.type
+
+        # Only handle matmul on memrefs for now
+        if (
+            not isa(a_type, builtin.MemRefType)
+            or not isa(b_type, builtin.MemRefType)
+            or not isa(c_type, builtin.MemRefType)
+        ):
+            raise DiagnosticException(
+                "Vectorizing matmul on tensors not yet implemented."
+            )
+
+        M, K = a_type.get_shape()
+        _K, N = b_type.get_shape()
+        _M, _N = c_type.get_shape()
+
+        assert M == _M
+        assert N == _N
+        assert K == _K
+        assert M != -1
+        assert N != -1
+        assert K != -1
+
+        vector_type = builtin.VectorType(a_type.element_type, (N,))
+
+        # All operations created inside this block are inserted before the matched op
+        with ImplicitBuilder(rewriter):
+            # Insert all the integer constants we'll need to index into the matrices
+            constants = tuple(
+                arith.ConstantOp(builtin.IntegerAttr(i, _index_type)).result
+                for i in range(max(M, N, K))
+            )
+            # Zero for convenience
+            c0 = constants[0]
+
+            # Load the rows of C as vectors
+            c_rows = [
+                vector.LoadOp(c, (constants[m], c0), vector_type).result
+                for m in range(M)
+            ]
+
+            # Load the rows of B as vectors
+            b_rows = tuple(
+                vector.LoadOp(b, (constants[k], c0), vector_type).result
+                for k in range(K)
+            )
+
+            for m in range(M):
+                # Load the mth column of A as scalars
+                a_col = tuple(
+                    memref.LoadOp.get(a, (constants[m], constants[k])).res
+                    for k in range(K)
+                )
+                # Broadcast the mth column of A to vectors
+                a_col_vectors = tuple(
+                    vector.BroadcastOp(a_col[k], vector_type) for k in range(K)
+                )
+
+                for k in range(K):
+                    # Accumulate the dot product of rows of B with A's column
+                    # The list c_rows is updated in place for convenience, but we're
+                    # really creating a new SSA value on each iteration
+                    c_rows[m] = vector.FMAOp(a_col_vectors[k], b_rows[k], c_rows[m]).res
+
+            for m in range(M):
+                vector.StoreOp(c_rows[m], c, (constants[m], c0))
+
+        rewriter.erase_matched_op()
+
+
+@dataclass(frozen=True)
+class TestVectorizeMatmulPass(ModulePass):
+    """
+    A test pass vectorizing linalg.matmul with a specific vectorization strategy.
+    """
+
+    name = "test-vectorize-matmul"
+
+    def apply(self, ctx: Context, op: builtin.ModuleOp) -> None:
+        PatternRewriteWalker(
+            VectorizeMatmulOp(), apply_recursively=False
+        ).rewrite_module(op)


### PR DESCRIPTION
A custom replica of the vectorization provided in MLIR, but in a way that we can control it manually in xDSL. Eventually I'd like to add proper vectorization to xDSL, but this is currently blocked on providing enough infrastructure in linalg, exposing the iteration spaces generically.