### PR TITLE
core: add ConstantLikeInterface

### DIFF
--- a/tests/dialects/test_arith.py
+++ b/tests/dialects/test_arith.py
@@ -126,13 +126,18 @@ class Test_integer_arith_construction:
 def test_constant_construction():
     c1 = ConstantOp(IntegerAttr(1, i32))
     assert c1.value.type == i32
+    assert c1.get_constant_value() == IntegerAttr(1, i32)
 
     c3 = ConstantOp(FloatAttr(1.0, f32))
     assert c3.value.type == f32
+    assert c3.get_constant_value() == FloatAttr(1.0, f32)
 
     value_type = TensorType(i32, [2, 2])
     c5 = ConstantOp(DenseIntOrFPElementsAttr.from_list(value_type, [1, 2, 3, 4]))
     assert c5.value.type == value_type
+    assert c5.get_constant_value() == DenseIntOrFPElementsAttr.from_list(
+        value_type, [1, 2, 3, 4]
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/dialects/test_arith.py
+++ b/tests/dialects/test_arith.py
@@ -66,6 +66,7 @@ from xdsl.dialects.builtin import (
     i64,
 )
 from xdsl.ir import Attribute
+from xdsl.traits import ConstantLike
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.test_value import create_ssa_value
 
@@ -126,16 +127,22 @@ class Test_integer_arith_construction:
 def test_constant_construction():
     c1 = ConstantOp(IntegerAttr(1, i32))
     assert c1.value.type == i32
-    assert c1.get_constant_value() == IntegerAttr(1, i32)
+    constantlike1 = c1.get_trait(ConstantLike)
+    assert constantlike1 is not None
+    assert constantlike1.get_constant_value(c1) == IntegerAttr(1, i32)
 
     c3 = ConstantOp(FloatAttr(1.0, f32))
     assert c3.value.type == f32
-    assert c3.get_constant_value() == FloatAttr(1.0, f32)
+    constantlike3 = c3.get_trait(ConstantLike)
+    assert constantlike3 is not None
+    assert constantlike3.get_constant_value(c3) == FloatAttr(1.0, f32)
 
     value_type = TensorType(i32, [2, 2])
     c5 = ConstantOp(DenseIntOrFPElementsAttr.from_list(value_type, [1, 2, 3, 4]))
     assert c5.value.type == value_type
-    assert c5.get_constant_value() == DenseIntOrFPElementsAttr.from_list(
+    constantlike5 = c5.get_trait(ConstantLike)
+    assert constantlike5 is not None
+    assert constantlike5.get_constant_value(c5) == DenseIntOrFPElementsAttr.from_list(
         value_type, [1, 2, 3, 4]
     )
 

--- a/tests/dialects/test_complex.py
+++ b/tests/dialects/test_complex.py
@@ -1,0 +1,14 @@
+from xdsl.dialects import complex
+from xdsl.dialects.builtin import (
+    ArrayAttr,
+    IntAttr,
+    i32,
+)
+
+
+def test_constant_construction():
+    c1 = complex.ConstantOp(
+        value=ArrayAttr([IntAttr(42), IntAttr(43)]),
+        result_type=complex.ComplexType(i32),
+    )
+    assert c1.get_constant_value() == ArrayAttr([IntAttr(42), IntAttr(43)])

--- a/tests/dialects/test_complex.py
+++ b/tests/dialects/test_complex.py
@@ -4,6 +4,7 @@ from xdsl.dialects.builtin import (
     IntAttr,
     i32,
 )
+from xdsl.traits import ConstantLike
 
 
 def test_constant_construction():
@@ -11,4 +12,6 @@ def test_constant_construction():
         value=ArrayAttr([IntAttr(42), IntAttr(43)]),
         result_type=complex.ComplexType(i32),
     )
-    assert c1.get_constant_value() == ArrayAttr([IntAttr(42), IntAttr(43)])
+    constantlike = c1.get_trait(ConstantLike)
+    assert constantlike is not None
+    assert constantlike.get_constant_value(c1) == ArrayAttr([IntAttr(42), IntAttr(43)])

--- a/tests/dialects/test_riscv.py
+++ b/tests/dialects/test_riscv.py
@@ -277,6 +277,8 @@ def test_get_constant_value():
     li_op = riscv.LiOp(1)
     li_val = get_constant_value(li_op.rd)
     assert li_val == IntegerAttr.from_int_and_width(1, 32)
+    # LiOp implements ConstantLikeInterface so it also has a get_constant_value method:
+    assert li_op.get_constant_value() == IntegerAttr.from_int_and_width(1, 32)
     zero_op = riscv.GetRegisterOp(riscv.Registers.ZERO)
     zero_val = get_constant_value(zero_op.res)
     assert zero_val == IntegerAttr.from_int_and_width(0, 32)

--- a/tests/dialects/test_riscv.py
+++ b/tests/dialects/test_riscv.py
@@ -10,6 +10,7 @@ from xdsl.dialects.builtin import (
     i32,
 )
 from xdsl.parser import Parser
+from xdsl.traits import ConstantLike
 from xdsl.transforms.canonicalization_patterns.riscv import get_constant_value
 from xdsl.utils.exceptions import ParseError, VerifyException
 from xdsl.utils.test_value import create_ssa_value
@@ -278,7 +279,11 @@ def test_get_constant_value():
     li_val = get_constant_value(li_op.rd)
     assert li_val == IntegerAttr.from_int_and_width(1, 32)
     # LiOp implements ConstantLikeInterface so it also has a get_constant_value method:
-    assert li_op.get_constant_value() == IntegerAttr.from_int_and_width(1, 32)
+    constantlike = li_op.get_trait(ConstantLike)
+    assert constantlike is not None
+    assert constantlike.get_constant_value(li_op) == IntegerAttr.from_int_and_width(
+        1, 32
+    )
     zero_op = riscv.GetRegisterOp(riscv.Registers.ZERO)
     zero_val = get_constant_value(zero_op.res)
     assert zero_val == IntegerAttr.from_int_and_width(0, 32)

--- a/tests/dialects/test_smt.py
+++ b/tests/dialects/test_smt.py
@@ -43,6 +43,7 @@ from xdsl.dialects.smt import (
     YieldOp,
 )
 from xdsl.ir import Block, Region
+from xdsl.traits import ConstantLike
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.test_value import create_ssa_value
 
@@ -51,12 +52,16 @@ def test_constant_bool():
     op = ConstantBoolOp(True)
     assert op.value is True
     assert op.value_attr == IntegerAttr(-1, 1)
-    assert op.get_constant_value() == IntegerAttr(-1, 1)
+    constantlike = op.get_trait(ConstantLike)
+    assert constantlike is not None
+    assert constantlike.get_constant_value(op) == IntegerAttr(-1, 1)
 
     op = ConstantBoolOp(False)
     assert op.value is False
     assert op.value_attr == IntegerAttr(0, 1)
-    assert op.get_constant_value() == IntegerAttr(0, 1)
+    constantlike = op.get_trait(ConstantLike)
+    assert constantlike is not None
+    assert constantlike.get_constant_value(op) == IntegerAttr(0, 1)
 
 
 def test_bv_type():
@@ -184,17 +189,23 @@ def test_bv_constant_op():
     op = BvConstantOp(bv_attr)
     assert op.value == bv_attr
     assert op.result.type == BitVectorType(32)
-    assert op.get_constant_value() == bv_attr
+    constantlike = op.get_trait(ConstantLike)
+    assert constantlike is not None
+    assert constantlike.get_constant_value(op) == bv_attr
 
     op2 = BvConstantOp(42, 32)
     assert op2.value == bv_attr
     assert op2.result.type == BitVectorType(32)
-    assert op2.get_constant_value() == bv_attr
+    constantlike2 = op2.get_trait(ConstantLike)
+    assert constantlike2 is not None
+    assert constantlike2.get_constant_value(op2) == bv_attr
 
     op3 = BvConstantOp(42, BitVectorType(32))
     assert op3.value == bv_attr
     assert op3.result.type == BitVectorType(32)
-    assert op3.get_constant_value() == bv_attr
+    constantlike3 = op3.get_trait(ConstantLike)
+    assert constantlike3 is not None
+    assert constantlike3.get_constant_value(op3) == bv_attr
 
 
 @pytest.mark.parametrize("op_type", [BVNotOp, BVNegOp])

--- a/tests/dialects/test_smt.py
+++ b/tests/dialects/test_smt.py
@@ -51,10 +51,12 @@ def test_constant_bool():
     op = ConstantBoolOp(True)
     assert op.value is True
     assert op.value_attr == IntegerAttr(-1, 1)
+    assert op.get_constant_value() == IntegerAttr(-1, 1)
 
     op = ConstantBoolOp(False)
     assert op.value is False
     assert op.value_attr == IntegerAttr(0, 1)
+    assert op.get_constant_value() == IntegerAttr(0, 1)
 
 
 def test_bv_type():
@@ -182,14 +184,17 @@ def test_bv_constant_op():
     op = BvConstantOp(bv_attr)
     assert op.value == bv_attr
     assert op.result.type == BitVectorType(32)
+    assert op.get_constant_value() == bv_attr
 
     op2 = BvConstantOp(42, 32)
     assert op2.value == bv_attr
     assert op2.result.type == BitVectorType(32)
+    assert op2.get_constant_value() == bv_attr
 
     op3 = BvConstantOp(42, BitVectorType(32))
     assert op3.value == bv_attr
     assert op3.result.type == BitVectorType(32)
+    assert op3.get_constant_value() == bv_attr
 
 
 @pytest.mark.parametrize("op_type", [BVNotOp, BVNegOp])

--- a/tests/filecheck/utils/codegen/simple.py
+++ b/tests/filecheck/utils/codegen/simple.py
@@ -31,7 +31,6 @@ from xdsl.irdl import (
     traits_def,
 )
 from xdsl.traits import (
-    ConstantLike,
     Pure,
 )
 from xdsl.utils.dialect_codegen import dump_dialect_pyfile, generate_dynamic_attr_class
@@ -176,7 +175,7 @@ ops = [
         "Test_TraitsOp",
         OpDef(
             name="test.traits",
-            traits=traits_def(ConstantLike(), Pure()),
+            traits=traits_def(Pure()),
         ),
     ),
     (
@@ -306,7 +305,7 @@ dump_dialect_pyfile(
 # CHECK-NEXT:  class Test_TraitsOp(IRDLOperation):
 # CHECK-NEXT:      name = "test.traits"
 # CHECK-EMPTY:
-# CHECK-NEXT:      traits = traits_def(ConstantLike(), Pure())
+# CHECK-NEXT:      traits = traits_def(Pure())
 
 # CHECK:       @irdl_op_definition
 # CHECK-NEXT:  class Test_AttributesOp(IRDLOperation):

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -27,6 +27,7 @@ from xdsl.dialects.builtin import (
     VectorType,
 )
 from xdsl.dialects.utils import FastMathAttrBase, FastMathFlag
+from xdsl.interfaces import ConstantLikeInterface
 from xdsl.ir import Attribute, BitEnumAttribute, Dialect, Operation, SSAValue
 from xdsl.irdl import (
     AnyAttr,
@@ -48,7 +49,6 @@ from xdsl.printer import Printer
 from xdsl.traits import (
     Commutative,
     ConditionallySpeculatable,
-    ConstantLike,
     HasCanonicalizationPatternsTrait,
     NoMemoryEffect,
     Pure,
@@ -128,7 +128,7 @@ class IntegerOverflowAttr(BitEnumAttribute[IntegerOverflowFlag]):
 
 
 @irdl_op_definition
-class ConstantOp(IRDLOperation):
+class ConstantOp(IRDLOperation, ConstantLikeInterface):
     name = "arith.constant"
     _T: ClassVar = VarConstraint("T", AnyAttr())
     result = result_def(_T)
@@ -139,7 +139,7 @@ class ConstantOp(IRDLOperation):
         | ParamAttrConstraint(DenseResourceAttr, (AnyAttr(), _T))
     )
 
-    traits = traits_def(ConstantLike(), Pure())
+    traits = traits_def(Pure())
 
     assembly_format = "attr-dict $value"
 
@@ -170,6 +170,9 @@ class ConstantOp(IRDLOperation):
                 "value": IntegerAttr(value, value_type, truncate_bits=truncate_bits)
             },
         )
+
+    def get_constant_value(self) -> Attribute:
+        return self.value
 
 
 class SignlessIntegerBinaryOperation(IRDLOperation, abc.ABC):

--- a/xdsl/dialects/complex.py
+++ b/xdsl/dialects/complex.py
@@ -16,6 +16,7 @@ from xdsl.dialects.builtin import (
     IntegerType,
     ParamAttrConstraint,
 )
+from xdsl.interfaces import ConstantLikeInterface
 from xdsl.ir import Attribute, Dialect, Operation, SSAValue
 from xdsl.irdl import (
     AnyOf,
@@ -30,7 +31,7 @@ from xdsl.irdl import (
     result_def,
     traits_def,
 )
-from xdsl.traits import ConstantLike, Pure
+from xdsl.traits import Pure
 from xdsl.utils.exceptions import VerifyException
 
 ComplexTypeConstr = ComplexType.constr(AnyFloat)
@@ -185,7 +186,7 @@ class ConjOp(ComplexUnaryComplexResultOperation):
 
 
 @irdl_op_definition
-class ConstantOp(IRDLOperation):
+class ConstantOp(IRDLOperation, ConstantLikeInterface):
     name = "complex.constant"
     T: ClassVar = VarConstraint("T", AnyFloatConstr | base(IntegerType))
     value = prop_def(
@@ -205,12 +206,15 @@ class ConstantOp(IRDLOperation):
     # have any complex result type, not just floating point:
     complex = result_def(ComplexType.constr(T))
 
-    traits = traits_def(Pure(), ConstantLike())
+    traits = traits_def(Pure())
 
     assembly_format = "$value attr-dict `:` type($complex)"
 
     def __init__(self, value: ArrayAttr, result_type: ComplexType):
         super().__init__(properties={"value": value}, result_types=[result_type])
+
+    def get_constant_value(self) -> Attribute:
+        return self.value
 
 
 @irdl_op_definition

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -30,6 +30,7 @@ from xdsl.dialects.builtin import (
     i32,
 )
 from xdsl.dialects.utils import FastMathAttrBase, FastMathFlag
+from xdsl.interfaces import ConstantLikeInterface
 from xdsl.ir import (
     Attribute,
     Block,
@@ -57,7 +58,6 @@ from xdsl.parser import AttrParser, Parser, UnresolvedOperand
 from xdsl.pattern_rewriter import RewritePattern
 from xdsl.printer import Printer
 from xdsl.traits import (
-    ConstantLike,
     HasCanonicalizationPatternsTrait,
     IsolatedFromAbove,
     IsTerminator,
@@ -3361,7 +3361,7 @@ class LiOpHasCanonicalizationPatternTrait(HasCanonicalizationPatternsTrait):
 
 
 @irdl_op_definition
-class LiOp(RISCVCustomFormatOperation, RISCVInstruction, ABC):
+class LiOp(RISCVCustomFormatOperation, RISCVInstruction, ConstantLikeInterface, ABC):
     """
     Loads a 32-bit immediate into rd.
 
@@ -3375,7 +3375,7 @@ class LiOp(RISCVCustomFormatOperation, RISCVInstruction, ABC):
     rd = result_def(IntRegisterType)
     immediate = attr_def(base(Imm32Attr) | base(LabelAttr))
 
-    traits = traits_def(Pure(), ConstantLike(), LiOpHasCanonicalizationPatternTrait())
+    traits = traits_def(Pure(), LiOpHasCanonicalizationPatternTrait())
 
     def __init__(
         self,
@@ -3401,6 +3401,9 @@ class LiOp(RISCVCustomFormatOperation, RISCVInstruction, ABC):
 
     def assembly_line_args(self) -> tuple[AssemblyInstructionArg, ...]:
         return self.rd, self.immediate
+
+    def get_constant_value(self):
+        return self.immediate
 
     @classmethod
     def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:

--- a/xdsl/dialects/smt.py
+++ b/xdsl/dialects/smt.py
@@ -7,6 +7,7 @@ from typing import ClassVar, TypeAlias, overload
 from typing_extensions import Self
 
 from xdsl.dialects.builtin import ArrayAttr, BoolAttr, IntAttr, StringAttr
+from xdsl.interfaces import ConstantLikeInterface
 from xdsl.ir import (
     Attribute,
     Dialect,
@@ -40,7 +41,7 @@ from xdsl.irdl import (
 )
 from xdsl.parser import AttrParser, Parser
 from xdsl.printer import Printer
-from xdsl.traits import ConstantLike, HasParent, IsTerminator, Pure
+from xdsl.traits import HasParent, IsTerminator, Pure
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.hints import isa
 
@@ -264,7 +265,7 @@ class ApplyFuncOp(IRDLOperation):
 
 
 @irdl_op_definition
-class ConstantBoolOp(IRDLOperation):
+class ConstantBoolOp(IRDLOperation, ConstantLikeInterface):
     """
     This operation represents a constant boolean value. The semantics are
     equivalent to the ‘true’ and ‘false’ keywords in the Core theory of the
@@ -276,7 +277,7 @@ class ConstantBoolOp(IRDLOperation):
     value_attr = prop_def(BoolAttr, prop_name="value")
     result = result_def(BoolType())
 
-    traits = traits_def(Pure(), ConstantLike())
+    traits = traits_def(Pure())
 
     assembly_format = "qualified($value) attr-dict"
 
@@ -287,6 +288,9 @@ class ConstantBoolOp(IRDLOperation):
     @property
     def value(self) -> bool:
         return bool(self.value_attr)
+
+    def get_constant_value(self) -> Attribute:
+        return self.value_attr
 
 
 @irdl_op_definition
@@ -600,7 +604,7 @@ class AssertOp(IRDLOperation):
 
 
 @irdl_op_definition
-class BvConstantOp(IRDLOperation):
+class BvConstantOp(IRDLOperation, ConstantLikeInterface):
     """
     This operation produces an SSA value equal to the bitvector constant specified
     by the ‘value’ attribute.
@@ -615,7 +619,7 @@ class BvConstantOp(IRDLOperation):
 
     assembly_format = "qualified($value) attr-dict"
 
-    traits = traits_def(ConstantLike(), Pure())
+    traits = traits_def(Pure())
 
     @overload
     def __init__(self, value: BitVectorAttr) -> None: ...
@@ -635,6 +639,9 @@ class BvConstantOp(IRDLOperation):
             assert isinstance(type, BitVectorType)
             value = BitVectorAttr(value, type)
         super().__init__(properties={"value": value}, result_types=[value.type])
+
+    def get_constant_value(self) -> Attribute:
+        return self.value
 
 
 class UnaryBVOp(IRDLOperation, ABC):

--- a/xdsl/interfaces.py
+++ b/xdsl/interfaces.py
@@ -11,10 +11,10 @@ import abc
 from dataclasses import dataclass
 from typing import cast
 
-from xdsl.ir import Operation
+from xdsl.ir import Attribute, Operation
 from xdsl.irdl import traits_def
 from xdsl.pattern_rewriter import RewritePattern
-from xdsl.traits import HasCanonicalizationPatternsTrait
+from xdsl.traits import ConstantLike, HasCanonicalizationPatternsTrait
 
 
 @dataclass(frozen=True)
@@ -48,4 +48,33 @@ class HasCanonicalizationPatternsInterface(Operation, abc.ABC):
     @classmethod
     @abc.abstractmethod
     def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+        raise NotImplementedError()
+
+
+class _ConstantLikeInterfaceTrait(ConstantLike):
+    """
+    Gets the constant value from the operation's implementation
+    of `ConstantLikeInterface`.
+    """
+
+    def verify(self, op: Operation) -> None:
+        return
+
+    @classmethod
+    def get_constant_value(cls, op: Operation) -> Attribute:
+        op = cast(ConstantLikeInterface, op)
+        return op.get_constant_value()
+
+
+class ConstantLikeInterface(Operation, abc.ABC):
+    """
+    An operation subclassing this interface must implement the
+    `get_constant_value` method, which returns the constant value of this operation.
+    Wraps `ConstantLikeTrait`.
+    """
+
+    traits = traits_def(_ConstantLikeInterfaceTrait())
+
+    @abc.abstractmethod
+    def get_constant_value(self) -> Attribute:
         raise NotImplementedError()

--- a/xdsl/traits.py
+++ b/xdsl/traits.py
@@ -33,12 +33,22 @@ class OpTrait:
 OpTraitInvT = TypeVar("OpTraitInvT", bound=OpTrait)
 
 
-class ConstantLike(OpTrait):
+class ConstantLike(OpTrait, abc.ABC):
     """
     Operation known to be constant-like.
 
     See external [documentation](https://mlir.llvm.org/doxygen/classmlir_1_1OpTrait_1_1ConstantLike.html).
     """
+
+    @abc.abstractmethod
+    def get_constant_value(self, op: Operation) -> Attribute:
+        """
+        Get the constant value from this constant-like operation.
+
+        Returns:
+            The constant value as an Attribute, or None if the value cannot be determined.
+        """
+        raise NotImplementedError()
 
 
 @dataclass(frozen=True)

--- a/xdsl/traits.py
+++ b/xdsl/traits.py
@@ -40,8 +40,9 @@ class ConstantLike(OpTrait, abc.ABC):
     See external [documentation](https://mlir.llvm.org/doxygen/classmlir_1_1OpTrait_1_1ConstantLike.html).
     """
 
+    @classmethod
     @abc.abstractmethod
-    def get_constant_value(self, op: Operation) -> Attribute:
+    def get_constant_value(cls, op: Operation) -> Attribute:
         """
         Get the constant value from this constant-like operation.
 


### PR DESCRIPTION
This adds the `get_constant_value` method to the `ConstantLike` trait and adds a `ConstantLikeInterface` for ease of use.
