### PR TITLE
documentation: show reference for class even if missing doc string

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,6 +57,7 @@ plugins:
           show_root_heading: true
           show_root_full_path: false
           show_signature_annotations: true
+          show_if_no_docstring: true
 - mkdocs-simple-hooks:
     hooks:
       on_post_build: "scripts.hooks:build_xdsl_wheel"


### PR DESCRIPTION
Either this was always broken or they recently changed the default. In either case now the scf dialect documentation works.