### PR TITLE
dialects: (fir) fir.result should take variadic, not optional arguments

### DIFF
--- a/xdsl/dialects/experimental/fir.py
+++ b/xdsl/dialects/experimental/fir.py
@@ -2033,7 +2033,7 @@ class ResultOp(IRDLOperation):
 
     name = "fir.result"
     regs = var_region_def()
-    _results = opt_operand_def()
+    _results = var_operand_def()
 
     traits = traits_def(IsTerminator())
 


### PR DESCRIPTION
The operation is described [here](https://flang.llvm.org/docs/FIRLangRef.html#fir-result-fir-resultop)