### PR TITLE
dialects: (pdl) add results to `pdl.apply_native_constraint`

### DIFF
--- a/tests/dialects/test_pdl.py
+++ b/tests/dialects/test_pdl.py
@@ -27,7 +27,7 @@ type_val, attr_val, val_val, op_val = block.args
 
 
 def test_build_anc():
-    anc = pdl.ApplyNativeConstraintOp("anc", [type_val])
+    anc = pdl.ApplyNativeConstraintOp("anc", [type_val], [])
 
     assert anc.constraint_name == StringAttr("anc")
     assert anc.args == (type_val,)

--- a/tests/interpreters/test_pdl_interpreter.py
+++ b/tests/interpreters/test_pdl_interpreter.py
@@ -47,7 +47,7 @@ def test_native_constraint():
     def pdl_module():
         with ImplicitBuilder(pdl.PatternOp(42, None).body):
             attr = pdl.AttributeOp().output
-            pdl.ApplyNativeConstraintOp("even_length_string", [attr])
+            pdl.ApplyNativeConstraintOp("even_length_string", [attr], [])
             op = pdl.OperationOp(
                 op_name=None,
                 attribute_value_names=ArrayAttr([StringAttr("attr")]),
@@ -486,7 +486,7 @@ def test_native_constraint_constant_parameter():
         with ImplicitBuilder(pdl.PatternOp(42, None).body):
             attr = pdl.AttributeOp().output
             four = pdl.AttributeOp(IntegerAttr(4, i32)).output
-            pdl.ApplyNativeConstraintOp("length_string", [attr, four])
+            pdl.ApplyNativeConstraintOp("length_string", [attr, four], [])
             op = pdl.OperationOp(
                 op_name=None,
                 attribute_value_names=ArrayAttr([StringAttr("attr")]),

--- a/xdsl/dialects/pdl.py
+++ b/xdsl/dialects/pdl.py
@@ -183,25 +183,23 @@ class ApplyNativeConstraintOp(IRDLOperation):
     name = "pdl.apply_native_constraint"
     constraint_name = prop_def(StringAttr, prop_name="name")
     args = var_operand_def(AnyPDLTypeConstr)
+    res = var_result_def(AnyPDLTypeConstr)
 
-    def __init__(self, name: str | StringAttr, args: Sequence[SSAValue]) -> None:
+    assembly_format = (
+        "$name (`(` $args^ `:` type($args) `)`)? (`:` type($res)^)? attr-dict"
+    )
+
+    def __init__(
+        self,
+        name: str | StringAttr,
+        args: Sequence[SSAValue],
+        result_types: Sequence[Attribute],
+    ) -> None:
         if isinstance(name, str):
             name = StringAttr(name)
-        super().__init__(operands=[args], properties={"name": name})
-
-    @classmethod
-    def parse(cls, parser: Parser) -> ApplyNativeConstraintOp:
-        name = parser.parse_str_literal()
-        parser.parse_punctuation("(")
-        operands = parse_operands_with_types(parser)
-        parser.parse_punctuation(")")
-        return ApplyNativeConstraintOp(name, operands)
-
-    def print(self, printer: Printer) -> None:
-        printer.print_string(" ")
-        printer.print_string_literal(self.constraint_name.data)
-        with printer.in_parens():
-            print_operands_with_types(printer, self.operands)
+        super().__init__(
+            result_types=[result_types], operands=[args], properties={"name": name}
+        )
 
 
 @irdl_op_definition


### PR DESCRIPTION
https://mlir.llvm.org/docs/Dialects/PDLOps/#pdlapply_native_constraint-pdlapplynativeconstraintop

I've also made a change to the type annotation for the `pdl.type` and `pdl.types` operations, to more closely match MLIR.
e.g. for `pdl.types`, MLIR has:
```
let arguments = (ins OptionalAttr<TypeArrayAttr>:$constantTypes);
```


I've also taken the opportunity to update the urls to external docs, as it seems like these changed.

If wanted I can of course split any of these changes in a separate pr if they are too disparate.
