### PR TITLE
dialects: (arm) remove AssemblyInstructionArg

### DIFF
--- a/tests/dialects/arm/test_assembly_arg_str.py
+++ b/tests/dialects/arm/test_assembly_arg_str.py
@@ -1,5 +1,10 @@
+from xdsl.dialects.arm.assembly import reg, square_brackets_reg
 from xdsl.dialects.arm.registers import IntRegisterType
+from xdsl.utils.test_value import create_ssa_value
 
 
 def test_assembly_arg_str_ARMRegister():
-    assert IntRegisterType.from_name("x0").assembly_str() == "x0"
+    x0 = IntRegisterType.from_name("x0")
+    x0_val = create_ssa_value(x0)
+    assert reg(x0_val) == "x0"
+    assert square_brackets_reg(x0_val) == "[x0]"

--- a/tests/dialects/test_arm_neon.py
+++ b/tests/dialects/test_arm_neon.py
@@ -4,7 +4,7 @@ from xdsl.dialects.arm_neon import (
     NeonArrangement,
     NeonArrangementAttr,
     NEONRegisterType,
-    VectorWithArrangement,
+    vector_with_arrangement,
 )
 from xdsl.dialects.builtin import VectorType, f16, f32, f64
 
@@ -12,15 +12,15 @@ from xdsl.dialects.builtin import VectorType, f16, f32, f64
 def test_assembly_str_without_index():
     reg = NEONRegisterType.from_name("v0")
     arrangement = NeonArrangementAttr(NeonArrangement.D)
-    vecreg = VectorWithArrangement(reg=reg, arrangement=arrangement, index=None)
-    assert vecreg.assembly_str() == "v0.2D"
+    vecreg = vector_with_arrangement(reg=reg, arrangement=arrangement, index=None)
+    assert vecreg == "v0.2D"
 
 
 def test_assembly_str_with_index():
     reg = NEONRegisterType.from_name("v0")
     arrangement = NeonArrangementAttr(NeonArrangement.D)
-    vecreg = VectorWithArrangement(reg=reg, arrangement=arrangement, index=5)
-    assert vecreg.assembly_str() == "v0.D[5]"
+    vecreg = vector_with_arrangement(reg=reg, arrangement=arrangement, index=5)
+    assert vecreg == "v0.D[5]"
 
 
 def test_arr_from_vec():

--- a/xdsl/dialects/arm/assembly.py
+++ b/xdsl/dialects/arm/assembly.py
@@ -1,48 +1,23 @@
-import abc
-
 from xdsl.backend.register_type import RegisterType
 from xdsl.ir import SSAValue
 
 
-class AssemblyInstructionArg(abc.ABC):
-    """
-    Abstract base class for arguments to one line of assembly.
-    """
-
-    @abc.abstractmethod
-    def assembly_str(self) -> str:
-        raise NotImplementedError()
-
-
-class reg(AssemblyInstructionArg):
+def reg(value: SSAValue) -> str:
     """
     A wrapper around SSAValue to be printed in assembly.
     Only valid if the type of the value is a RegisterType.
     """
 
-    value: SSAValue
-
-    def __init__(self, value: SSAValue) -> None:
-        self.value = value
-
-    def assembly_str(self) -> str:
-        assert isinstance(self.value.type, RegisterType)
-        return self.value.type.register_name.data
+    assert isinstance(value.type, RegisterType)
+    return value.type.register_name.data
 
 
-class square_brackets_reg(AssemblyInstructionArg):
+def square_brackets_reg(value: SSAValue):
     """
     A wrapper around SSAValue to be printed in assembly.
     Only valid if the type of the value is a RegisterType.
     This class handles the case where a register contains a pointer reference,
     and therefore should be printed within square brackets.
     """
-
-    value: SSAValue
-
-    def __init__(self, value: SSAValue) -> None:
-        self.value = value
-
-    def assembly_str(self) -> str:
-        assert isinstance(self.value.type, RegisterType)
-        return f"[{self.value.type.register_name.data}]"
+    assert isinstance(value.type, RegisterType)
+    return f"[{value.type.register_name.data}]"

