### PR TITLE
core: add is_pure_affine helper to AffineExpr

### DIFF
--- a/tests/test_affine_builtins.py
+++ b/tests/test_affine_builtins.py
@@ -471,3 +471,41 @@ def test_apply_permutation_map(
     permutation_map: AffineMap, inputs: Sequence[_T], expected: tuple[_T, ...]
 ):
     assert permutation_map.apply_permutation(inputs) == expected
+
+
+d0 = AffineExpr.dimension(0)
+d1 = AffineExpr.dimension(1)
+s0 = AffineExpr.symbol(0)
+c2 = AffineExpr.constant(2)
+c3 = AffineExpr.constant(3)
+
+
+@pytest.mark.parametrize(
+    "expr, expected",
+    [
+        # Pure affine: only addition, multiplication by constant, dimensions, symbols, constants
+        (d0 + d1, True),  # d0 + d1 is pure affine
+        (c2 * d0 + c3 * d1, True),  # 2 * d0 + 3 * d1 is pure affine
+        (d0 * 2 + d1 * 3, True),  # d0 * 2 + d1 * 3 is pure affine
+        (d0 + s0, True),  # d0 + s0 is pure affine
+        (d0 + 5, True),  # d0 + 5 is pure affine
+        (d0 // 2, True),  # d0 // 2 is pure affine (floordiv by constant)
+        ((d0 + d1) // 3, True),  # (d0 + d1) // 3 is pure affine
+        (d0 % 4, True),  # d0 % 4 is pure affine (mod by constant)
+        ((d0 + d1) % 5, True),  # (d0 + d1) % 5 is pure affine
+        (d0.ceil_div(7), True),  # d0.ceil_div(7) is pure affine (ceildiv by constant)
+        ((d0 + d1).ceil_div(2), True),  # (d0 + d1).ceil_div(2) is pure affine
+        # Not pure affine: multiplication by symbol
+        (AffineBinaryOpExpr(AffineBinaryOpKind.Mul, d0, s0), False),
+        # Not pure affine: multiplication by dimension
+        (AffineBinaryOpExpr(AffineBinaryOpKind.Mul, d0, d1), False),
+        # Not pure affine: floordiv by symbol
+        (AffineBinaryOpExpr(AffineBinaryOpKind.FloorDiv, d0, s0), False),
+        # Not pure affine: mod by symbol
+        (AffineBinaryOpExpr(AffineBinaryOpKind.Mod, d0, s0), False),
+        # Not pure affine: ceildiv by symbol
+        (AffineBinaryOpExpr(AffineBinaryOpKind.CeilDiv, d0, s0), False),
+    ],
+)
+def test_is_pure_affine(expr: AffineExpr, expected: bool):
+    assert expr.is_pure_affine() is expected

--- a/xdsl/ir/affine/affine_expr.py
+++ b/xdsl/ir/affine/affine_expr.py
@@ -308,6 +308,14 @@ class AffineExpr:
     def used_dims(self) -> set[int]:
         return {expr.position for expr in self.dfs() if isinstance(expr, AffineDimExpr)}
 
+    @abstractmethod
+    def is_pure_affine(self) -> bool:
+        """
+        Returns true if this is a pure affine expression, i.e., multiplication,
+        floordiv, ceildiv, and mod is only allowed w.r.t constants.
+        """
+        ...
+
 
 class AffineBinaryOpKind(Enum):
     """Enum for the kind of storage node used in AffineExpr."""
@@ -340,13 +348,40 @@ class AffineBinaryOpExpr(AffineExpr):
     lhs: AffineExpr
     rhs: AffineExpr
 
-    def __str__(self) -> str:
-        return f"({self.lhs} {self.kind.get_token()} {self.rhs})"
-
     def dfs(self) -> Iterator[AffineExpr]:
         yield self
         yield from self.lhs.dfs()
         yield from self.rhs.dfs()
+
+    def is_pure_affine(self) -> bool:
+        match self.kind:
+            case AffineBinaryOpKind.Add:
+                return self.lhs.is_pure_affine() and self.rhs.is_pure_affine()
+            case AffineBinaryOpKind.Mul:
+                # Multiplication is only allowed with a constant on the right
+                # or left for pure affine expressions.
+                # Check if either lhs or rhs is a constant and the other is pure affine.
+                lhs_is_const = isinstance(self.lhs, AffineConstantExpr)
+                rhs_is_const = isinstance(self.rhs, AffineConstantExpr)
+
+                return (
+                    (lhs_is_const or rhs_is_const)
+                    and self.lhs.is_pure_affine()
+                    and self.rhs.is_pure_affine()
+                )
+            case (
+                AffineBinaryOpKind.Mod
+                | AffineBinaryOpKind.FloorDiv
+                | AffineBinaryOpKind.CeilDiv
+            ):
+                # Mod, floordiv, ceildiv are only allowed with a constant on the right for pure affine
+                return (
+                    isinstance(self.rhs, AffineConstantExpr)
+                    and self.lhs.is_pure_affine()
+                )
+
+    def __str__(self) -> str:
+        return f"({self.lhs} {self.kind.get_token()} {self.rhs})"
 
 
 @dataclass(frozen=True)
@@ -354,6 +389,9 @@ class AffineDimExpr(AffineExpr):
     """An affine expression storage node representing a dimension."""
 
     position: int
+
+    def is_pure_affine(self) -> bool:
+        return True
 
     def __str__(self) -> str:
         return f"d{self.position}"
@@ -365,6 +403,9 @@ class AffineSymExpr(AffineExpr):
 
     position: int
 
+    def is_pure_affine(self) -> bool:
+        return True
+
     def __str__(self) -> str:
         return f"s{self.position}"
 
@@ -374,6 +415,9 @@ class AffineConstantExpr(AffineExpr):
     """An affine expression storage node representing a constant."""
 
     value: int
+
+    def is_pure_affine(self) -> bool:
+        return True
 
     def __str__(self) -> str:
         return f"{self.value}"


### PR DESCRIPTION
We actually don't really support semi-affine maps in xDSL, and raise exceptions when constructing them using the helpers, but I still want to add this helper to assert that this is the case and catch things early when the situation changes.