### PR TITLE
dependencies: (Renovate) add `lockFileMaintenance`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,5 +13,8 @@
   },
   "nix": {
     "enabled": true
+  },
+  "lockFileMaintenance": {
+    "enabled": true
   }
 }


### PR DESCRIPTION
This will possibly fix the nix stuff in renovate, and maybe will do the lock file updating we wanted for uv anyway.