### PR TITLE
core: ((Operands|Results)Directive) refactor to allow multiple variadics

### DIFF
--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -51,6 +51,7 @@ from xdsl.irdl import (
     ParsePropInAttrDict,
     RangeOf,
     RangeVarConstraint,
+    SameVariadicOperandSize,
     SameVariadicResultSize,
     TypedAttributeConstraint,  # pyright: ignore[reportDeprecated]
     VarConstraint,
@@ -1339,6 +1340,69 @@ def test_operands_directive_fails_with_two_var():
             assembly_format = "operands attr-dict `:` type(operands)"
 
 
+@pytest.mark.parametrize(
+    "program",
+    [
+        "test.two_var_op :",
+        "test.two_var_op %0, %1 : i32, i32",
+        "test.two_var_op %0, %1, %2, %3 : i32, i32, i32, i32",
+    ],
+)
+def test_operands_directive_works_with_two_var_and_option(program: str):
+    """
+    Test operands directive can be used with two variadic operands as long as they have
+    the same length.
+    """
+
+    @irdl_op_definition
+    class TwoVarOp(IRDLOperation):
+        name = "test.two_var_op"
+
+        res1 = var_operand_def()
+        res2 = var_operand_def()
+
+        irdl_options = [SameVariadicOperandSize()]
+
+        assembly_format = "operands attr-dict  `:` type(operands)"
+
+    ctx = Context()
+    ctx.load_op(TwoVarOp)
+    ctx.load_dialect(Test)
+
+    check_roundtrip(program, ctx)
+
+
+@pytest.mark.parametrize(
+    "program",
+    [
+        "test.two_var_op :",
+        "test.two_var_op %0, %1 : i32, i32",
+    ],
+)
+def test_operands_directive_works_with_two_opt_and_option(program: str):
+    """
+    Test operands directive can be used with two optional operands as long as they have
+    the same length.
+    """
+
+    @irdl_op_definition
+    class TwoVarOp(IRDLOperation):
+        name = "test.two_var_op"
+
+        res1 = var_operand_def()
+        res2 = var_operand_def()
+
+        irdl_options = [SameVariadicOperandSize()]
+
+        assembly_format = "operands attr-dict `:` type(operands)"
+
+    ctx = Context()
+    ctx.load_op(TwoVarOp)
+    ctx.load_dialect(Test)
+
+    check_roundtrip(program, ctx)
+
+
 def test_operands_directive_fails_with_no_operands():
     """Test operands directive cannot be used with no operands"""
 
@@ -1825,7 +1889,15 @@ def test_results_directive_fails_with_two_var():
             assembly_format = "attr-dict `:` type(results)"
 
 
-def test_results_directive_works_with_two_var_and_option():
+@pytest.mark.parametrize(
+    "program",
+    [
+        "test.two_var_op :",
+        "%0, %1 = test.two_var_op : i32, i32",
+        "%0, %1, %2, %3 = test.two_var_op : i32, i32, i32, i32",
+    ],
+)
+def test_results_directive_works_with_two_var_and_option(program: str):
     """
     Test results directive can be used with two variadic results as long as they have
     the same length.
@@ -1846,8 +1918,38 @@ def test_results_directive_works_with_two_var_and_option():
     ctx.load_op(TwoVarOp)
     ctx.load_dialect(Test)
 
-    check_roundtrip("%0, %1 = test.two_var_op : i32, i32", ctx)
-    check_roundtrip("%0, %1, %2, %3 = test.two_var_op : i32, i32, i32, i32", ctx)
+    check_roundtrip(program, ctx)
+
+
+@pytest.mark.parametrize(
+    "program",
+    [
+        "test.two_var_op :",
+        "%0, %1 = test.two_var_op : i32, i32",
+    ],
+)
+def test_results_directive_works_with_two_opt_and_option(program: str):
+    """
+    Test results directive can be used with two optional results as long as they have
+    the same length.
+    """
+
+    @irdl_op_definition
+    class TwoVarOp(IRDLOperation):
+        name = "test.two_var_op"
+
+        res1 = var_result_def()
+        res2 = var_result_def()
+
+        irdl_options = [SameVariadicResultSize()]
+
+        assembly_format = "attr-dict `:` type(results)"
+
+    ctx = Context()
+    ctx.load_op(TwoVarOp)
+    ctx.load_dialect(Test)
+
+    check_roundtrip(program, ctx)
 
 
 def test_results_directive_fails_with_no_results():

--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -51,6 +51,7 @@ from xdsl.irdl import (
     ParsePropInAttrDict,
     RangeOf,
     RangeVarConstraint,
+    SameVariadicResultSize,
     TypedAttributeConstraint,  # pyright: ignore[reportDeprecated]
     VarConstraint,
     VarOperand,
@@ -1392,15 +1393,15 @@ def test_operands_directive_fails_with_other_type_directive():
 @pytest.mark.parametrize(
     "program, error",
     [
-        ("test.two_operands %0 : i32, i32", "Expected 2 operands but found 1"),
+        ("test.two_operands %0 : i32, i32", "Expected 2 operands, but got 1"),
         (
             "test.two_operands %0, %1, %2 : i32, i32",
-            "Expected 2 operands but found 3",
+            "Expected 2 operands, but got 3",
         ),
-        ("test.two_operands %0, %1 : i32", "Expected 2 operand types but found 1"),
+        ("test.two_operands %0, %1 : i32", "Expected 2 operand types, but got 1"),
         (
             "test.two_operands %0, %1 : i32, i32, i32",
-            "Expected 2 operand types but found 3",
+            "Expected 2 operand types, but got 3",
         ),
     ],
 )
@@ -1427,19 +1428,19 @@ def test_operands_directive_bounds(program: str, error: str):
     [
         (
             "test.three_operands %0 : i32, i32",
-            "Expected at least 2 operands but found 1",
+            "Expected 2 or 3 operands, but got 1",
         ),
         (
             "test.three_operands %0, %1, %2, %3 : i32, i32, i32",
-            "Expected at most 3 operands but found 4",
+            "Expected 2 or 3 operands, but got 4",
         ),
         (
             "test.three_operands %0, %1 : i32",
-            "Expected at least 2 operand types but found 1",
+            "Expected 2 or 3 operand types, but got 1",
         ),
         (
             "test.three_operands %0, %1, %3 : i32, i32, i32, i32",
-            "Expected at most 3 operand types but found 4",
+            "Expected 2 or 3 operand types, but got 4",
         ),
     ],
 )
@@ -1467,11 +1468,11 @@ def test_operands_directive_bounds_with_opt(program: str, error: str):
     [
         (
             "test.three_operands %0 : i32, i32",
-            "Expected at least 2 operands but found 1",
+            "Expected at least 2 operands, but got 1",
         ),
         (
             "test.three_operands %0, %1 : i32",
-            "Expected at least 2 operand types but found 1",
+            "Expected at least 2 operand types, but got 1",
         ),
     ],
 )
@@ -1501,10 +1502,10 @@ def test_operands_directive_with_non_variadic_type_directive():
     # an OperandsDirective, but we can manually make one.
     format_program = FormatProgram(
         (
-            OperandsDirective(None),
+            OperandsDirective(),
             AttrDictDirective(False, set(), set()),
             PunctuationDirective(":"),
-            TypeDirective(OperandsDirective(None)),
+            TypeDirective(OperandsDirective()),
         ),
     )
 
@@ -1536,10 +1537,10 @@ def test_operands_directive_with_variadic_type_directive():
     # an OperandsDirective, but we can manually make one.
     format_program = FormatProgram(
         (
-            OperandsDirective((False, 1)),
+            OperandsDirective(),
             AttrDictDirective(False, set(), set()),
             PunctuationDirective(":"),
-            TypeDirective(OperandsDirective((False, 1))),
+            TypeDirective(OperandsDirective()),
         ),
     )
 
@@ -1824,6 +1825,31 @@ def test_results_directive_fails_with_two_var():
             assembly_format = "attr-dict `:` type(results)"
 
 
+def test_results_directive_works_with_two_var_and_option():
+    """
+    Test results directive can be used with two variadic results as long as they have
+    the same length.
+    """
+
+    @irdl_op_definition
+    class TwoVarOp(IRDLOperation):
+        name = "test.two_var_op"
+
+        res1 = var_result_def()
+        res2 = var_result_def()
+
+        irdl_options = [SameVariadicResultSize()]
+
+        assembly_format = "attr-dict `:` type(results)"
+
+    ctx = Context()
+    ctx.load_op(TwoVarOp)
+    ctx.load_dialect(Test)
+
+    check_roundtrip("%0, %1 = test.two_var_op : i32, i32", ctx)
+    check_roundtrip("%0, %1, %2, %3 = test.two_var_op : i32, i32, i32, i32", ctx)
+
+
 def test_results_directive_fails_with_no_results():
     """Test results directive cannot be used with no results"""
 
@@ -1860,10 +1886,10 @@ def test_results_directive_fails_with_other_type_directive():
 @pytest.mark.parametrize(
     "program, error",
     [
-        ("%0 = test.two_results : i32", "Expected 2 result types but found 1"),
+        ("%0 = test.two_results : i32", "Expected 2 result types, but got 1"),
         (
             "%0, %1, %2 = test.two_results : i32, i32, i32",
-            "Expected 2 result types but found 3",
+            "Expected 2 result types, but got 3",
         ),
     ],
 )
@@ -1890,11 +1916,11 @@ def test_results_directive_bounds(program: str, error: str):
     [
         (
             "%0 = test.three_results : i32",
-            "Expected at least 2 result types but found 1",
+            "Expected 2 or 3 result types, but got 1",
         ),
         (
             "%0, %1, %2, %3 = test.three_results : i32, i32, i32, i32",
-            "Expected at most 3 result types but found 4",
+            "Expected 2 or 3 result types, but got 4",
         ),
     ],
 )
@@ -1923,7 +1949,7 @@ def test_results_directive_bound_with_var():
         name = "test.three_results"
 
         res1 = result_def()
-        res2 = opt_result_def()
+        res2 = var_result_def()
         res3 = result_def()
 
         assembly_format = "attr-dict `:` type(results)"
@@ -1931,9 +1957,7 @@ def test_results_directive_bound_with_var():
     ctx = Context()
     ctx.load_op(ThreeResultsOp)
 
-    with pytest.raises(
-        ParseError, match="Expected at least 2 result types but found 1"
-    ):
+    with pytest.raises(ParseError, match="Expected at least 2 result types, but got 1"):
         parser = Parser(ctx, "%0 = test.three_results : i32")
         parser.parse_operation()
 
@@ -1947,7 +1971,7 @@ def test_results_directive_with_non_variadic_type_directive():
         (
             AttrDictDirective(False, set(), set()),
             PunctuationDirective(":"),
-            TypeDirective(ResultsDirective(None)),
+            TypeDirective(ResultsDirective()),
         ),
     )
 
@@ -1981,7 +2005,7 @@ def test_results_directive_with_variadic_type_directive():
         (
             AttrDictDirective(False, set(), set()),
             PunctuationDirective(":"),
-            TypeDirective(ResultsDirective((False, 1))),
+            TypeDirective(ResultsDirective()),
         ),
     )
 

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -31,18 +31,22 @@ from xdsl.ir import (
     TypedAttribute,
 )
 from xdsl.irdl import (
+    BaseAccessor,
     ConstraintContext,
     IRDLOperation,
     IRDLOperationInvT,
     OpDef,
     OptionalDef,
     Successor,
+    VarIRConstruct,
     VarOperand,
+    get_construct_defs,
     is_const_classvar,
+    verify_variadic_same_size,
 )
 from xdsl.parser import Parser, UnresolvedOperand
 from xdsl.printer import Printer
-from xdsl.utils.exceptions import PyRDLError
+from xdsl.utils.exceptions import PyRDLError, VerifyException
 from xdsl.utils.hints import isa
 from xdsl.utils.mlir_lexer import PunctuationSpelling
 
@@ -62,9 +66,12 @@ class ParsingState:
     successors: list[None | Sequence[Successor]]
     attributes: dict[str, Attribute]
     properties: dict[str, Attribute]
+    op_type: type[IRDLOperation]
     context: ConstraintContext
 
-    def __init__(self, op_def: OpDef):
+    def __init__(self, op_type: type[IRDLOperation]):
+        op_def = op_type.get_irdl_definition()
+        self.op_type = op_type
         self.operands = [None] * len(op_def.operands)
         self.operand_types = [None] * len(op_def.operands)
         self.result_types = [None] * len(op_def.results)
@@ -133,7 +140,7 @@ class FormatProgram:
         """
         # Parse elements one by one
         op_def = op_type.get_irdl_definition()
-        state = ParsingState(op_def)
+        state = ParsingState(op_type)
         for stmt in self.stmts:
             stmt.parse(parser, state)
 
@@ -344,9 +351,9 @@ class TypeableDirective(Directive, ABC):
     """
 
     @abstractmethod
-    def set_types(self, state: ParsingState, types: Sequence[Attribute]) -> str | None:
+    def set_types(self, state: ParsingState, types: Sequence[Attribute]) -> None:
         """
-        Set the types for this directive to the given sequence, possibly returning an error.
+        Set the types for this directive to the given sequence.
         """
         ...
 
@@ -680,12 +687,6 @@ class OperandsOrResultDirective(TypeableDirective, ABC):
     Base class for the 'operands' and 'results' directives.
     """
 
-    variadic_index: tuple[bool, int] | None
-    """
-    Represents the position of a (single) variadic variable, with the boolean
-    representing whether it is optional
-    """
-
     def is_variadic_like(self) -> bool:
         return True
 
@@ -694,25 +695,24 @@ class OperandsOrResultDirective(TypeableDirective, ABC):
 
     def _set_using_variadic_index(
         self,
+        op_type: type[IRDLOperation],
         field: list[None | Sequence[_T]],
+        construct: VarIRConstruct,
         field_name: str,
         set_to: Sequence[_T],
-    ) -> str | None:
-        if self.variadic_index is None:
-            if len(set_to) != len(field):
-                return f"Expected {len(field)} {field_name} but found {len(set_to)}"
-            field[:] = ((x,) for x in set_to)
-            return
+    ) -> None:
+        op_def = op_type.get_irdl_definition()
+        verify_variadic_same_size(len(set_to), op_def, construct, field_name)
 
