### PR TITLE
frontend: (pyast) handle parsing of indented code

### DIFF
--- a/tests/filecheck/frontend/dialects/func.py
+++ b/tests/filecheck/frontend/dialects/func.py
@@ -43,3 +43,19 @@ def f3(x: int) -> int:
 
 
 print(f3.module)
+
+try:
+    # CHECK:      func.func @f4(%{{.*}} : !bigint.bigint) -> !bigint.bigint {
+    # CHECK-NEXT:   symref.declare "x"
+    # CHECK-NEXT:   symref.update @x = %{{.*}} : !bigint.bigint
+    # CHECK-NEXT:   %{{.*}} = symref.fetch @x : !bigint.bigint
+    # CHECK-NEXT:   func.return %{{.*}} : !bigint.bigint
+    # CHECK-NEXT: }
+    @ctx.parse_program
+    def f4(x: int) -> int:
+        return x
+
+    print(f4.module)
+except Exception as e:
+    print(e)
+    exit(1)

--- a/xdsl/frontend/pyast/context.py
+++ b/xdsl/frontend/pyast/context.py
@@ -1,5 +1,6 @@
 import ast
 import functools
+import textwrap
 from collections.abc import Callable
 from contextlib import AbstractContextManager
 from dataclasses import dataclass, field
@@ -107,8 +108,12 @@ class PyASTContext:
         func_file = func_frame.f_code.co_filename
         func_globals = func_frame.f_globals
 
+        # Remove leading indentation from the source code to avoid parsing errors
+        source = getsource(func.__code__)
+        source = textwrap.dedent(source)
+
         # Retrieve the AST for the function body, without the decorator
-        func_ast = ast.parse(getsource(func.__code__)).body[0]
+        func_ast = ast.parse(source).body[0]
         assert isinstance(func_ast, ast.FunctionDef)
         assert func_ast.name == func.__name__
         assert len(func_ast.decorator_list) == 1


### PR DESCRIPTION
We currently don't support indented function definitions.