### PR TITLE
core: use Lexer token in spec parser

### DIFF
--- a/tests/test_pass_lexer.py
+++ b/tests/test_pass_lexer.py
@@ -3,11 +3,9 @@ import pytest
 from xdsl.utils.exceptions import PassPipelineParseError
 from xdsl.utils.parse_pipeline import (
     PipelineLexer,
-    Token,
+    SpecTokenKind,
     parse_pipeline,
 )
-
-Kind = Token.Kind
 
 generator = PipelineLexer._generator  # pyright: ignore[reportPrivateUsage]
 
@@ -20,16 +18,16 @@ def test_pass_lexer():
     )
 
     assert [t.kind for t in tokens] == [
-        Kind.IDENT, Kind.COMMA,  # pass-1,
-        Kind.IDENT, Kind.L_BRACE,  # pass-2{
-        Kind.IDENT, Kind.EQUALS, Kind.NUMBER, Kind.SPACE,  # arg1=1
-        Kind.IDENT, Kind.EQUALS, Kind.IDENT, Kind.SPACE,  # arg2=test
-        Kind.IDENT, Kind.EQUALS, Kind.STRING_LIT, Kind.SPACE,  # arg3="test-str"
-        Kind.IDENT, Kind.EQUALS, Kind.NUMBER, Kind.SPACE,  # arg-4=-34.4e-12
-        Kind.IDENT,  # no-val-arg
-        Kind.R_BRACE, Kind.COMMA,  # },
-        Kind.IDENT,  # pass-3
-        Kind.EOF,
+        SpecTokenKind.IDENT, SpecTokenKind.COMMA,  # pass-1,
+        SpecTokenKind.IDENT, SpecTokenKind.L_BRACE,  # pass-2{
+        SpecTokenKind.IDENT, SpecTokenKind.EQUALS, SpecTokenKind.NUMBER, SpecTokenKind.SPACE,  # arg1=1
+        SpecTokenKind.IDENT, SpecTokenKind.EQUALS, SpecTokenKind.IDENT, SpecTokenKind.SPACE,  # arg2=test
+        SpecTokenKind.IDENT, SpecTokenKind.EQUALS, SpecTokenKind.STRING_LIT, SpecTokenKind.SPACE,  # arg3="test-str"
+        SpecTokenKind.IDENT, SpecTokenKind.EQUALS, SpecTokenKind.NUMBER, SpecTokenKind.SPACE,  # arg-4=-34.4e-12
+        SpecTokenKind.IDENT,  # no-val-arg
+        SpecTokenKind.R_BRACE, SpecTokenKind.COMMA,  # },
+        SpecTokenKind.IDENT,  # pass-3
+        SpecTokenKind.EOF,
     ]  # fmt: skip
 
     assert tokens[-2].span.text == "pass-3"

--- a/xdsl/utils/exceptions.py
+++ b/xdsl/utils/exceptions.py
@@ -12,7 +12,7 @@ from typing import Any
 if typing.TYPE_CHECKING:
     from xdsl.ir import Attribute
     from xdsl.parser import Span
-    from xdsl.utils.parse_pipeline import Token
+    from xdsl.utils.parse_pipeline import SpecToken
 
 
 class UnregisteredConstructException(Exception):
@@ -138,7 +138,7 @@ class MultipleSpansParseError(ParseError):
 
 
 class PassPipelineParseError(BaseException):
-    def __init__(self, token: Token, msg: str):
+    def __init__(self, token: SpecToken, msg: str):
         super().__init__(
             "Error parsing pass pipeline specification:\n"
             + token.span.print_with_context(msg)


### PR DESCRIPTION
The Lexer Token and spec parser Token have the same fields but in a different order. 

This PR removes the last custom Token class, hopefully a non-controversial bit of cleanup.