### PR TITLE
dialects: Overload BvConstantOp.__init__

### DIFF
--- a/tests/dialects/test_smt.py
+++ b/tests/dialects/test_smt.py
@@ -183,11 +183,11 @@ def test_bv_constant_op():
     assert op.value == bv_attr
     assert op.result.type == BitVectorType(32)
 
-    op2 = BvConstantOp.from_value_and_type(42, 32)
+    op2 = BvConstantOp(42, 32)
     assert op2.value == bv_attr
     assert op2.result.type == BitVectorType(32)
 
-    op3 = BvConstantOp.from_value_and_type(42, BitVectorType(32))
+    op3 = BvConstantOp(42, BitVectorType(32))
     assert op3.value == bv_attr
     assert op3.result.type == BitVectorType(32)
 

--- a/xdsl/dialects/smt.py
+++ b/xdsl/dialects/smt.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from abc import ABC
 from collections.abc import Sequence
-from typing import ClassVar, TypeAlias
+from typing import ClassVar, TypeAlias, overload
 
 from typing_extensions import Self
 
@@ -617,17 +617,24 @@ class BvConstantOp(IRDLOperation):
 
     traits = traits_def(ConstantLike(), Pure())
 
-    def __init__(self, value: BitVectorAttr) -> None:
-        super().__init__(properties={"value": value}, result_types=[value.type])
+    @overload
+    def __init__(self, value: BitVectorAttr) -> None: ...
 
-    @staticmethod
-    def from_value_and_type(value: int, type: BitVectorType | int) -> BvConstantOp:
+    @overload
+    def __init__(self, value: int, type: BitVectorType | int) -> None: ...
+
+    def __init__(
+        self, value: BitVectorAttr | int, type: int | BitVectorType | None = None
+    ):
         """
         Create a new `BvConstantOp` from a value and a bitvector width.
         """
-        if isinstance(type, int):
-            type = BitVectorType(type)
-        return BvConstantOp(BitVectorAttr(value, type))
+        if not isinstance(value, BitVectorAttr):
+            if isinstance(type, int):
+                type = BitVectorType(type)
+            assert isinstance(type, BitVectorType)
+            value = BitVectorAttr(value, type)
+        super().__init__(properties={"value": value}, result_types=[value.type])
 
 
 class UnaryBVOp(IRDLOperation, ABC):


### PR DESCRIPTION
I really really find the `.from_value_and_type` too verbose.
`BvConstantOp(4, 32)` is much more readable to me than `BvConstantOp.from_value_and_type(4, 32)`, which can often span multiple lines.