-        is_optional, var_position = self.variadic_index
-        var_length = len(set_to) - len(field) + 1
-        if var_length < 0:
-            return f"Expected at least {len(field) - 1} {field_name} but found {len(set_to)}"
-        if var_length > 1 and is_optional:
-            return f"Expected at most {len(field)} {field_name} but found {len(set_to)}"
-        field[:var_position] = ((x,) for x in set_to[:var_position])
-        field[var_position] = set_to[var_position : var_position + var_length]
-        field[var_position + 1 :] = ((x,) for x in set_to[var_position + var_length :])
+        for i, (name, _) in enumerate(get_construct_defs(op_def, construct)):
+            accessor = op_type.__dict__[name]
+            assert isinstance(accessor, BaseAccessor)
+            res = accessor.index(set_to)
+            if res is None:
+                res = ()
+            if not isinstance(res, Sequence):
+                res = (res,)
+            field[i] = res
 
 
 class OperandsDirective(OperandsOrResultDirective, FormatDirective):
@@ -722,9 +722,13 @@ class OperandsDirective(OperandsOrResultDirective, FormatDirective):
     Prints each operand of the operation, inserting a comma between each.
     """
 
-    def set_types(self, state: ParsingState, types: Sequence[Attribute]) -> str | None:
-        return self._set_using_variadic_index(
-            state.operand_types, "operand types", types
+    def set_types(self, state: ParsingState, types: Sequence[Attribute]) -> None:
+        self._set_using_variadic_index(
+            state.op_type,
+            state.operand_types,
+            VarIRConstruct.OPERAND,
+            "operand type",
+            types,
         )
 
     def parse(self, parser: Parser, state: ParsingState) -> bool:
@@ -737,8 +741,16 @@ class OperandsDirective(OperandsOrResultDirective, FormatDirective):
             or []
         )
 
-        if s := self._set_using_variadic_index(state.operands, "operands", operands):
-            parser.raise_error(s, at_position=pos_start, end_position=parser.pos)
+        try:
+            self._set_using_variadic_index(
+                state.op_type,
+                state.operands,
+                VarIRConstruct.OPERAND,
+                "operand",
+                operands,
+            )
+        except VerifyException as e:
+            parser.raise_error(str(e), at_position=pos_start, end_position=parser.pos)
         return bool(operands)
 
     def parse_types(self, parser: Parser, state: ParsingState) -> bool:
@@ -750,8 +762,10 @@ class OperandsDirective(OperandsOrResultDirective, FormatDirective):
             or []
         )
 
-        if s := self.set_types(state, types):
-            parser.raise_error(s, at_position=pos_start, end_position=parser.pos)
+        try:
+            self.set_types(state, types)
+        except VerifyException as e:
+            parser.raise_error(str(e), at_position=pos_start, end_position=parser.pos)
         return bool(types)
 
     def parse_single_type(self, parser: Parser, state: ParsingState) -> None:
@@ -855,8 +869,14 @@ class ResultsDirective(OperandsOrResultDirective):
     A typeable directive which processes the result types of the operation.
     """
 
