### PR TITLE
documentation: fix method signature doc in tutorial notebook

### DIFF
--- a/docs/marimo/ir_gen.py
+++ b/docs/marimo/ir_gen.py
@@ -143,7 +143,7 @@ def _(mo):
     * math.powf: PowFOp(lhs, rhs)
     * arith.select: SelectOp(cond, lhs, rhs)
         * Represents the formula `if cond then lhs else rhs`
-    * arith.cmpf: CmpfOp("olt", lhs, rhs)
+    * arith.cmpf: CmpfOp(lhs, rhs, "olt")
         * Represents `lhs < rhs` with floating points
     * scf.if: IfOp(cond, region1, region2)
         * Regions should have a single block, without block arguments. The last operation in the regions should be an `scf.yield` with constructor `YieldOp([result])`


### PR DESCRIPTION
The signature given for the `CmpfOp` in the IR generation Tutorial was inconsistent to how it is defined [here](https://github.com/xdslproject/xdsl/blob/621d8000b386f0f47fa20990bd56104247a0f105/xdsl/dialects/arith.py#L936).