### PR TITLE
core: unify SSAValue and Block name logic in IRWithName

### DIFF
--- a/tests/test_ssa_value.py
+++ b/tests/test_ssa_value.py
@@ -61,8 +61,20 @@ def test_invalid_ssa_vals(name: str):
     structured.
     """
     val = BlockArgument(i32, Block(), 0)
-    with pytest.raises(ValueError, match="Invalid SSA Value name format"):
+    with pytest.raises(ValueError, match="Invalid BlockArgument name format"):
         val.name_hint = name
+
+
+def test_extract_valid_name():
+    """
+    This test tests invalid name hints that raise an error, because
+    they don't conform to the rules of how SSA value names should be
+    structured.
+    """
+    assert SSAValue.extract_valid_name("hello") == "hello"
+    assert SSAValue.extract_valid_name("hello_1") == "hello"
+    with pytest.raises(ValueError, match="Invalid SSAValue name format"):
+        SSAValue.extract_valid_name("1hello")
 
 
 def test_rewrite_type():


### PR DESCRIPTION
A small refactor to share logic between IR nodes with names. Hopefully with nicer error messages.

Motivation for this PR is to extract the valid name extraction function for an upcoming PR.