-    def set_types(self, state: ParsingState, types: Sequence[Attribute]) -> str | None:
-        return self._set_using_variadic_index(state.result_types, "result types", types)
+    def set_types(self, state: ParsingState, types: Sequence[Attribute]) -> None:
+        self._set_using_variadic_index(
+            state.op_type,
+            state.result_types,
+            VarIRConstruct.RESULT,
+            "result type",
+            types,
+        )
 
     def parse_types(self, parser: Parser, state: ParsingState) -> bool:
         pos_start = parser.pos
@@ -867,8 +887,10 @@ class ResultsDirective(OperandsOrResultDirective):
             or []
         )
 
-        if s := self.set_types(state, types):
-            parser.raise_error(s, at_position=pos_start, end_position=parser.pos)
+        try:
+            self.set_types(state, types)
+        except VerifyException as e:
+            parser.raise_error(str(e), at_position=pos_start, end_position=parser.pos)
         return bool(types)
 
     def parse_single_type(self, parser: Parser, state: ParsingState) -> None:

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -774,7 +774,8 @@ class OperandsDirective(OperandsOrResultDirective, FormatDirective):
             parser.raise_error(s, at_position=pos_start, end_position=parser.pos)
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
-        state.print_whitespace(printer)
+        if op.operands:
+            state.print_whitespace(printer)
         printer.print_list(op.operands, printer.print_ssa_value)
 
     def get_types(self, op: IRDLOperation) -> Sequence[Attribute]:

