### PR TITLE
documentation: use text_area in expression example

### DIFF
--- a/docs/marimo/expressions.py
+++ b/docs/marimo/expressions.py
@@ -56,7 +56,7 @@ def _(mo):
 
 @app.cell
 def _(mo):
-    expr_str = mo.ui.text(value = "1 + 2", debounce=False)
+    expr_str = mo.ui.text_area(value = "let c = 1 + 2;\nc + 3", rows = 10, full_width = True, debounce=False)
     expr_str
     return (expr_str,)
 


### PR DESCRIPTION
As list-lang meanwhile supports `let` and `;`, multi-line input is possible, and a text_area is consequently more appropriate.