### PR TITLE
documentation: fix 'path not defined' error in marimo build

### DIFF
--- a/docs/marimo/expressions.py
+++ b/docs/marimo/expressions.py
@@ -36,7 +36,7 @@ async def _():
             if buildnumber != url:
                 new_url = new_url + "/" + buildnumber + "/"
             elif netloc == "xdsl.readthedocs.io":
-                new_url = new_url + (path.split("/")[1])
+                new_url = new_url + "/" + (path.split("/")[1])
 
             print(f"DEBUG: notebook url (trimmed): {new_url}")
 


### PR DESCRIPTION
We forgot a '/' in the path.

