### PR TITLE
core: Update `DYNAMIC_INDEX` to match C++ MLIR

### DIFF
--- a/tests/dialects/test_builtin.py
+++ b/tests/dialects/test_builtin.py
@@ -8,6 +8,7 @@ from typing_extensions import TypeVar
 
 from xdsl.dialects.arith import ConstantOp
 from xdsl.dialects.builtin import (
+    DYNAMIC_INDEX,
     AnyFloat,
     ArrayAttr,
     ArrayOfConstraint,
@@ -918,21 +919,21 @@ def test_shaped_type_has_static_shape():
     scalar_tensor = TensorType(f64, [])
     assert scalar_tensor.has_static_shape() is True
 
-    dynamic_tensor = TensorType(f32, [3, -1])
+    dynamic_tensor = TensorType(f32, [3, DYNAMIC_INDEX])
     assert dynamic_tensor.has_static_shape() is False
 
     # Test VectorType
     static_vector = VectorType(i32, [8])
     assert static_vector.has_static_shape() is True
 
-    dynamic_vector = VectorType(f32, [4, -1])
+    dynamic_vector = VectorType(f32, [4, DYNAMIC_INDEX])
     assert dynamic_vector.has_static_shape() is False
 
     # Test MemRefType
     static_memref = MemRefType(i64, [8, 16])
     assert static_memref.has_static_shape() is True
 
-    dynamic_memref = MemRefType(i32, [-1])
+    dynamic_memref = MemRefType(i32, [DYNAMIC_INDEX])
     assert dynamic_memref.has_static_shape() is False
 
 
@@ -990,7 +991,7 @@ def test_static_shape_array_constraint():
     static_shape = ArrayAttr([IntAttr(1), IntAttr(2), IntAttr(3)])
     StaticShapeArrayConstr.verify(static_shape, ConstraintContext())
 
-    dynamic_shape = ArrayAttr([IntAttr(1), IntAttr(-1), IntAttr(3)])
+    dynamic_shape = ArrayAttr([IntAttr(1), IntAttr(DYNAMIC_INDEX), IntAttr(3)])
     with pytest.raises(
         VerifyException, match="expected static shape, but got dynamic dimension"
     ):

--- a/tests/dialects/test_emitc.py
+++ b/tests/dialects/test_emitc.py
@@ -1,6 +1,6 @@
 import pytest
 
-from xdsl.dialects.builtin import i32
+from xdsl.dialects.builtin import DYNAMIC_INDEX, i32
 from xdsl.dialects.emitc import EmitC_ArrayType, EmitC_CallOpaqueOp
 from xdsl.utils.exceptions import VerifyException
 
@@ -9,7 +9,7 @@ def test_emitc_array_negative_dimension():
     with pytest.raises(
         VerifyException, match="expected static shape, but got dynamic dimension"
     ):
-        EmitC_ArrayType([-1], i32)
+        EmitC_ArrayType([DYNAMIC_INDEX], i32)
 
 
 def test_call_opaque_with_str_callee():

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -8,6 +8,7 @@ import pytest
 from xdsl.context import Context
 from xdsl.dialect_interfaces import OpAsmDialectInterface
 from xdsl.dialects.builtin import (
+    DYNAMIC_INDEX,
     ArrayAttr,
     Builtin,
     DictionaryAttr,
@@ -1215,7 +1216,7 @@ def test_parse_identifier_or_str_literal(input: str, expected: str | None):
         ("", []),
         ("2x3x4", [2, 3, 4]),
         ("9x1x5x", [9, 1, 5]),
-        ("9x?x1x?", [9, -1, 1, -1]),
+        ("9x?x1x?", [9, DYNAMIC_INDEX, 1, DYNAMIC_INDEX]),
     ],
 )
 def test_parse_dimension_list(input: str, expected: list[int]):

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -9,6 +9,7 @@ from xdsl.context import Context
 from xdsl.dialects import test
 from xdsl.dialects.arith import AddiOp, Arith, ConstantOp
 from xdsl.dialects.builtin import (
+    DYNAMIC_INDEX,
     AnyFloat,
     Builtin,
     ComplexType,
@@ -959,7 +960,7 @@ def test_float_attr_specials():
     [
         ([], ""),
         ([1, 2, 3], "1x2x3"),
-        ([1, -1, 3, -1], "1x?x3x?"),
+        ([1, DYNAMIC_INDEX, 3, DYNAMIC_INDEX], "1x?x3x?"),
         ([5], "5"),
     ],
 )

