### PR TITLE
misc: (DisjointSet) Add `rooted_union` method to DisjointSet

### DIFF
--- a/tests/utils/test_disjoint_set.py
+++ b/tests/utils/test_disjoint_set.py
@@ -151,33 +151,33 @@ def test_int_disjoint_set_rooted_union():
     ds = IntDisjointSet(size=5)
 
     # Test successful rooted union
-    assert ds.rooted_union(0, 1)  # Union with 0 as root
+    assert ds.union_left(0, 1)  # Union with 0 as root
     assert ds[1] == 0
     assert ds.connected(0, 1)
 
     # Test rooted union with multiple elements
-    assert ds.rooted_union(0, 2)  # Add 2 to the set rooted at 0
+    assert ds.union_left(0, 2)  # Add 2 to the set rooted at 0
     assert ds[2] == 0
     assert ds.connected(0, 2)
     assert ds.connected(1, 2)
 
     # Test rooted union when sets are already connected
-    assert not ds.rooted_union(0, 1)  # Should return False
+    assert not ds.union_left(0, 1)  # Should return False
     assert ds[1] == 0  # Still connected
 
     # Test error when representative is not a root
     with pytest.raises(
         ValueError, match="The given representative is not a root of its set"
     ):
-        ds.rooted_union(1, 3)  # 1 is not a root, 0 is its root
+        ds.union_left(1, 3)  # 1 is not a root, 0 is its root
 
     # Test that the specified representative becomes the root
-    assert ds.rooted_union(3, 4)  # 3 becomes root of its own set with 4
+    assert ds.union_left(3, 4)  # 3 becomes root of its own set with 4
     assert ds[3] == 3
     assert ds[4] == 3
 
     # Now union the two sets with 0 as the specified root
-    assert ds.rooted_union(0, 3)
+    assert ds.union_left(0, 3)
     assert ds[3] == 0  # 3's set is now under 0
     assert ds[4] == 0  # 4 also points to 0
     assert ds.connected(0, 4)
@@ -187,40 +187,40 @@ def test_generic_disjoint_set_rooted_union():
     ds = DisjointSet(["a", "b", "c", "d", "e"])
 
     # Test successful rooted union
-    assert ds.rooted_union("a", "b")  # Union with "a" as root
+    assert ds.union_left("a", "b")  # Union with "a" as root
     assert ds.find("b") == "a"
     assert ds.connected("a", "b")
 
     # Test rooted union with multiple elements
-    assert ds.rooted_union("a", "c")  # Add "c" to the set rooted at "a"
+    assert ds.union_left("a", "c")  # Add "c" to the set rooted at "a"
     assert ds.find("c") == "a"
     assert ds.connected("a", "c")
     assert ds.connected("b", "c")
 
     # Test rooted union when sets are already connected
-    assert not ds.rooted_union("a", "b")  # Should return False
+    assert not ds.union_left("a", "b")  # Should return False
     assert ds.find("b") == "a"  # Still connected
 
     # Test error when representative is not a root
     with pytest.raises(
         ValueError, match="The given representative is not a root of its set"
     ):
-        ds.rooted_union("b", "d")  # "b" is not a root, "a" is its root
+        ds.union_left("b", "d")  # "b" is not a root, "a" is its root
 
     # Test that the specified representative becomes the root
-    assert ds.rooted_union("d", "e")  # "d" becomes root of its own set with "e"
+    assert ds.union_left("d", "e")  # "d" becomes root of its own set with "e"
     assert ds.find("d") == "d"
     assert ds.find("e") == "d"
 
     # Now union the two sets with "a" as the specified root
-    assert ds.rooted_union("a", "d")
+    assert ds.union_left("a", "d")
     assert ds.find("d") == "a"  # "d"'s set is now under "a"
     assert ds.find("e") == "a"  # "e" also points to "a"
     assert ds.connected("a", "e")
 
     # Test with KeyError for non-existent values
     with pytest.raises(KeyError):
-        ds.rooted_union("a", "nonexistent")
+        ds.union_left("a", "nonexistent")
 
     with pytest.raises(KeyError):
-        ds.rooted_union("nonexistent", "a")
+        ds.union_left("nonexistent", "a")

