### PR TITLE
backend: (x86) add Arch enum and use for register type selection

### DIFF
--- a/tests/filecheck/backend/x86/convert_ptr_to_x86.mlir
+++ b/tests/filecheck/backend/x86/convert_ptr_to_x86.mlir
@@ -51,7 +51,7 @@
 
 // -----
 
-// CHECK: The vector size and target architecture are inconsistent.
+// CHECK: The vector size 1024 and target architecture avx512 are inconsistent.
 %ptr4 = "test.op"(): () -> !ptr_xdsl.ptr
 %v4 = ptr_xdsl.load %ptr4 : !ptr_xdsl.ptr -> vector<32xf32>
 

--- a/tests/filecheck/backend/x86/convert_ptr_to_x86.mlir
+++ b/tests/filecheck/backend/x86/convert_ptr_to_x86.mlir
@@ -51,7 +51,7 @@
 
 // -----
 
-// CHECK: The vector size 1024 and target architecture avx512 are inconsistent.
+// CHECK: The vector size (1024 bits) and target architecture `avx512` are inconsistent.
 %ptr4 = "test.op"(): () -> !ptr_xdsl.ptr
 %v4 = ptr_xdsl.load %ptr4 : !ptr_xdsl.ptr -> vector<32xf32>
 

--- a/xdsl/backend/x86/lowering/convert_vector_to_x86.py
+++ b/xdsl/backend/x86/lowering/convert_vector_to_x86.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from typing import cast
 
+from xdsl.backend.x86.lowering.helpers import Arch
 from xdsl.context import Context
 from xdsl.dialects import builtin, vector, x86
 from xdsl.dialects.builtin import (
@@ -18,12 +19,10 @@ from xdsl.pattern_rewriter import (
 )
 from xdsl.utils.exceptions import DiagnosticException
 
-from .helpers import vector_type_to_register_type
-
 
 @dataclass
 class VectorBroadcastToX86(RewritePattern):
-    arch: str
+    arch: Arch
 
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: vector.BroadcastOp, rewriter: PatternRewriter):
@@ -50,7 +49,7 @@ class VectorBroadcastToX86(RewritePattern):
                 )
         broadcast_op = broadcast(
             source=source_x86,
-            destination=vector_type_to_register_type(op.vector.type, self.arch),
+            destination=self.arch.register_type_for_type(op.vector.type).unallocated(),
         )
         # Get back the abstract vector
         dest_cast_op, _ = UnrealizedConversionCastOp.cast_one(
@@ -62,12 +61,12 @@ class VectorBroadcastToX86(RewritePattern):
 
 @dataclass
 class VectorFMAToX86(RewritePattern):
-    arch: str
+    arch: Arch
 
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: vector.FMAOp, rewriter: PatternRewriter):
         vect_type = cast(VectorType, op.acc.type)