--- a/xdsl/irdl/declarative_assembly_format_parser.py
+++ b/xdsl/irdl/declarative_assembly_format_parser.py
@@ -33,6 +33,8 @@ from xdsl.irdl import (
     OptSuccessorDef,
     ParamAttrConstraint,
     ParsePropInAttrDict,
+    SameVariadicOperandSize,
+    SameVariadicResultSize,
     VarConstraint,
     VariadicDef,
     VarOperandDef,
@@ -854,16 +856,14 @@ class FormatParser(BaseParser):
             for i, (_, o) in enumerate(self.op_def.operands)
             if isinstance(o, VariadicDef)
         )
-        if len(variadics) > 1:
+        if len(variadics) > 1 and SameVariadicOperandSize() not in self.op_def.options:
             self.raise_error("'operands' is ambiguous with multiple variadic operands")
         if not inside_ref:
             if not inside_type:
                 self.seen_operands = [True] * len(self.seen_operands)
             else:
                 self.seen_operand_types = [True] * len(self.seen_operand_types)
-        if not variadics:
-            return OperandsDirective(None)
-        return OperandsDirective(variadics[0])
+        return OperandsDirective()
 
     def create_results_directive(self, inside_ref: bool) -> ResultsDirective:
         """
@@ -881,10 +881,8 @@ class FormatParser(BaseParser):
             for i, (_, o) in enumerate(self.op_def.results)
             if isinstance(o, VarResultDef)
         )
-        if len(variadics) > 1:
+        if len(variadics) > 1 and SameVariadicResultSize() not in self.op_def.options:
             self.raise_error("'results' is ambiguous with multiple variadic results")
         if not inside_ref:
             self.seen_result_types = [True] * len(self.seen_result_types)
-        if not variadics:
-            return ResultsDirective(None)
-        return ResultsDirective(variadics[0])
+        return ResultsDirective()

--- a/xdsl/irdl/operations.py
+++ b/xdsl/irdl/operations.py
@@ -1240,12 +1240,11 @@ def get_construct_name(construct: VarIRConstruct) -> str:
             return "successor"
 
 
-def get_numbered_construct_name(number: int, construct: VarIRConstruct) -> str:
+def get_plural_name(number: int, name: str) -> str:
     """
