### PR TITLE
core: add `has_effects` helper to find the effects of an operation

### DIFF
--- a/tests/test_traits.py
+++ b/tests/test_traits.py
@@ -53,11 +53,13 @@ from xdsl.traits import (
     ConditionallySpeculatable,
     HasAncestor,
     HasParent,
+    MemoryEffectKind,
     OptionalSymbolOpInterface,
     RecursivelySpeculatable,
     SameOperandsAndResultType,
     SymbolOpInterface,
     SymbolTable,
+    has_effects,
     is_speculatable,
 )
 from xdsl.utils.exceptions import PyRDLOpDefinitionError, VerifyException
@@ -990,6 +992,20 @@ def test_same_operands_and_result_type_trait_for_mixed_rank_and_mixed_shapes(
     )
 
     op.verify()
+
+
+def test_memory_effects():
+    from xdsl.dialects.test import TestPureOp, TestReadOp, TestWriteOp
+
+    assert not has_effects(TestPureOp(), MemoryEffectKind.ALLOC)
+    assert not has_effects(TestReadOp(), MemoryEffectKind.ALLOC)
+    assert not has_effects(TestWriteOp(), MemoryEffectKind.ALLOC)
+    assert not has_effects(TestPureOp(), MemoryEffectKind.READ)
+    assert has_effects(TestReadOp(), MemoryEffectKind.READ)
+    assert not has_effects(TestWriteOp(), MemoryEffectKind.READ)
+    assert not has_effects(TestPureOp(), MemoryEffectKind.WRITE)
+    assert not has_effects(TestReadOp(), MemoryEffectKind.WRITE)
+    assert has_effects(TestWriteOp(), MemoryEffectKind.WRITE)
 
 
 @irdl_op_definition

--- a/xdsl/traits.py
+++ b/xdsl/traits.py
@@ -4,7 +4,7 @@ import abc
 from collections.abc import Iterator
 from dataclasses import dataclass, field
 from enum import Enum, auto
-from typing import TYPE_CHECKING, final
+from typing import TYPE_CHECKING
 
 from typing_extensions import TypeVar
 
@@ -554,14 +554,13 @@ class MemoryEffect(OpTrait):
         """
         raise NotImplementedError()
 
-    @final
-    @classmethod
-    def has_effects(cls, op: Operation) -> bool:
-        """
-        Returns if the operation has any side effects.
-        """
-        effects = cls.get_effects(op)
-        return (effects is not None) and len(effects) > 0
+
+def has_effects(op: Operation, effect: MemoryEffectKind) -> bool:
+    """
+    Returns if the operation has side effects of this kind.
+    """
+    effects = get_effects(op)
+    return effects is not None and any(e.kind == effect for e in effects)
 
 
 def has_exact_effect(op: Operation, effect: MemoryEffectKind) -> bool:


### PR DESCRIPTION
The existing helper is kind of buggy and untested/unused, I thought I'd move it to top-level to be more like the other helpers for memory effects.