### PR TITLE
core: add ConstantMaterializationInterface

### DIFF
--- a/docs/marimo/expressions.py
+++ b/docs/marimo/expressions.py
@@ -1,6 +1,6 @@
 import marimo
 
-__generated_with = "0.15.2"
+__generated_with = "0.15.3"
 app = marimo.App(width="medium")
 
 
@@ -105,6 +105,7 @@ def _(mo, slider, slider_choices):
 def _(mo, pass_list, res, slider, xmo):
     from xdsl.passes import PassPipeline
     from xdsl.transforms import get_all_passes
+    from xdsl.dialects import get_all_dialects
     from xdsl.context import Context
 
     module = res.clone()
@@ -117,7 +118,12 @@ def _(mo, pass_list, res, slider, xmo):
 
     pipeline = PassPipeline.parse_spec(get_all_passes(), ",".join(pass_list), callback)
 
-    pipeline.apply(Context(), module)
+    ctx = Context()
+    for name, func in get_all_dialects().items():
+        ctx.register_dialect(name, func)
+
+
+    pipeline.apply(ctx, module)
     module_list.append(module.clone())
 
     res_str_0 = xmo.module_md(module_list[slider.value]).text.replace("\n", "<br>")

--- a/tests/dialects/test_arith.py
+++ b/tests/dialects/test_arith.py
@@ -1,10 +1,13 @@
 import pytest
 
