### PR TITLE
docs: Use `mo.md` instead of code editor for MLIR

### DIFF
--- a/docs/marimo/mlir_introduction.py
+++ b/docs/marimo/mlir_introduction.py
@@ -74,8 +74,8 @@ def _(Printer, mo):
         for op in module.ops:
             printer.print_op(op)
             printer.print_string("\n")
-    
-        return mo.ui.code_editor(language = "rust", value = output.getvalue()[:-1], disabled = True)
+
+        return mo.md("`"*3 + "mlir\n" + output.getvalue()[:-1] + "\n" + "`"*3)
 
     def compilation_output(code_editor: Any) -> mo.md:
         try:


### PR DESCRIPTION
`mo.ui.code_editor` doesn't support `mlir`, but `mo.md` does.
We need to use "`"*3 instead of "```" because otherwise the export fails