### PR TITLE
misc: (Annotated) remove some easy uses

### DIFF
--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import textwrap
 from collections.abc import Callable
 from io import StringIO
-from typing import Annotated, ClassVar, Generic
+from typing import ClassVar, Generic
 
 import pytest
 from typing_extensions import TypeVar
@@ -746,7 +746,7 @@ def test_typed_attribute_variable(program: str, generic_program: str):
     class TypedAttributeOp(IRDLOperation):
         name = "test.typed_attr"
         attr = attr_def(IntegerAttr[I32])
-        float_attr = attr_def(FloatAttr[Annotated[Float64Type, Float64Type()]])
+        float_attr = attr_def(FloatAttr[Float64Type])
 
         assembly_format = "$attr $float_attr attr-dict"
 

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -866,18 +866,18 @@ class IntegerAttr(
 
     @overload
     def __init__(
-        self,
+        self: IntegerAttr[IntegerType[IntCovT, Literal[Signedness.SIGNLESS]]],
         value: int | IntAttr,
-        value_type: _IntegerAttrType,
+        value_type: IntCovT,
         *,
         truncate_bits: bool = False,
     ) -> None: ...
 
     @overload
     def __init__(
-        self: IntegerAttr[IntegerType[IntCovT, Literal[Signedness.SIGNLESS]]],
+        self,
         value: int | IntAttr,
-        value_type: IntCovT,
+        value_type: _IntegerAttrType,
         *,
         truncate_bits: bool = False,
     ) -> None: ...

--- a/xdsl/dialects/csl/csl.py
+++ b/xdsl/dialects/csl/csl.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 from abc import ABC
 from collections.abc import Sequence
 from dataclasses import KW_ONLY, dataclass, field
-from typing import Annotated, ClassVar, Literal, TypeAlias
+from typing import ClassVar, Literal, TypeAlias
 
 from xdsl.dialects import builtin
 from xdsl.dialects.builtin import (
@@ -408,15 +408,13 @@ class VarType(ParametrizedAttribute, TypeAttribute, ContainerType):
         return self.child_type
 
 
-ColorIdAttr: TypeAlias = IntegerAttr[
-    Annotated[
-        IntegerType,
-        eq(IntegerType(5, Signedness.UNSIGNED))
-        | eq(IntegerType(6, Signedness.UNSIGNED)),
-    ]
-]
+ColorId = IntegerType[Literal[5, 6], Signedness.UNSIGNED]
 
-QueueIdAttr: TypeAlias = IntegerAttr[Annotated[IntegerType, IntegerType(3)]]
+ColorIdAttr: TypeAlias = IntegerAttr[ColorId]
+
+I3 = IntegerType[3, Signedness.SIGNLESS]
+
+QueueIdAttr: TypeAlias = IntegerAttr[I3]
 
 ParamAttr: TypeAlias = FloatAttr | IntegerAttr
 
@@ -849,7 +847,7 @@ class TaskOp(_FuncBase):
             task_kind = TaskKindAttr(task_kind)
         if isinstance(id, int):
             id = IntegerAttr(
-                id, IntegerType(task_kind.get_color_bits(), Signedness.UNSIGNED)
+                id, ColorId(task_kind.get_color_bits(), Signedness.UNSIGNED)
             )
         if id is not None:
             assert id.type.width.data == task_kind.get_color_bits(), (
@@ -965,9 +963,7 @@ class ActivateOp(IRDLOperation):
         if isinstance(kind, TaskKind):
             kind = TaskKindAttr(kind)
         if isinstance(id, int):
-            id = IntegerAttr(
-                id, IntegerType(kind.get_color_bits(), Signedness.UNSIGNED)
-            )
+            id = IntegerAttr(id, ColorId(kind.get_color_bits(), Signedness.UNSIGNED))
 
         super().__init__(properties={"id": id, "kind": kind})
 

--- a/xdsl/dialects/stencil.py
+++ b/xdsl/dialects/stencil.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from itertools import pairwise
 from math import prod
 from operator import add, lt, neg
-from typing import Annotated, Generic, TypeAlias, cast
+from typing import Generic, TypeAlias, cast
 
 from typing_extensions import TypeVar
 
@@ -809,8 +809,8 @@ class CombineOp(IRDLOperation):
 
     name = "stencil.combine"
 
-    dim = attr_def(IntegerAttr[Annotated[IndexType, IndexType()]])
-    index = attr_def(IntegerAttr[Annotated[IndexType, IndexType()]])
+    dim = attr_def(IntegerAttr[IndexType])
+    index = attr_def(IntegerAttr[IndexType])
     lower = var_operand_def(TempType)
     upper = var_operand_def(TempType)
     lowerext = var_operand_def(TempType)
@@ -954,7 +954,7 @@ class IndexOp(IRDLOperation):
     """
 
     name = "stencil.index"
-    dim = attr_def(IntegerAttr[Annotated[IndexType, IndexType()]])
+    dim = attr_def(IntegerAttr[IndexType])
     offset = attr_def(IndexAttr)
     idx = result_def(builtin.IndexType())
 

--- a/xdsl/dialects/transform.py
+++ b/xdsl/dialects/transform.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from abc import ABC
 from collections.abc import Mapping, Sequence
-from typing import Annotated, TypeAlias
 
 from xdsl.dialects.builtin import (
     ArrayAttr,
@@ -34,7 +33,6 @@ from xdsl.ir import (
     TypeAttribute,
 )
 from xdsl.irdl import (
-    AnyOf,
     AttrSizedOperandSegments,
     IRDLOperation,
     ParsePropInAttrDict,
@@ -148,11 +146,6 @@ class FailurePropagationModeAttr(
     EnumAttribute[FailurePropagationModeType], TypeAttribute
 ):
     name = "transform.failures"
-
-
-AnyIntegerOrFailurePropagationModeAttr: TypeAlias = Annotated[
-    Attribute, AnyOf([IntegerType, FailurePropagationModeAttr])
-]
 
 
 @irdl_op_definition


### PR DESCRIPTION
Thought I'd start the effort towards deprecating `Annotated` now that the `In` stuff is merged