### PR TITLE
dialects: (builtin) Add default `AnyAttr` for `element_type` in `TensorType.constr`

### DIFF
--- a/tests/dialects/test_builtin.py
+++ b/tests/dialects/test_builtin.py
@@ -538,6 +538,12 @@ def test_DenseIntOrFPElementsAttr_values():
 
 
 def test_tensor_constr():
+    # No constraint
+    constr = TensorType.constr()
+    constr.verify(TensorType(i32, [1]), ConstraintContext())
+    constr.verify(TensorType(i32, [50, 1000, 2]), ConstraintContext())
+    constr.verify(TensorType(f64, [50]), ConstraintContext())
+
     # int32 constraint
     constr = TensorType.constr(i32)
     constr.verify(TensorType(i32, [1]), ConstraintContext())
@@ -571,8 +577,8 @@ def test_tensor_constr():
 
     # f64, no shape constraint
     constr = TensorType.constr(f64)
-    constr.verify(TensorType(i32, [50]), ConstraintContext())
-    constr.verify(TensorType(i32, [50, 1000, 2, 4, 10]), ConstraintContext())
+    constr.verify(TensorType(f64, [50]), ConstraintContext())
+    constr.verify(TensorType(f64, [50, 1000, 2, 4, 10]), ConstraintContext())
     with pytest.raises(VerifyException):
         constr.verify(TensorType(i32, [50]), ConstraintContext())
 

--- a/tests/dialects/test_builtin.py
+++ b/tests/dialects/test_builtin.py
@@ -569,6 +569,13 @@ def test_tensor_constr():
     with pytest.raises(VerifyException):
         constr.verify(TensorType(i64, [50, 1000]), ConstraintContext())
 
+    # f64, no shape constraint
+    constr = TensorType.constr(f64)
+    constr.verify(TensorType(i32, [50]), ConstraintContext())
+    constr.verify(TensorType(i32, [50, 1000, 2, 4, 10]), ConstraintContext())
+    with pytest.raises(VerifyException):
+        constr.verify(TensorType(i32, [50]), ConstraintContext())
+
 
 @pytest.mark.parametrize(
     "ref,expected",

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -1466,9 +1466,10 @@ class TensorType(
     ) -> AttrConstraint[TensorType[AttributeInvT]]:
         if element_type is None and shape is None:
             return BaseAttr[TensorType[AttributeInvT]](TensorType)
+        element_type_constr = AnyAttr() if element_type is None else element_type
         shape_constr = AnyAttr() if shape is None else shape
         return ParamAttrConstraint[TensorType[AttributeInvT]](
-            TensorType, (shape_constr, element_type, AnyAttr())
+            TensorType, (shape_constr, element_type_constr, AnyAttr())
         )
 
 


### PR DESCRIPTION
#5061 added a shape constraint to `TensorType.constr`, but the default constraint for the element type was left incomplete. The default `element_type` is `None`, but this should be normalized to `AnyAttr()`. This PR just makes that change.