--- a/tests/utils/test_disjoint_set.py
+++ b/tests/utils/test_disjoint_set.py
@@ -148,7 +148,7 @@ def test_generic_disjoint_set_union_by_size():
 
 
 def test_int_disjoint_set_rooted_union():
-    ds = IntDisjointSet(size=5)
+    ds = IntDisjointSet(size=6)
 
     # Test successful rooted union
     assert ds.union_left(0, 1)  # Union with 0 as root
@@ -166,25 +166,24 @@ def test_int_disjoint_set_rooted_union():
     assert ds[1] == 0  # Still connected
 
     # Test error when representative is not a root
-    with pytest.raises(
-        ValueError, match="The given representative is not a root of its set"
-    ):
-        ds.union_left(1, 3)  # 1 is not a root, 0 is its root
+    ds.union_left(1, 3)  # 1 is not a root, 0 is its root
+    assert ds[3] == 0
+    assert ds.connected(1, 3)
 
     # Test that the specified representative becomes the root
-    assert ds.union_left(3, 4)  # 3 becomes root of its own set with 4
-    assert ds[3] == 3
-    assert ds[4] == 3
+    assert ds.union_left(4, 5)  # 4 becomes root of its own set with 5
+    assert ds[4] == 4
+    assert ds[5] == 4
 
     # Now union the two sets with 0 as the specified root
-    assert ds.union_left(0, 3)
-    assert ds[3] == 0  # 3's set is now under 0
-    assert ds[4] == 0  # 4 also points to 0
-    assert ds.connected(0, 4)
+    assert ds.union_left(0, 4)
+    assert ds[4] == 0  # 4's set is now under 0
+    assert ds[5] == 0  # 5 also points to 0
+    assert ds.connected(0, 5)
 
 
 def test_generic_disjoint_set_rooted_union():
-    ds = DisjointSet(["a", "b", "c", "d", "e"])
+    ds = DisjointSet(["a", "b", "c", "d", "e", "f"])
 
     # Test successful rooted union
     assert ds.union_left("a", "b")  # Union with "a" as root
@@ -202,21 +201,20 @@ def test_generic_disjoint_set_rooted_union():
     assert ds.find("b") == "a"  # Still connected
 
     # Test error when representative is not a root
-    with pytest.raises(
-        ValueError, match="The given representative is not a root of its set"
-    ):
-        ds.union_left("b", "d")  # "b" is not a root, "a" is its root
+    ds.union_left("b", "d")  # "b" is not a root, "a" is its root
+    assert ds.find("d") == "a"
+    assert ds.connected("b", "d")
 
     # Test that the specified representative becomes the root
-    assert ds.union_left("d", "e")  # "d" becomes root of its own set with "e"
-    assert ds.find("d") == "d"
-    assert ds.find("e") == "d"
+    assert ds.union_left("e", "f")  # "e" becomes root of its own set with "f"
+    assert ds.find("e") == "e"
+    assert ds.find("f") == "e"
 
     # Now union the two sets with "a" as the specified root
-    assert ds.union_left("a", "d")
-    assert ds.find("d") == "a"  # "d"'s set is now under "a"
-    assert ds.find("e") == "a"  # "e" also points to "a"
-    assert ds.connected("a", "e")
+    assert ds.union_left("a", "e")
+    assert ds.find("e") == "a"  # "e"'s set is now under "a"
+    assert ds.find("f") == "a"  # "f" also points to "a"
+    assert ds.connected("a", "f")
 
     # Test with KeyError for non-existent values
     with pytest.raises(KeyError):

--- a/tests/utils/test_disjoint_set.py
+++ b/tests/utils/test_disjoint_set.py
@@ -145,3 +145,82 @@ def test_generic_disjoint_set_union_by_size():
     ds.union("d", "c")
     assert ds.find("d") == "a"
     assert ds.find("c") == "a"