-        x86_vect_type = vector_type_to_register_type(vect_type, self.arch)
+        x86_vect_type = self.arch.register_type_for_type(vect_type).unallocated()
         # Pointer casts
         lhs_cast_op, lhs_new = UnrealizedConversionCastOp.cast_one(
             op.lhs, x86_vect_type
@@ -110,11 +109,12 @@ class ConvertVectorToX86Pass(ModulePass):
     arch: str
 
     def apply(self, ctx: Context, op: builtin.ModuleOp) -> None:
+        arch = Arch.arch_for_name(self.arch)
         PatternRewriteWalker(
             GreedyRewritePatternApplier(
                 [
-                    VectorFMAToX86(self.arch),
-                    VectorBroadcastToX86(self.arch),
+                    VectorFMAToX86(arch),
+                    VectorBroadcastToX86(arch),
                 ]
             ),
             apply_recursively=False,

--- a/xdsl/backend/x86/lowering/helpers.py
+++ b/xdsl/backend/x86/lowering/helpers.py
@@ -83,7 +83,7 @@ class Arch(StrEnum):
         return self._scalar_type_for_type(value_type)
 
 
-_ARCH_BY_NAME = {str(case).lower(): case for case in Arch}
+_ARCH_BY_NAME = {str(case): case for case in Arch}
 """
 Handled architectures in x86 backend.
 """

--- a/xdsl/backend/x86/lowering/helpers.py
+++ b/xdsl/backend/x86/lowering/helpers.py
@@ -53,7 +53,7 @@ class Arch(StrEnum):
                 return x86.register.SSERegisterType
             case _:
                 raise DiagnosticException(
-                    f"The vector size {vector_size} and target architecture {self} are inconsistent."
+                    f"The vector size ({vector_size} bits) and target architecture `{self}` are inconsistent."
                 )
 
     def _scalar_type_for_type(self, value_type: Attribute) -> type[X86RegisterType]:

--- a/xdsl/backend/x86/lowering/helpers.py
+++ b/xdsl/backend/x86/lowering/helpers.py
@@ -1,6 +1,7 @@
-from typing import cast
+from __future__ import annotations
 
-from xdsl.backend.register_type import RegisterType
+from typing import cast, overload
+
 from xdsl.backend.utils import cast_to_regs
 from xdsl.dialects import x86
 from xdsl.dialects.builtin import (
@@ -9,49 +10,91 @@ from xdsl.dialects.builtin import (
     ShapedType,
     VectorType,
 )
-from xdsl.dialects.x86.register import X86VectorRegisterType
+from xdsl.dialects.x86.register import X86RegisterType, X86VectorRegisterType
 from xdsl.ir import Attribute, SSAValue
 from xdsl.pattern_rewriter import PatternRewriter
 from xdsl.utils.exceptions import DiagnosticException
+from xdsl.utils.hints import isa
+from xdsl.utils.str_enum import StrEnum
 
 
-def vector_type_to_register_type(
-    value_type: VectorType,
-    arch: str,
-) -> X86VectorRegisterType:
-    vector_num_elements = value_type.element_count()
-    element_type = cast(FixedBitwidthType, value_type.get_element_type())
-    element_size = element_type.bitwidth
-    vector_size = vector_num_elements * element_size
-    # Choose the x86 vector register according to the
-    # target architecture and the abstract vector size
-    if vector_size == 128:
-        vect_reg_type = x86.register.UNALLOCATED_SSE
-    elif vector_size == 256 and (arch == "avx2" or arch == "avx512"):
-        vect_reg_type = x86.register.UNALLOCATED_AVX2
-    elif vector_size == 512 and arch == "avx512":
-        vect_reg_type = x86.register.UNALLOCATED_AVX512
-    else:
-        raise DiagnosticException(
-            "The vector size and target architecture are inconsistent."
-        )
-    return vect_reg_type
+class Arch(StrEnum):
+    UNKNOWN = "unknown"
+    AVX2 = "avx2"
+    AVX512 = "avx512"
+
+    @staticmethod
+    def arch_for_name(name: str | None) -> Arch:
+        if name is None:
+            return Arch.UNKNOWN
+        try:
+            return _ARCH_BY_NAME[name]
+        except KeyError:
+            raise DiagnosticException(f"Unsupported arch {name}")
+
+    def _register_type_for_vector_type(
+        self, value_type: VectorType
+    ) -> type[X86VectorRegisterType]:
+        """
+        Given any vector type, returns the appropriate register type.
+        The vector type must fit exactly into a full bitwidth vector supported by the
+        ISA, otherwise a `DiagnosticException` is raised.
+        """
+        vector_num_elements = value_type.element_count()
+        element_type = cast(FixedBitwidthType, value_type.get_element_type())
+        element_size = element_type.bitwidth
+        vector_size = vector_num_elements * element_size
+        match self, vector_size:
+            case ((Arch.AVX2 | Arch.AVX512), 256):
+                return x86.register.AVX2RegisterType
+            case Arch.AVX512, 512:
+                return x86.register.AVX512RegisterType
+            case _, 128:
+                return x86.register.SSERegisterType
+            case _:
+                raise DiagnosticException(
+                    f"The vector size {vector_size} and target architecture {self} are inconsistent."
+                )
+
+    def _scalar_type_for_type(self, value_type: Attribute) -> type[X86RegisterType]:
+        assert not isinstance(value_type, ShapedType)
+        if (
+            isinstance(value_type, FixedBitwidthType) and value_type.bitwidth <= 64
+        ) or isinstance(value_type, IndexType):
+            return x86.register.GeneralRegisterType
+        else:
+            raise DiagnosticException("Not implemented for bitwidth larger than 64.")
+
+    @overload
+    def register_type_for_type(
+        self, value_type: VectorType
+    ) -> type[X86VectorRegisterType]: ...
+
+    @overload
+    def register_type_for_type(
+        self, value_type: Attribute
+    ) -> type[X86RegisterType]: ...
+
+    def register_type_for_type(self, value_type: Attribute) -> type[X86RegisterType]:
+        if isinstance(value_type, X86RegisterType):
+            return type(value_type)
+        if isa(value_type, VectorType):
+            return self._register_type_for_vector_type(value_type)
+        return self._scalar_type_for_type(value_type)
 
 
-def scalar_type_to_register_type(value_type: Attribute) -> type[RegisterType]:
-    assert not isinstance(value_type, ShapedType)
-    if (
-        isinstance(value_type, FixedBitwidthType) and value_type.bitwidth <= 64
-    ) or isinstance(value_type, IndexType):
-        return x86.register.GeneralRegisterType
-    else:
-        raise DiagnosticException("Not implemented for bitwidth larger than 64.")
+_ARCH_BY_NAME = {str(case).lower(): case for case in Arch}
+"""
+Handled architectures in x86 backend.
+"""
 
 
-def cast_operands_to_regs(rewriter: PatternRewriter) -> list[SSAValue[Attribute]]:
+def cast_operands_to_regs(
+    arch: Arch, rewriter: PatternRewriter
+) -> list[SSAValue[Attribute]]:
     new_ops, new_operands = cast_to_regs(
         values=rewriter.current_operation.operands,
-        register_map=scalar_type_to_register_type,
+        register_map=arch.register_type_for_type,
     )
     rewriter.insert_op_before_matched_op(new_ops)
     return new_operands


### PR DESCRIPTION
The aim of this PR is to unify the register type getters. These shouldn't be separate, as we need a way to generically handle lowering target-independent values passed in functions and as loop iter arguments. The best way I could come up with to model this is the `Arch` enum, although it feels like that's a bit of a misnomer. It would be nice to polish this later and get it to be more in line with how LLVM represents the same concept in its backend, hopefully in an extensible way. I think this will do for now, though.