### PR TITLE
documentation: substitute xDSL wheel import when building marimo

### DIFF
--- a/docs/marimo/expressions.py
+++ b/docs/marimo/expressions.py
@@ -4,49 +4,15 @@ __generated_with = "0.15.0"
 app = marimo.App(width="medium")
 
 
-@app.cell
-async def _():
-    import sys
+@app.cell(hide_code=True)
+def _():
     import marimo as mo
-    import urllib
+    return mo
 
-    # Use the locally built xDSL wheel when running in Marimo
-    if sys.platform == 'emscripten':
+def _():
+    from xdsl.utils import marimo as xmo
+    return xmo
 
-        # Get the current notebook URL, drop the 'blob' URL components that seem to be added,
-        # and add the buildnumber that a makethedocs PR build seems to add. This allows to load
-        # the wheel both locally and when deployed to makethedocs. 
-        def get_url():
-            import re
-            url = str(mo.notebook_location()).replace("blob:", "")
-            print(f"DEBUG: notebook url (full): {url}")
-
-            url_parsed = urllib.parse.urlparse(url)
-            scheme = url_parsed.scheme
-            netloc = url_parsed.netloc
-            path = url_parsed.path
-
-            print(f"DEBUG: notebook url (parsed): {url_parsed}")
-
-            url = re.sub('([^/])/([a-f0-9-]+-[a-f0-9-]+-[a-f0-9-]+-[a-f0-9-]+)', '\\1/', url, count=1)
-            buildnumber = re.sub('.*--([0-9+]+).*', '\\1', url, count=1)
-
-            new_url = scheme + "://" + netloc
-
-            if buildnumber != url:
-                new_url = new_url + "/" + buildnumber + "/"
-            elif netloc == "xdsl.readthedocs.io":
-                new_url = new_url + "/" + (path.split("/")[1])
-
-            print(f"DEBUG: notebook url (trimmed): {new_url}")
-
-            return new_url
-
-        import micropip
-        await micropip.install("xdsl @ " + get_url() + "/xdsl-0.0.0-py3-none-any.whl")
-
-    from xdsl.printer import Printer
-    return (mo,)
 
 
 @app.cell(hide_code=True)

--- a/docs/marimo/mlir_introduction.py
+++ b/docs/marimo/mlir_introduction.py
@@ -5,52 +5,18 @@ app = marimo.App()
 
 
 @app.cell(hide_code=True)
-async def _():
-    import sys
+def _():
     import marimo as mo
-    import urllib
+    return mo
 
-    # Use the locally built xDSL wheel when running in Marimo
-    if sys.platform == 'emscripten':
 
-        # Get the current notebook URL, drop the 'blob' URL components that seem to be added,
-        # and add the buildnumber that a makethedocs PR build seems to add. This allows to load
-        # the wheel both locally and when deployed to makethedocs. 
-        def get_url():
-            import re
-            url = str(mo.notebook_location()).replace("blob:", "")
-            print(f"DEBUG: notebook url (full): {url}")
-
-            url_parsed = urllib.parse.urlparse(url)
-            scheme = url_parsed.scheme
-            netloc = url_parsed.netloc
-            path = url_parsed.path
-
-            print(f"DEBUG: notebook url (parsed): {url_parsed}")
-
-            url = re.sub('([^/])/([a-f0-9-]+-[a-f0-9-]+-[a-f0-9-]+-[a-f0-9-]+)', '\\1/', url, count=1)
-            buildnumber = re.sub('.*--([0-9+]+).*', '\\1', url, count=1)
-
-            new_url = scheme + "://" + netloc
-
-            if buildnumber != url:
-                new_url = new_url + "/" + buildnumber + "/"
-            elif netloc == "xdsl.readthedocs.io":
-                new_url = new_url + "/" + (path.split("/")[1])
-
-            print(f"DEBUG: notebook url (trimmed): {new_url}")
-
-            return new_url
-
-        import micropip
-        await micropip.install("xdsl @ " + get_url() + "/xdsl-0.0.0-py3-none-any.whl")
-
-    from xdsl.printer import Printer
-    return Printer, mo
+def _():
+    from xdsl.utils import marimo as xmo
+    return xmo
 
 
 @app.cell(hide_code=True)
-def _(Printer, mo):
+def _(mo):
     from typing import Any
     from io import StringIO
 
@@ -58,6 +24,7 @@ def _(Printer, mo):
     from xdsl.dialects import builtin
     from xdsl.builder import Builder, InsertPoint
     from xdsl.passes import PassPipeline
+    from xdsl.printer import Printer
     from xdsl.transforms import get_all_passes
     from xdsl.context import Context
     from xdsl.frontend.listlang.lowerings import LowerListToTensor
@@ -585,6 +552,7 @@ def _(mo, pass_editor8):
 def _(mo, outputs8, slider8):
     mo.vstack([*outputs8[slider8.value]])
     return
+
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ docs = [
     "mkdocstrings[python]>=0.27.0",
     "pymdown-extensions>=10.7",
     "riscemu==2.2.7",
+    "micropip>=0.7",
 ]
 
 [project.urls]