--- a/xdsl/backend/csl/print_csl.py
+++ b/xdsl/backend/csl/print_csl.py
@@ -8,6 +8,7 @@ from typing import IO, Literal, cast
 
 from xdsl.dialects import arith, csl, memref, scf
 from xdsl.dialects.builtin import (
+    DYNAMIC_INDEX,
     ArrayAttr,
     DenseIntOrFPElementsAttr,
     DictionaryAttr,
@@ -339,7 +340,7 @@ class CslPrintContext:
         We need to get the SSAValue passed here, as for unknown sizes, we need to put the
         variable name in the type.
 
-        For every unknown size (-1) in the shape, we look up the corresponding operand to the value
+        For every unknown size (DYNAMIC_INDEX) in the shape, we look up the corresponding operand to the value
         that created the memref (e.g. memref.alloc, csl.constants, ...)
         """
         type = val.type
@@ -350,7 +351,7 @@ class CslPrintContext:
         dims: list[str] = []
         idx = 0
         for dim in type.get_shape():
-            if dim == -1:
+            if dim == DYNAMIC_INDEX:
                 dims.append(self.variables[val.owner.operands[idx]])
                 idx += 1
             else:
@@ -395,7 +396,7 @@ class CslPrintContext:
             case IntegerType():
                 return f"i{cast(IntegerType, type_attr).width.data}"
             case MemRefType(element_type=Attribute() as elem_t, shape=shape):
-                if any(dim.data == -1 for dim in shape):
+                if any(dim.data == DYNAMIC_INDEX for dim in shape):
                     raise ValueError(
                         "Can't print memrefs using mlir_type_to_csl_type if they have dynamic sizes. "
                         "Use _memref_type_to_string instead"

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -101,9 +101,10 @@ if TYPE_CHECKING:
     from xdsl.printer import Printer
 
 
-DYNAMIC_INDEX = -1
+DYNAMIC_INDEX = -9_223_372_036_854_775_808
 """
 A constant value denoting a dynamic index in a shape.
+Equal to -(2 ** 63) which is used in C++ MLIR.
 """
 
 

--- a/xdsl/dialects/gpu.py
+++ b/xdsl/dialects/gpu.py
@@ -5,6 +5,7 @@ from enum import auto
 
 from xdsl.dialects import memref
 from xdsl.dialects.builtin import (
+    DYNAMIC_INDEX,
     AffineMapAttr,
     DenseArrayBase,
     FunctionType,
@@ -157,7 +158,7 @@ class AllocOp(IRDLOperation):
     def verify_(self) -> None:
         ndyn = len(self.dynamicSizes)
         assert isinstance(res_type := self.result.type, memref.MemRefType)
-        ndyn_type = len([i for i in res_type.get_shape() if i == -1])
+        ndyn_type = len([i for i in res_type.get_shape() if i == DYNAMIC_INDEX])
         if ndyn != ndyn_type:
             raise VerifyException(
                 f"Expected {ndyn_type} dynamic sizes, got {ndyn}. All "

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -7,6 +7,7 @@ from typing import ClassVar, cast
 from typing_extensions import Self
 
 from xdsl.dialects.builtin import (
+    DYNAMIC_INDEX,
     I64,
     AnyFloatConstr,
     ArrayAttr,
@@ -220,7 +221,7 @@ class AllocOp(IRDLOperation):
     def verify_(self) -> None:
         memref_type = self.memref.type
 
-        dyn_dims = [x for x in memref_type.shape.data if x.data == -1]
+        dyn_dims = [x for x in memref_type.shape.data if x.data == DYNAMIC_INDEX]
         if len(dyn_dims) != len(self.dynamic_sizes):
             raise VerifyException(
                 "op dimension operand count does not equal memref dynamic dimension count."
@@ -358,7 +359,7 @@ class AllocaOp(IRDLOperation):
     def verify_(self) -> None:
         memref_type = self.memref.type
 
-        dyn_dims = [x for x in memref_type.shape.data if x.data == -1]
+        dyn_dims = [x for x in memref_type.shape.data if x.data == DYNAMIC_INDEX]
         if len(dyn_dims) != len(self.dynamic_sizes):
             raise VerifyException(
                 "op dimension operand count does not equal memref dynamic dimension count."
@@ -959,7 +960,7 @@ class ReinterpretCastOp(IRDLOperation):
                 strict=True,
             )
         ):
-            if expected == ReinterpretCastOp.DYNAMIC_INDEX and actual != -1:
+            if expected == ReinterpretCastOp.DYNAMIC_INDEX and actual != DYNAMIC_INDEX:
                 raise VerifyException(
                     f"Expected result type with dynamic size instead of {actual} in dim = {dim}"
                 )

--- a/xdsl/dialects/stencil.py
+++ b/xdsl/dialects/stencil.py
@@ -11,6 +11,7 @@ from typing_extensions import TypeVar
 
 from xdsl.dialects import builtin, memref
 from xdsl.dialects.builtin import (
+    DYNAMIC_INDEX,
     ArrayAttr,
     IndexType,
     IntAttr,
@@ -275,7 +276,7 @@ class StencilType(
 
     def get_shape(self) -> tuple[int, ...]:
         if isinstance(self.bounds, IntAttr):
-            return (-1,) * self.bounds.data
+            return (DYNAMIC_INDEX,) * self.bounds.data
         else:
             return tuple(self.bounds.ub - self.bounds.lb)
 
@@ -286,7 +287,7 @@ class StencilType(
     def parse_parameters(cls, parser: AttrParser) -> list[Attribute]:
         def parse_interval() -> tuple[int, int] | int:
             if parser.parse_optional_punctuation("?"):
-                return -1
+                return DYNAMIC_INDEX
             parser.parse_punctuation("[")
             l = parser.parse_integer(allow_boolean=False)
             parser.parse_punctuation(",")

--- a/xdsl/dialects/tensor.py
+++ b/xdsl/dialects/tensor.py
@@ -8,6 +8,7 @@ from typing_extensions import Self
 
 from xdsl.dialects import memref
 from xdsl.dialects.builtin import (
+    DYNAMIC_INDEX,
     AnySignlessIntegerOrIndexType,
     ArrayAttr,
     DenseArrayBase,
@@ -716,7 +717,7 @@ class SplatOp(IRDLOperation):
         super().__init__(operands=(input, dynamicSizes), result_types=(result_type,))
 
     def verify_(self):
-        if self.result.type.get_shape().count(-1) != len(self.dynamicSizes):
+        if self.result.type.get_shape().count(DYNAMIC_INDEX) != len(self.dynamicSizes):
             raise VerifyException(
                 "number of dynamic sizes must equal number of unknown dimensions in result tensor"
             )

--- a/xdsl/dialects/utils/reshape_ops_utils.py
+++ b/xdsl/dialects/utils/reshape_ops_utils.py
@@ -10,7 +10,14 @@ from typing import cast
 
 from typing_extensions import TypeVar
 
-from xdsl.dialects.builtin import I64, Annotated, ArrayAttr, IntegerAttr, ShapedType
+from xdsl.dialects.builtin import (
+    DYNAMIC_INDEX,
+    I64,
+    Annotated,
+    ArrayAttr,
+    IntegerAttr,
+    ShapedType,
+)
 from xdsl.ir import Attribute
 from xdsl.irdl import (
     AtLeast,
@@ -117,14 +124,14 @@ def verify_reshape_like_shapes_are_compatible(
 
         # Look at the next `len(rm)` dims in expanded_shape
         for dim in expanded_shape[expanded_dim_start : expanded_dim_start + len(rm)]:
-            if dim == -1:
+            if dim == DYNAMIC_INDEX:
                 found_dynamic = True
             else:
                 linearized_static *= dim
 
         if found_dynamic:
             # if any is dynamic, the collapsed must be dynamic too
-            if not collapsed_shape[map_idx] == -1:
+            if not collapsed_shape[map_idx] == DYNAMIC_INDEX:
                 raise VerifyException(
                     f"expected dimension {map_idx} of collapsed type to be dynamic "
                     f"since one or more of the corresponding dimensions in the "

--- a/xdsl/interpreters/tensor.py
+++ b/xdsl/interpreters/tensor.py
@@ -5,7 +5,7 @@ from typing import Any, cast
 from typing_extensions import TypeVar
 
 from xdsl.dialects import tensor
-from xdsl.dialects.builtin import TensorType
+from xdsl.dialects.builtin import DYNAMIC_INDEX, TensorType
 from xdsl.interpreter import (
     Interpreter,
     InterpreterFunctions,
@@ -32,7 +32,7 @@ class TensorFunctions(InterpreterFunctions):
 
         dynamic_dims = iter(args)
         for i in range(len(result_shape)):
-            if result_shape[i] == -1:
+            if result_shape[i] == DYNAMIC_INDEX:
                 result_shape[i] = next(dynamic_dims)
         assert next(dynamic_dims, None) is None
 

--- a/xdsl/parser/attribute_parser.py
+++ b/xdsl/parser/attribute_parser.py
@@ -12,6 +12,7 @@ import xdsl.parser as affine_parser
 from xdsl.context import Context
 from xdsl.dialect_interfaces import OpAsmDialectInterface
 from xdsl.dialects.builtin import (
+    DYNAMIC_INDEX,
     AffineMapAttr,
     AffineSetAttr,
     AnyDenseElement,
@@ -452,10 +453,10 @@ class AttrParser(BaseParser):
     def parse_shape_dimension(self, allow_dynamic: bool = True) -> int:
         """
         Parse a single shape dimension, which is a decimal literal or `?`.
-        `?` is interpreted as -1. Note that if the integer literal is in
+        `?` is interpreted as DYNAMIC_INDEX. Note that if the integer literal is in
         hexadecimal form, it will be split into multiple tokens. For example,
         `0x10` will be split into `0` and `x10`.
-        Optionally allows to not parse `?` as -1.
+        Optionally allows to not parse `?` as DYNAMIC_INDEX.
         """
         if self._current_token.kind not in (
             MLIRTokenKind.INTEGER_LIT,
@@ -473,7 +474,7 @@ class AttrParser(BaseParser):
 
         if self.parse_optional_punctuation("?") is not None:
             if allow_dynamic:
-                return -1
+                return DYNAMIC_INDEX
             self.raise_error("Unexpected dynamic dimension!")
 
         # If the integer literal starts with `0x`, this is decomposed into
@@ -799,7 +800,7 @@ class AttrParser(BaseParser):
             )
 
         # Check for static shapes in type
-        if any(dim == -1 for dim in list(type.get_shape())):
+        if any(dim == DYNAMIC_INDEX for dim in list(type.get_shape())):
             self.raise_error("Dense literal attribute should have a static shape.")
         return type
 

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -11,6 +11,7 @@ from typing_extensions import TypeVar, deprecated
 
 from xdsl.dialect_interfaces import OpAsmDialectInterface
 from xdsl.dialects.builtin import (
+    DYNAMIC_INDEX,
     AnyFloat,
     BuiltinAttribute,
     ComplexType,
@@ -414,12 +415,14 @@ class Printer(BasePrinter):
         Prints the dimension list of a shape, ending with a dimension.
 
         e.g.:
-          Input: [5, 1, -1, 4]
+          Input: [5, 1, DYNAMIC_INDEX, 4]
           Prints: "5x1x?x4"
         """
         self.print_list(
             dims,
-            lambda x: self.print_int(x) if x != -1 else self.print_string("?"),
+            lambda x: self.print_int(x)
+            if x != DYNAMIC_INDEX
+            else self.print_string("?"),
             "x",
         )
 


### PR DESCRIPTION
In C++ MLIR dynamic indices are specified by kDynamicShape which represents the smallest integer in `i64`: `-(2 ** 63)`. This PR updates xDSL to use this value as it is required for printing some ops in generic format, e.g.:

```
mesh.mesh @mesh0(shape = ?x2)
```

ran with `mlir-opt --mlir-print-op-generic` becomes:

```
"builtin.module"() ({
  "mesh.mesh"() <{shape = array<i64: -9223372036854775808, 2>, sym_name = "mesh0"}> : () -> ()
}) : () -> ()
```

Meaning this is required for generic MLIR compatibility. The previous code often used `-1` as a value instead of `DYNAMIC_INDEX` so this also updates that, but it's possible that some untested code isn't updated in this PR. 