### PR TITLE
transformations: (eqsat-extract) Remove assert for minimal e-node to have a cost

### DIFF
--- a/xdsl/transforms/eqsat_extract.py
+++ b/xdsl/transforms/eqsat_extract.py
@@ -26,10 +26,8 @@ def eqsat_extract(block: Block):
                         if isinstance(operand, OpResult)
                     )
                 if isinstance(min_cost_operand, OpResult):
-                    assert eqsat.EQSAT_COST_LABEL in min_cost_operand.op.attributes, (
-                        min_cost_operand.op
-                    )
-                    del min_cost_operand.op.attributes[eqsat.EQSAT_COST_LABEL]
+                    if eqsat.EQSAT_COST_LABEL in min_cost_operand.op.attributes:
+                        del min_cost_operand.op.attributes[eqsat.EQSAT_COST_LABEL]
                 Rewriter.replace_op(op, (), new_results=(min_cost_operand,))
             continue
 


### PR DESCRIPTION
With ILP extraction, we (currently) don't associate a cost to e-nodes, we only indicate which e-node is minimal at the e-class level.