--- a/scripts/marimo_import_xdsl_wheel.py
+++ b/scripts/marimo_import_xdsl_wheel.py
@@ -1,0 +1,41 @@
+async def _():
+    # Get the current notebook URL, drop the 'blob' URL components that seem to be added,
+    # and add the buildnumber that a makethedocs PR build seems to add. This allows to load
+    # the wheel both locally and when deployed to makethedocs.
+    async def import_xdsl():
+        import re
+        from urllib.parse import urlparse
+
+        import micropip
+        from marimo import notebook_location
+
+        url = str(notebook_location()).replace("blob:", "")
+        print(f"DEBUG: notebook url (full): {url}")
+
+        url_parsed = urlparse(url)
+        scheme = url_parsed.scheme
+        netloc = url_parsed.netloc
+        path = url_parsed.path
+
+        print(f"DEBUG: notebook url (parsed): {url_parsed}")
+
+        url = re.sub(
+            "([^/])/([a-f0-9-]+-[a-f0-9-]+-[a-f0-9-]+-[a-f0-9-]+)", "\\1/", url, count=1
+        )
+        buildnumber = re.sub(".*--([0-9+]+).*", "\\1", url, count=1)
+
+        new_url = scheme + "://" + netloc
+
+        if buildnumber != url:
+            new_url = new_url + "/" + buildnumber + "/"
+        elif netloc == "xdsl.readthedocs.io":
+            new_url = new_url + "/" + (path.split("/")[1])
+
+        print(f"DEBUG: notebook url (trimmed): {new_url}")
+
+        await micropip.install("xdsl @ " + new_url + "/xdsl-0.0.0-py3-none-any.whl")
+
+    await import_xdsl()
+    from xdsl.utils import marimo as xmo
+
+    return xmo

--- a/uv.lock
+++ b/uv.lock
@@ -1430,6 +1430,46 @@ wheels = [
 ]
 
 [[package]]
+name = "micropip"
+version = "0.7.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.11.*'",
+    "python_full_version < '3.11'",
+]
+dependencies = [
+    { name = "packaging", marker = "python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f7/14/2801c64f5aff127521d16e574b87a7af93176ef0d488d8c1acce9d0d1641/micropip-0.7.2.tar.gz", hash = "sha256:e50f67efb5bdec33d4e5f6930206f8715e9a3c6f4006224c59fbc9def359960e", size = 1718933, upload-time = "2024-11-26T10:27:34.072Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/18/75709500db9e76e1191c410e6b19e04b7ba0fa9c51a188a7625b79f8caf7/micropip-0.7.2-py3-none-any.whl", hash = "sha256:d2b63ea316a2a9dcbfeadd4f855d8cec7d54f65b3849e638a7cc627e6d35e4d5", size = 46904, upload-time = "2024-11-26T10:27:32.976Z" },
+]
+
+[[package]]
+name = "micropip"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.12.*'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/6f/aeef5f7696480704c133206511ff785dd86b76b6eba77391d14de162c1ab/micropip-0.9.0.tar.gz", hash = "sha256:d72c3224537a14e5d9d02f29e945bf7cde02404ec744291e8f6a310cedf60b66", size = 1783814, upload-time = "2025-02-01T15:55:25.23Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/6d/195810e3e73e5f351dc6082cada41bb4d5b0746a6804155ba6bae4304612/micropip-0.9.0-py3-none-any.whl", hash = "sha256:babcf68c1849e229aa887564bc5f2de50273c3212e73c9aff8e3e6e80f2b6a23", size = 114896, upload-time = "2025-02-01T15:55:23.436Z" },
+]
+
+[[package]]
+name = "micropip"
+version = "0.10.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/f2/d4a2c5ab1fb78f31210c09faddf75f353b86250100f832354d9d9adfd6e6/micropip-0.10.1.tar.gz", hash = "sha256:f9f82234852818d4ca2973a8201af1be22fe51c92ad275e86a4170bd28467fff", size = 1785645, upload-time = "2025-07-05T12:29:39.689Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/79/3dda562c22b4978493adda6a7810f43b513b46cef82cbfd2aef48c3e29e0/micropip-0.10.1-py3-none-any.whl", hash = "sha256:126a501fecb40fc87f7edb67974a45f32db87e8ff3d932452aefbbcde27e53f5", size = 115174, upload-time = "2025-07-05T12:29:38.123Z" },
+]
+
+[[package]]
 name = "mistune"
 version = "3.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -3649,6 +3689,9 @@ dev = [
 ]
 docs = [
     { name = "lzstring2" },
+    { name = "micropip", version = "0.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "micropip", version = "0.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.12.*'" },
+    { name = "micropip", version = "0.10.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
     { name = "mkdocs" },
     { name = "mkdocs-awesome-nav" },
     { name = "mkdocs-gen-files" },
@@ -3704,6 +3747,7 @@ dev = [
 ]
 docs = [
     { name = "lzstring2", git = "https://github.com/superlopuh/lz-string.git" },
+    { name = "micropip", specifier = ">=0.7" },
     { name = "mkdocs", specifier = ">=1.6.1" },
     { name = "mkdocs-awesome-nav", specifier = ">=3.1.2" },
     { name = "mkdocs-gen-files", specifier = ">=0.5.0" },


### PR DESCRIPTION
Marimo has a pytest integration that breaks in the presence of async cells. In order to make the notebooks with pytest cells possible to run on the documentation website, we need to have all cells be non-`async`, which is not possible with micropip. This PR adds the async import only when building the notebook.

Currently requires that all notebooks contain exactly the following cell, which will be replaced with an async cell:

```python
def _():
    from xdsl.utils import marimo as xmo
    return xmo
```