### PR TITLE
core: make `operation._successor_uses` public

### DIFF
--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -1157,12 +1157,12 @@ class Operation(_IRNode):
     def successors(self, new: Sequence[Block]):
         new = tuple(new)
         new_uses = tuple(Use(self, idx) for idx in range(len(new)))
-        for successor, use in zip(self._successors, self._successor_uses):
+        for successor, use in zip(self._successors, self.successor_uses):
             successor.remove_use(use)
         for successor, use in zip(new, new_uses):
             successor.add_use(use)
         self._successors = new
-        self._successor_uses = new_uses
+        self.successor_uses = new_uses
 
     def __post_init__(self):
         assert self.name != ""
@@ -2147,7 +2147,7 @@ class OpSuccessors(Sequence[Block]):
 
     def __setitem__(self, idx: int, successor: Block) -> None:
         successors = self._op._successors  # pyright: ignore[reportPrivateUsage]
-        successor_uses = self._op._successor_uses  # pyright: ignore[reportPrivateUsage]
+        successor_uses = self._op.successor_uses
         successors[idx].remove_use(successor_uses[idx])
         successor.add_use(successor_uses[idx])
         new_successors = (*successors[:idx], successor, *successors[idx + 1 :])

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -1027,7 +1027,7 @@ class Operation(_IRNode):
     This list should be empty for non-terminator operations.
     """
 
-    _successor_uses: tuple[Use, ...] = field(default=())
+    successor_uses: tuple[Use, ...] = field(default=())
     """
     The uses for each successor.
     They are stored separately from the successors to allow for more efficient

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -1027,7 +1027,7 @@ class Operation(_IRNode):
     This list should be empty for non-terminator operations.
     """
 
-    successor_uses: tuple[Use, ...] = field(default=())
+    _successor_uses: tuple[Use, ...] = field(default=())
     """
     The uses for each successor.
     They are stored separately from the successors to allow for more efficient
@@ -1157,12 +1157,16 @@ class Operation(_IRNode):
     def successors(self, new: Sequence[Block]):
         new = tuple(new)
         new_uses = tuple(Use(self, idx) for idx in range(len(new)))
-        for successor, use in zip(self._successors, self.successor_uses):
+        for successor, use in zip(self._successors, self._successor_uses):
             successor.remove_use(use)
         for successor, use in zip(new, new_uses):
             successor.add_use(use)
         self._successors = new
-        self.successor_uses = new_uses
+        self._successor_uses = new_uses
+
+    @property
+    def successor_uses(self) -> Sequence[Use]:
+        return self._successor_uses
 
     def __post_init__(self):
         assert self.name != ""

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -2151,7 +2151,7 @@ class OpSuccessors(Sequence[Block]):
 
     def __setitem__(self, idx: int, successor: Block) -> None:
         successors = self._op._successors  # pyright: ignore[reportPrivateUsage]
-        successor_uses = self._op.successor_uses
+        successor_uses = self._op._successor_uses  # pyright: ignore[reportPrivateUsage]
         successors[idx].remove_use(successor_uses[idx])
         successor.add_use(successor_uses[idx])
         new_successors = (*successors[:idx], successor, *successors[idx + 1 :])


### PR DESCRIPTION
context: https://github.com/xdslproject/xdsl/pull/4968#discussion_r2269571403
