### PR TITLE
core: (assembly-format) Add optional anchor support for `Custom<DynamicIndexList>`

### DIFF
--- a/xdsl/dialects/utils/dynamic_index_list.py
+++ b/xdsl/dialects/utils/dynamic_index_list.py
@@ -259,9 +259,7 @@ class DynamicIndexList(CustomDirective):
         dynamic_empty = len(self.dynamic_position.get(op)) == 0
 
         static_vals = self.static_position.get(op)
-        static_empty = (
-            static_vals == DenseArrayBase.from_list(i64, []) or static_vals is None
-        )
+        static_empty = static_vals == DenseArrayBase.from_list(i64, [])
 
         return not (dynamic_empty and static_empty)
 

--- a/xdsl/dialects/utils/dynamic_index_list.py
+++ b/xdsl/dialects/utils/dynamic_index_list.py
@@ -11,7 +11,7 @@ where `MARKER` is a special value that indicates that the value at that position
 from __future__ import annotations
 
 from collections.abc import Iterable, Sequence
-from typing import ClassVar
+from typing import ClassVar, override
 
 from xdsl.dialects.builtin import DenseArrayBase, IntegerType, i64
 from xdsl.ir import Attribute, SSAValue
@@ -248,3 +248,23 @@ class DynamicIndexList(CustomDirective):
         print_dynamic_index_list(
             printer, self.DYNAMIC_INDEX, dynamic, static.get_values()
         )
+
+    @override
+    def set_empty(self, state: ParsingState):
+        self.dynamic_position.set(state, [])
+        self.static_position.set(state, DenseArrayBase.from_list(i64, []))
+
+    @override
+    def is_present(self, op: IRDLOperation) -> bool:
+        dynamic_empty = len(self.dynamic_position.get(op)) == 0
+
+        static_vals = self.static_position.get(op)
+        static_empty = (
+            static_vals == DenseArrayBase.from_list(i64, []) or static_vals is None
+        )
+
+        return not (dynamic_empty and static_empty)
+
+    @override
+    def is_anchorable(self) -> bool:
+        return True

--- a/xdsl/dialects/utils/dynamic_index_list.py
+++ b/xdsl/dialects/utils/dynamic_index_list.py
@@ -11,7 +11,7 @@ where `MARKER` is a special value that indicates that the value at that position
 from __future__ import annotations
 
 from collections.abc import Iterable, Sequence
-from typing import ClassVar, override
+from typing import ClassVar
 
 from xdsl.dialects.builtin import DenseArrayBase, IntegerType, i64
 from xdsl.ir import Attribute, SSAValue
@@ -249,12 +249,10 @@ class DynamicIndexList(CustomDirective):
             printer, self.DYNAMIC_INDEX, dynamic, static.get_values()
         )
 
-    @override
     def set_empty(self, state: ParsingState):
         self.dynamic_position.set(state, [])
         self.static_position.set(state, DenseArrayBase.from_list(i64, []))
 
-    @override
     def is_present(self, op: IRDLOperation) -> bool:
         dynamic_empty = len(self.dynamic_position.get(op)) == 0
 
@@ -263,6 +261,5 @@ class DynamicIndexList(CustomDirective):
 
         return not (dynamic_empty and static_empty)
 
-    @override
     def is_anchorable(self) -> bool:
         return True

--- a/xdsl/dialects/utils/dynamic_index_list.py
+++ b/xdsl/dialects/utils/dynamic_index_list.py
@@ -254,10 +254,11 @@ class DynamicIndexList(CustomDirective):
         self.static_position.set(state, DenseArrayBase.from_list(i64, []))
 
     def is_present(self, op: IRDLOperation) -> bool:
-        dynamic_empty = len(self.dynamic_position.get(op)) == 0
+        dynamic_empty = not self.dynamic_position.get(op)
 
         static_vals = self.static_position.get(op)
-        static_empty = static_vals == DenseArrayBase.from_list(i64, [])
+        assert isa(static_vals, DenseArrayBase[IntegerType])
+        static_empty = not static_vals.data.data
 
         return not (dynamic_empty and static_empty)
 


### PR DESCRIPTION
Adds support for `custom<DynamicIndexList>` to be used as an aqchorable directive, as in C++ MLIR. This lets it be used in optional clauses, which [some MLIR operations](https://github.com/llvm/llvm-project/blob/6146a88f60492b520a36f8f8f3231e15f3cc6082/mlir/include/mlir/Dialect/Mesh/IR/MeshOps.td#L305) use.

e.g. you can have assembly formats as the following:

```assembly_format = (`keyword` custom<DynamicIndexList>($dynamics, $statics)^)?```

Not super familiar with this code so open to feedback