### PR TITLE
core: allow Literal enum cases in irdl_to_attr_constraint

### DIFF
--- a/tests/test_pyrdl.py
+++ b/tests/test_pyrdl.py
@@ -22,6 +22,7 @@ from xdsl.irdl import (
     AllOf,
     AnyAttr,
     AnyInt,
+    AnyOf,
     AttrConstraint,
     BaseAttr,
     ConstraintContext,
@@ -430,6 +431,15 @@ def test_irdl_to_attr_constraint():
     assert irdl_to_attr_constraint(TestEnum.A) == EqAttrConstraint(
         TestEnumAttr(TestEnum.A)
     )
+    assert irdl_to_attr_constraint(Literal[TestEnum.A]) == EqAttrConstraint(
+        TestEnumAttr(TestEnum.A)
+    )
+    assert irdl_to_attr_constraint(Literal[TestEnum.A, TestEnum.B]) == AnyOf(  # pyright: ignore[reportArgumentType]
+        (
+            EqAttrConstraint(TestEnumAttr(TestEnum.A)),
+            EqAttrConstraint(TestEnumAttr(TestEnum.B)),
+        )
+    )
     assert irdl_to_attr_constraint(IntAttr) == BaseAttr(IntAttr)
     assert irdl_to_attr_constraint(IntAttr[int]) == IntAttrConstraint(
         int_constraint=AnyInt()
@@ -519,6 +529,15 @@ def test_get_constraint():
     )
     assert get_constraint(TestEnum) == BaseAttr(TestEnumAttr)
     assert get_constraint(TestEnum.A) == EqAttrConstraint(TestEnumAttr(TestEnum.A))
+    assert get_constraint(Literal[TestEnum.A]) == EqAttrConstraint(
+        TestEnumAttr(TestEnum.A)
+    )
+    assert get_constraint(Literal[TestEnum.A, TestEnum.B]) == AnyOf(
+        (
+            EqAttrConstraint(TestEnumAttr(TestEnum.A)),
+            EqAttrConstraint(TestEnumAttr(TestEnum.B)),
+        )
+    )
 
     with pytest.raises(
         PyRDLTypeError, match="Unexpected irdl constraint: <class 'str'>"

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -728,26 +728,24 @@ class IntegerType(
         return f[format_index]
 
 
-i64 = IntegerType[64, Signedness.SIGNLESS](64)
-i32 = IntegerType[32, Signedness.SIGNLESS](32)
-i16 = IntegerType[16, Signedness.SIGNLESS](16)
-i8 = IntegerType[8, Signedness.SIGNLESS](8)
-i1 = IntegerType[1, Signedness.SIGNLESS](1)
-I64 = IntegerType[64, Signedness.SIGNLESS]
-I32 = IntegerType[32, Signedness.SIGNLESS]
-I16 = IntegerType[16, Signedness.SIGNLESS]
-I8 = IntegerType[8, Signedness.SIGNLESS]
-I1 = IntegerType[1, Signedness.SIGNLESS]
+I64: TypeAlias = IntegerType[Literal[64], Literal[Signedness.SIGNLESS]]
+I32: TypeAlias = IntegerType[Literal[32], Literal[Signedness.SIGNLESS]]
+I16: TypeAlias = IntegerType[Literal[16], Literal[Signedness.SIGNLESS]]
+I8: TypeAlias = IntegerType[Literal[8], Literal[Signedness.SIGNLESS]]
+I1: TypeAlias = IntegerType[Literal[1], Literal[Signedness.SIGNLESS]]
+i64: I64 = IntegerType(64)
+i32: I32 = IntegerType(32)
+i16: I16 = IntegerType(16)
+i8: I8 = IntegerType(8)
+i1: I1 = IntegerType(1)
 
 _IntegerTypeInvT = TypeVar("_IntegerTypeInvT", bound=IntegerType, default=IntegerType)
 
-SignlessIntegerConstraint = ParamAttrConstraint(
-    IntegerType, [IntAttr, SignednessAttr(Signedness.SIGNLESS)]
-)
-"""Type constraint for signless IntegerType."""
-
-AnySignlessIntegerType: TypeAlias = Annotated[IntegerType, SignlessIntegerConstraint]
+AnySignlessIntegerType: TypeAlias = IntegerType[int, Literal[Signedness.SIGNLESS]]
 """Type alias constrained to signless IntegerType."""
+
+SignlessIntegerConstraint = irdl_to_attr_constraint(AnySignlessIntegerType)
+"""Type constraint for signless IntegerType."""
 
 
 @irdl_attr_definition

--- a/xdsl/irdl/attributes.py
+++ b/xdsl/irdl/attributes.py
@@ -568,6 +568,12 @@ def irdl_to_attr_constraint(
         attr_data = cast(type[ConstraintConvertible[AttributeInvT]], irdl)
         return attr_data.base_constr()
 
+    if origin is Literal:
+        literal_args = get_args(irdl)
+        if len(literal_args) == 1:
+            return irdl_to_attr_constraint(literal_args[0])
+        return AnyOf(literal_args)
+
     # Better error messages for missing GenericData in Data definitions
     if isclass(origin) and issubclass(origin, Data):
         raise PyRDLTypeError(


### PR DESCRIPTION
Turns out that you need the TypeAlias annotation for Pyright to reason about the type as a type specifically. When I added the annotation it started complaining that the generic arguments are not `Literal`, which we actually didn't support for enum cases. This PR adds support for it and updates Builtin's `I_` types and values.