### PR TITLE
dialects: (riscv_snitch) use i3 and i4 for frep params

### DIFF
--- a/tests/filecheck/dialects/riscv/frep_verification.mlir
+++ b/tests/filecheck/dialects/riscv/frep_verification.mlir
@@ -67,6 +67,6 @@ riscv_snitch.frep_outer %i0 {
 ^bb0:
     %f1 = "riscv.fadd.s"(%f0, %f0) : (!riscv.freg, !riscv.freg) -> !riscv.freg
     "test.termop"() : () -> ()
-}) {"stagger_mask" = #builtin.int<0>, "stagger_count" = #builtin.int<0>} : (!riscv.reg) -> ()
+}) : (!riscv.reg) -> ()
 
 // CHECK: Operation does not verify: 'riscv_snitch.frep_outer' terminates with operation test.termop instead of riscv_snitch.frep_yield

--- a/tests/filecheck/dialects/riscv_snitch/ops.mlir
+++ b/tests/filecheck/dialects/riscv_snitch/ops.mlir
@@ -126,11 +126,11 @@ riscv_func.func @simd() {
 // CHECK-GENERIC-NEXT:    "riscv_snitch.frep_outer"(%{{.*}}) ({
 // CHECK-GENERIC-NEXT:      %{{.*}} = "riscv.add"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-GENERIC-NEXT:      "riscv_snitch.frep_yield"() : () -> ()
-// CHECK-GENERIC-NEXT:    }) {stagger_mask = #builtin.int<0>, stagger_count = #builtin.int<0>} : (!riscv.reg) -> ()
+// CHECK-GENERIC-NEXT:    }) {stagger_mask = 0 : i4, stagger_count = 0 : i3} : (!riscv.reg) -> ()
 // CHECK-GENERIC-NEXT:    "riscv_snitch.frep_inner"(%{{.*}}) ({
 // CHECK-GENERIC-NEXT:      %{{.*}} = "riscv.add"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-GENERIC-NEXT:      "riscv_snitch.frep_yield"() : () -> ()
-// CHECK-GENERIC-NEXT:    }) {stagger_mask = #builtin.int<0>, stagger_count = #builtin.int<0>} : (!riscv.reg) -> ()
+// CHECK-GENERIC-NEXT:    }) {stagger_mask = 0 : i4, stagger_count = 0 : i3} : (!riscv.reg) -> ()
 // CHECK-GENERIC-NEXT:        %readable = "riscv_snitch.get_stream"() : () -> !snitch.readable<!riscv.freg<ft0>>
 // CHECK-GENERIC-NEXT:        %writable = "riscv_snitch.get_stream"() : () -> !snitch.writable<!riscv.freg<ft1>>
 // CHECK-GENERIC-NEXT:        "riscv_snitch.frep_outer"(%0) ({
@@ -138,13 +138,13 @@ riscv_func.func @simd() {
 // CHECK-GENERIC-NEXT:          %val1 = "riscv.fmv.d"(%val0) : (!riscv.freg<ft0>) -> !riscv.freg<ft1>
 // CHECK-GENERIC-NEXT:          "riscv_snitch.write"(%val1, %writable) : (!riscv.freg<ft1>, !snitch.writable<!riscv.freg<ft1>>) -> ()
 // CHECK-GENERIC-NEXT:          "riscv_snitch.frep_yield"() : () -> ()
-// CHECK-GENERIC-NEXT:        }) {stagger_mask = #builtin.int<0>, stagger_count = #builtin.int<0>} : (!riscv.reg) -> ()
+// CHECK-GENERIC-NEXT:        }) {stagger_mask = 0 : i4, stagger_count = 0 : i3} : (!riscv.reg) -> ()
 // CHECK-GENERIC-NEXT:    %init = "test.op"() : () -> !riscv.freg<ft3>
 // CHECK-GENERIC-NEXT:    %z = "riscv_snitch.frep_outer"(%0, %init) ({
 // CHECK-GENERIC-NEXT:    ^bb0(%acc : !riscv.freg<ft3>):
 // CHECK-GENERIC-NEXT:      %res = "riscv.fadd.d"(%acc, %acc) {fastmath = #riscv.fastmath<none>} : (!riscv.freg<ft3>, !riscv.freg<ft3>) -> !riscv.freg<ft3>
 // CHECK-GENERIC-NEXT:      "riscv_snitch.frep_yield"(%res) : (!riscv.freg<ft3>) -> ()
-// CHECK-GENERIC-NEXT:    }) {stagger_mask = #builtin.int<0>, stagger_count = #builtin.int<0>} : (!riscv.reg, !riscv.freg<ft3>) -> !riscv.freg<ft3>
+// CHECK-GENERIC-NEXT:    }) {stagger_mask = 0 : i4, stagger_count = 0 : i3} : (!riscv.reg, !riscv.freg<ft3>) -> !riscv.freg<ft3>
 // CHECK-GENERIC-NEXT:     "riscv_func.return"() : () -> ()
 // CHECK-GENERIC-NEXT:   }) {sym_name = "xfrep", function_type = () -> ()} : () -> ()
 // CHECK-GENERIC-NEXT:   "riscv_func.func"() ({

--- a/tests/filecheck/dialects/riscv_snitch/verification.mlir
+++ b/tests/filecheck/dialects/riscv_snitch/verification.mlir
@@ -7,8 +7,8 @@
 ^bb0(%acc : !riscv.freg<fa0>):
     riscv.sw %0, %0, 0 : (!riscv.reg<a0>, !riscv.reg<a0>) -> ()
     %res = "riscv.fadd.d"(%acc, %acc) : (!riscv.freg<fa0>, !riscv.freg<fa0>) -> !riscv.freg<fa0>
-    "riscv_snitch.frep_yield"(%res) : (!riscv.freg<fa0>) -> ()
-}) {"stagger_mask" = #builtin.int<0>, "stagger_count" = #builtin.int<0>} : (!riscv.reg<a0>, !riscv.freg<fa0>) -> !riscv.freg<fa0>
+    riscv_snitch.frep_yield %res : !riscv.freg<fa0>
+}) : (!riscv.reg<a0>, !riscv.freg<fa0>) -> !riscv.freg<fa0>
 
 // CHECK: Operation does not verify: Frep operation body may not contain instructions with side-effects, found riscv.sw
 
