### PR TITLE
CI: try adjusting renovate settings to fix dependency updating

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,6 +14,7 @@
   "nix": {
     "enabled": true
   },
+  "rangeStrategy": "replace",
   "lockFileMaintenance": {
     "enabled": true
   }


### PR DESCRIPTION
According to this comment this might be the setting we want to get both lockfile updates on direct dependencies and weekly transitive dependency updates: https://github.com/renovatebot/renovate/discussions/19285