### PR TITLE
API: add `ModulePass.apply_to_clone` helper

### DIFF
--- a/docs/marimo/eqsat.py
+++ b/docs/marimo/eqsat.py
@@ -1,6 +1,6 @@
 import marimo
 
-__generated_with = "0.14.11"
+__generated_with = "0.14.17"
 app = marimo.App(width="medium")
 
 with app.setup:
@@ -49,9 +49,7 @@ def _():
 def _(ctx, input_module):
     from xdsl.transforms.eqsat_create_eclasses import EqsatCreateEclassesPass
 
-    eclass_module = input_module.clone()
-
-    EqsatCreateEclassesPass().apply(ctx, eclass_module)
+    _, eclass_module = EqsatCreateEclassesPass().apply_to_clone(ctx, input_module)
 
     xmo.module_html(eclass_module)
     return (eclass_module,)
@@ -86,10 +84,8 @@ def _():
 def _(ctx, saturated_module):
     from xdsl.transforms.eqsat_add_costs import EqsatAddCostsPass
 
-    cost_module = saturated_module.clone()
-
     # Use a default cost since the resulting IR is currently recursive and we can't handle that
-    EqsatAddCostsPass(default=1000).apply(ctx, cost_module)
+    _, cost_module = EqsatAddCostsPass(default=1000).apply_to_clone(ctx, saturated_module)
 
     xmo.module_html(cost_module)
     return (cost_module,)
@@ -105,9 +101,7 @@ def _():
 def _(cost_module, ctx):
     from xdsl.transforms.eqsat_extract import EqsatExtractPass
 
-    extracted_module = cost_module.clone()
-
-    EqsatExtractPass().apply(ctx, extracted_module)
+    _, extracted_module = EqsatExtractPass().apply_to_clone(ctx, cost_module)
 
     xmo.module_html(extracted_module)
     return (extracted_module,)

--- a/xdsl/passes.py
+++ b/xdsl/passes.py
@@ -64,6 +64,18 @@ class ModulePass(ABC):
     @abstractmethod
     def apply(self, ctx: Context, op: builtin.ModuleOp) -> None: ...
 
+    def apply_to_clone(
+        self, ctx: Context, op: builtin.ModuleOp
+    ) -> tuple[Context, builtin.ModuleOp]:
+        """
+        Creates deep copies of the inputs, and returns the result of calling `apply` on
+        them.
+        """
+        ctx = ctx.clone()
+        op = op.clone()
+        self.apply(ctx, op)
+        return ctx, op
+
     @classmethod
     def from_pass_spec(cls, spec: PipelinePassSpec) -> Self:
         """
@@ -179,11 +191,9 @@ class ModulePass(ABC):
         Parametrizable passes should override this implementation to provide a full
         schedule space of transformations.
         """
-        cloned_module = module_op.clone()
-        cloned_ctx = ctx.clone()
         try:
             pass_instance = cls()
-            pass_instance.apply(cloned_ctx, cloned_module)
+            _, cloned_module = pass_instance.apply_to_clone(ctx, module_op)
             if module_op.is_structurally_equivalent(cloned_module):
                 return ()
         except Exception:


### PR DESCRIPTION
This bit of sugar helps in all contexts that need to track changes via assignment as opposed to deep mutation, such as marimo, gui, and exhaustive exploration of rewrites.