### PR TITLE
dialects: (emitc) use EmitCArrayElementType in ArrayType

### DIFF
--- a/tests/filecheck/dialects/emitc/emitc_types_invalid.mlir
+++ b/tests/filecheck/dialects/emitc/emitc_types_invalid.mlir
@@ -9,28 +9,28 @@
 
 // -----
 
-// CHECK: EmitC array element type 'i0' is not a supported EmitC type.
+// CHECK: Invalid value 0, expected one of {32, 1, 64, 16, 8}
 "test.op"() {
   bad_type = !emitc.array<1xi0>>
 }: ()->()
 
 // -----
 
-// CHECK: EmitC array element type 'memref<1xi32>' is not a supported EmitC type.
+// CHECK: Unexpected attribute memref<1xi32>
 "test.op"() {
   bad_type = !emitc.array<1xmemref<1xi32>>
 }: ()->()
 
 // -----
 
-// CHECK: EmitC array element type cannot be another EmitC_ArrayType.
+// CHECK: Unexpected attribute !emitc.array<3xf32>
 "test.op"() {
   nested = !emitc.array<2x!emitc.array<3xf32>>
 }: ()->()
 
 // -----
 
-// CHECK: EmitC array element type 'tensor<1x!emitc.array<1xf32>>' is not a supported EmitC type.
+// CHECK: Unexpected attribute tensor<1x!emitc.array<1xf32>>
 "test.op"() {
   tensor_with_emitc_array = !emitc.array<1xtensor<1x!emitc.array<1xf32>>>
 }: ()->()
@@ -72,7 +72,7 @@
 
 // -----
 
-// CHECK: EmitC array element type '!emitc.lvalue<i32>' is not a supported EmitC type.
+// CHECK: Unexpected attribute !emitc.lvalue<i32>
 "test.op"() {
   lvalue_element_type = !emitc.array<4x!emitc.lvalue<i32>>
 }: ()->()
@@ -142,7 +142,7 @@
 
 // -----
 
-// CHECK: EmitC array element type 'f80' is not a supported EmitC type.
+// CHECK: Unexpected attribute f80
 "test.op"() {
   unsupported_f80 = !emitc.array<1xf80>
 }: ()->()

--- a/xdsl/dialects/emitc.py
+++ b/xdsl/dialects/emitc.py
@@ -29,7 +29,6 @@ from xdsl.dialects.builtin import (
 )
 from xdsl.ir import (
     Attribute,
-    AttributeCovT,
     Dialect,
     ParametrizedAttribute,
     SSAValue,
@@ -146,19 +145,19 @@ class EmitC_ArrayType(
     ParametrizedAttribute,
     TypeAttribute,
     ShapedType,
-    ContainerType[AttributeCovT],
+    ContainerType[EmitCArrayElementType],
 ):
     """EmitC array type"""
 
     name = "emitc.array"
 
     shape: ArrayAttr[IntAttr]
-    element_type: AttributeCovT
+    element_type: EmitCArrayElementType
 
     def __init__(
         self,
         shape: Iterable[int | IntAttr],
-        element_type: AttributeCovT,
+        element_type: EmitCArrayElementType,
     ):
         shape = ArrayAttr(
             [IntAttr(dim) if isinstance(dim, int) else dim for dim in shape]
@@ -175,26 +174,13 @@ class EmitC_ArrayType(
                     "EmitC array dimensions must have non-negative size"
                 )
 
-        element_type = self.get_element_type()
-
-        if isinstance(element_type, EmitC_ArrayType):
-            raise VerifyException(
-                "EmitC array element type cannot be another EmitC_ArrayType."
-            )
-
-        # Check that the element type is a supported EmitC type.
-        if not EmitCArrayElementTypeConstr.verifies(element_type):
-            raise VerifyException(
-                f"EmitC array element type '{element_type}' is not a supported EmitC type."
-            )
-
     def get_num_dims(self) -> int:
         return len(self.shape.data)
 
     def get_shape(self) -> tuple[int, ...]:
         return tuple(i.data for i in self.shape.data)
 
-    def get_element_type(self) -> AttributeCovT:
+    def get_element_type(self) -> EmitCArrayElementType:
         return self.element_type
 
     @classmethod


### PR DESCRIPTION
Was part of #5072, keeping it separate to investigate a type checker issue in test_emitc.py (ref [discussion](https://github.com/xdslproject/xdsl/pull/5072/commits/07a962200fb02b116dfd45779bac70f4c747790c#r2285734120))