### PR TITLE
dialects: (builtin) remove abstract name from MemRefLayoutAttr

### DIFF
--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -1873,8 +1873,6 @@ class MemRefLayoutAttr(Attribute, ABC):
     Interface for any attribute acceptable as a memref layout.
     """
 
-    name = "abstract.memref_layout_att"
-
     @abstractmethod
     def get_affine_map(self) -> AffineMap:
         """


### PR DESCRIPTION
We used to need this for some constraint logic but we no longer require it.