### PR TITLE
dialects: (memref) remove memref.SubviewOp.DYNAMIC_INDEX

### DIFF
--- a/tests/dialects/test_tensor.py
+++ b/tests/dialects/test_tensor.py
@@ -1,5 +1,4 @@
-from xdsl.dialects import memref
-from xdsl.dialects.builtin import DenseArrayBase, TensorType, f64, i64
+from xdsl.dialects.builtin import DYNAMIC_INDEX, DenseArrayBase, TensorType, f64, i64
 from xdsl.dialects.stencil import IndexAttr
 from xdsl.dialects.tensor import ExtractSliceOp, InsertSliceOp
 from xdsl.dialects.test import TestOp
@@ -89,8 +88,8 @@ def test_insert_slice_dynamic():
     )
 
     assert insert_slice.static_offsets == DenseArrayBase.from_list(
-        i64, 2 * [memref.SubviewOp.DYNAMIC_INDEX]
+        i64, 2 * [DYNAMIC_INDEX]
     )
     assert insert_slice.static_strides == DenseArrayBase.from_list(
-        i64, 2 * [memref.SubviewOp.DYNAMIC_INDEX]
+        i64, 2 * [DYNAMIC_INDEX]
     )

--- a/xdsl/backend/riscv/lowering/convert_memref_to_riscv.py
+++ b/xdsl/backend/riscv/lowering/convert_memref_to_riscv.py
@@ -11,6 +11,7 @@ from xdsl.builder import ImplicitBuilder
 from xdsl.context import Context
 from xdsl.dialects import memref, riscv, riscv_func
 from xdsl.dialects.builtin import (
+    DYNAMIC_INDEX,
     AnyFloat,
     DenseArrayBase,
     DenseIntOrFPElementsAttr,
@@ -361,7 +362,7 @@ class ConvertMemRefSubviewOp(RewritePattern):
             dynamic_offset_index = 0
             for static_offset in op.static_offsets.iter_values():
                 assert isinstance(static_offset, int)
-                if static_offset == memref.SubviewOp.DYNAMIC_INDEX:
+                if static_offset == DYNAMIC_INDEX:
                     index_ops.append(
                         cast_index_op := UnrealizedConversionCastOp.get(
                             (op.offsets[dynamic_offset_index],),

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -611,12 +611,6 @@ class MemRefHasCanonicalizationPatternsTrait(HasCanonicalizationPatternsTrait):
 
 @irdl_op_definition
 class SubviewOp(IRDLOperation):
-    DYNAMIC_INDEX: ClassVar[int] = -9223372036854775808
-    """
-    Constant value used to denote dynamic indices in offsets, sizes, and strides.
-    Same constant as in MLIR.
-    """
-
     name = "memref.subview"
 
     source = operand_def(MemRefType)
@@ -649,13 +643,13 @@ class SubviewOp(IRDLOperation):
         static_sizes = self.static_sizes.get_values()
         static_strides = self.static_strides.get_values()
         verify_dynamic_index_list(
-            static_sizes, self.sizes, self.DYNAMIC_INDEX, " in the size arguments"
+            static_sizes, self.sizes, DYNAMIC_INDEX, " in the size arguments"
         )
         verify_dynamic_index_list(
-            static_offsets, self.offsets, self.DYNAMIC_INDEX, " in the offset arguments"
+            static_offsets, self.offsets, DYNAMIC_INDEX, " in the offset arguments"
         )
         verify_dynamic_index_list(
-            static_strides, self.strides, self.DYNAMIC_INDEX, " in the stride arguments"
+            static_strides, self.strides, DYNAMIC_INDEX, " in the stride arguments"
         )
 
     def __init__(
@@ -693,15 +687,9 @@ class SubviewOp(IRDLOperation):
         strides: Sequence[SSAValue | int],
         result_type: Attribute,
     ) -> SubviewOp:
-        static_offsets, dyn_offsets = split_dynamic_index_list(
-            offsets, SubviewOp.DYNAMIC_INDEX
-        )
-        static_sizes, dyn_sizes = split_dynamic_index_list(
-            sizes, SubviewOp.DYNAMIC_INDEX
-        )
-        static_strides, dyn_strides = split_dynamic_index_list(
-            strides, SubviewOp.DYNAMIC_INDEX
-        )
+        static_offsets, dyn_offsets = split_dynamic_index_list(offsets, DYNAMIC_INDEX)
+        static_sizes, dyn_sizes = split_dynamic_index_list(sizes, DYNAMIC_INDEX)
+        static_strides, dyn_strides = split_dynamic_index_list(strides, DYNAMIC_INDEX)
 
         return SubviewOp(
             source,

--- a/xdsl/dialects/tensor.py
+++ b/xdsl/dialects/tensor.py
@@ -6,7 +6,6 @@ from typing import ClassVar, cast
 
 from typing_extensions import Self
 
-from xdsl.dialects import memref
 from xdsl.dialects.builtin import (
     DYNAMIC_INDEX,
     AnySignlessIntegerOrIndexType,
@@ -502,11 +501,11 @@ class InsertSliceOp(IRDLOperation):
         sizes = [] if sizes is None else sizes
         strides = [] if strides is None else strides
         if not static_offsets:
-            static_offsets = [memref.SubviewOp.DYNAMIC_INDEX] * len(offsets) + (
+            static_offsets = [DYNAMIC_INDEX] * len(offsets) + (
                 [0] * (dims - len(offsets))
             )
         if not static_strides:
-            static_strides = [memref.SubviewOp.DYNAMIC_INDEX] * len(strides) + (
+            static_strides = [DYNAMIC_INDEX] * len(strides) + (
                 [1] * (dims - len(strides))
             )
         return InsertSliceOp.build(

--- a/xdsl/transforms/convert_stencil_to_csl_stencil.py
+++ b/xdsl/transforms/convert_stencil_to_csl_stencil.py
@@ -4,8 +4,9 @@ from math import prod
 
 from xdsl.builder import ImplicitBuilder
 from xdsl.context import Context
-from xdsl.dialects import arith, builtin, memref, stencil, tensor, varith
+from xdsl.dialects import arith, builtin, stencil, tensor, varith
 from xdsl.dialects.builtin import (
+    DYNAMIC_INDEX,
     AnyTensorType,
     DenseIntOrFPElementsAttr,
     FloatAttr,
@@ -623,7 +624,7 @@ class TransformPrefetch(RewritePattern):
                     source=ac_op.result,
                     dest=dest,
                     static_sizes=[1, *ac_op.result.type.get_shape()],
-                    static_offsets=[i, memref.SubviewOp.DYNAMIC_INDEX],
+                    static_offsets=[i, DYNAMIC_INDEX],
                     offsets=[offset],
                 ).result
             csl_stencil.YieldOp(dest)

--- a/xdsl/transforms/csl_stencil_bufferize.py
+++ b/xdsl/transforms/csl_stencil_bufferize.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from xdsl.context import Context
 from xdsl.dialects import arith, bufferization, func, linalg, memref, stencil, tensor
 from xdsl.dialects.builtin import (
+    DYNAMIC_INDEX,
     AnyDenseElement,
     AnyTensorType,
     AnyTensorTypeConstr,
@@ -229,7 +230,7 @@ class ApplyOpBufferize(RewritePattern):
                     result_types=[chunk_type],
                     properties={
                         "static_offsets": DenseArrayBase.from_list(
-                            i64, (memref.SubviewOp.DYNAMIC_INDEX,)
+                            i64, (DYNAMIC_INDEX,)
                         ),
                         "static_sizes": DenseArrayBase.from_list(
                             i64, chunk_type.get_shape()
@@ -262,9 +263,7 @@ class ApplyOpBufferize(RewritePattern):
             operands=[to_tensor.tensor, [offset], [], []],
             result_types=[TensorType(typ.get_element_type(), typ.get_shape()[1:])],
             properties={
-                "static_offsets": DenseArrayBase.from_list(
-                    i64, (memref.SubviewOp.DYNAMIC_INDEX,)
-                ),
+                "static_offsets": DenseArrayBase.from_list(i64, (DYNAMIC_INDEX,)),
                 "static_sizes": DenseArrayBase.from_list(i64, typ.get_shape()[1:]),
                 "static_strides": DenseArrayBase.from_list(i64, (1,)),
             },

--- a/xdsl/transforms/memref_to_dsd.py
+++ b/xdsl/transforms/memref_to_dsd.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from xdsl.context import Context
 from xdsl.dialects import arith, builtin, csl, memref
 from xdsl.dialects.builtin import (
+    DYNAMIC_INDEX,
     AffineMapAttr,
     ArrayAttr,
     Float16Type,
@@ -142,7 +143,7 @@ class LowerSubviewOpPass(RewritePattern):
             )
 
             amap: list[AffineExpr] = [
-                AffineConstantExpr(o if o != memref.SubviewOp.DYNAMIC_INDEX else 0)
+                AffineConstantExpr(o if o != DYNAMIC_INDEX else 0)
                 for o in op.static_offsets.get_values()
             ]
             amap[sizes.index(size)] += AffineDimExpr(0)
@@ -188,7 +189,7 @@ class LowerSubviewOpPass(RewritePattern):
 
         static_sizes = subview.static_sizes.get_values()
 
-        if static_sizes[0] == memref.SubviewOp.DYNAMIC_INDEX:
+        if static_sizes[0] == DYNAMIC_INDEX:
             ops.append(cast_op := arith.IndexCastOp(subview.sizes[0], i16))
             ops.append(
                 curr_op := csl.SetDsdLengthOp.build(
@@ -221,7 +222,7 @@ class LowerSubviewOpPass(RewritePattern):
 
         static_strides = subview.static_strides.get_values()
 
-        if static_strides[0] == memref.SubviewOp.DYNAMIC_INDEX:
+        if static_strides[0] == DYNAMIC_INDEX:
             ops.append(cast_op := arith.IndexCastOp(subview.strides[0], i8))
             ops.append(
                 csl.SetDsdStrideOp.build(


### PR DESCRIPTION
The two definitions of DYNAMIC_INDEX now agree so let's use the one in builtin.