### PR TITLE
documentation: do not run micropip when not in emscripten

### DIFF
--- a/docs/marimo/expressions.py
+++ b/docs/marimo/expressions.py
@@ -6,10 +6,11 @@ app = marimo.App(width="medium")
 
 @app.cell
 async def _():
+    import sys
     import marimo as mo
 
     # Use the locally built xDSL wheel when running in Marimo
-    if mo.running_in_notebook():
+    if sys.platform == 'emscripten':
 
         # Get the current notebook URL, drop the 'blob' URL components that seem to be added,
         # and add the buildnumber that a makethedocs PR build seems to add. This allows to load


### PR DESCRIPTION
I previously tried to achieve this via `mo.running_in_notebook()`,
but this did still triggered the microscript call when running our
tests. The test `sys.platform == 'emscripten'` does not.

This fixes a bug introducd in https://github.com/xdslproject/xdsl/pull/5102.