@@ -19,8 +19,8 @@
 %z = "riscv_snitch.frep_outer"(%0, %init) ({
 ^bb0(%acc : !riscv.freg<fa0>, %extra : !riscv.freg<fa1>):
     %res = "riscv.fadd.d"(%acc, %acc) : (!riscv.freg<fa0>, !riscv.freg<fa0>) -> !riscv.freg<fa0>
-    "riscv_snitch.frep_yield"(%res) : (!riscv.freg<fa0>) -> ()
-}) {"stagger_mask" = #builtin.int<0>, "stagger_count" = #builtin.int<0>} : (!riscv.reg<a0>, !riscv.freg<fa0>) -> !riscv.freg<fa0>
+    riscv_snitch.frep_yield %res : !riscv.freg<fa0>
+}) : (!riscv.reg<a0>, !riscv.freg<fa0>) -> !riscv.freg<fa0>
 
 // CHECK: Operation does not verify: Wrong number of block arguments, expected 1, got 2. The body must have the induction variable and loop-carried variables as arguments.
 
@@ -31,8 +31,8 @@
 %z = "riscv_snitch.frep_outer"(%0, %init) ({
 ^bb0(%acc : !riscv.freg<fa1>):
     %res = "riscv.fadd.d"(%acc, %acc) : (!riscv.freg<fa1>, !riscv.freg<fa1>) -> !riscv.freg<fa0>
-    "riscv_snitch.frep_yield"(%res) : (!riscv.freg<fa0>) -> ()
-}) {"stagger_mask" = #builtin.int<0>, "stagger_count" = #builtin.int<0>} : (!riscv.reg<a0>, !riscv.freg<fa0>) -> !riscv.freg<fa0>
+    riscv_snitch.frep_yield %res : !riscv.freg<fa0>
+}) : (!riscv.reg<a0>, !riscv.freg<fa0>) -> !riscv.freg<fa0>
 
 // CHECK: Operation does not verify: Block argument 0 has wrong type, expected !riscv.freg<fa0>, got !riscv.freg<fa1>. Arguments after the induction variable must match the carried variables.
 
@@ -43,8 +43,8 @@
 %z = "riscv_snitch.frep_outer"(%0, %init) ({
 ^bb0(%acc : !riscv.freg<fa0>):
     %res = "riscv.fadd.d"(%acc, %acc) : (!riscv.freg<fa0>, !riscv.freg<fa0>) -> !riscv.freg<fa0>
-    "riscv_snitch.frep_yield"() : () -> ()
-}) {"stagger_mask" = #builtin.int<0>, "stagger_count" = #builtin.int<0>} : (!riscv.reg<a0>, !riscv.freg<fa0>) -> !riscv.freg<fa0>
+    riscv_snitch.frep_yield
+}) : (!riscv.reg<a0>, !riscv.freg<fa0>) -> !riscv.freg<fa0>
 
 // CHECK: Operation does not verify: Expected 1 args, got 0. The riscv_scf.frep must yield its carried variables.
 
