### PR TITLE
core: (AnyOf) relax the disjointness condition

### DIFF
--- a/tests/irdl/test_attr_constraint.py
+++ b/tests/irdl/test_attr_constraint.py
@@ -81,23 +81,27 @@ class AttrD(Base):
     param: AttrA | AttrC
 
 
+class AttrE(ParametrizedAttribute):
+    name = "test.attr_e"
+
+
 @pytest.mark.parametrize(
     "constraint, expected",
     [
         (AnyAttr(), None),
         (EqAttrConstraint(AttrB(AttrA())), {AttrB}),
-        (BaseAttr(Base), None),
+        (BaseAttr(Base), {Base}),
         (BaseAttr(AttrA), {AttrA}),
         (EqAttrConstraint(AttrB(AttrA())) | BaseAttr(AttrA), {AttrA, AttrB}),
         (
             EqAttrConstraint(AttrD(AttrA())) | EqAttrConstraint(AttrD(AttrC())),
             {AttrD},
         ),
-        (AllOf((AnyAttr(), BaseAttr(Base))), None),
+        (AllOf((AnyAttr(), BaseAttr(Base))), {Base}),
         (AllOf((AnyAttr(), BaseAttr(AttrA))), {AttrA}),
         (ParamAttrConstraint(AttrB, [BaseAttr(AttrA)]), {AttrB}),
-        (ParamAttrConstraint(Base, [BaseAttr(AttrA)]), None),
-        (VarConstraint("T", BaseAttr(Base)), None),
+        (ParamAttrConstraint(Base, [BaseAttr(AttrA)]), {Base}),
+        (VarConstraint("T", BaseAttr(Base)), {Base}),
         (VarConstraint("T", BaseAttr(AttrA)), {AttrA}),
         (
             AllOf(
@@ -335,6 +339,10 @@ def test_any_of_overlapping(c1: AttrConstraint, c2: AttrConstraint, msg: str):
             BaseAttr(AttrA),
             BaseAttr(AttrC),
             EqAttrConstraint(AttrD(AttrC())),
+        ),
+        (
+            BaseAttr(Base),
+            BaseAttr(AttrE),
         ),
     ],
 )

--- a/xdsl/irdl/constraints.py
+++ b/xdsl/irdl/constraints.py
@@ -390,9 +390,7 @@ class BaseAttr(Generic[AttributeCovT], AttrConstraint[AttributeCovT]):
         return attr
 
     def get_bases(self) -> set[type[Attribute]] | None:
-        if is_runtime_final(self.attr):
-            return {self.attr}
-        return None
+        return {self.attr}
 
     def mapping_type_vars(
         self, type_var_mapping: Mapping[TypeVar, AttrConstraint | IntConstraint]
@@ -685,9 +683,7 @@ class ParamAttrConstraint(
         return attr
 
     def get_bases(self) -> set[type[Attribute]] | None:
-        if is_runtime_final(self.base_attr):
-            return {self.base_attr}
-        return None
+        return {self.base_attr}
 
     def mapping_type_vars(
         self, type_var_mapping: Mapping[TypeVar, AttrConstraint | IntConstraint]

--- a/xdsl/irdl/declarative_assembly_format_parser.py
+++ b/xdsl/irdl/declarative_assembly_format_parser.py
@@ -82,6 +82,7 @@ from xdsl.irdl.declarative_assembly_format import (
 from xdsl.parser import BaseParser, ParserState
 from xdsl.utils.lexer import Input
 from xdsl.utils.mlir_lexer import MLIRLexer, MLIRToken, MLIRTokenKind
+from xdsl.utils.runtime_final import is_runtime_final
 
 
 @dataclass
@@ -529,7 +530,13 @@ class FormatParser(BaseParser):
             is_optional = isinstance(attr_def, OptionalDef)
 
             bases = attr_def.constr.get_bases()
-            unique_base = bases.pop() if bases is not None and len(bases) == 1 else None
+            if bases is not None and len(bases) == 1:
+                unique_base = bases.pop()
+                if not is_runtime_final(unique_base):
+                    # Make sure abstract superclasses don't count as unique bases
+                    unique_base = None
+            else:
+                unique_base = None
 
             if qualified:
                 # Ensure qualified attributes stay qualified


### PR DESCRIPTION
This was one of the options for making `any_of` a bit more permissive. The downside of such an approach is that it gives you the opportunity to shoot yourself in the foot with interfaces (though tbh I can't think of a good example).

On the other hand it's likely to alleviate some of the pain points people have had with the current implementation.