### PR TITLE
core: Make get_canonicalization_patterns a method

### DIFF
--- a/docs/Toy/toy/dialects/toy.py
+++ b/docs/Toy/toy/dialects/toy.py
@@ -366,8 +366,7 @@ class ReturnOp(IRDLOperation):
 
 
 class ReshapeOpHasCanonicalizationPatternsTrait(HasCanonicalizationPatternsTrait):
-    @classmethod
-    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+    def get_canonicalization_patterns(self) -> tuple[RewritePattern, ...]:
         from ..rewrites.optimise_toy import (
             FoldConstantReshapeOpPattern,
             ReshapeReshapeOpPattern,
@@ -423,8 +422,7 @@ class TransposeOpHasShapeInferencePatternsTrait(HasShapeInferencePatternsTrait):
 
 
 class TransposeOpHasCanonicalizationPatternsTrait(HasCanonicalizationPatternsTrait):
-    @classmethod
-    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+    def get_canonicalization_patterns(self) -> tuple[RewritePattern, ...]:
         from ..rewrites.optimise_toy import SimplifyRedundantTranspose
 
         return (SimplifyRedundantTranspose(),)

--- a/tests/interactive/test_rewrites.py
+++ b/tests/interactive/test_rewrites.py
@@ -24,8 +24,7 @@ from xdsl.transforms.individual_rewrite import ApplyIndividualRewritePass
 
 
 class MyTestOpHasCanonicalizationPatternsTrait(traits.HasCanonicalizationPatternsTrait):
-    @classmethod
-    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+    def get_canonicalization_patterns(self) -> tuple[RewritePattern, ...]:
         return (Rewrite(),)
 
 

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -231,8 +231,7 @@ class SignlessIntegerBinaryOperation(IRDLOperation, abc.ABC):
 class SignlessIntegerBinaryOperationHasCanonicalizationPatternsTrait(
     HasCanonicalizationPatternsTrait
 ):
-    @classmethod
-    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+    def get_canonicalization_patterns(self) -> tuple[RewritePattern, ...]:
         from xdsl.transforms.canonicalization_patterns.arith import (
             SignlessIntegerBinaryOperationConstantProp,
             SignlessIntegerBinaryOperationZeroOrUnitRight,
@@ -282,8 +281,7 @@ class SignlessIntegerBinaryOperationWithOverflow(
 class FloatingPointLikeBinaryOpHasCanonicalizationPatternsTrait(
     HasCanonicalizationPatternsTrait
 ):
-    @classmethod
-    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+    def get_canonicalization_patterns(self) -> tuple[RewritePattern, ...]:
         from xdsl.transforms.canonicalization_patterns.arith import FoldConstConstOp
 
         return (FoldConstConstOp(),)
@@ -292,8 +290,7 @@ class FloatingPointLikeBinaryOpHasCanonicalizationPatternsTrait(
 class FloatingPointLikeBinaryOpHasFastReassociativeCanonicalizationPatternsTrait(
     HasCanonicalizationPatternsTrait
 ):
-    @classmethod
-    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+    def get_canonicalization_patterns(self) -> tuple[RewritePattern, ...]:
         from xdsl.transforms.canonicalization_patterns.arith import (
             FoldConstConstOp,
             FoldConstsByReassociation,
@@ -785,8 +782,7 @@ class ComparisonOperation(IRDLOperation):
 
 
 class CmpiHasCanonicalizationPatterns(HasCanonicalizationPatternsTrait):
-    @classmethod
-    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+    def get_canonicalization_patterns(self) -> tuple[RewritePattern, ...]:
         from xdsl.transforms.canonicalization_patterns import arith
 
         return (arith.ApplyCmpiPredicateToEqualOperands(),)
@@ -998,8 +994,7 @@ class CmpfOp(ComparisonOperation):
 
 
 class SelectHasCanonicalizationPatterns(HasCanonicalizationPatternsTrait):
-    @classmethod
-    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+    def get_canonicalization_patterns(self) -> tuple[RewritePattern, ...]:
         from xdsl.transforms.canonicalization_patterns.arith import (
             SelectConstPattern,
             SelectFoldCmpfPattern,

--- a/xdsl/dialects/cf.py
+++ b/xdsl/dialects/cf.py
@@ -50,8 +50,7 @@ from xdsl.utils.hints import isa
 
 
 class AssertHasCanonicalizationPatterns(HasCanonicalizationPatternsTrait):
-    @classmethod
-    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+    def get_canonicalization_patterns(self) -> tuple[RewritePattern, ...]:
         from xdsl.transforms.canonicalization_patterns.cf import AssertTrue
 
         return (AssertTrue(),)
@@ -80,8 +79,7 @@ class AssertOp(IRDLOperation):
 
 
 class BranchOpHasCanonicalizationPatterns(HasCanonicalizationPatternsTrait):
-    @classmethod
-    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+    def get_canonicalization_patterns(self) -> tuple[RewritePattern, ...]:
         from xdsl.transforms.canonicalization_patterns.cf import (
             SimplifyBrToBlockWithSinglePred,
             SimplifyPassThroughBr,
@@ -108,8 +106,7 @@ class BranchOp(IRDLOperation):
 
 
 class ConditionalBranchOpHasCanonicalizationPatterns(HasCanonicalizationPatternsTrait):
-    @classmethod
-    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+    def get_canonicalization_patterns(self) -> tuple[RewritePattern, ...]:
         from xdsl.transforms.canonicalization_patterns.cf import (
             CondBranchTruthPropagation,
             SimplifyCondBranchIdenticalSuccessors,
@@ -165,8 +162,7 @@ class ConditionalBranchOp(IRDLOperation):
 
 
 class SwitchOpHasCanonicalizationPatterns(HasCanonicalizationPatternsTrait):
-    @classmethod
-    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+    def get_canonicalization_patterns(self) -> tuple[RewritePattern, ...]:
         from xdsl.transforms.canonicalization_patterns.cf import (
             DropSwitchCasesThatMatchDefault,
             SimplifyConstSwitchValue,

--- a/xdsl/dialects/csl/csl.py
+++ b/xdsl/dialects/csl/csl.py
@@ -1084,8 +1084,7 @@ class SetTileCodeOp(IRDLOperation):
 
 
 class DsdOpHasCanonicalizationPatternsTrait(HasCanonicalizationPatternsTrait):
-    @classmethod
-    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+    def get_canonicalization_patterns(self) -> tuple[RewritePattern, ...]:
         from xdsl.transforms.canonicalization_patterns.csl import (
             GetDsdAndLengthFolding,
             GetDsdAndOffsetFolding,
@@ -1102,8 +1101,7 @@ class DsdOpHasCanonicalizationPatternsTrait(HasCanonicalizationPatternsTrait):
 class IncrementDsdOffsetOpHasCanonicalizationPatternsTrait(
     HasCanonicalizationPatternsTrait
 ):
-    @classmethod
-    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+    def get_canonicalization_patterns(self) -> tuple[RewritePattern, ...]:
         from xdsl.transforms.canonicalization_patterns.csl import (
             ChainedDsdOffsetFolding,
         )
@@ -1112,8 +1110,7 @@ class IncrementDsdOffsetOpHasCanonicalizationPatternsTrait(
 
 
 class SetDsdLengthOpHasCanonicalizationPatternsTrait(HasCanonicalizationPatternsTrait):
-    @classmethod
-    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+    def get_canonicalization_patterns(self) -> tuple[RewritePattern, ...]:
         from xdsl.transforms.canonicalization_patterns.csl import (
             ChainedDsdLengthFolding,
         )
@@ -1122,8 +1119,7 @@ class SetDsdLengthOpHasCanonicalizationPatternsTrait(HasCanonicalizationPatterns
 
 
 class SetDsdStrideOpHasCanonicalizationPatternsTrait(HasCanonicalizationPatternsTrait):
-    @classmethod
-    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+    def get_canonicalization_patterns(self) -> tuple[RewritePattern, ...]:
         from xdsl.transforms.canonicalization_patterns.csl import (
             ChainedDsdStrideFolding,
         )

--- a/xdsl/dialects/csl/csl_stencil.py
+++ b/xdsl/dialects/csl/csl_stencil.py
@@ -165,8 +165,7 @@ class CoeffAttr(ParametrizedAttribute):
 
 
 class ApplyOpHasCanonicalizationPatternsTrait(HasCanonicalizationPatternsTrait):
-    @classmethod
-    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+    def get_canonicalization_patterns(self) -> tuple[RewritePattern, ...]:
         from xdsl.transforms.canonicalization_patterns.csl_stencil import (
             RedundantAccumulatorInitialisation,
         )

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -155,8 +155,7 @@ class StoreOp(IRDLOperation):
 
 
 class AllocOpHasCanonicalizationPatterns(HasCanonicalizationPatternsTrait):
-    @classmethod
-    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+    def get_canonicalization_patterns(self) -> tuple[RewritePattern, ...]:
         from xdsl.transforms.canonicalization_patterns.memref import ElideUnusedAlloc
 
         return (ElideUnusedAlloc(),)
@@ -597,8 +596,7 @@ class ExtractAlignedPointerAsIndexOp(IRDLOperation):
 
 
 class MemRefHasCanonicalizationPatternsTrait(HasCanonicalizationPatternsTrait):
-    @classmethod
-    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+    def get_canonicalization_patterns(self) -> tuple[RewritePattern, ...]:
         from xdsl.transforms.canonicalization_patterns.memref import (
             MemRefSubviewOfSubviewFolding,
         )

--- a/xdsl/dialects/memref_stream.py
+++ b/xdsl/dialects/memref_stream.py
@@ -434,8 +434,7 @@ class StreamingRegionOp(IRDLOperation):
 
 
 class GenericOpHasCanonicalizationPatternsTrait(HasCanonicalizationPatternsTrait):
-    @classmethod
-    def get_canonicalization_patterns(cls):
+    def get_canonicalization_patterns(self):
         from xdsl.transforms.canonicalization_patterns.memref_stream import (
             RemoveUnusedInitOperandPattern,
         )

--- a/xdsl/dialects/ptr.py
+++ b/xdsl/dialects/ptr.py
@@ -44,8 +44,7 @@ class PtrType(ParametrizedAttribute, TypeAttribute):
 
 
 class PtrAddOpHasCanonicalizationPatterns(HasCanonicalizationPatternsTrait):
-    @classmethod
-    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+    def get_canonicalization_patterns(self) -> tuple[RewritePattern, ...]:
         from xdsl.transforms.canonicalization_patterns import ptr
 
         return (ptr.PtrAddZero(),)
@@ -150,8 +149,7 @@ class LoadOp(IRDLOperation):
 
 
 class ToPtrOpHasCanonicalizationPatternsTrait(HasCanonicalizationPatternsTrait):
-    @classmethod
-    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+    def get_canonicalization_patterns(self) -> tuple[RewritePattern, ...]:
         from xdsl.transforms.canonicalization_patterns.ptr import RedundantToPtr
 
         return (RedundantToPtr(),)
@@ -173,8 +171,7 @@ class ToPtrOp(IRDLOperation):
 
 
 class FromPtrOpHasCanonicalizationPatternsTrait(HasCanonicalizationPatternsTrait):
-    @classmethod
-    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+    def get_canonicalization_patterns(self) -> tuple[RewritePattern, ...]:
         from xdsl.transforms.canonicalization_patterns.ptr import RedundantFromPtr
 
         return (RedundantFromPtr(),)

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -1444,8 +1444,7 @@ class CsrBitwiseImmOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC):
 
 
 class AddiOpHasCanonicalizationPatternsTrait(HasCanonicalizationPatternsTrait):
-    @classmethod
-    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+    def get_canonicalization_patterns(self) -> tuple[RewritePattern, ...]:
         from xdsl.transforms.canonicalization_patterns.riscv import (
             AddImmediateConstant,
             AddImmediateZero,
@@ -1544,8 +1543,7 @@ class XoriOp(RdRsImmIntegerOperation):
 
 
 class SlliOpHasCanonicalizationPatternsTrait(HasCanonicalizationPatternsTrait):
-    @classmethod
-    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+    def get_canonicalization_patterns(self) -> tuple[RewritePattern, ...]:
         from xdsl.transforms.canonicalization_patterns.riscv import (
             ShiftLeftbyZero,
             ShiftLeftImmediate,
@@ -1571,8 +1569,7 @@ class SlliOp(RdRsImmShiftOperation):
 
 
 class SrliOpHasCanonicalizationPatternsTrait(HasCanonicalizationPatternsTrait):
-    @classmethod
-    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+    def get_canonicalization_patterns(self) -> tuple[RewritePattern, ...]:
         from xdsl.transforms.canonicalization_patterns.riscv import ShiftRightbyZero
 
         return (ShiftRightbyZero(),)
@@ -1793,8 +1790,7 @@ class AuipcOp(RdImmIntegerOperation):
 
 
 class MVHasCanonicalizationPatternsTrait(HasCanonicalizationPatternsTrait):
-    @classmethod
-    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+    def get_canonicalization_patterns(self) -> tuple[RewritePattern, ...]:
         from xdsl.transforms.canonicalization_patterns.riscv import (
             RemoveRedundantMv,
         )
@@ -1819,8 +1815,7 @@ class MVOp(RdRsIntegerOperation[IntRegisterType]):
 
 
 class FMVHasCanonicalizationPatternsTrait(HasCanonicalizationPatternsTrait):
-    @classmethod
-    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+    def get_canonicalization_patterns(self) -> tuple[RewritePattern, ...]:
         from xdsl.transforms.canonicalization_patterns.riscv import RemoveRedundantFMv
 
         return (RemoveRedundantFMv(),)
@@ -1850,8 +1845,7 @@ class FMVOp(RdRsFloatOperation[FloatRegisterType]):
 
 
 class AddOpHasCanonicalizationPatternsTrait(HasCanonicalizationPatternsTrait):
-    @classmethod
-    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+    def get_canonicalization_patterns(self) -> tuple[RewritePattern, ...]:
         from xdsl.transforms.canonicalization_patterns.riscv import (
             AddImmediates,
             AdditionOfSameVariablesToMultiplyByTwo,
@@ -1910,8 +1904,7 @@ class SltuOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
 
 
 class BitwiseAndHasCanonicalizationPatternsTrait(HasCanonicalizationPatternsTrait):
-    @classmethod
-    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+    def get_canonicalization_patterns(self) -> tuple[RewritePattern, ...]:
         from xdsl.transforms.canonicalization_patterns.riscv import BitwiseAndByZero
 
         return (BitwiseAndByZero(),)
@@ -1933,8 +1926,7 @@ class AndOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
 
 
 class BitwiseOrHasCanonicalizationPatternsTrait(HasCanonicalizationPatternsTrait):
-    @classmethod
-    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+    def get_canonicalization_patterns(self) -> tuple[RewritePattern, ...]:
         from xdsl.transforms.canonicalization_patterns.riscv import BitwiseOrByZero
 
         return (BitwiseOrByZero(),)
@@ -1956,8 +1948,7 @@ class OrOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
 
 
 class BitwiseXorHasCanonicalizationPatternsTrait(HasCanonicalizationPatternsTrait):
-    @classmethod
-    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+    def get_canonicalization_patterns(self) -> tuple[RewritePattern, ...]:
         from xdsl.transforms.canonicalization_patterns.riscv import (
             BitwiseXorByZero,
             XorBySelf,
@@ -2010,8 +2001,7 @@ class SrlOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
 
 
 class SubOpHasCanonicalizationPatternsTrait(HasCanonicalizationPatternsTrait):
-    @classmethod
-    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+    def get_canonicalization_patterns(self) -> tuple[RewritePattern, ...]:
         from xdsl.transforms.canonicalization_patterns.riscv import (
             SubAddi,
             SubImmediates,
@@ -2298,8 +2288,7 @@ class LhuOp(RdRsImmIntegerOperation):
 
 
 class LwOpHasCanonicalizationPatternTrait(HasCanonicalizationPatternsTrait):
-    @classmethod
-    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+    def get_canonicalization_patterns(self) -> tuple[RewritePattern, ...]:
         from xdsl.transforms.canonicalization_patterns.riscv import (
             LoadWordWithKnownOffset,
         )
@@ -2366,8 +2355,7 @@ class ShOp(RsRsImmIntegerOperation):
 
 
 class SwOpHasCanonicalizationPatternTrait(HasCanonicalizationPatternsTrait):
-    @classmethod
-    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+    def get_canonicalization_patterns(self) -> tuple[RewritePattern, ...]:
         from xdsl.transforms.canonicalization_patterns.riscv import (
             StoreWordWithKnownOffset,
         )
@@ -2545,8 +2533,7 @@ class CsrrciOp(CsrBitwiseImmOperation):
 
 
 class MulOpHasCanonicalizationPatternsTrait(HasCanonicalizationPatternsTrait):
-    @classmethod
-    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+    def get_canonicalization_patterns(self) -> tuple[RewritePattern, ...]:
         from xdsl.transforms.canonicalization_patterns.riscv import (
             MultiplyImmediates,
         )
@@ -2623,8 +2610,7 @@ class MulwOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
 
 
 class DivOpHasCanonicalizationPatternsTrait(HasCanonicalizationPatternsTrait):
-    @classmethod
-    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+    def get_canonicalization_patterns(self) -> tuple[RewritePattern, ...]:
         from xdsl.transforms.canonicalization_patterns.riscv import (
             DivideByOneIdentity,
         )
@@ -3348,8 +3334,7 @@ class CZeroNezOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
 
 
 class LiOpHasCanonicalizationPatternTrait(HasCanonicalizationPatternsTrait):
-    @classmethod
-    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+    def get_canonicalization_patterns(self) -> tuple[RewritePattern, ...]:
         from xdsl.transforms.canonicalization_patterns.riscv import (
             LoadImmediate0,
         )
@@ -4361,8 +4346,7 @@ class FMvWXOp(RdRsFloatOperation[IntRegisterType]):
 
 
 class FLwOpHasCanonicalizationPatternTrait(HasCanonicalizationPatternsTrait):
-    @classmethod
-    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+    def get_canonicalization_patterns(self) -> tuple[RewritePattern, ...]:
         from xdsl.transforms.canonicalization_patterns.riscv import (
             LoadFloatWordWithKnownOffset,
         )
@@ -4397,8 +4381,7 @@ class FLwOp(RdRsImmFloatOperation):
 
 
 class FSwOpHasCanonicalizationPatternTrait(HasCanonicalizationPatternsTrait):
-    @classmethod
-    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+    def get_canonicalization_patterns(self) -> tuple[RewritePattern, ...]:
         from xdsl.transforms.canonicalization_patterns.riscv import (
             StoreFloatWordWithKnownOffset,
         )
@@ -4466,8 +4449,7 @@ class FMSubDOp(RdRsRsRsFloatOperation):
 
 
 class FuseMultiplyAddDCanonicalizationPatternTrait(HasCanonicalizationPatternsTrait):
-    @classmethod
-    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+    def get_canonicalization_patterns(self) -> tuple[RewritePattern, ...]:
         from xdsl.transforms.canonicalization_patterns.riscv import (
             FuseMultiplyAddD,
         )
@@ -4537,8 +4519,7 @@ class FDivDOp(RdRsRsFloatOperationWithFastMath):
 
 
 class FLdOpHasCanonicalizationPatternTrait(HasCanonicalizationPatternsTrait):
-    @classmethod
-    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+    def get_canonicalization_patterns(self) -> tuple[RewritePattern, ...]:
         from xdsl.transforms.canonicalization_patterns.riscv import (
             LoadDoubleWithKnownOffset,
         )
@@ -4640,8 +4621,7 @@ class FLdOp(RdRsImmFloatOperation):
 
 
 class FSdOpHasCanonicalizationPatternTrait(HasCanonicalizationPatternsTrait):
-    @classmethod
-    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+    def get_canonicalization_patterns(self) -> tuple[RewritePattern, ...]:
         from xdsl.transforms.canonicalization_patterns.riscv import (
             StoreDoubleWithKnownOffset,
         )
@@ -4674,8 +4654,7 @@ class FSdOp(RsRsImmFloatOperation):
 
 
 class FMvDHasCanonicalizationPatternsTrait(HasCanonicalizationPatternsTrait):
-    @classmethod
-    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+    def get_canonicalization_patterns(self) -> tuple[RewritePattern, ...]:
         from xdsl.transforms.canonicalization_patterns.riscv import RemoveRedundantFMvD
 
         return (RemoveRedundantFMvD(),)

--- a/xdsl/dialects/riscv_cf.py
+++ b/xdsl/dialects/riscv_cf.py
@@ -44,8 +44,7 @@ def _parse_type_pair(parser: Parser) -> SSAValue:
 
 
 class ConditionalBranchOpCanonicalizationPatternTrait(HasCanonicalizationPatternsTrait):
-    @classmethod
-    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+    def get_canonicalization_patterns(self) -> tuple[RewritePattern, ...]:
         from xdsl.transforms.canonicalization_patterns.riscv_cf import (
             ElideConstantBranches,
         )

--- a/xdsl/dialects/riscv_snitch.py
+++ b/xdsl/dialects/riscv_snitch.py
@@ -75,8 +75,7 @@ from xdsl.utils.exceptions import VerifyException
 
 
 class ScfgwOpHasCanonicalizationPatternsTrait(HasCanonicalizationPatternsTrait):
-    @classmethod
-    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+    def get_canonicalization_patterns(self) -> tuple[RewritePattern, ...]:
         from xdsl.transforms.canonicalization_patterns.riscv import (
             ScfgwOpUsingImmediate,
         )

--- a/xdsl/dialects/scf.py
+++ b/xdsl/dialects/scf.py
@@ -285,8 +285,7 @@ class IfOp(IRDLOperation):
 
 
 class ForOpHasCanonicalizationPatternsTrait(HasCanonicalizationPatternsTrait):
-    @classmethod
-    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+    def get_canonicalization_patterns(self) -> tuple[RewritePattern, ...]:
         from xdsl.transforms.canonicalization_patterns.scf import (
             RehoistConstInLoops,
             SimplifyTrivialLoops,

--- a/xdsl/dialects/stencil.py
+++ b/xdsl/dialects/stencil.py
@@ -414,8 +414,7 @@ class ResultType(ParametrizedAttribute, TypeAttribute):
 
 
 class ApplyOpHasCanonicalizationPatternsTrait(HasCanonicalizationPatternsTrait):
-    @classmethod
-    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+    def get_canonicalization_patterns(self) -> tuple[RewritePattern, ...]:
         from xdsl.transforms.canonicalization_patterns.stencil import (
             ApplyRedundantOperands,
             ApplyUnusedOperands,
@@ -692,8 +691,7 @@ class AllocOp(IRDLOperation):
 
 
 class CastOpHasCanonicalizationPatternsTrait(HasCanonicalizationPatternsTrait):
-    @classmethod
-    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+    def get_canonicalization_patterns(self) -> tuple[RewritePattern, ...]:
         from xdsl.transforms.canonicalization_patterns.stencil import (
             RemoveCastWithNoEffect,
         )

--- a/xdsl/dialects/x86/ops.py
+++ b/xdsl/dialects/x86/ops.py
@@ -427,8 +427,7 @@ class RM_Operation(
 
 
 class DM_OperationHasCanonicalizationPatterns(HasCanonicalizationPatternsTrait):
-    @classmethod
-    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+    def get_canonicalization_patterns(self) -> tuple[RewritePattern, ...]:
         from xdsl.transforms.canonicalization_patterns.x86 import (
             DM_Operation_ConstantOffset,
         )
@@ -597,8 +596,7 @@ class RI_Operation(Generic[R1InvT], X86Instruction, X86CustomFormatOperation, AB
 
 
 class MS_OperationHasCanonicalizationPatterns(HasCanonicalizationPatternsTrait):
-    @classmethod
-    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+    def get_canonicalization_patterns(self) -> tuple[RewritePattern, ...]:
         from xdsl.transforms.canonicalization_patterns.x86 import (
             MS_Operation_ConstantOffset,
         )
@@ -1060,8 +1058,7 @@ class RSS_Operation(
 
 
 class RS_AddOpHasCanonicalizationPatterns(HasCanonicalizationPatternsTrait):
-    @classmethod
-    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+    def get_canonicalization_patterns(self) -> tuple[RewritePattern, ...]:
         from xdsl.transforms.canonicalization_patterns.x86 import RS_Add_Zero
 
         return (RS_Add_Zero(),)
@@ -1183,8 +1180,7 @@ class RS_XorOp(RS_Operation[GeneralRegisterType, GeneralRegisterType]):
 
 
 class DS_MovOpHasCanonicalizationPatterns(HasCanonicalizationPatternsTrait):
-    @classmethod
-    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+    def get_canonicalization_patterns(self) -> tuple[RewritePattern, ...]:
         from xdsl.transforms.canonicalization_patterns.x86 import RemoveRedundantDS_Mov
 
         return (RemoveRedundantDS_Mov(),)

--- a/xdsl/traits.py
+++ b/xdsl/traits.py
@@ -464,7 +464,6 @@ class HasCanonicalizationPatternsTrait(OpTrait):
     def verify(self, op: Operation) -> None:
         return
 
-    @classmethod
     @abc.abstractmethod
     def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
         raise NotImplementedError()


### PR DESCRIPTION
Previously, this method was a class method, which is not necessary at all.