+
+
+def test_int_disjoint_set_rooted_union():
+    ds = IntDisjointSet(size=5)
+
+    # Test successful rooted union
+    assert ds.rooted_union(0, 1)  # Union with 0 as root
+    assert ds[1] == 0
+    assert ds.connected(0, 1)
+
+    # Test rooted union with multiple elements
+    assert ds.rooted_union(0, 2)  # Add 2 to the set rooted at 0
+    assert ds[2] == 0
+    assert ds.connected(0, 2)
+    assert ds.connected(1, 2)
+
+    # Test rooted union when sets are already connected
+    assert not ds.rooted_union(0, 1)  # Should return False
+    assert ds[1] == 0  # Still connected
+
+    # Test error when representative is not a root
+    with pytest.raises(
+        ValueError, match="The given representative is not a root of its set"
+    ):
+        ds.rooted_union(1, 3)  # 1 is not a root, 0 is its root
+
+    # Test that the specified representative becomes the root
+    assert ds.rooted_union(3, 4)  # 3 becomes root of its own set with 4
+    assert ds[3] == 3
+    assert ds[4] == 3
+
+    # Now union the two sets with 0 as the specified root
+    assert ds.rooted_union(0, 3)
+    assert ds[3] == 0  # 3's set is now under 0
+    assert ds[4] == 0  # 4 also points to 0
+    assert ds.connected(0, 4)
+
+
+def test_generic_disjoint_set_rooted_union():
+    ds = DisjointSet(["a", "b", "c", "d", "e"])
+
+    # Test successful rooted union
+    assert ds.rooted_union("a", "b")  # Union with "a" as root
+    assert ds.find("b") == "a"
+    assert ds.connected("a", "b")
+
+    # Test rooted union with multiple elements
+    assert ds.rooted_union("a", "c")  # Add "c" to the set rooted at "a"
+    assert ds.find("c") == "a"
+    assert ds.connected("a", "c")
+    assert ds.connected("b", "c")
+
+    # Test rooted union when sets are already connected
+    assert not ds.rooted_union("a", "b")  # Should return False
+    assert ds.find("b") == "a"  # Still connected
+
+    # Test error when representative is not a root
+    with pytest.raises(
+        ValueError, match="The given representative is not a root of its set"
+    ):
+        ds.rooted_union("b", "d")  # "b" is not a root, "a" is its root
+
+    # Test that the specified representative becomes the root
+    assert ds.rooted_union("d", "e")  # "d" becomes root of its own set with "e"
+    assert ds.find("d") == "d"
+    assert ds.find("e") == "d"
+
+    # Now union the two sets with "a" as the specified root
+    assert ds.rooted_union("a", "d")
+    assert ds.find("d") == "a"  # "d"'s set is now under "a"
+    assert ds.find("e") == "a"  # "e" also points to "a"
+    assert ds.connected("a", "e")
+
+    # Test with KeyError for non-existent values
+    with pytest.raises(KeyError):
+        ds.rooted_union("a", "nonexistent")
+
+    with pytest.raises(KeyError):
+        ds.rooted_union("nonexistent", "a")

--- a/xdsl/utils/disjoint_set.py
+++ b/xdsl/utils/disjoint_set.py
@@ -75,6 +75,30 @@ class IntDisjointSet:
 
         return root
 
+    def rooted_union(self, representative: int, other: int) -> bool:
+        """
+        Merges the set with the given representative and the set containing `other`.
+        The `representative` must be a root of its set (i.e. `ds[representative] == representative`).
+        Returns True if the sets were merged, False if they were already the same set.
+
+        In contrast to `union`, this does not do union by size - the `other` set is always
+        attached to the `representative` set. This is useful when we want to control
+        which element becomes the representative of the merged set.
+        """
+        if self[representative] != representative:
+            raise ValueError("The given representative is not a root of its set.")
+
+        other_root = self[other]
+        if representative == other_root:
+            return False
+
+        rep_count = self._count[representative]
+        other_count = self._count[other_root]
+        self._parent[other_root] = representative
+        self._count[representative] = rep_count + other_count
+        # Note: We don't need to update _count[other_root] since it's no longer a root
+        return True
+
     def union(self, lhs: int, rhs: int) -> bool:
         """
         Merges the sets containing lhs and rhs if they are different.
@@ -153,6 +177,25 @@ class DisjointSet(Generic[_T]):
         """
         index = self._base[self._index_by_value[value]]
         return self._values[index]
