### PR TITLE
dialects: (builtin) make IntegerType generic over width type

### DIFF
--- a/tests/test_pyrdl.py
+++ b/tests/test_pyrdl.py
@@ -8,7 +8,12 @@ from typing import Literal
 import pytest
 from typing_extensions import Self, TypeVar
 
-from xdsl.dialects.builtin import IntAttr, IntAttrConstraint
+from xdsl.dialects.builtin import (
+    IntAttr,
+    IntAttrConstraint,
+    IntegerType,
+    SignednessAttr,
+)
 from xdsl.ir import Attribute, Data, ParametrizedAttribute
 from xdsl.irdl import (
     AllOf,
@@ -431,6 +436,23 @@ def test_irdl_to_attr_constraint():
     )
     assert irdl_to_attr_constraint(IntAttr[2]) == IntAttrConstraint(
         int_constraint=EqIntConstraint(value=2)
+    )
+
+    assert irdl_to_attr_constraint(IntegerType) == BaseAttr(IntegerType)
+    assert irdl_to_attr_constraint(IntegerType[int]) == ParamAttrConstraint(
+        IntegerType,
+        (IntAttrConstraint(AnyInt()), BaseAttr(SignednessAttr)),
+    )
+    assert irdl_to_attr_constraint(IntegerType[32]) == ParamAttrConstraint(
+        IntegerType,
+        (IntAttrConstraint(EqIntConstraint(32)), BaseAttr(SignednessAttr)),
+    )
+    assert irdl_to_attr_constraint(IntegerType[Literal[32, 64]]) == ParamAttrConstraint(
+        IntegerType,
+        (
+            IntAttrConstraint(IntSetConstraint(frozenset((32, 64)))),
+            BaseAttr(SignednessAttr),
+        ),
     )
 
 

--- a/xdsl/backend/csl/print_csl.py
+++ b/xdsl/backend/csl/print_csl.py
@@ -389,12 +389,11 @@ class CslPrintContext:
             case IntegerType(width=IntAttr(1)):
                 return "bool"
             case IntegerType(
-                width=IntAttr(data=width),
                 signedness=SignednessAttr(data=Signedness.UNSIGNED),
             ):
