### PR TITLE
misc: use f16, f32, etc constants instead of inits

### DIFF
--- a/benchmarks/workloads.py
+++ b/benchmarks/workloads.py
@@ -7,11 +7,11 @@ from math import prod
 from xdsl.dialects.arith import AddfOp, AddiOp, ConstantOp
 from xdsl.dialects.builtin import (
     DenseIntOrFPElementsAttr,
-    Float32Type,
     FunctionType,
     IntegerAttr,
     ModuleOp,
     TensorType,
+    f32,
     i8,
     i32,
 )
@@ -155,7 +155,7 @@ class WorkloadBuilder:
         """
         assert num_add_ops >= 0
         random.seed(RANDOM_SEED)
-        tensor_type = TensorType(shape=tensor_shape, element_type=Float32Type())
+        tensor_type = TensorType(shape=tensor_shape, element_type=f32)
         function_type = FunctionType.from_lists(
             inputs=[tensor_type], outputs=[tensor_type]
         )

--- a/tests/dialects/test_arm_neon.py
+++ b/tests/dialects/test_arm_neon.py
@@ -6,7 +6,7 @@ from xdsl.dialects.arm_neon import (
     NEONRegisterType,
     VectorWithArrangement,
 )
-from xdsl.dialects.builtin import Float16Type, Float32Type, Float64Type, VectorType
+from xdsl.dialects.builtin import VectorType, f16, f32, f64
 
 
 def test_assembly_str_without_index():
@@ -24,20 +24,11 @@ def test_assembly_str_with_index():
 
 
 def test_arr_from_vec():
-    assert (
-        NeonArrangement.from_vec_type(VectorType(Float16Type(), [8]))
-        == NeonArrangement.H
-    )
-    assert (
-        NeonArrangement.from_vec_type(VectorType(Float32Type(), [4]))
-        == NeonArrangement.S
-    )
-    assert (
-        NeonArrangement.from_vec_type(VectorType(Float64Type(), [2]))
-        == NeonArrangement.D
-    )
+    assert NeonArrangement.from_vec_type(VectorType(f16, [8])) == NeonArrangement.H
+    assert NeonArrangement.from_vec_type(VectorType(f32, [4])) == NeonArrangement.S
+    assert NeonArrangement.from_vec_type(VectorType(f64, [2])) == NeonArrangement.D
 
     with pytest.raises(
         ValueError, match="Invalid vector type for ARM NEON: vector<3xf16>"
     ):
-        NeonArrangement.from_vec_type(VectorType(Float16Type(), [3]))
+        NeonArrangement.from_vec_type(VectorType(f16, [3]))

--- a/tests/dialects/test_builtin.py
+++ b/tests/dialects/test_builtin.py
@@ -11,18 +11,12 @@ from xdsl.dialects.builtin import (
     AnyFloat,
     ArrayAttr,
     ArrayOfConstraint,
-    BFloat16Type,
     BoolAttr,
     BytesAttr,
     ComplexType,
     ContainerOf,
     DenseArrayBase,
     DenseIntOrFPElementsAttr,
-    Float16Type,
-    Float32Type,
-    Float64Type,
-    Float80Type,
-    Float128Type,
     FloatAttr,
     IndexType,
     IntAttr,
@@ -41,9 +35,12 @@ from xdsl.dialects.builtin import (
     VectorBaseTypeConstraint,
     VectorRankConstraint,
     VectorType,
+    bf16,
     f16,
     f32,
     f64,
+    f80,
+    f128,
     i1,
     i8,
     i16,
@@ -68,24 +65,24 @@ from xdsl.utils.exceptions import VerifyException
 
 
 def test_FloatType_bitwidths():
-    assert BFloat16Type().bitwidth == 16
-    assert Float16Type().bitwidth == 16
-    assert Float32Type().bitwidth == 32
-    assert Float64Type().bitwidth == 64
-    assert Float80Type().bitwidth == 80
-    assert Float128Type().bitwidth == 128
+    assert bf16.bitwidth == 16
+    assert f16.bitwidth == 16
+    assert f32.bitwidth == 32
+    assert f64.bitwidth == 64
+    assert f80.bitwidth == 80
+    assert f128.bitwidth == 128
 
 
 def test_FloatType_formats():
     with pytest.raises(NotImplementedError):
-        BFloat16Type().format
-    assert Float16Type().format == "<e"
-    assert Float32Type().format == "<f"
-    assert Float64Type().format == "<d"
+        bf16.format
+    assert f16.format == "<e"
+    assert f32.format == "<f"
+    assert f64.format == "<d"
     with pytest.raises(NotImplementedError):
-        Float80Type().format
+        f80.format
     with pytest.raises(NotImplementedError):
-        Float128Type().format
+        f128.format
 
 
 def test_IntegerType_verifier():
@@ -148,9 +145,7 @@ def test_IntegerType_size():
     assert IntegerType(64).size == 8
 
 
-@pytest.mark.parametrize(
-    "elem_ty", [IntegerType(1), IntegerType(32), Float16Type(), Float32Type()]
-)
+@pytest.mark.parametrize("elem_ty", [IntegerType(1), IntegerType(32), f16, f32])
 def test_ComplexType_size(elem_ty: AnyFloat | IntegerType):
     assert ComplexType(elem_ty).size == elem_ty.size * 2
 

--- a/tests/dialects/test_csl.py
+++ b/tests/dialects/test_csl.py
@@ -1,11 +1,11 @@
 import pytest
 
-from xdsl.dialects.builtin import Float32Type, IntegerType, Signedness, TensorType
+from xdsl.dialects.builtin import IntegerType, Signedness, TensorType, f32
 from xdsl.dialects.csl import Add16Op, DsdKind, DsdType, GetMemDsdOp
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.test_value import create_ssa_value
 
-tensor = create_ssa_value(TensorType(Float32Type(), [4]))
+tensor = create_ssa_value(TensorType(f32, [4]))
 size_i32 = create_ssa_value(IntegerType(32, Signedness.SIGNED))
 dest_dsd = GetMemDsdOp(
     operands=[tensor, size_i32], result_types=[DsdType(DsdKind.mem1d_dsd)]

--- a/tests/dialects/test_dlti.py
+++ b/tests/dialects/test_dlti.py
@@ -5,10 +5,10 @@ import pytest
 
 from xdsl.dialects.builtin import (
     ArrayAttr,
-    Float32Type,
     FloatAttr,
     IntAttr,
     StringAttr,
+    f32,
     i32,
 )
 from xdsl.dialects.dlti import (
@@ -39,9 +39,9 @@ def test_data_layout_entry():
     assert entry.value == IntAttr(12)
 
     # Test passing string for key and float for value
-    entry = DataLayoutEntryAttr("test3", FloatAttr(99.45, Float32Type()))
+    entry = DataLayoutEntryAttr("test3", FloatAttr(99.45, f32))
     assert entry.key == StringAttr("test3")
-    assert entry.value == FloatAttr(99.45, Float32Type())
+    assert entry.value == FloatAttr(99.45, f32)
 
     # Test passing type for key and string for value
     entry = DataLayoutEntryAttr(i32, "test")
@@ -66,7 +66,7 @@ def test_incorrect_data_layout_entry():
     "entries",
     [
         [StringAttr("value1"), IntAttr(23), IntAttr(43)],
-        [IntAttr(23), FloatAttr(2.4, Float32Type())],
+        [IntAttr(23), FloatAttr(2.4, f32)],
     ],
 )
 def test_entry_maps(

--- a/tests/dialects/test_gpu.py
+++ b/tests/dialects/test_gpu.py
@@ -42,7 +42,7 @@ def test_dimension():
 
 
 def test_alloc():
-    memref_type = memref.MemRefType(builtin.Float32Type(), [10, 10, 10])
+    memref_type = memref.MemRefType(builtin.f32, [10, 10, 10])
     alloc = AllocOp(memref_type, is_async=True)
 
     assert isinstance(alloc, AllocOp)
@@ -53,7 +53,7 @@ def test_alloc():
     assert isinstance(alloc.asyncToken.type, AsyncTokenType)
     assert alloc.hostShared is None
 
-    dyn_type = memref.MemRefType(builtin.Float32Type(), [-1, -1, -1])
+    dyn_type = memref.MemRefType(builtin.f32, [-1, -1, -1])
     ten = arith.ConstantOp.from_int_and_width(10, builtin.IndexType())
     dynamic_sizes = [ten, ten, ten]
     token = alloc.asyncToken
@@ -136,7 +136,7 @@ def test_block_id():
 
 
 def test_dealloc():
-    memref_type = memref.MemRefType(builtin.Float32Type(), [10, 10, 10])
+    memref_type = memref.MemRefType(builtin.f32, [10, 10, 10])
     alloc = AllocOp(memref_type, is_async=True)
 
     assert alloc.asyncToken is not None  # For pyright
@@ -327,8 +327,8 @@ def test_launchfunc():
 
 
 def test_memcpy():
-    memref_type = memref.MemRefType(builtin.Float32Type(), [10, 10, 10])
-    host_alloc = memref.AllocOp.get(builtin.Float32Type(), 0, [10, 10, 10])
+    memref_type = memref.MemRefType(builtin.f32, [10, 10, 10])
+    host_alloc = memref.AllocOp.get(builtin.f32, 0, [10, 10, 10])
     alloc = AllocOp(memref_type, is_async=True)
 
     assert alloc.asyncToken is not None  # for Pyright

--- a/tests/filecheck/utils/codegen/simple.py
+++ b/tests/filecheck/utils/codegen/simple.py
@@ -3,13 +3,13 @@
 from xdsl.dialects.builtin import (
     AnyTensorTypeConstr,
     ComplexType,
-    Float32Type,
     IndexType,
     IntAttr,
     IntegerAttr,
     IntegerType,
     NoneType,
     Signedness,
+    f32,
 )
 from xdsl.irdl import (
     AllOf,
@@ -132,7 +132,7 @@ ops = [
                     OperandDef(EqAttrConstraint(IntegerType(8, Signedness.UNSIGNED))),
                 ),
                 ("d", OperandDef(EqAttrConstraint(IndexType()))),
-                ("e", OperandDef(EqAttrConstraint(Float32Type()))),
+                ("e", OperandDef(EqAttrConstraint(f32))),
                 ("f", OperandDef(EqAttrConstraint(NoneType()))),
                 ("v1", OperandDef(ParamAttrConstraint(ComplexType, (AnyAttr(),)))),
             ],

--- a/tests/interpreters/test_memref_stream_interpreter.py
+++ b/tests/interpreters/test_memref_stream_interpreter.py
@@ -5,12 +5,12 @@ from xdsl.dialects import arith, memref_stream
 from xdsl.dialects.builtin import (
     AffineMapAttr,
     ArrayAttr,
-    Float32Type,
     IndexType,
     IntAttr,
     IntegerAttr,
     MemRefType,
     ModuleOp,
+    f32,
     i32,
 )
 from xdsl.interpreter import Interpreter
@@ -183,8 +183,6 @@ def test_memref_stream_generic_imperfect_nesting():
     interpreter.register_implementations(MemRefStreamFunctions())
     interpreter.register_implementations(ArithFunctions())
 
-    f32 = Float32Type()
-
     op = memref_stream.GenericOp(
         (
             create_ssa_value(MemRefType(f32, [3, 2])),
@@ -234,8 +232,6 @@ def test_memref_stream_generic_reduction_with_initial_value():
     interpreter.register_implementations(MemRefStreamFunctions())
     interpreter.register_implementations(ArithFunctions())
 
-    f32 = Float32Type()
-
     op = memref_stream.GenericOp(
         (
             create_ssa_value(MemRefType(f32, [3, 2])),
@@ -284,8 +280,6 @@ def test_memref_stream_interleaved_reduction_with_initial_value():
     interpreter = Interpreter(ModuleOp([]))
     interpreter.register_implementations(MemRefStreamFunctions())
     interpreter.register_implementations(ArithFunctions())
-
-    f32 = Float32Type()
 
     op = memref_stream.GenericOp(
         (

--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -26,6 +26,7 @@ from xdsl.dialects.builtin import (
     StringAttr,
     SymbolNameConstraint,
     UnitAttr,
+    f32,
     i32,
 )
 from xdsl.dialects.test import Test, TestType
@@ -845,7 +846,7 @@ def test_dense_array_special_cases(program: str, generic_program: str, format: s
         i64s = opt_prop_def(DenseArrayBase[I64])
         f32s = prop_def(
             DenseArrayBase[Float32Type],
-            default_value=DenseArrayBase.from_list(Float32Type(), (9.0,)),
+            default_value=DenseArrayBase.from_list(f32, (9.0,)),
         )
         f64s = prop_def(
             VarConstraint("F64S", irdl_to_attr_constraint(DenseArrayBase[Float64Type]))

--- a/tests/test_rewriter.py
+++ b/tests/test_rewriter.py
@@ -6,7 +6,7 @@ import pytest
 from xdsl.context import Context
 from xdsl.dialects import test
 from xdsl.dialects.arith import AddiOp, Arith, ConstantOp
-from xdsl.dialects.builtin import Builtin, Float32Type, Float64Type, ModuleOp, i32, i64
+from xdsl.dialects.builtin import Builtin, ModuleOp, f32, f64, i32, i64
 from xdsl.ir import Block, Region
 from xdsl.parser import Parser
 from xdsl.printer import Printer
@@ -518,8 +518,8 @@ def test_inline_region_before():
     def transformation(module: ModuleOp, rewriter: Rewriter) -> None:
         region = Region(
             (
-                Block((test.TestOp(result_types=(Float32Type(),)),)),
-                Block((test.TestOp(result_types=(Float64Type(),)),)),
+                Block((test.TestOp(result_types=(f32,)),)),
+                Block((test.TestOp(result_types=(f64,)),)),
             )
         )
         rewriter.inline_region(region, BlockInsertPoint.before(module.body.blocks[1]))
@@ -552,8 +552,8 @@ def test_inline_region_after():
     def transformation(module: ModuleOp, rewriter: Rewriter) -> None:
         region = Region(
             (
-                Block((test.TestOp(result_types=(Float32Type(),)),)),
-                Block((test.TestOp(result_types=(Float64Type(),)),)),
+                Block((test.TestOp(result_types=(f32,)),)),
+                Block((test.TestOp(result_types=(f64,)),)),
             )
         )
         rewriter.inline_region(region, BlockInsertPoint.after(module.body.blocks[0]))
@@ -586,8 +586,8 @@ def test_inline_region_at_start():
     def transformation(module: ModuleOp, rewriter: Rewriter) -> None:
         region = Region(
             (
-                Block((test.TestOp(result_types=(Float32Type(),)),)),
-                Block((test.TestOp(result_types=(Float64Type(),)),)),
+                Block((test.TestOp(result_types=(f32,)),)),
+                Block((test.TestOp(result_types=(f64,)),)),
             )
         )
         rewriter.inline_region(region, BlockInsertPoint.at_start(module.body))
@@ -620,8 +620,8 @@ def test_inline_region_at_end():
     def transformation(module: ModuleOp, rewriter: Rewriter) -> None:
         region = Region(
             (
-                Block((test.TestOp(result_types=(Float32Type(),)),)),
-                Block((test.TestOp(result_types=(Float64Type(),)),)),
+                Block((test.TestOp(result_types=(f32,)),)),
+                Block((test.TestOp(result_types=(f64,)),)),
             )
         )
         rewriter.inline_region(region, BlockInsertPoint.at_end(module.body))

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -1133,15 +1133,15 @@ class FloatAttr(Generic[_FloatAttrType], BuiltinAttribute, TypedAttribute):
     ) -> None:
         if isinstance(type, int):
             if type == 16:
-                type = Float16Type()
+                type = f16
             elif type == 32:
-                type = Float32Type()
+                type = f32
             elif type == 64:
-                type = Float64Type()
+                type = f64
             elif type == 80:
-                type = Float80Type()
+                type = f80
             elif type == 128:
-                type = Float128Type()
+                type = f128
             else:
                 raise ValueError(f"Invalid bitwidth: {type}")
 

--- a/xdsl/dialects/csl/csl.py
+++ b/xdsl/dialects/csl/csl.py
@@ -34,6 +34,8 @@ from xdsl.dialects.builtin import (
     SymbolNameConstraint,
     SymbolRefAttr,
     TensorType,
+    f16,
+    f32,
     i8,
     i16,
 )
@@ -355,12 +357,8 @@ DsdElementTypeConstr = (
 )
 
 
-f16_pointer = PtrType(
-    Float16Type(), PtrKindAttr(PtrKind.SINGLE), PtrConstAttr(PtrConst.VAR)
-)
-f32_pointer = PtrType(
-    Float32Type(), PtrKindAttr(PtrKind.SINGLE), PtrConstAttr(PtrConst.VAR)
-)
+f16_pointer = PtrType(f16, PtrKindAttr(PtrKind.SINGLE), PtrConstAttr(PtrConst.VAR))
+f32_pointer = PtrType(f32, PtrKindAttr(PtrKind.SINGLE), PtrConstAttr(PtrConst.VAR))
 i8_value = IntegerType(8, Signedness.SIGNED)
 u16_value = IntegerType(16, Signedness.UNSIGNED)
 i16_value = IntegerType(16, Signedness.SIGNED)

--- a/xdsl/dialects/stim/ops.py
+++ b/xdsl/dialects/stim/ops.py
@@ -2,7 +2,7 @@ from abc import ABC
 from collections.abc import Sequence
 from io import StringIO
 
-from xdsl.dialects.builtin import ArrayAttr, Float64Type, FloatData, IntAttr
+from xdsl.dialects.builtin import ArrayAttr, FloatData, IntAttr, f64
 from xdsl.dialects.stim.stim_printer_parser import StimPrintable, StimPrinter
 from xdsl.ir import ParametrizedAttribute, Region, TypeAttribute
 from xdsl.irdl import (
@@ -109,7 +109,7 @@ class QubitMappingAttr(StimPrintable, ParametrizedAttribute):
                     self.coords,
                     lambda c: printer.print_int(c.data)
                     if isinstance(c, IntAttr)
-                    else printer.print_float(c.data, Float64Type()),
+                    else printer.print_float(c.data, f64),
                 )
             printer.print_string(", ")
             printer.print_attribute(self.qubit_name)

--- a/xdsl/interpreters/snitch_stream.py
+++ b/xdsl/interpreters/snitch_stream.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from xdsl.dialects import snitch_stream
+from xdsl.dialects.builtin import f64
 from xdsl.interpreter import (
     Interpreter,
     InterpreterFunctions,
@@ -23,7 +24,7 @@ class StridedPointerInputStream(ReadableStream[float]):
     def read(self) -> float:
         self.index += 1
         offset = next(self.offset_iter)
-        return ptr.TypedPtr((self.pointer + offset), xtype=ptr.float64)[0]
+        return ptr.TypedPtr((self.pointer + offset), xtype=f64)[0]
 
 
 @dataclass
@@ -35,7 +36,7 @@ class StridedPointerOutputStream(WritableStream[float]):
     def write(self, value: float) -> None:
         self.index += 1
         offset = next(self.offset_iter)
-        ptr.TypedPtr((self.pointer + offset), xtype=ptr.float64)[0] = value
+        ptr.TypedPtr((self.pointer + offset), xtype=f64)[0] = value
 
 
 @register_impls

--- a/xdsl/parser/attribute_parser.py
+++ b/xdsl/parser/attribute_parser.py
@@ -20,7 +20,6 @@ from xdsl.dialects.builtin import (
     AnyUnrankedTensorType,
     AnyVectorType,
     ArrayAttr,
-    BFloat16Type,
     BoolAttr,
     BytesAttr,
     ComplexType,
@@ -60,6 +59,8 @@ from xdsl.dialects.builtin import (
     UnrankedTensorType,
     UnregisteredAttr,
     VectorType,
+    bf16,
+    f64,
     i64,
 )
 from xdsl.ir import Attribute, Data, ParametrizedAttribute, TypeAttribute
@@ -1293,7 +1294,7 @@ class AttrParser(BaseParser):
         # If no types are given, we take the default ones
         if self._current_token.kind != MLIRTokenKind.COLON:
             if isinstance(value, float):
-                return FloatAttr(value, Float64Type())
+                return FloatAttr(value, f64)
             return IntegerAttr(value, i64)
 
         # Otherwise, we parse the attribute type
@@ -1458,7 +1459,7 @@ class AttrParser(BaseParser):
         # bf16 type
         if name == "bf16":
             self._consume_token()
-            return BFloat16Type()
+            return bf16
 
         # Float type
         if (re_match := self._builtin_float_type_regex.match(name)) is not None:

--- a/xdsl/transforms/csl_stencil_set_global_coeffs.py
+++ b/xdsl/transforms/csl_stencil_set_global_coeffs.py
@@ -2,12 +2,7 @@ from dataclasses import dataclass
 
 from xdsl.context import Context
 from xdsl.dialects import arith, memref, stencil
-from xdsl.dialects.builtin import (
-    DenseIntOrFPElementsAttr,
-    Float32Type,
-    IntegerAttr,
-    ModuleOp,
-)
+from xdsl.dialects.builtin import DenseIntOrFPElementsAttr, IntegerAttr, ModuleOp, f32
 from xdsl.dialects.csl import csl, csl_stencil, csl_wrapper
 from xdsl.ir import Operation
 from xdsl.passes import ModulePass
@@ -63,7 +58,6 @@ def get_dir_and_distance_ops(
 
 def get_coeff_api_ops(op: csl_stencil.ApplyOp, wrapper: csl_wrapper.ModuleOp):
     coeffs = list(op.coeffs or [])
-    elem_t = Float32Type()
     pattern = wrapper.get_param_value("pattern").value.data
     neighbours = pattern - 1
     is_wse2 = wrapper.target.data == "wse2"
@@ -87,7 +81,7 @@ def get_coeff_api_ops(op: csl_stencil.ApplyOp, wrapper: csl_wrapper.ModuleOp):
             distance -= 1
         cmap[direction][distance] = c.coeff.value.data
 
-    memref_t = memref.MemRefType(elem_t, shape)
+    memref_t = memref.MemRefType(f32, shape)
     ptr_t = csl.PtrType.get(memref_t, is_single=True, is_const=True)
 
     cnsts = {

--- a/xdsl/transforms/function_transformations.py
+++ b/xdsl/transforms/function_transformations.py
@@ -93,10 +93,8 @@ class TestAddBenchTimersToTopLevelFunctions(ModulePass):
         ):
             return
 
-        start_func_t = func.FunctionType.from_lists([], [builtin.Float64Type()])
-        end_func_t = func.FunctionType.from_lists(
-            [builtin.Float64Type()], [builtin.Float64Type()]
-        )
+        start_func_t = func.FunctionType.from_lists([], [builtin.f64])
+        end_func_t = func.FunctionType.from_lists([builtin.f64], [builtin.f64])
         start_func = func.FuncOp(TIMER_START, start_func_t, Region([]), "private")
         end_func = func.FuncOp(TIMER_END, end_func_t, Region([]), "private")
 

--- a/xdsl/transforms/linalg_to_csl.py
+++ b/xdsl/transforms/linalg_to_csl.py
@@ -1,11 +1,9 @@
 from dataclasses import dataclass
 
 from xdsl.context import Context
-from xdsl.dialects import arith, linalg
+from xdsl.dialects import arith, builtin, linalg
 from xdsl.dialects.builtin import (
     DenseIntOrFPElementsAttr,
-    Float16Type,
-    Float32Type,
     FloatAttr,
     IntegerAttr,
     MemRefType,
@@ -31,9 +29,9 @@ def match_op_for_precision(
     """Returns the op type matching a given precision."""
     # todo support mixed-precision
     match prec:
-        case Float16Type():
+        case builtin.f16:
             return f16
-        case Float32Type():
+        case builtin.f32:
             return f32
         case _:
             raise ValueError(f"Unsupported element type {prec}")

--- a/xdsl/transforms/lower_csl_stencil.py
+++ b/xdsl/transforms/lower_csl_stencil.py
@@ -15,6 +15,7 @@ from xdsl.dialects.builtin import (
     MemRefType,
     ModuleOp,
     UnrealizedConversionCastOp,
+    f32,
     i16,
 )
 from xdsl.dialects.csl import csl, csl_stencil, csl_wrapper
@@ -428,7 +429,7 @@ class FullStencilAccessImmediateReductionOptimization(RewritePattern):
             (elem_t := accumulator.type.get_element_type()), Float16Type | Float32Type
         )
         zero = arith.ConstantOp(FloatAttr(0.0, elem_t))
-        mov_op = csl.FmovsOp if elem_t == Float32Type() else csl.FmovhOp
+        mov_op = csl.FmovsOp if elem_t == f32 else csl.FmovhOp
         rewriter.insert_op(
             [zero, mov_op(operands=[[op.accumulator, zero]])], InsertPoint.before(op)
         )


### PR DESCRIPTION
Just find/replace throughout project, I think this is a small but strict improvement.