### PR TITLE
misc: add `dependency-groups` to make `uv sync` work

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,10 @@ bench = [
     "bytesight",
 ]
 
+[dependency-groups]
+dev = ["xdsl[dev,docs,gui,jax,riscv,bench]"]
+
+
 [project.urls]
 Homepage = "https://xdsl.dev/"
 "Source Code" = "https://github.com/xdslproject/xdsl"

--- a/uv.lock
+++ b/uv.lock
@@ -3572,6 +3572,11 @@ riscv = [
     { name = "riscemu" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "xdsl", extra = ["bench", "dev", "docs", "gui", "jax", "riscv"] },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "asv", marker = "extra == 'bench'", specifier = ">=0.6.4" },
@@ -3614,6 +3619,9 @@ requires-dist = [
     { name = "viztracer", marker = "extra == 'bench'", specifier = ">=1.0.1" },
 ]
 provides-extras = ["dev", "docs", "gui", "jax", "riscv", "bench"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "xdsl", extras = ["dev", "docs", "gui", "jax", "riscv", "bench"] }]
 
 [[package]]
 name = "yarl"


### PR DESCRIPTION
This lets us add dev dependencies that aren't distributed with xdsl optional dependencies. In the future it would make sense to move things like ruff in there also, even if I think it's useful to ship some dependencies to make it easier to set up downstream xdsl modules.