### PR TITLE
documentation: make marimo location detection more robust

### DIFF
--- a/docs/marimo/expressions.py
+++ b/docs/marimo/expressions.py
@@ -18,10 +18,13 @@ async def _():
         def get_url():
             import re
             url = str(mo.notebook_location())[5:]
-            url = re.sub('([^/])/([a-f0-9-]+)', '\\1/', url, count=1)
+            print(f"DEBUG: notebook url (full): {url}")
+            url = re.sub('([^/])/([a-f0-9-]+-[a-f0-9-]+-[a-f0-9-]+-[a-f0-9-]+)', '\\1/', url, count=1)
             buildnumber = re.sub('.*--([0-9+]+).*', '\\1', url, count=1)
             if buildnumber != url:
                 url = url + buildnumber + "/"
+
+            print(f"DEBUG: notebook url (trimmed): {url}")
 
             return url
 


### PR DESCRIPTION
The 'https://xdsl.readthedocs.io/latest/marimo/expressions/' deployment broke, as we detected URLs that started with '/e' as a hash that had to be removed. To start to resolve this we (a) add debug printing and (b) try to make the hash detection a bit more robust.
