### PR TITLE
dialects: (tosa) add reciprocal, reduce operations

### DIFF
--- a/tests/filecheck/dialects/tosa/ops.mlir
+++ b/tests/filecheck/dialects/tosa/ops.mlir
@@ -141,3 +141,35 @@ func.func @test_reduce_any(%arg0: tensor<31x5x3xi1>) -> tensor<1x5x3xi1> {
   %0 = tosa.reduce_any %arg0 {axis = 0 : i32} : (tensor<31x5x3xi1>) -> tensor<1x5x3xi1>
   return %0 : tensor<1x5x3xi1>
 }
+
+// -----
+// CHECK-LABEL: reduce_max
+func.func @test_reduce_max(%arg0: tensor<31x5x3xf32>) -> tensor<1x5x3xf32> {
+  // CHECK: {{%.*}} = tosa.reduce_max {{%.*}} {axis = 0 : i32} : (tensor<31x5x3xf32>) -> tensor<1x5x3xf32>
+  %0 = tosa.reduce_max %arg0 {axis = 0 : i32} : (tensor<31x5x3xf32>) -> tensor<1x5x3xf32>
+  return %0 : tensor<1x5x3xf32>
+}
+
+// -----
+// CHECK-LABEL: reduce_min
+func.func @test_reduce_min(%arg0: tensor<31x5x3xf32>) -> tensor<1x5x3xf32> {
+  // CHECK: {{%.*}} = tosa.reduce_min {{%.*}} {axis = 0 : i32} : (tensor<31x5x3xf32>) -> tensor<1x5x3xf32>
+  %0 = tosa.reduce_min %arg0 {axis = 0 : i32} : (tensor<31x5x3xf32>) -> tensor<1x5x3xf32>
+  return %0 : tensor<1x5x3xf32>
+}
+
+// -----
+// CHECK-LABEL: reduce_prod
+func.func @test_reduce_prod(%arg0: tensor<31x5x3xf32>) -> tensor<1x5x3xf32> {
+  // CHECK: {{%.*}} = tosa.reduce_prod {{%.*}} {axis = 0 : i32} : (tensor<31x5x3xf32>) -> tensor<1x5x3xf32>
+  %0 = tosa.reduce_prod %arg0 {axis = 0 : i32} : (tensor<31x5x3xf32>) -> tensor<1x5x3xf32>
+  return %0 : tensor<1x5x3xf32>
+}
+
+// -----
+// CHECK-LABEL: reduce_sum
+func.func @test_reduce_sum(%arg0: tensor<31x5x3xf32>) -> tensor<1x5x3xf32> {
+  // CHECK: {{%.*}} = tosa.reduce_sum {{%.*}} {axis = 0 : i32} : (tensor<31x5x3xf32>) -> tensor<1x5x3xf32>
+  %0 = tosa.reduce_sum %arg0 {axis = 0 : i32} : (tensor<31x5x3xf32>) -> tensor<1x5x3xf32>
+  return %0 : tensor<1x5x3xf32>
+}