-                return f"u{width}"
-            case IntegerType(width=IntAttr(data=width)):
-                return f"i{width}"
+                return f"u{cast(IntegerType, type_attr).width.data}"
+            case IntegerType():
+                return f"i{cast(IntegerType, type_attr).width.data}"
             case MemRefType(element_type=Attribute() as elem_t, shape=shape):
                 if any(dim.data == -1 for dim in shape):
                     raise ValueError(
@@ -440,9 +439,7 @@ class CslPrintContext:
         match attr:
             case IntAttr():
                 return str(cast(IntAttr[int], attr).data)
-            case IntegerAttr(
-                value=val, type=IntegerType(width=IntAttr(data=width))
-            ) if width == 1:
+            case IntegerAttr(value=val, type=IntegerType(width=IntAttr(data=1))):
                 return str(bool(val.data)).lower()
             case IntegerAttr(value=val):
                 return str(val.data)

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -54,6 +54,7 @@ from xdsl.traits import (
     Pure,
 )
 from xdsl.utils.exceptions import VerifyException
+from xdsl.utils.hints import isa
 from xdsl.utils.str_enum import StrEnum
 from xdsl.utils.type import get_element_type_or_self, have_compatible_shape
 
@@ -1319,8 +1320,7 @@ class TruncIOp(IRDLOperation):
         super().__init__(operands=[op], result_types=[target_type])
 
     def verify_(self) -> None:
-        assert isinstance(self.input.type, IntegerType)
-        assert isinstance(self.result.type, IntegerType)
+        assert isa(self.input.type, IntegerType)
         if not self.result.type.width.data < self.input.type.width.data:
             raise VerifyException(
                 "Destination bit-width must be smaller than the input bit-width"
@@ -1342,8 +1342,7 @@ class ExtSIOp(IRDLOperation):
         super().__init__(operands=[op], result_types=[target_type])
 
     def verify_(self) -> None:
-        assert isinstance(self.input.type, IntegerType)
-        assert isinstance(self.result.type, IntegerType)
+        assert isa(self.input.type, IntegerType)
         if not self.result.type.width.data > self.input.type.width.data:
             raise VerifyException(
                 "Destination bit-width must be larger than the input bit-width"
@@ -1363,8 +1362,7 @@ class ExtUIOp(IRDLOperation):
         super().__init__(operands=[op], result_types=[target_type])
 
     def verify_(self) -> None:
-        assert isinstance(self.input.type, IntegerType)
-        assert isinstance(self.result.type, IntegerType)
+        assert isa(self.input.type, IntegerType)
         if not self.result.type.width.data > self.input.type.width.data:
             raise VerifyException(
                 "Destination bit-width must be larger than the input bit-width"

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -593,15 +593,19 @@ Bitwidths: `<B`: 1-8, `<H`: 9-16, `<I`: 17-32, `<Q`: 33-64.
 
 @irdl_attr_definition
 class IntegerType(
-    ParametrizedAttribute, StructPackableType[int], FixedBitwidthType, BuiltinAttribute
+    Generic[IntCovT],
+    ParametrizedAttribute,
+    StructPackableType[int],
+    FixedBitwidthType,
+    BuiltinAttribute,
 ):
     name = "integer_type"
-    width: IntAttr
+    width: IntAttr[IntCovT]
     signedness: SignednessAttr
 
     def __init__(
         self,
-        data: int | IntAttr,
+        data: IntCovT | IntAttr[IntCovT],
         signedness: Signedness | SignednessAttr = Signedness.SIGNLESS,
     ) -> None:
         if isinstance(data, int):
@@ -888,13 +892,7 @@ class IntegerAttr(
 
     def print_builtin(self, printer: Printer) -> None:
         # boolean shorthands
-        if (
-            isinstance(
-                (ty := self.get_type()),
-                IntegerType,
-            )
-            and ty.width.data == 1
-        ):
+        if isa((ty := self.get_type()), IntegerType) and ty.width.data == 1:
             printer.print_string("true" if self.value.data else "false")
         else:
             self.print_without_type(printer)
@@ -912,7 +910,7 @@ class IntegerAttr(
         parser: AttrParser,
         type: Attribute,
     ) -> TypedAttribute:
-        assert isinstance(type, IntegerType | IndexType)
+        assert isa(type, IntegerType | IndexType)
         return IntegerAttr(parser.parse_integer(allow_boolean=(type == i1)), type)
 
     def print_without_type(self, printer: Printer):

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -892,7 +892,7 @@ class IntegerAttr(
 
     def print_builtin(self, printer: Printer) -> None:
         # boolean shorthands
-        if isa((ty := self.get_type()), IntegerType) and ty.width.data == 1:
+        if isa((ty := self.get_type()), IntegerType[1]):
             printer.print_string("true" if self.value.data else "false")
         else:
             self.print_without_type(printer)

--- a/xdsl/dialects/cf.py
+++ b/xdsl/dialects/cf.py
@@ -237,7 +237,7 @@ class SwitchOpCases(CustomDirective):
             flag_type = state.operand_types[self.flag.inner.index]
             assert flag_type is not None
             flag_type = flag_type[0]
-            assert isinstance(flag_type, IntegerType | IndexType)
+            assert isa(flag_type, IntegerType | IndexType)
             cases = parser.parse_comma_separated_list(
                 Parser.Delimiter.NONE, lambda: self._parse_case(parser)
             )

--- a/xdsl/dialects/comb.py
+++ b/xdsl/dialects/comb.py
@@ -35,6 +35,7 @@ from xdsl.irdl import (
 from xdsl.parser import Parser
 from xdsl.printer import Printer
 from xdsl.utils.exceptions import VerifyException
+from xdsl.utils.hints import isa
 
 ICMP_COMPARISON_OPERATIONS = [
     "eq",
@@ -416,7 +417,7 @@ class ExtractOp(IRDLOperation):
         )
 
     def verify_(self) -> None:
-        assert isinstance(self.input.type, IntegerType)
+        assert isa(self.input.type, IntegerType)
         assert isinstance(self.result.type, IntegerType)
         if (
             self.low_bit.value.data + self.result.type.width.data
@@ -440,7 +441,7 @@ class ExtractOp(IRDLOperation):
             parser.raise_error(
                 "expected exactly one input and exactly one output types"
             )
-        if not isinstance(result_type.outputs.data[0], IntegerType):
+        if not isa(result_type.outputs.data[0], IntegerType):
             parser.raise_error(
                 f"expected output to be an integer type, got '{result_type.outputs.data[0]}'"
             )
@@ -461,7 +462,7 @@ def _get_sum_of_int_width(int_types: Sequence[Attribute]) -> int | None:
     """
     sum_of_width = 0
     for typ in int_types:
-        if not isinstance(typ, IntegerType):
+        if not isa(typ, IntegerType):
             return None
         sum_of_width += typ.width.data
     return sum_of_width

--- a/xdsl/dialects/csl/csl.py
+++ b/xdsl/dialects/csl/csl.py
@@ -2042,7 +2042,7 @@ class SignednessCastOp(IRDLOperation):
         """
         if result_type is None:
             typ = op.results[0].type if isinstance(op, Operation) else op.type
-            assert isinstance(typ, IntegerType)
+            assert isa(typ, IntegerType)
             result_type = IntegerType(
                 typ.width,
                 (
@@ -2054,7 +2054,7 @@ class SignednessCastOp(IRDLOperation):
         super().__init__(operands=[op], result_types=[result_type])
 
     def verify_(self) -> None:
-        assert isinstance(self.inp.type, IntegerType)
+        assert isa(self.inp.type, IntegerType)
         assert isinstance(self.result.type, IntegerType)
         if self.inp.type.width != self.result.type.width:
             raise VerifyException("Input and output type must be of same bitwidth")

--- a/xdsl/dialects/emitc.py
+++ b/xdsl/dialects/emitc.py
@@ -20,7 +20,6 @@ from xdsl.dialects.builtin import (
     FloatAttr,
     IndexType,
     IntAttr,
-    IntAttrConstraint,
     IntegerAttr,
     IntegerType,
     ShapedType,
@@ -38,11 +37,10 @@ from xdsl.ir import (
 )
 from xdsl.irdl import (
     IRDLOperation,
-    ParamAttrConstraint,
     ParsePropInAttrDict,
-    get_int_constraint,
     irdl_attr_definition,
     irdl_op_definition,
+    irdl_to_attr_constraint,
     opt_prop_def,
     prop_def,
     var_operand_def,
@@ -216,14 +214,13 @@ class EmitC_SizeT(ParametrizedAttribute, TypeAttribute):
     name = "emitc.size_t"
 
 
-EmitCIntegerBitwidthConstr = get_int_constraint(Literal[1, 8, 16, 32, 64])
+EmitCIntegerType = IntegerType[Literal[1, 8, 16, 32, 64]]
 """
-Constraint for the bitwidth parameter of integer types supported by EmitC.
+Type for integer types supported by EmitC.
+See external [documentation](https://github.com/llvm/llvm-project/blob/main/mlir/lib/Dialect/EmitC/IR/EmitC.cpp#L96).
 """
 
-EmitCIntegerConstr = ParamAttrConstraint(
-    IntegerType, (IntAttrConstraint(EmitCIntegerBitwidthConstr), None)
-)
+EmitCIntegerTypeConstr = irdl_to_attr_constraint(EmitCIntegerType)
 """
 Constraint for integer types supported by EmitC.
 See external [documentation](https://github.com/llvm/llvm-project/blob/main/mlir/lib/Dialect/EmitC/IR/EmitC.cpp#L96).
@@ -262,7 +259,7 @@ def is_integer_index_or_opaque_type(
     See external [documentation](https://github.com/llvm/llvm-project/blob/main/mlir/lib/Dialect/EmitC/IR/EmitC.cpp#L112).
     """
     return (
-        EmitCIntegerConstr.verifies(type_attr)
+        EmitCIntegerTypeConstr.verifies(type_attr)
         or isinstance(type_attr, IndexType)
         or is_pointer_wide_type(type_attr)
     )
@@ -275,7 +272,7 @@ def is_supported_emitc_type(type_attr: Attribute) -> bool:
     """
     match type_attr:
         case IntegerType():
-            return EmitCIntegerConstr.verifies(type_attr)
+            return EmitCIntegerTypeConstr.verifies(cast(IntegerType, type_attr))
         case IndexType():
             return True
         case EmitC_OpaqueType():

--- a/xdsl/dialects/linalg.py
+++ b/xdsl/dialects/linalg.py
@@ -576,7 +576,7 @@ class NamedOperation(IRDLOperation, ABC):
                 element_type = op_type.get_element_type()
             else:  # int or float
                 element_type = op_type
-            assert isinstance(element_type, AnyFloat | IntegerType)
+            assert isa(element_type, AnyFloat | IntegerType)
             result.append(element_type)
 
         return result

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -753,7 +753,7 @@ class TruncOp(IntegerConversionOpOverflow):
     name = "llvm.trunc"
 
     def verify(self, verify_nested_ops: bool = True):
-        assert isinstance(self.arg.type, IntegerType)
+        assert isa(self.arg.type, IntegerType)
         assert isinstance(self.res.type, IntegerType)
         if self.arg.type.bitwidth <= self.res.type.bitwidth:
             raise VerifyException(
@@ -767,7 +767,7 @@ class ZExtOp(IntegerConversionOpNNeg):
     name = "llvm.zext"
 
     def verify(self, verify_nested_ops: bool = True):
-        assert isinstance(self.arg.type, IntegerType)
+        assert isa(self.arg.type, IntegerType)
         assert isinstance(self.res.type, IntegerType)
         if self.arg.type.bitwidth >= self.res.type.bitwidth:
             raise VerifyException(
@@ -781,7 +781,7 @@ class SExtOp(IntegerConversionOp):
     name = "llvm.sext"
 
     def verify(self, verify_nested_ops: bool = True):
-        assert isinstance(self.arg.type, IntegerType)
+        assert isa(self.arg.type, IntegerType)
         assert isinstance(self.res.type, IntegerType)
         if self.arg.type.bitwidth >= self.res.type.bitwidth:
             raise VerifyException(

--- a/xdsl/dialects/varith.py
+++ b/xdsl/dialects/varith.py
@@ -33,6 +33,7 @@ from xdsl.irdl import (
 from xdsl.parser import Parser
 from xdsl.printer import Printer
 from xdsl.traits import Pure
+from xdsl.utils.hints import isa
 
 integerOrFloatLike = ContainerOf(
     AnyOf(
@@ -128,7 +129,7 @@ class VarithSwitchOp(IRDLOperation):
         unresolved_flag = parser.parse_unresolved_operand()
         parser.parse_punctuation(":")
         flag_type = parser.parse_type()
-        assert isinstance(flag_type, IntegerType | IndexType)
+        assert isa(flag_type, IntegerType | IndexType)
         flag = parser.resolve_operand(unresolved_flag, flag_type)
         parser.parse_punctuation("->")
         return_type = parser.parse_type()

--- a/xdsl/irdl/attributes.py
+++ b/xdsl/irdl/attributes.py
@@ -62,6 +62,7 @@ from .constraints import (  # noqa: TID251
     EqIntConstraint,
     IntConstraint,
     IntSetConstraint,
+    IntTypeVarConstraint,
     ParamAttrConstraint,
     RangeConstraint,
     RangeOf,
@@ -647,6 +648,12 @@ def get_optional_int_constraint(arg: Any) -> IntConstraint | None:
                 for literal_arg in get_args(union_arg)
             )
             return IntSetConstraint(ints)
+
+    if (
+        isinstance(arg, TypeVar)
+        and (base := get_optional_int_constraint(arg.__bound__)) is not None
+    ):
+        return IntTypeVarConstraint(arg, base)
 
 
 def get_int_constraint(arg: "int | TypeForm[int]") -> IntConstraint:

--- a/xdsl/parser/attribute_parser.py
+++ b/xdsl/parser/attribute_parser.py
@@ -71,6 +71,7 @@ from xdsl.utils.bitwise_casts import (
     convert_u64_to_f64,
 )
 from xdsl.utils.exceptions import ParseError, VerifyException
+from xdsl.utils.hints import isa
 from xdsl.utils.lexer import Position, Span
 from xdsl.utils.mlir_lexer import MLIRTokenKind, StringLiteral
 
@@ -540,7 +541,7 @@ class AttrParser(BaseParser):
 
     def _parse_complex_attrs(self) -> ComplexType:
         element_type = self.parse_attribute()
-        if not isinstance(element_type, IntegerType | AnyFloat):
+        if not isa(element_type, IntegerType | AnyFloat):
             self.raise_error(
                 "Complex type must be parameterized by an integer or float type!"
             )
@@ -938,7 +939,7 @@ class AttrParser(BaseParser):
         pos = self.pos
         element_type = self.parse_attribute()
 
-        if not isinstance(element_type, IntegerType | AnyFloat):
+        if not isa(element_type, IntegerType | AnyFloat):
             self.raise_error(
                 "dense array element type must be an integer or floating point type",
                 pos,
@@ -1314,7 +1315,7 @@ class AttrParser(BaseParser):
                         )
             return FloatAttr(float(value), type)
 
-        if isinstance(type, IntegerType | IndexType):
+        if isa(type, IntegerType | IndexType):
             if isinstance(value, float):
                 self.raise_error("Floating point value is not valid for integer type.")
             return IntegerAttr(value, type)

--- a/xdsl/transforms/constant_fold_interp.py
+++ b/xdsl/transforms/constant_fold_interp.py
@@ -69,7 +69,7 @@ class ConstantFoldInterpPattern(RewritePattern):
     ) -> Operation | None:
         match (value, value_type):
             case int(), IntegerType():
-                attr = IntegerAttr(value, value_type)
+                attr = IntegerAttr(value, cast(IntegerType, value_type))
                 return arith.ConstantOp(attr)
             case _:
                 return None

--- a/xdsl/transforms/lower_csl_stencil.py
+++ b/xdsl/transforms/lower_csl_stencil.py
@@ -370,7 +370,7 @@ class FullStencilAccessImmediateReductionOptimization(RewritePattern):
         chunk_size = wrapper.get_program_param("chunk_size")
         new_ops: list[Operation]
         if wrapper.target.data != "wse2":
-            assert isinstance(pattern.type, IntegerType)
+            assert isa(pattern.type, IntegerType)
             one = arith.ConstantOp.from_int_and_width(1, pattern.type)
             pattern_m_one = arith.SubiOp(pattern, one)
             new_ops = [one, pattern_m_one]

--- a/xdsl/transforms/lower_mpi.py
+++ b/xdsl/transforms/lower_mpi.py
@@ -262,7 +262,7 @@ class _MPIToLLVMRewriteBase(RewritePattern, ABC):
             return self.info.MPI_FLOAT
         if isinstance(mpi_type, builtin.Float64Type):
             return self.info.MPI_DOUBLE
-        if isinstance(mpi_type, IntegerType):
+        if isa(mpi_type, IntegerType):
             width: int = mpi_type.width.data
             if mpi_type.signedness.data == Signedness.UNSIGNED:
                 # unsigned branch

--- a/xdsl/transforms/varith_transformations.py
+++ b/xdsl/transforms/varith_transformations.py
@@ -14,6 +14,7 @@ from xdsl.pattern_rewriter import (
     op_type_rewrite_pattern,
 )
 from xdsl.rewriter import InsertPoint
+from xdsl.utils.hints import isa
 from xdsl.utils.type import get_element_type_or_self
 
 # map the arith operation to the right varith op:
@@ -193,9 +194,7 @@ class FuseRepeatedAddArgsPattern(RewritePattern):
     def match_and_rewrite(self, op: varith.VarithAddOp, rewriter: PatternRewriter, /):
         elem_t = get_element_type_or_self(op.res.type)
 
-        assert isinstance(
-            elem_t, builtin.IntegerType | builtin.IndexType | builtin.AnyFloat
-        )
+        assert isa(elem_t, builtin.IntegerType | builtin.IndexType | builtin.AnyFloat)
 
         consts: list[arith.ConstantOp] = []
         fusions: list[Operation] = []


### PR DESCRIPTION
Also adds functionality to `get_optional_int_constraint` to construct a constraint from a TypeVar.

I updated the EmitC dialect as it's the only one that cares just about the bitwidth and not signedness.