### PR TITLE
gui: fix empty line and alignment in gui input text box

### DIFF
--- a/xdsl/interactive/app.py
+++ b/xdsl/interactive/app.py
@@ -78,12 +78,11 @@ class InputApp(App[None]):
     A dictionary that maps names on to Screen objects.
     """
 
-    INITIAL_IR_TEXT = """
-        func.func @hello(%n : i32) -> i32 {
-          %two = arith.constant 0 : i32
-          %res = arith.addi %two, %n : i32
-          func.return %res : i32
-        }
+    INITIAL_IR_TEXT = """func.func @hello(%n : i32) -> i32 {
+    %two = arith.constant 0 : i32
+    %res = arith.addi %two, %n : i32
+    func.return %res : i32
+}
         """
 
     all_dialects: tuple[tuple[str, Callable[[], Dialect]], ...]


### PR DESCRIPTION
Fix empty line and alignment in gui input text box. This spacing misalignment has sincerely bothered me since the gui's birth. 

Before:
<img width="1190" height="418" alt="image" src="https://github.com/user-attachments/assets/702f14d5-5e84-4e9c-a79b-3ec29f5c1e2b" />

After:
<img width="1190" height="418" alt="image" src="https://github.com/user-attachments/assets/313bf2b3-3ece-40f1-aea4-0e641580c63a" />