+
+    def rooted_union(self, representative: _T, other: _T) -> bool:
+        """
+        Merges the set with the given representative and the set containing `other`.
+        The `representative` must be a root of its set (i.e. `ds.find(representative) == representative`).
+        Returns True if the sets were merged, False if they were already the same set.
+
+        In contrast to `union`, this does not do union by size - the `other` set is always
+        attached to the `representative` set. This is useful when we want to control
+        which element becomes the representative of the merged set.
+
+        Raises:
+            KeyError: If either value is not in the disjoint set
+            ValueError: If the given representative is not a root of its set
+        """
+        return self._base.rooted_union(
+            self._index_by_value[representative],
+            self._index_by_value[other],
+        )
 
     def union(self, lhs: _T, rhs: _T) -> bool:
         """

--- a/xdsl/utils/disjoint_set.py
+++ b/xdsl/utils/disjoint_set.py
@@ -75,28 +75,25 @@ class IntDisjointSet:
 
         return root
 
-    def rooted_union(self, representative: int, other: int) -> bool:
+    def union_left(self, lhs: int, rhs: int) -> bool:
         """
-        Merges the set with the given representative and the set containing `other`.
-        The `representative` must be a root of its set (i.e. `ds[representative] == representative`).
+        Merge the sets containing the two given values, with `rhs`'s tree being attached to `lhs`'s tree.
         Returns True if the sets were merged, False if they were already the same set.
 
-        In contrast to `union`, this does not do union by size - the `other` set is always
-        attached to the `representative` set. This is useful when we want to control
+        In contrast to `union`, this does not do union by size - the `rhs` set is always
+        attached to the `lhs` set. This is useful when we want to control
         which element becomes the representative of the merged set.
         """
-        if self[representative] != representative:
-            raise ValueError("The given representative is not a root of its set.")
-
-        other_root = self[other]
-        if representative == other_root:
+        lhs = self[lhs]
+        rhs = self[rhs]
+        if lhs == rhs:
             return False
 
-        rep_count = self._count[representative]
-        other_count = self._count[other_root]
-        self._parent[other_root] = representative
-        self._count[representative] = rep_count + other_count
-        # Note: We don't need to update _count[other_root] since it's no longer a root
+        lhs_count = self._count[lhs]
+        rhs_count = self._count[rhs]
+        self._parent[rhs] = lhs
+        self._count[lhs] = lhs_count + rhs_count
+        # Note: We don't need to update _count[rhs] since it's no longer a root
         return True
 
     def union(self, lhs: int, rhs: int) -> bool:
@@ -178,23 +175,21 @@ class DisjointSet(Generic[_T]):
         index = self._base[self._index_by_value[value]]
         return self._values[index]
 
-    def rooted_union(self, representative: _T, other: _T) -> bool:
+    def union_left(self, lhs: _T, rhs: _T) -> bool:
         """
-        Merges the set with the given representative and the set containing `other`.
-        The `representative` must be a root of its set (i.e. `ds.find(representative) == representative`).
+        Merge the sets containing the two given values, with `rhs`'s tree being attached to `lhs`'s tree.
         Returns True if the sets were merged, False if they were already the same set.
 
-        In contrast to `union`, this does not do union by size - the `other` set is always
-        attached to the `representative` set. This is useful when we want to control
+        In contrast to `union`, this does not do union by size - the `rhs` set is always
+        attached to the `lhs` set. This is useful when we want to control
         which element becomes the representative of the merged set.
 
         Raises:
             KeyError: If either value is not in the disjoint set
-            ValueError: If the given representative is not a root of its set
         """
-        return self._base.rooted_union(
-            self._index_by_value[representative],
-            self._index_by_value[other],
+        return self._base.union_left(
+            self._index_by_value[lhs],
+            self._index_by_value[rhs],
         )
 
     def union(self, lhs: _T, rhs: _T) -> bool:


### PR DESCRIPTION
Sometimes it's useful to force a particular set to become the representative when `union`ing two sets. E.g. in eqsat when merging an `EClassOp` with a `ConstantEClassOp`, we want the `ConstantEClassOp` to be representative.
(`ConstantEClassOp` is yet to be merged)