@@ -55,7 +55,7 @@
 %z = "riscv_snitch.frep_outer"(%0, %init) ({
 ^bb0(%acc : !riscv.freg<fa0>):
     %res = "riscv.fadd.d"(%acc, %acc) : (!riscv.freg<fa0>, !riscv.freg<fa0>) -> !riscv.freg<fa1>
-    "riscv_snitch.frep_yield"(%res) : (!riscv.freg<fa1>) -> ()
-}) {"stagger_mask" = #builtin.int<0>, "stagger_count" = #builtin.int<0>} : (!riscv.reg<a0>, !riscv.freg<fa0>) -> !riscv.freg<fa0>
+    riscv_snitch.frep_yield %res : !riscv.freg<fa1>
+}) : (!riscv.reg<a0>, !riscv.freg<fa0>) -> !riscv.freg<fa0>
 
 // CHECK: Operation does not verify: Expected !riscv.freg<fa0>, got !riscv.freg<fa1>. The riscv_snitch.frep's riscv_snitch.frep_yield must match carriedvariables types.

--- a/tests/filecheck/dialects/snitch_stream/ops.mlir
+++ b/tests/filecheck/dialects/snitch_stream/ops.mlir
@@ -46,5 +46,5 @@ snitch_stream.streaming_region {
 // CHECK-GENERIC-NEXT:        %c = "riscv.fadd.d"(%a, %b) {fastmath = #riscv.fastmath<none>} : (!riscv.freg<ft0>, !riscv.freg<ft1>) -> !riscv.freg<ft2>
 // CHECK-GENERIC-NEXT:        "riscv_snitch.write"(%c, %c_stream) : (!riscv.freg<ft2>, !snitch.writable<!riscv.freg<ft2>>) -> ()
 // CHECK-GENERIC-NEXT:        "riscv_snitch.frep_yield"() : () -> ()
-// CHECK-GENERIC-NEXT:      }) {stagger_mask = #builtin.int<0>, stagger_count = #builtin.int<0>} : (!riscv.reg) -> ()
+// CHECK-GENERIC-NEXT:      }) {stagger_mask = 0 : i4, stagger_count = 0 : i3} : (!riscv.reg) -> ()
 // CHECK-GENERIC-NEXT:    }) : (!riscv.reg, !riscv.reg, !riscv.reg) -> ()

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -447,7 +447,7 @@ class RISCVCustomFormatOperation(IRDLOperation, ABC):
 
 
 AssemblyInstructionArg: TypeAlias = (
-    IntegerAttr | LabelAttr | SSAValue | IntRegisterType | str | int
+    IntegerAttr | LabelAttr | SSAValue | IntRegisterType | str
 )
 
 

--- a/xdsl/dialects/riscv_snitch.py
+++ b/xdsl/dialects/riscv_snitch.py
@@ -276,13 +276,13 @@ class FRepOperation(RISCVInstruction):
         max_rep: SSAValue | Operation,
         body: Sequence[Operation] | Sequence[Block] | Region,
         iter_args: Sequence[SSAValue | Operation] = (),
-        stagger_mask: IntegerAttr[IntegerType[Literal[4]]] | None = None,
-        stagger_count: IntegerAttr[IntegerType[Literal[3]]] | None = None,
+        stagger_mask: IntegerAttr[I4] | None = None,
+        stagger_count: IntegerAttr[I3] | None = None,
     ):
         if stagger_mask is None:
-            stagger_mask = IntegerAttr(0, IntegerType[Literal[4]](4))
+            stagger_mask = IntegerAttr(0, i4)
         if stagger_count is None:
-            stagger_count = IntegerAttr(0, IntegerType[Literal[3]](3))
+            stagger_count = IntegerAttr(0, i3)
         super().__init__(
             operands=(max_rep, iter_args),
             result_types=[[SSAValue.get(a).type for a in iter_args]],
@@ -352,8 +352,8 @@ class FRepOperation(RISCVInstruction):
             max_rep,
             body,
             iter_arg_operands,
-            IntegerAttr(stagger_mask, IntegerType(4)),
-            IntegerAttr(stagger_count, IntegerType(3)),
+            IntegerAttr(stagger_mask, i4),
+            IntegerAttr(stagger_count, i3),
         )
         if remaining_attributes is not None:
             frep.attributes |= remaining_attributes.data


### PR DESCRIPTION
Tiny change motivated by wanting to drop raw int printing in RISC-V assembly. Encodes the bitwidths of the instruction encoding in the constraints of the op.