--- a/xdsl/dialects/arm/ops.py
+++ b/xdsl/dialects/arm/ops.py
@@ -12,7 +12,7 @@ from xdsl.irdl import (
     result_def,
 )
 
-from .assembly import AssemblyInstructionArg, reg
+from .assembly import reg
 from .registers import IntRegisterType
 
 
@@ -35,7 +35,7 @@ class ARMInstruction(ARMOperation, ABC):
     """
 
     @abstractmethod
-    def assembly_line_args(self) -> tuple[AssemblyInstructionArg | None, ...]:
+    def assembly_line_args(self) -> tuple[str | None, ...]:
         """
         The arguments to the instruction, in the order they should be printed in the
         assembly.
@@ -52,9 +52,7 @@ class ARMInstruction(ARMOperation, ABC):
     def assembly_line(self) -> str | None:
         # default assembly code generator
         instruction_name = self.assembly_instruction_name()
-        arg_str = ", ".join(
-            arg.assembly_str() for arg in self.assembly_line_args() if arg is not None
-        )
+        arg_str = ", ".join(arg for arg in self.assembly_line_args() if arg is not None)
         return AssemblyPrinter.assembly_line(instruction_name, arg_str, self.comment)
 
 

--- a/xdsl/dialects/arm/registers.py
+++ b/xdsl/dialects/arm/registers.py
@@ -5,16 +5,11 @@ import abc
 from xdsl.backend.register_type import RegisterType
 from xdsl.irdl import irdl_attr_definition
 
-from .assembly import AssemblyInstructionArg
 
-
-class ARMRegisterType(RegisterType, AssemblyInstructionArg, abc.ABC):
+class ARMRegisterType(RegisterType, abc.ABC):
     """
     The abstract class for all ARM register types.
     """
-
-    def assembly_str(self) -> str:
-        return self.register_name.data
 
 
 ARM_INDEX_BY_NAME = {f"x{i}": i for i in range(0, 31)}

--- a/xdsl/dialects/arm_neon.py
+++ b/xdsl/dialects/arm_neon.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import ClassVar
 