+from xdsl.context import Context
+from xdsl.dialect_interfaces import ConstantMaterializationInterface
 from xdsl.dialects.arith import (
     AddfOp,
     AddiOp,
     AddUIExtendedOp,
     AndIOp,
+    Arith,
     BitcastOp,
     CeilDivSIOp,
     CeilDivUIOp,
@@ -51,6 +54,7 @@ from xdsl.dialects.arith import (
 )
 from xdsl.dialects.builtin import (
     DenseIntOrFPElementsAttr,
+    DenseResourceAttr,
     FloatAttr,
     IndexType,
     IntegerAttr,
@@ -490,3 +494,43 @@ def test_extui_incorrect_bitwidth():
     # bitwidth of b has to be larger than the one of a
     with pytest.raises(VerifyException):
         _extui_op = ExtUIOp(a, i32).verify()
+
+
+def test_constant_materialization():
+    ctx = Context()
+    ctx.load_dialect(Arith)
+    interface = Arith.get_interface(ConstantMaterializationInterface)
+    assert interface is not None
+    const = interface.materialize_constant(
+        ctx, IntegerAttr.from_int_and_width(42, 32), i32
+    )
+    assert isinstance(const, ConstantOp)
+    assert const.value == IntegerAttr.from_int_and_width(42, 32)
+    assert const.result_types[0] == i32
+
+    const = interface.materialize_constant(ctx, FloatAttr(42.0, f64), f64)
+    assert isinstance(const, ConstantOp)
+    assert const.value == FloatAttr(42.0, f64)
+    assert const.result_types[0] == f64
+
+    const = interface.materialize_constant(
+        ctx,
+        DenseIntOrFPElementsAttr.from_list(TensorType(i32, [2]), [1, 2]),
+        TensorType(i32, [2]),
+    )
+    assert isinstance(const, ConstantOp)
+    assert const.value == DenseIntOrFPElementsAttr.from_list(
+        TensorType(i32, [2]), [1, 2]
+    )
+    assert const.result_types[0] == TensorType(i32, [2])
+
+    const = interface.materialize_constant(
+        ctx,
+        DenseResourceAttr.from_params("my_resource", TensorType(i32, [2])),
+        TensorType(i32, [2]),
+    )
+    assert isinstance(const, ConstantOp)
+    assert const.value == DenseResourceAttr.from_params(
+        "my_resource", TensorType(i32, [2])
+    )
+    assert const.result_types[0] == TensorType(i32, [2])

--- a/tests/dialects/test_arith.py
+++ b/tests/dialects/test_arith.py
@@ -1,6 +1,5 @@
 import pytest
 
-from xdsl.context import Context
 from xdsl.dialect_interfaces import ConstantMaterializationInterface
 from xdsl.dialects.arith import (
     AddfOp,
@@ -497,24 +496,19 @@ def test_extui_incorrect_bitwidth():
 
 
 def test_constant_materialization():
-    ctx = Context()
-    ctx.load_dialect(Arith)
     interface = Arith.get_interface(ConstantMaterializationInterface)
     assert interface is not None
-    const = interface.materialize_constant(
-        ctx, IntegerAttr.from_int_and_width(42, 32), i32
-    )
+    const = interface.materialize_constant(IntegerAttr.from_int_and_width(42, 32), i32)
     assert isinstance(const, ConstantOp)
     assert const.value == IntegerAttr.from_int_and_width(42, 32)
     assert const.result_types[0] == i32
 
-    const = interface.materialize_constant(ctx, FloatAttr(42.0, f64), f64)
+    const = interface.materialize_constant(FloatAttr(42.0, f64), f64)
     assert isinstance(const, ConstantOp)
     assert const.value == FloatAttr(42.0, f64)
     assert const.result_types[0] == f64
 
     const = interface.materialize_constant(
-        ctx,
         DenseIntOrFPElementsAttr.from_list(TensorType(i32, [2]), [1, 2]),
         TensorType(i32, [2]),
     )
@@ -525,7 +519,6 @@ def test_constant_materialization():
     assert const.result_types[0] == TensorType(i32, [2])
 
     const = interface.materialize_constant(
-        ctx,
         DenseResourceAttr.from_params("my_resource", TensorType(i32, [2])),
         TensorType(i32, [2]),
     )

--- a/xdsl/dialect_interfaces.py
+++ b/xdsl/dialect_interfaces.py
@@ -3,7 +3,7 @@ from collections.abc import Iterable
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from xdsl.ir import Attribute, Operation, TypeAttribute
+    from xdsl.ir import Attribute, Operation
 
 
 class DialectInterface:
@@ -33,14 +33,14 @@ class ConstantMaterializationInterface(DialectInterface, ABC):
 
     @abstractmethod
     def materialize_constant(
-        self, value: "Attribute", type: "TypeAttribute"
+        self, value: "Attribute", type: "Attribute"
     ) -> "Operation | None":
         """
         Materializes a constant operation in the dialect.
 
         Args:
             value (Attribute): The attribute representing the constant value.
-            type (TypeAttribute): The type of the constant.
+            type (Attribute): The type of the constant.
 
         Returns:
             Operation: The created constant operation.

--- a/xdsl/dialect_interfaces.py
+++ b/xdsl/dialect_interfaces.py
@@ -3,7 +3,6 @@ from collections.abc import Iterable
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from xdsl.context import Context
     from xdsl.ir import Attribute, Operation, TypeAttribute
 
 
@@ -34,13 +33,12 @@ class ConstantMaterializationInterface(DialectInterface, ABC):
 
     @abstractmethod
     def materialize_constant(
-        self, ctx: "Context", value: "Attribute", type: "TypeAttribute"
+        self, value: "Attribute", type: "TypeAttribute"
     ) -> "Operation | None":
         """
         Materializes a constant operation in the dialect.
 
         Args:
-            ctx (Context): The context to use for creating the operation (necessary).
             value (Attribute): The attribute representing the constant value.
             type (TypeAttribute): The type of the constant.
 

--- a/xdsl/dialect_interfaces.py
+++ b/xdsl/dialect_interfaces.py
@@ -1,4 +1,10 @@
+from abc import ABC, abstractmethod
 from collections.abc import Iterable
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from xdsl.context import Context
+    from xdsl.ir import Attribute, Operation, TypeAttribute
 
 
 class DialectInterface:
@@ -14,6 +20,34 @@ class DialectInterface:
     """
 
     pass
+
+
+class ConstantMaterializationInterface(DialectInterface, ABC):
+    """
+    An interface for dialects that support constant materialization.
+
+    A dialect that implements this interface should provide the `materialize_constant` method,
+    which creates a constant operation of the dialect given a value and a type.
+
+    This is useful for transformations that need to create constants in a dialect-specific way.
+    """
+
+    @abstractmethod
+    def materialize_constant(
+        self, ctx: "Context", value: "Attribute", type: "TypeAttribute"
+    ) -> "Operation | None":
+        """
+        Materializes a constant operation in the dialect.
+
+        Args:
+            ctx (Context): The context to use for creating the operation (necessary).
+            value (Attribute): The attribute representing the constant value.
+            type (TypeAttribute): The type of the constant.
+
+        Returns:
+            Operation: The created constant operation.
+        """
+        raise NotImplementedError("Dialect does not implement materialize_constant")
 
 
 class OpAsmDialectInterface(DialectInterface):

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -4,9 +4,12 @@ import abc
 from collections.abc import Mapping, Sequence
 from typing import ClassVar, Literal, cast
 
+from xdsl.context import Context
+from xdsl.dialect_interfaces import ConstantMaterializationInterface
 from xdsl.dialects.builtin import (
     AnyFloat,
     AnyFloatConstr,
+    ComplexType,
     ContainerOf,
     DenseIntOrFPElementsAttr,
     DenseResourceAttr,
@@ -28,7 +31,14 @@ from xdsl.dialects.builtin import (
 )
 from xdsl.dialects.utils import FastMathAttrBase, FastMathFlag
 from xdsl.interfaces import ConstantLikeInterface
-from xdsl.ir import Attribute, BitEnumAttribute, Dialect, Operation, SSAValue
+from xdsl.ir import (
+    Attribute,
+    BitEnumAttribute,
+    Dialect,
+    Operation,
+    SSAValue,
+    TypeAttribute,
+)
 from xdsl.irdl import (
     AnyAttr,
     AnyOf,
@@ -1376,6 +1386,34 @@ class ExtUIOp(IRDLOperation):
     traits = traits_def(Pure())
 
 
+class ArithConstantMaterializationInterface(ConstantMaterializationInterface):
+    def materialize_constant(
+        self, ctx: Context, value: Attribute, type: TypeAttribute
+    ) -> Operation:
+        if not isinstance(
+            value,
+            IntegerAttr | FloatAttr | DenseIntOrFPElementsAttr | DenseResourceAttr,
+        ):
+            raise ValueError(
+                "expected IntegerAttr, FloatAttr, DenseIntOrFPElementsAttr, or DenseResourceAttr"
+            )
+
+        if isinstance(value, IntegerAttr):
+            value = cast(IntegerAttr[IntegerType | IndexType], value)
+        elif isinstance(value, FloatAttr):
+            value = cast(FloatAttr[AnyFloat], value)
+        elif isinstance(value, DenseIntOrFPElementsAttr):
+            value = cast(
+                DenseIntOrFPElementsAttr[
+                    IntegerType | IndexType | AnyFloat | ComplexType
+                ],
+                value,
+            )
+        # DenseResourceAttr doesn't need type casting
+
+        return ConstantOp(value=value, value_type=type)
+
+
 Arith = Dialect(
     "arith",
     [
@@ -1437,5 +1475,8 @@ Arith = Dialect(
     [
         FastMathFlagsAttr,
         IntegerOverflowAttr,
+    ],
+    [
+        ArithConstantMaterializationInterface(),
     ],
 )

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -8,7 +8,6 @@ from xdsl.dialect_interfaces import ConstantMaterializationInterface
 from xdsl.dialects.builtin import (
     AnyFloat,
     AnyFloatConstr,
-    ComplexType,
     ContainerOf,
     DenseIntOrFPElementsAttr,
     DenseResourceAttr,
@@ -1386,28 +1385,10 @@ class ExtUIOp(IRDLOperation):
 
 class ArithConstantMaterializationInterface(ConstantMaterializationInterface):
     def materialize_constant(self, value: Attribute, type: Attribute) -> Operation:
-        if not isinstance(
-            value,
-            IntegerAttr | FloatAttr | DenseIntOrFPElementsAttr | DenseResourceAttr,
-        ):
-            raise ValueError(
-                "expected IntegerAttr, FloatAttr, DenseIntOrFPElementsAttr, or DenseResourceAttr"
-            )
-
-        if isinstance(value, IntegerAttr):
-            value = cast(IntegerAttr[IntegerType | IndexType], value)
-        elif isinstance(value, FloatAttr):
-            value = cast(FloatAttr[AnyFloat], value)
-        elif isinstance(value, DenseIntOrFPElementsAttr):
-            value = cast(
-                DenseIntOrFPElementsAttr[
-                    IntegerType | IndexType | AnyFloat | ComplexType
-                ],
-                value,
-            )
-        # DenseResourceAttr doesn't need type casting
-
-        return ConstantOp(value=value, value_type=type)
+        return cast(
+            Operation,
+            ConstantOp.build(properties={"value": value}, result_types=(type,)),
+        )
 
 
 Arith = Dialect(

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -36,7 +36,6 @@ from xdsl.ir import (
     Dialect,
     Operation,
     SSAValue,
-    TypeAttribute,
 )
 from xdsl.irdl import (
     AnyAttr,
@@ -1386,7 +1385,7 @@ class ExtUIOp(IRDLOperation):
 
 
 class ArithConstantMaterializationInterface(ConstantMaterializationInterface):
-    def materialize_constant(self, value: Attribute, type: TypeAttribute) -> Operation:
+    def materialize_constant(self, value: Attribute, type: Attribute) -> Operation:
         if not isinstance(
             value,
             IntegerAttr | FloatAttr | DenseIntOrFPElementsAttr | DenseResourceAttr,

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -4,7 +4,6 @@ import abc
 from collections.abc import Mapping, Sequence
 from typing import ClassVar, Literal, cast
 
-from xdsl.context import Context
 from xdsl.dialect_interfaces import ConstantMaterializationInterface
 from xdsl.dialects.builtin import (
     AnyFloat,
@@ -1387,9 +1386,7 @@ class ExtUIOp(IRDLOperation):
 
 
 class ArithConstantMaterializationInterface(ConstantMaterializationInterface):
-    def materialize_constant(
-        self, ctx: Context, value: Attribute, type: TypeAttribute
-    ) -> Operation:
+    def materialize_constant(self, value: Attribute, type: TypeAttribute) -> Operation:
         if not isinstance(
             value,
             IntegerAttr | FloatAttr | DenseIntOrFPElementsAttr | DenseResourceAttr,

--- a/xdsl/transforms/constant_fold_interp.py
+++ b/xdsl/transforms/constant_fold_interp.py
@@ -8,7 +8,7 @@ from typing import Any, cast
 
 from xdsl.context import Context
 from xdsl.dialect_interfaces import ConstantMaterializationInterface
-from xdsl.dialects import arith, builtin
+from xdsl.dialects import builtin
 from xdsl.dialects.builtin import IntegerAttr, IntegerType
 from xdsl.interpreter import Interpreter
 from xdsl.interpreters import register_implementations
@@ -44,6 +44,13 @@ class ConstantFoldInterpPattern(RewritePattern):
             # Only rewrite operations where all the operands are constants
             return
 
+        dialect = self.ctx.get_dialect(op.dialect_name())
+
+        if (
+            materializer := dialect.get_interface(ConstantMaterializationInterface)
+        ) is None:
+            return
+
         try:
             args = tuple(
                 self.interpreter.run_op(cast(OpResult, operand).op, ())[0]
@@ -53,35 +60,22 @@ class ConstantFoldInterpPattern(RewritePattern):
         except InterpretationError:
             return
 
-        dialect = self.ctx.get_dialect(op.dialect_name())
-
-        if (
-            materializer := dialect.get_interface(ConstantMaterializationInterface)
-        ) is None:
-            raise ValueError(
-                f"Dialect {dialect.name} does not implement the ConstantMaterializationInterface"
-            )
-
-        new_ops = [
-            materializer.materialize_constant(interp_result, op_result.type)
-            for interp_result, op_result in zip(results, op.results)
-        ]
-
-        if any(new_op is None for new_op in new_ops):
-            # If we don't know how to create a constant for one of the results, bail
-            return
-
-        new_ops = cast(list[Operation], new_ops)
+        new_ops: list[Operation] = []
+        for interp_result, op_result in zip(results, op.results):
+            result_attr = self.convert_to_attr(interp_result, op_result.type)
+            if result_attr is None:
+                return
+            new_op = materializer.materialize_constant(result_attr, op_result.type)
+            if new_op is None:
+                return
+            new_ops.append(new_op)
 
         rewriter.replace_matched_op(new_ops, [new_op.results[0] for new_op in new_ops])
 
-    def constant_op_for_value(
-        self, value: Any, value_type: Attribute
-    ) -> Operation | None:
+    def convert_to_attr(self, value: Any, value_type: Attribute) -> Attribute | None:
         match (value, value_type):
             case int(), IntegerType():
-                attr = IntegerAttr(value, cast(IntegerType, value_type))
-                return arith.ConstantOp(attr)
+                return IntegerAttr(value, cast(IntegerType, value_type))
             case _:
                 return None
 


### PR DESCRIPTION
This is a dialect interface containing `materialize_constant` to create a constant operation from a dialect given a constant attribute.
I had to use `if TYPE_CHECKING` to handle a circular import issue.

(on top of https://github.com/xdslproject/xdsl/pull/5233)