### PR TITLE
dialects: (builtin) MemReftype layout constraint is MemRefLayoutAttr | NoneAttr

### DIFF
--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -2350,7 +2350,7 @@ class MemRefType(
 
     shape: ArrayAttr[IntAttr]
     element_type: _MemRefTypeElement
-    layout: StridedLayoutAttr | AffineMapAttr | NoneAttr
+    layout: MemRefLayoutAttr | NoneAttr
     memory_space: Attribute
 
     def __init__(


### PR DESCRIPTION
The layout attribute of a `MemRefType` should allow for any attribute that implements the `MemRefLayoutAttr` base class

Made possible through #5240 