-from xdsl.dialects.arm.assembly import AssemblyInstructionArg, reg, square_brackets_reg
+from xdsl.dialects.arm.assembly import reg, square_brackets_reg
 from xdsl.dialects.arm.ops import ARMInstruction, ARMOperation
 from xdsl.dialects.arm.registers import ARMRegisterType, IntRegisterType
 from xdsl.dialects.builtin import (
@@ -135,56 +135,37 @@ class NeonArrangementAttr(EnumAttribute[NeonArrangement], SpacedOpaqueSyntaxAttr
     name = "arm_neon.arrangement"
 
 
-class VectorWithArrangement(AssemblyInstructionArg):
-    reg: NEONRegisterType
-    arrangement: NeonArrangementAttr
-    index: int | None = None
-
-    def __init__(
-        self,
-        reg: NEONRegisterType | SSAValue,
-        arrangement: NeonArrangementAttr,
-        *,
-        index: int | None = None,
-    ):
-        if isinstance(reg, SSAValue):
-            assert isinstance(reg.type, NEONRegisterType)
-            reg = reg.type
-
-        self.reg = reg
-        self.arrangement = arrangement
-        self.index = index
-
-    def assembly_str(self):
-        if self.index is None:
-            return (
-                f"{self.reg.register_name.data}."
-                f"{self.arrangement.data.num_elements}"
-                f"{self.arrangement.data.name}"
-            )
-        else:
-            return f"{self.reg.register_name.data}.{self.arrangement.data.name}[{self.index}]"
+def vector_with_arrangement(
+    reg: NEONRegisterType | SSAValue,
+    arrangement: NeonArrangementAttr,
+    *,
+    index: int | None = None,
+) -> str:
+    if isinstance(reg, SSAValue):
+        assert isinstance(reg.type, NEONRegisterType)
+        reg = reg.type
+    if index is None:
+        return (
+            f"{reg.register_name.data}."
+            f"{arrangement.data.num_elements}"
+            f"{arrangement.data.name}"
+        )
+    else:
+        return f"{reg.register_name.data}.{arrangement.data.name}[{index}]"
 
 
-class VariadicNeonRegArg(AssemblyInstructionArg):
-    regs: Sequence[VectorWithArrangement]
-    arrangement: NeonArrangementAttr
-
-    def __init__(
-        self,
-        regs: Sequence[SSAValue],
-        arrangement: NeonArrangementAttr,
-    ):
-        self.arrangement = arrangement
-        vectors: Sequence[VectorWithArrangement] = []
-        for register in regs:
-            assert isinstance(register.type, NEONRegisterType)
-            vectors.append(VectorWithArrangement(register, self.arrangement))
-
-        self.regs = vectors
-
-    def assembly_str(self):
-        return "{" + ", ".join(s.assembly_str() for s in self.regs) + "}"
+def variadic_neon_reg_arg(
+    regs: Sequence[SSAValue],
+    arrangement: NeonArrangementAttr,
+) -> str:
+    """
+    Returns the assembly string for a variadic NEON register argument with the given arrangement.
+    """
+    return (
+        "{"
+        + ", ".join(vector_with_arrangement(register, arrangement) for register in regs)
+        + "}"
+    )
 
 
 @irdl_op_definition
@@ -264,9 +245,9 @@ class DSSFMulOp(ARMInstruction):
 
     def assembly_line_args(self):
         return (
-            VectorWithArrangement(self.d, self.arrangement),
-            VectorWithArrangement(self.s1, self.arrangement),
-            VectorWithArrangement(
+            vector_with_arrangement(self.d, self.arrangement),
+            vector_with_arrangement(self.s1, self.arrangement),
+            vector_with_arrangement(
                 self.s2,
                 self.arrangement,
                 index=self.scalar_idx.value.data
@@ -340,9 +321,9 @@ class DSSFmlaVecScalarOp(ARMInstruction):
 
     def assembly_line_args(self):
         return (
-            VectorWithArrangement(self.res, self.arrangement),
-            VectorWithArrangement(self.s1, self.arrangement),
-            VectorWithArrangement(
+            vector_with_arrangement(self.res, self.arrangement),
+            vector_with_arrangement(self.s1, self.arrangement),
+            vector_with_arrangement(
                 self.s2, self.arrangement, index=self.scalar_idx.value.data
             ),
         )
@@ -384,7 +365,7 @@ class DSDupOp(ARMInstruction):
 
     def assembly_line_args(self):
         return (
-            VectorWithArrangement(self.d, self.arrangement),
+            vector_with_arrangement(self.d, self.arrangement),
             reg(self.s),
         )
 
@@ -436,7 +417,7 @@ class DSVecMovOp(ARMInstruction):
     def assembly_line_args(self):
         return (
             reg(self.d),
-            VectorWithArrangement(
+            vector_with_arrangement(
                 self.s, self.arrangement, index=self.scalar_idx.value.data
             ),
         )
@@ -491,7 +472,7 @@ class DVarSLd1Op(ARMInstruction):
 
     def assembly_line_args(self):
         return (
-            VariadicNeonRegArg(self.dest_regs, self.arrangement),
+            variadic_neon_reg_arg(self.dest_regs, self.arrangement),
             square_brackets_reg(self.s),
         )
 
@@ -545,7 +526,7 @@ class DVarSSt1Op(ARMInstruction):
 
     def assembly_line_args(self):
         return (
-            VariadicNeonRegArg(self.src_regs, self.arrangement),
+            variadic_neon_reg_arg(self.src_regs, self.arrangement),
             square_brackets_reg(self.d),
         )
 


### PR DESCRIPTION
I suggested this as a way to have a slightly more structured assembly printing than the one we have in RISC-V and x86, as an experiment, and I'm not sure that it adds anything. In order to make the assembly printing infrastructure more uniform across backends for some upcoming changes I'd like to change it into functions for now.