### PR TITLE
installation: try renovate nix support

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,5 +10,8 @@
   ],
   "pre-commit": {
     "enabled": true
+  },
+  "nix": {
+    "enabled": true
   }
 }


### PR DESCRIPTION
I guess we try the default config first and see what happens. From reading the docs this should try to update the lock file once a week. I'm not 100% sure if this is a great idea without any CI but I guess I can manually test the commits for now.

Is there a way to get renovate to test the config in this PR?