### PR TITLE
documentation: make mkdocs-marimo work on 'latest' branch

### DIFF
--- a/docs/marimo/expressions.py
+++ b/docs/marimo/expressions.py
@@ -26,6 +26,9 @@ async def _():
             if buildnumber != url:
                 url = url + buildnumber + "/"
 
+            if url == "https://xdsl.readthedocs.io/":
+                url = url + "latest/"
+
             print(f"DEBUG: notebook url (trimmed): {url}")
 
             return url


### PR DESCRIPTION
When the documentation is shipped to readthedocs.io, the wheel is either in the `latest/` or `stable/` branch, but it is currently unclear how to distinguish. As we currently look in `/` which is universally wrong, I change this to `latest/` hoping to fing a more principled soluation over the next weeks.