--- a/tests/filecheck/dialects/tosa/ops.mlir
+++ b/tests/filecheck/dialects/tosa/ops.mlir
@@ -129,6 +129,15 @@ func.func @test_recip_f32(%arg0: tensor<12x24xf32>) -> tensor<12x24xf32> {
 // -----
 // CHECK-LABEL: reduce_all
 func.func @test_reduce_all(%arg0: tensor<31x5x3xi1>) -> tensor<1x5x3xi1> {
+  // CHECK: {{%.*}} = tosa.reduce_all {{%.*}} {axis = 0 : i32} : (tensor<31x5x3xi1>) -> tensor<1x5x3xi1>
   %0 = tosa.reduce_all %arg0 {axis = 0 : i32} : (tensor<31x5x3xi1>) -> tensor<1x5x3xi1>
+  return %0 : tensor<1x5x3xi1>
+}
+
+// -----
+// CHECK-LABEL: reduce_any
+func.func @test_reduce_any(%arg0: tensor<31x5x3xi1>) -> tensor<1x5x3xi1> {
+  // CHECK: {{%.*}} = tosa.reduce_any {{%.*}} {axis = 0 : i32} : (tensor<31x5x3xi1>) -> tensor<1x5x3xi1>
+  %0 = tosa.reduce_any %arg0 {axis = 0 : i32} : (tensor<31x5x3xi1>) -> tensor<1x5x3xi1>
   return %0 : tensor<1x5x3xi1>
 }

--- a/tests/filecheck/dialects/tosa/ops.mlir
+++ b/tests/filecheck/dialects/tosa/ops.mlir
@@ -109,3 +109,19 @@ func.func @test_sin(%arg0: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {
   %0 = tosa.sin %arg0 : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
   return %0 : tensor<13x21x3xf32>
 }
+
+// -----
+// CHECK-LABEL: recip_i32
+func.func @test_recip_i32(%arg0: tensor<12x24xi32>) -> tensor<12x24xi32> {
+  // CHECK: {{%.*}} = tosa.reciprocal {{%.*}} : (tensor<12x24xi32>) -> tensor<12x24xi32>
+  %0 = tosa.reciprocal %arg0 : (tensor<12x24xi32>) -> tensor<12x24xi32>
+  return %0 : tensor<12x24xi32>
+}
+
+// -----
+// CHECK-LABEL: recip_f32
+func.func @test_recip_f32(%arg0: tensor<12x24xf32>) -> tensor<12x24xf32> {
+  // CHECK: {{%.*}} = tosa.reciprocal {{%.*}} : (tensor<12x24xf32>) -> tensor<12x24xf32>
+  %0 = tosa.reciprocal %arg0 : (tensor<12x24xf32>) -> tensor<12x24xf32>
+  return %0 : tensor<12x24xf32>
+}

--- a/tests/filecheck/dialects/tosa/ops.mlir
+++ b/tests/filecheck/dialects/tosa/ops.mlir
@@ -125,3 +125,10 @@ func.func @test_recip_f32(%arg0: tensor<12x24xf32>) -> tensor<12x24xf32> {
   %0 = tosa.reciprocal %arg0 : (tensor<12x24xf32>) -> tensor<12x24xf32>
   return %0 : tensor<12x24xf32>
 }
+
+// -----
+// CHECK-LABEL: reduce_all
+func.func @test_reduce_all(%arg0: tensor<31x5x3xi1>) -> tensor<1x5x3xi1> {
+  %0 = tosa.reduce_all %arg0 {axis = 0 : i32} : (tensor<31x5x3xi1>) -> tensor<1x5x3xi1>
+  return %0 : tensor<1x5x3xi1>
+}

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/tosa/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/tosa/ops.mlir
@@ -124,3 +124,10 @@ func.func @test_recip_f32(%arg0: tensor<12x24xf32>) -> tensor<12x24xf32> {
   %0 = tosa.reciprocal %arg0 : (tensor<12x24xf32>) -> tensor<12x24xf32>
   return %0 : tensor<12x24xf32>
 }
+
+// -----
+// CHECK-LABEL: reduce_all
+func.func @test_reduce_all(%arg0: tensor<31x5x3xi1>) -> tensor<1x5x3xi1> {
+  %0 = tosa.reduce_all %arg0 {axis = 0 : i32} : (tensor<31x5x3xi1>) -> tensor<1x5x3xi1>
+  return %0 : tensor<1x5x3xi1>
+}

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/tosa/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/tosa/ops.mlir
@@ -140,3 +140,35 @@ func.func @test_reduce_any(%arg0: tensor<31x5x3xi1>) -> tensor<1x5x3xi1> {
   %0 = tosa.reduce_any %arg0 {axis = 0 : i32} : (tensor<31x5x3xi1>) -> tensor<1x5x3xi1>
   return %0 : tensor<1x5x3xi1>
 }
+
+// -----
+// CHECK-LABEL: reduce_max
+func.func @test_reduce_max(%arg0: tensor<31x5x3xf32>) -> tensor<1x5x3xf32> {
+  // CHECK: {{%.*}} = tosa.reduce_max {{%.*}} {axis = 0 : i32} : (tensor<31x5x3xf32>) -> tensor<1x5x3xf32>
+  %0 = tosa.reduce_max %arg0 {axis = 0 : i32} : (tensor<31x5x3xf32>) -> tensor<1x5x3xf32>
+  return %0 : tensor<1x5x3xf32>
+}
+
+// -----
+// CHECK-LABEL: reduce_min
+func.func @test_reduce_min(%arg0: tensor<31x5x3xf32>) -> tensor<1x5x3xf32> {
+  // CHECK: {{%.*}} = tosa.reduce_min {{%.*}} {axis = 0 : i32} : (tensor<31x5x3xf32>) -> tensor<1x5x3xf32>
+  %0 = tosa.reduce_min %arg0 {axis = 0 : i32} : (tensor<31x5x3xf32>) -> tensor<1x5x3xf32>
+  return %0 : tensor<1x5x3xf32>
+}
+
+// -----
+// CHECK-LABEL: reduce_prod
+func.func @test_reduce_prod(%arg0: tensor<31x5x3xf32>) -> tensor<1x5x3xf32> {
+  // CHECK: {{%.*}} = tosa.reduce_prod {{%.*}} {axis = 0 : i32} : (tensor<31x5x3xf32>) -> tensor<1x5x3xf32>
+  %0 = tosa.reduce_prod %arg0 {axis = 0 : i32} : (tensor<31x5x3xf32>) -> tensor<1x5x3xf32>
+  return %0 : tensor<1x5x3xf32>
+}
+
+// -----
+// CHECK-LABEL: reduce_sum
+func.func @test_reduce_sum(%arg0: tensor<31x5x3xf32>) -> tensor<1x5x3xf32> {
+  // CHECK: {{%.*}} = tosa.reduce_sum {{%.*}} {axis = 0 : i32} : (tensor<31x5x3xf32>) -> tensor<1x5x3xf32>
+  %0 = tosa.reduce_sum %arg0 {axis = 0 : i32} : (tensor<31x5x3xf32>) -> tensor<1x5x3xf32>
+  return %0 : tensor<1x5x3xf32>
+}

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/tosa/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/tosa/ops.mlir
@@ -128,6 +128,15 @@ func.func @test_recip_f32(%arg0: tensor<12x24xf32>) -> tensor<12x24xf32> {
 // -----
 // CHECK-LABEL: reduce_all
 func.func @test_reduce_all(%arg0: tensor<31x5x3xi1>) -> tensor<1x5x3xi1> {
+  // CHECK: {{%.*}} = tosa.reduce_all %{{.*}} {axis = 0 : i32} : (tensor<31x5x3xi1>) -> tensor<1x5x3xi1>
   %0 = tosa.reduce_all %arg0 {axis = 0 : i32} : (tensor<31x5x3xi1>) -> tensor<1x5x3xi1>
+  return %0 : tensor<1x5x3xi1>
+}
+
+// -----
+// CHECK-LABEL: reduce_any
+func.func @test_reduce_any(%arg0: tensor<31x5x3xi1>) -> tensor<1x5x3xi1> {
+  // CHECK: {{%.*}} = tosa.reduce_any %{{.*}} {axis = 0 : i32} : (tensor<31x5x3xi1>) -> tensor<1x5x3xi1>
+  %0 = tosa.reduce_any %arg0 {axis = 0 : i32} : (tensor<31x5x3xi1>) -> tensor<1x5x3xi1>
   return %0 : tensor<1x5x3xi1>
 }

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/tosa/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/tosa/ops.mlir
@@ -108,3 +108,19 @@ func.func @test_sin(%arg0: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {
   %0 = tosa.sin %arg0 : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
   return %0 : tensor<13x21x3xf32>
 }
+
+// -----
+// CHECK-LABEL: recip_i32
+func.func @test_recip_i32(%arg0: tensor<12x24xi32>) -> tensor<12x24xi32> {
+  // CHECK: {{%.*}} = tosa.reciprocal {{%.*}} : (tensor<12x24xi32>) -> tensor<12x24xi32>
+  %0 = tosa.reciprocal %arg0 : (tensor<12x24xi32>) -> tensor<12x24xi32>
+  return %0 : tensor<12x24xi32>
+}
+
+// -----
+// CHECK-LABEL: recip_f32
+func.func @test_recip_f32(%arg0: tensor<12x24xf32>) -> tensor<12x24xf32> {
+  // CHECK: {{%.*}} = tosa.reciprocal {{%.*}} : (tensor<12x24xf32>) -> tensor<12x24xf32>
+  %0 = tosa.reciprocal %arg0 : (tensor<12x24xf32>) -> tensor<12x24xf32>
+  return %0 : tensor<12x24xf32>
+}

--- a/xdsl/dialects/tosa.py
+++ b/xdsl/dialects/tosa.py
@@ -323,44 +323,6 @@ class MatMulOp(IRDLOperation):
         #     )
 
 
-################################################################################
-# Reduction ops                                                                #
-################################################################################
-
-
-class ReductionOperation(IRDLOperation, ABC):
-    """
-    Base class for all TOSA reduction operations
-    """
-
-    input = operand_def(TensorType)
-    axis = prop_def(IntegerAttr[I32])
-
-    output = result_def(TensorType)
-
-    assembly_format = "$input attr-dict `:` functional-type(operands, results)"
-
-    irdl_options = [ParsePropInAttrDict()]
-
-
-@irdl_op_definition
-class ReduceAllOp(ReductionOperation):
-    """
-    Reduce a tensor along the given axis with a logical AND operation
-    """
-
-    name = "tosa.reduce_all"
-
-
-@irdl_op_definition
-class ReduceAnyOp(ReductionOperation):
-    """
-    Reduce a tensor along the given axis with a logical OR operation
-    """
-
-    name = "tosa.reduce_any"
-
-
 @irdl_op_definition
 class MaxPool2DOp(IRDLOperation):
     """
@@ -448,6 +410,84 @@ class ConcatOp(IRDLOperation):
     assembly_format = "$tensors attr-dict `:` `(` type($tensors) `)` `->` type($output)"
 
 
+################################################################################
+# Reduction ops                                                                #
+################################################################################
+
+
+class ReductionOperation(IRDLOperation, ABC):
+    """
+    Base class for all TOSA reduction operations
+    """
+
+    input = operand_def(TensorType)
+    axis = prop_def(IntegerAttr[I32])
+
+    output = result_def(TensorType)
+
+    assembly_format = "$input attr-dict `:` functional-type(operands, results)"
+
+    irdl_options = [ParsePropInAttrDict()]
+
+
+@irdl_op_definition
+class ReduceAllOp(ReductionOperation):
+    """
+    Reduce a tensor along the given axis with a logical AND operation
+    """
+
+    name = "tosa.reduce_all"
+
+
+@irdl_op_definition
+class ReduceAnyOp(ReductionOperation):
+    """
+    Reduce a tensor along the given axis with a logical OR operation
+    """
+
+    name = "tosa.reduce_any"
+
+
+@irdl_op_definition
+class ReduceMaxOp(ReductionOperation):
+    """
+    Reduce a tensor along the given axis by taking the maximum value
+    """
+
+    name = "tosa.reduce_max"
+
+    nan_mode = prop_def(StringAttr, default_value=StringAttr("PROPAGATE"))
+
+
+@irdl_op_definition
+class ReduceMinOp(ReductionOperation):
+    """
+    Reduce a tensor along the given axis by taking the minimum value
+    """
+
+    name = "tosa.reduce_min"
+
+    nan_mode = prop_def(StringAttr, default_value=StringAttr("PROPAGATE"))
+
+
+@irdl_op_definition
+class ReduceProdOp(ReductionOperation):
+    """
+    Reduce a tensor along the given axis by taking the product of all values
+    """
+
+    name = "tosa.reduce_prod"
+
+
+@irdl_op_definition
+class ReduceSumOp(ReductionOperation):
+    """
+    Reduce a tensor along the given axis by taking the product of all values
+    """
+
+    name = "tosa.reduce_sum"
+
+
 TOSA = Dialect(
     "tosa",
     [
@@ -461,6 +501,10 @@ TOSA = Dialect(
         ReciprocalOp,
         ReduceAllOp,
         ReduceAnyOp,
+        ReduceMaxOp,
+        ReduceMinOp,
+        ReduceProdOp,
+        ReduceSumOp,
         MatMulOp,
         MaxPool2DOp,
         AvgPool2DOp,

--- a/xdsl/dialects/tosa.py
+++ b/xdsl/dialects/tosa.py
@@ -324,6 +324,24 @@ class MatMulOp(IRDLOperation):
 
 
 @irdl_op_definition
+class ReduceAllOp(IRDLOperation):
+    """
+    Reduce a tensor along the given axis with a logical AND operation
+    """
+
+    name = "tosa.reduce_all"
+
+    input = operand_def(TensorType)
+    axis = prop_def(IntegerAttr[I32])
+
+    output = result_def(TensorType)
+
+    assembly_format = "$input attr-dict `:` functional-type(operands, results)"
+
+    irdl_options = [ParsePropInAttrDict()]
+
+
+@irdl_op_definition
 class MaxPool2DOp(IRDLOperation):
     """
     TOSA dialect operation for performing 2D max pooling on a tensor.
@@ -421,6 +439,7 @@ TOSA = Dialect(
         SinOp,
         CosOp,
         ReciprocalOp,
+        ReduceAllOp,
         MatMulOp,
         MaxPool2DOp,
         AvgPool2DOp,

--- a/xdsl/dialects/tosa.py
+++ b/xdsl/dialects/tosa.py
@@ -227,6 +227,17 @@ class CosOp(ElementwiseUnaryOperation[TensorType[AnyFloat]]):
 
 
 @irdl_op_definition
+class ReciprocalOp(ElementwiseUnaryOperation[TensorType]):
+    """
+    Elementwise reciprocal operation.
+
+    See [external documentation](https://mlir.llvm.org/docs/Dialects/TOSA/#tosareciprocal-mlirtosareciprocalop).
+    """
+
+    name = "tosa.reciprocal"
+
+
+@irdl_op_definition
 class MatMulOp(IRDLOperation):
     """
     TOSA dialect operation for computing 2D matmuls. Expects 3D tensors as input with leading rank of 1 element, e.g.
@@ -384,6 +395,7 @@ TOSA = Dialect(
         MulOp,
         SinOp,
         CosOp,
+        ReciprocalOp,
         MatMulOp,
         MaxPool2DOp,
         AvgPool2DOp,

--- a/xdsl/dialects/tosa.py
+++ b/xdsl/dialects/tosa.py
@@ -323,13 +323,15 @@ class MatMulOp(IRDLOperation):
         #     )
 
 
-@irdl_op_definition
-class ReduceAllOp(IRDLOperation):
-    """
-    Reduce a tensor along the given axis with a logical AND operation
-    """
+################################################################################
+# Reduction ops                                                                #
+################################################################################
 
-    name = "tosa.reduce_all"
+
+class ReductionOperation(IRDLOperation, ABC):
+    """
+    Base class for all TOSA reduction operations
+    """
 
     input = operand_def(TensorType)
     axis = prop_def(IntegerAttr[I32])
@@ -339,6 +341,24 @@ class ReduceAllOp(IRDLOperation):
     assembly_format = "$input attr-dict `:` functional-type(operands, results)"
 
     irdl_options = [ParsePropInAttrDict()]
+
+
+@irdl_op_definition
+class ReduceAllOp(ReductionOperation):
+    """
+    Reduce a tensor along the given axis with a logical AND operation
+    """
+
+    name = "tosa.reduce_all"
+
+
+@irdl_op_definition
+class ReduceAnyOp(ReductionOperation):
+    """
+    Reduce a tensor along the given axis with a logical OR operation
+    """
+
+    name = "tosa.reduce_any"
 
 
 @irdl_op_definition
@@ -440,6 +460,7 @@ TOSA = Dialect(
         CosOp,
         ReciprocalOp,
         ReduceAllOp,
+        ReduceAnyOp,
         MatMulOp,
         MaxPool2DOp,
         AvgPool2DOp,


### PR DESCRIPTION
Adds the reciprocal and reduce operations to the TOSA dialect, with xDSL roundtrip and MLIR conversion tests.