### PR TITLE
documentation: fix link to GETTING_STARTED.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ These may be useful for projects wanting to replicate the xDSL testing setup.
 
 ## Getting Started
 
-Check out the dedicated [Getting Started guide](https://xdsl.readthedocs.io/stable/) for a comprehensive tutorial.
+Check out the dedicated [Getting Started guide](https://xdsl.readthedocs.io/stable/)
+for a comprehensive tutorial.
 
 To get familiar with xDSL, we recommend starting with our Jupyter notebooks. The
 notebooks consist of examples and documentation concerning the core xDSL data

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ These may be useful for projects wanting to replicate the xDSL testing setup.
 
 ## Getting Started
 
-Check out the dedicated [Getting Started guide](GETTING_STARTED.md) for a comprehensive tutorial.
+Check out the dedicated [Getting Started guide](https://xdsl.readthedocs.io/stable/) for a comprehensive tutorial.
 
 To get familiar with xDSL, we recommend starting with our Jupyter notebooks. The
 notebooks consist of examples and documentation concerning the core xDSL data


### PR DESCRIPTION
Fixes #5101

We'll need to rewrite the Getting Started section and our website I think before the summer school, but this is a simple enough fix in the short term.