### PR TITLE
CI: run code formatting with Python 3.13

### DIFF
--- a/.github/workflows/code-formatting.yml
+++ b/.github/workflows/code-formatting.yml
@@ -14,9 +14,6 @@ jobs:
   code-formatting:
 
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ['3.10']
 
     steps:
     - uses: actions/checkout@v5
@@ -27,10 +24,10 @@ jobs:
         enable-cache: true
         cache-dependency-glob: "uv.lock"
 
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python 3.13
       uses: actions/setup-python@v6
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: '3.13'
 
     - name: Run code formatting checks with pre-commit
       uses: pre-commit/action@v3.0.1


### PR DESCRIPTION
Feels like the latest ruff might have a discrepancy, and I'd rather stay consistent with the newest Python we support and not the oldest.