-    Print a number followed by a construct name,
-    possibly making the construct name plural.
+    Print a number followed by a name, possibly making the name plural.
     """
-    return f"{number} {get_construct_name(construct)}{'' if number == 1 else 's'}"
+    return f"{number} {name}{'' if number == 1 else 's'}"
 
 
 def get_construct_defs(
@@ -1372,7 +1371,9 @@ def verify_variadic_attr_size(
             raise VerifyException(f"expected 1 value for {name}, but got {l}")
 
 
-def verify_variadic_same_size(length: int, op_def: OpDef, construct: VarIRConstruct):
+def verify_variadic_same_size(
+    length: int, op_def: OpDef, construct: VarIRConstruct, construct_name: str
+):
     """
     Verify the number of 'construct' is valid, assuming all variadics have the same size.
     """
@@ -1385,14 +1386,14 @@ def verify_variadic_same_size(length: int, op_def: OpDef, construct: VarIRConstr
     if not variadic_defs:
         if length != len(defs):
             raise VerifyException(
-                f"Expected {get_numbered_construct_name(len(defs), construct)}, but got {length}"
+                f"Expected {get_plural_name(len(defs), construct_name)}, but got {length}"
             )
 
     # If there is an optional argument they must all be empty or all be singletons
     elif has_optional:
         if length not in (len(defs), len(defs) - len(variadic_defs)):
             raise VerifyException(
-                f"Expected {len(defs) - len(variadic_defs)} or {len(defs)} {get_construct_name(construct)}s, but got {length}"
+                f"Expected {len(defs) - len(variadic_defs)} or {len(defs)} {construct_name}s, but got {length}"
             )
 
     # Otherwise they must all have the same size.
@@ -1400,13 +1401,13 @@ def verify_variadic_same_size(length: int, op_def: OpDef, construct: VarIRConstr
         # There must be enough arguments
         if length < len(defs) - len(variadic_defs):
             raise VerifyException(
-                f"Expected at least {get_numbered_construct_name(len(defs) - len(variadic_defs), construct)}, "
+                f"Expected at least {get_plural_name(len(defs) - len(variadic_defs), construct_name)}, "
                 f"but got {length}"
             )
         # And the (variadic) arguments must be able to be split evenly between the definitions.
         if (length - len(defs)) % len(variadic_defs):
             raise VerifyException(
-                f"Operation has {get_numbered_construct_name(length - len(defs) + len(variadic_defs), construct)} "
+                f"Operation has {get_plural_name(length - len(defs) + len(variadic_defs), construct_name)} "
                 f"for {len(variadic_defs)} variadic {get_construct_name(construct)}s marked as having the same size."
             )
 
@@ -1423,7 +1424,10 @@ def verify_variadic_size(op: Operation, op_def: OpDef, construct: VarIRConstruct
         verify_variadic_attr_size(op, op_def, construct, option)
     else:
         verify_variadic_same_size(
-            len(get_op_constructs(op, construct)), op_def, construct
+            len(get_op_constructs(op, construct)),
+            op_def,
+            construct,
+            get_construct_name(construct),
         )
 
 


### PR DESCRIPTION
Verifies the test from #4983 

All ended up a bit messier than I would have liked, an alternative could be to store Accessors in the `op_def`. I can probably also split this into multiple PRs

Probably needs a corresponding `operands` and `operand types` test.