### PR TITLE
core: add folding mechanism

### DIFF
--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -234,7 +234,7 @@ class SignlessIntegerBinaryOperation(IRDLOperation, HasFolderInterface, abc.ABC)
                 result = self.py_operation(lhs.value.data, rhs.value.data)
                 if result is not None:
                     return (IntegerAttr(result, lhs.type),)
-        if isa(rhs, IntegerAttr) and self.is_right_unit(rhs) == 0:
+        if isa(rhs, IntegerAttr) and self.is_right_unit(rhs):
             return (self.lhs,)
 
     def __init__(

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -229,17 +229,12 @@ class SignlessIntegerBinaryOperation(IRDLOperation, HasFolderInterface, abc.ABC)
         lhs = self.get_constant(self.lhs)
         rhs = self.get_constant(self.rhs)
         if lhs is not None and rhs is not None:
-            if isinstance(lhs, IntegerAttr) and isinstance(rhs, IntegerAttr):
-                lhs = cast(IntegerAttr, lhs)
-                rhs = cast(IntegerAttr, rhs)
+            if isa(lhs, IntegerAttr) and isa(rhs, IntegerAttr):
                 assert lhs.type == rhs.type
                 result = self.py_operation(lhs.value.data, rhs.value.data)
                 if result is not None:
                     return (IntegerAttr(result, lhs.type),)
-        if (
-            isinstance(rhs, IntegerAttr)
-            and self.is_right_unit(cast(IntegerAttr, rhs)) == 0
-        ):
+        if isa(rhs, IntegerAttr) and self.is_right_unit(rhs) == 0:
             return (self.lhs,)
 
     def __init__(
@@ -378,20 +373,6 @@ class AddiOp(SignlessIntegerBinaryOperationWithOverflow):
     @staticmethod
     def is_right_unit(attr: IntegerAttr) -> bool:
         return attr.value.data == 0
-
-    def fold(self):
-        lhs = self.get_constant(self.lhs)
-        rhs = self.get_constant(self.rhs)
-        if lhs is not None and rhs is not None:
-            if isinstance(lhs, IntegerAttr) and isinstance(rhs, IntegerAttr):
-                lhs = cast(IntegerAttr, lhs)
-                rhs = cast(IntegerAttr, rhs)
-                assert lhs.type == rhs.type
-                result = self.py_operation(lhs.value.data, rhs.value.data)
-                if result is not None:
-                    return (IntegerAttr(result, lhs.type),)
-        if isinstance(rhs, IntegerAttr) and self.is_right_unit(cast(IntegerAttr, rhs)):
-            return (self.lhs,)
 
 
 @irdl_op_definition

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -236,6 +236,10 @@ class SignlessIntegerBinaryOperation(IRDLOperation, HasFolderInterface, abc.ABC)
                     return (IntegerAttr(result, lhs.type),)
         if isa(rhs, IntegerAttr) and self.is_right_unit(rhs):
             return (self.lhs,)
+        if not self.has_trait(Commutative):
+            return None
+        if isa(lhs, IntegerAttr) and self.is_right_unit(lhs):
+            return (self.rhs,)
 
     def __init__(
         self,

--- a/xdsl/interfaces.py
+++ b/xdsl/interfaces.py
@@ -12,7 +12,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import cast
 
-from xdsl.ir import Attribute, Operation, OpResult, SSAValue
+from xdsl.ir import Attribute, Operation, SSAValue
 from xdsl.irdl import traits_def
 from xdsl.pattern_rewriter import RewritePattern
 from xdsl.traits import (
@@ -110,10 +110,10 @@ class HasFolderInterface(Operation, abc.ABC):
     traits = traits_def(_HasFolderInterfaceTrait())
 
     def get_constant(self, operand: SSAValue) -> Attribute | None:
-        if not isinstance(operand, OpResult):
-            return None
-        operand_op = operand.owner
-        if (t := operand_op.get_trait(ConstantLike)) is not None:
+        if (
+            isinstance(operand_op := operand.owner, Operation)
+            and (t := operand_op.get_trait(ConstantLike)) is not None
+        ):
             return t.get_constant_value(operand_op)
 
     @abc.abstractmethod

--- a/xdsl/interfaces.py
+++ b/xdsl/interfaces.py
@@ -122,8 +122,7 @@ class HasFolderInterface(Operation, abc.ABC):
         Attempts to fold the operation. The fold method cannot modify the IR.
         Returns either an existing SSAValue or an Attribute for each result of the operation.
         When folding is unsuccessful, returns None.
+
+        The fold method is not allowed to mutate the operation being folded.
         """
-        # TODO: should we support fold methods that mutate the operation?
-        #   That would require fold to return an additional flag
-        #   indicating whether the operation was modified?
         raise NotImplementedError()

--- a/xdsl/traits.py
+++ b/xdsl/traits.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import abc
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
 from dataclasses import dataclass, field
 from enum import Enum, auto
 from typing import TYPE_CHECKING
@@ -48,6 +48,22 @@ class ConstantLike(OpTrait, abc.ABC):
 
         Returns:
             The constant value as an Attribute, or None if the value cannot be determined.
+        """
+        raise NotImplementedError()
+
+
+class HasFolder(OpTrait):
+    """
+    Operation known to support folding.
+    """
+
+    @classmethod
+    @abc.abstractmethod
+    def fold(cls, op: Operation) -> Sequence[SSAValue | Attribute] | None:
+        """
+        Attempts to fold the operation. The fold method cannot modify the IR.
+        Returns either an existing SSAValue or an Attribute for each result of the operation.
+        When folding is unsuccessful, returns None.
         """
         raise NotImplementedError()
 


### PR DESCRIPTION
This pr includes
* a `HasFolderInterface` operation interface
* ~~a `get_constant_value` in the `ConstantLike` trait~~ (moved to #5233)
* ~~a `ConstantMaterializationInterface ` dialect interface~~ (moved to #5234)
* an implementation of folding for arith's SignlessIntegerBinaryOperation.

~~I'm opening this as a draft to check whether this seems like the right direction for a folding implementation. If it is, I can split this up in separate PRs.~~