### PR TITLE
documentation: load xdsl for marimo released builds

### DIFF
--- a/docs/marimo/expressions.py
+++ b/docs/marimo/expressions.py
@@ -33,8 +33,8 @@ async def _():
 
             if buildnumber != url:
                 new_url = new_url + "/" + buildnumber + "/"
-            elif url == "https://xdsl.readthedocs.io/":
-                new_url = new_url + "/latest/"
+            elif netloc == "xdsl.readthedocs.io":
+                new_url = new_url + (path.split("/")[1])
 
             print(f"DEBUG: notebook url (trimmed): {new_url}")
 


### PR DESCRIPTION
The makethedocs releases carry the version as the first directory in the URL. Our xdsl wheel is in the directory after the version.
