### PR TITLE
dialects: (x86_scf) ForRofOperation: RegisterAllocatableOperation

### DIFF
--- a/tests/filecheck/backend/x86/x86_allocate_registers.mlir
+++ b/tests/filecheck/backend/x86/x86_allocate_registers.mlir
@@ -1,14 +1,13 @@
 // RUN: xdsl-opt -p x86-allocate-registers %s | filecheck %s
 
-// CHECK:       builtin.module {
 
-// CHECK-NEXT:    x86_func.func @external() -> ()
+// CHECK-LABEL:    @external
 x86_func.func @external() -> ()
 
-
-// CHECK-NEXT:    x86_func.func @main_avx2() {
-// CHECK-NEXT:      %ymm0, %ymm1, %ymm2, %ymm3 = "test.op"() : () -> (!x86.avx2reg<ymm0>, !x86.avx2reg<ymm1>, !x86.avx2reg<ymm2>, !x86.avx2reg<ymm3>)
+// CHECK-LABEL:    @main_avx2
 x86_func.func @main_avx2() {
+
+// CHECK-NEXT:      %ymm0, %ymm1, %ymm2, %ymm3 = "test.op"() : () -> (!x86.avx2reg<ymm0>, !x86.avx2reg<ymm1>, !x86.avx2reg<ymm2>, !x86.avx2reg<ymm3>)
   %ymm0, %ymm1, %ymm2, %ymm3 = "test.op"() : () -> (!x86.avx2reg<ymm0>, !x86.avx2reg<ymm1>, !x86.avx2reg<ymm2>, !x86.avx2reg<ymm3>)
 
 // inout is allocated to same register
@@ -25,11 +24,9 @@ x86_func.func @main_avx2() {
   x86_func.ret
 }
 
-// CHECK-NEXT:    }
-
-// CHECK-NEXT:    x86_func.func @main_avx512() {
-// CHECK-NEXT:      %zmm0, %zmm1, %zmm2, %zmm3 = "test.op"() : () -> (!x86.avx512reg<zmm0>, !x86.avx512reg<zmm1>, !x86.avx512reg<zmm2>, !x86.avx512reg<zmm3>)
+// CHECK-LABEL:    @main_avx512
 x86_func.func @main_avx512() {
+// CHECK-NEXT:      %zmm0, %zmm1, %zmm2, %zmm3 = "test.op"() : () -> (!x86.avx512reg<zmm0>, !x86.avx512reg<zmm1>, !x86.avx512reg<zmm2>, !x86.avx512reg<zmm3>)
   %zmm0, %zmm1, %zmm2, %zmm3 = "test.op"() : () -> (!x86.avx512reg<zmm0>, !x86.avx512reg<zmm1>, !x86.avx512reg<zmm2>, !x86.avx512reg<zmm3>)
 
 // inout is allocated to same register
@@ -46,6 +43,21 @@ x86_func.func @main_avx512() {
   x86_func.ret
 }
 
-// CHECK-NEXT:    }
+// CHECK-LABEL:  @loops
+x86_func.func @loops() {
 
-// CHECK-NEXT:  }
+// CHECK-NEXT:      %start, %end, %step = "test.op"() : () -> (!x86.reg<rcx>, !x86.reg<rdx>, !x86.reg<rax>)
+  %start, %end, %step = "test.op"() : () -> (!x86.reg, !x86.reg, !x86.reg)
+
+// CHECK-NEXT:      %for_result = x86_scf.for %iv : !x86.reg<rcx>  = %start to %end step %step iter_args(%iter_val = %step) -> (!x86.reg<rax>) {
+// CHECK-NEXT:        %moved_val = x86.ds.mov %iter_val : (!x86.reg<rax>) -> !x86.reg<rax>
+// CHECK-NEXT:        x86_scf.yield %moved_val : !x86.reg<rax>
+// CHECK-NEXT:      }
+  %for_result = x86_scf.for %iv : !x86.reg = %start to %end step %step iter_args(%iter_val = %step) -> (!x86.reg) {
+    %moved_val = x86.ds.mov %iter_val : (!x86.reg) -> !x86.reg
+    x86_scf.yield %moved_val : !x86.reg
+  }
+
+// CHECK-NEXT:      x86_func.ret
+  x86_func.ret
+}


### PR DESCRIPTION
Now supports register allocation. Mostly a copy/paste of riscv_scf implementation. Makes me think that this should actually go into an `asm` dialect, to share between backends.