### PR TITLE
dialects: (hw) Modernise dialect with properties instead of attributes

### DIFF
--- a/xdsl/dialects/hw.py
+++ b/xdsl/dialects/hw.py
@@ -35,11 +35,11 @@ from xdsl.ir import (
 )
 from xdsl.irdl import (
     IRDLOperation,
-    attr_def,
     irdl_attr_definition,
     irdl_op_definition,
     lazy_traits_def,
-    opt_attr_def,
+    opt_prop_def,
+    prop_def,
     region_def,
     traits_def,
     var_operand_def,
@@ -812,10 +812,10 @@ class HWModuleOp(IRDLOperation):
 
     name = "hw.module"
 
-    sym_name = attr_def(SymbolNameConstraint())
-    module_type = attr_def(ModuleType)
-    sym_visibility = opt_attr_def(StringAttr)
-    parameters = opt_attr_def(ArrayAttr[ParamDeclAttr])
+    sym_name = prop_def(SymbolNameConstraint())
+    module_type = prop_def(ModuleType)
+    sym_visibility = opt_prop_def(StringAttr)
+    parameters = opt_prop_def(ArrayAttr[ParamDeclAttr])
 
     body = region_def("single_block")
 
@@ -836,7 +836,7 @@ class HWModuleOp(IRDLOperation):
         parameters: ArrayAttr[ParamDeclAttr] = ArrayAttr([]),
         visibility: str | StringAttr | None = None,
     ):
-        attributes: dict[str, Attribute] = {
+        properties: dict[str, Attribute] = {
             "sym_name": sym_name,
             "module_type": module_type,
             "parameters": parameters,
@@ -845,16 +845,16 @@ class HWModuleOp(IRDLOperation):
         if visibility:
             if isinstance(visibility, str):
                 visibility = StringAttr(visibility)
-            attributes["sym_visibility"] = visibility
+            properties["sym_visibility"] = visibility
 
         return super().__init__(
-            attributes=attributes,
+            properties=properties,
             regions=[body],
         )
 
     def verify_(self) -> None:
         if self.parameters is not None:
-            # FIXME: once xDSL supports typed attributes, check that parameter
+            # FIXME: once xDSL supports typed properties, check that parameter
             # types are consistent with their default values
             param_names = [param.port_name.data for param in self.parameters.data]
             if len(set(param_names)) != len(param_names):
@@ -895,7 +895,7 @@ class HWModuleOp(IRDLOperation):
         )
 
         if attrs is not None:
-            module_op.attributes.update(attrs.data)
+            module_op.properties.update(attrs.data)
 
         return module_op
 
@@ -908,9 +908,9 @@ class HWModuleOp(IRDLOperation):
             arg_ssa_iter=self.body.block.args,
             module_type=self.module_type,
         )
-        printer.print_op_attributes(
-            self.attributes,
-            reserved_attr_names=_MODULE_OP_ATTRS_HANDLED_BY_CUSTOM_FORMAT,
+        printer.print_op_properties(
+            self.properties,
+            reserved_prop_names=_MODULE_OP_ATTRS_HANDLED_BY_CUSTOM_FORMAT,
             print_keyword=True,
         )
         printer.print_string(" ")
@@ -929,11 +929,11 @@ class HWModuleExternOp(IRDLOperation):
 
     name = "hw.module.extern"
 
-    sym_name = attr_def(SymbolNameConstraint())
-    module_type = attr_def(ModuleType)
-    sym_visibility = opt_attr_def(StringAttr)
-    parameters = opt_attr_def(ArrayAttr[ParamDeclAttr])
-    verilog_name = opt_attr_def(StringAttr, attr_name="verilogName")
+    sym_name = prop_def(SymbolNameConstraint())
+    module_type = prop_def(ModuleType)
+    sym_visibility = opt_prop_def(StringAttr)
+    parameters = opt_prop_def(ArrayAttr[ParamDeclAttr])
+    verilog_name = opt_prop_def(StringAttr, prop_name="verilogName")
 
     traits = lazy_traits_def(
         lambda: (
@@ -949,7 +949,7 @@ class HWModuleExternOp(IRDLOperation):
         parameters: ArrayAttr[ParamDeclAttr] = ArrayAttr([]),
         visibility: str | StringAttr | None = None,
     ):
-        attributes: dict[str, Attribute] = {
+        properties: dict[str, Attribute] = {
             "sym_name": sym_name,
             "module_type": module_type,
             "parameters": parameters,
@@ -958,9 +958,9 @@ class HWModuleExternOp(IRDLOperation):
         if visibility:
             if isinstance(visibility, str):
                 visibility = StringAttr(visibility)
-            attributes["sym_visibility"] = visibility
+            properties["sym_visibility"] = visibility
 
-        return super().__init__(attributes=attributes)
+        return super().__init__(properties=properties)
 
     @classmethod
     def parse(cls, parser: Parser) -> "HWModuleExternOp":
@@ -978,7 +978,7 @@ class HWModuleExternOp(IRDLOperation):
         )
 
         if attrs is not None:
-            module_op.attributes.update(attrs.data)
+            module_op.properties.update(attrs.data)
 
         return module_op
 
@@ -997,9 +997,9 @@ class HWModuleExternOp(IRDLOperation):
             arg_ssa_iter=arg_ssa_names,
             module_type=self.module_type,
         )
-        printer.print_op_attributes(
-            self.attributes,
-            reserved_attr_names=_MODULE_OP_ATTRS_HANDLED_BY_CUSTOM_FORMAT,
+        printer.print_op_properties(
+            self.properties,
+            reserved_prop_names=_MODULE_OP_ATTRS_HANDLED_BY_CUSTOM_FORMAT,
             print_keyword=True,
         )
 
@@ -1009,18 +1009,18 @@ class InstanceOp(IRDLOperation):
     """
     This represents an instance of a module. The inputs and outputs are the
     referenced module's inputs and outputs. The argNames and resultNames
-    attributes must match the referenced module's input and output names.
+    properties must match the referenced module's input and output names.
     """
 
     name = "hw.instance"
 
-    instance_name = attr_def(StringAttr, attr_name="instanceName")
-    module_name = attr_def(FlatSymbolRefAttrConstr, attr_name="moduleName")
+    instance_name = prop_def(StringAttr, prop_name="instanceName")
+    module_name = prop_def(FlatSymbolRefAttrConstr, prop_name="moduleName")
     inputs = var_operand_def()
     outputs = var_result_def()
-    arg_names = attr_def(ArrayAttr[StringAttr], attr_name="argNames")
-    result_names = attr_def(ArrayAttr[StringAttr], attr_name="resultNames")
-    inner_sym = opt_attr_def(InnerSymAttr)
+    arg_names = prop_def(ArrayAttr[StringAttr], prop_name="argNames")
+    result_names = prop_def(ArrayAttr[StringAttr], prop_name="resultNames")
+    inner_sym = opt_prop_def(InnerSymAttr)
 
     def __init__(
         self,
@@ -1032,18 +1032,18 @@ class InstanceOp(IRDLOperation):
     ):
         arg_names = ArrayAttr(StringAttr(port[0]) for port in inputs)
         result_names = ArrayAttr(StringAttr(port[0]) for port in outputs)
-        attributes: dict[str, Attribute] = {
+        properties: dict[str, Attribute] = {
             "instanceName": StringAttr(instance_name),
             "moduleName": module_name,
             "argNames": arg_names,
             "resultNames": result_names,
         }
         if inner_sym is not None:
-            attributes["inner_sym"] = inner_sym
+            properties["inner_sym"] = inner_sym
         super().__init__(
             operands=(tuple(port[1] for port in inputs),),
             result_types=(tuple(port[1] for port in outputs),),
-            attributes=attributes,
+            properties=properties,
         )
 
     def verify_(self) -> None:
@@ -1158,7 +1158,7 @@ class InstanceOp(IRDLOperation):
         output_ports = parser.parse_comma_separated_list(
             Parser.Delimiter.PAREN, parse_output_port, "output port list expected"
         )
-        attributes_attr = parser.parse_optional_attr_dict_with_reserved_attr_names(
+        properties_attr = parser.parse_optional_attr_dict_with_reserved_prop_names(
             (
                 "instanceName",
                 "moduleName",
@@ -1167,20 +1167,20 @@ class InstanceOp(IRDLOperation):
                 "inner_sym",
             )
         )
-        attributes = dict(attributes_attr.data) if attributes_attr is not None else {}
+        properties = dict(properties_attr.data) if properties_attr is not None else {}
 
         operands = tuple(port[1] for port in input_ports)
         result_types = tuple(port[1] for port in output_ports)
-        attributes["instanceName"] = StringAttr(instance_name)
-        attributes["moduleName"] = module_name
-        attributes["argNames"] = ArrayAttr(StringAttr(port[0]) for port in input_ports)
-        attributes["resultNames"] = ArrayAttr(
+        properties["instanceName"] = StringAttr(instance_name)
+        properties["moduleName"] = module_name
+        properties["argNames"] = ArrayAttr(StringAttr(port[0]) for port in input_ports)
+        properties["resultNames"] = ArrayAttr(
             StringAttr(port[0]) for port in output_ports
         )
         if inner_sym is not None:
-            attributes["inner_sym"] = inner_sym
+            properties["inner_sym"] = inner_sym
         return cls.create(
-            operands=operands, result_types=result_types, attributes=attributes
+            operands=operands, result_types=result_types, properties=properties
         )
 
     def print(self, printer: Printer) -> None:
@@ -1219,9 +1219,9 @@ class InstanceOp(IRDLOperation):
                 ),
                 lambda x: print_output_port(*x),
             )
-        printer.print_op_attributes(
-            self.attributes,
-            reserved_attr_names=(
+        printer.print_op_properties(
+            self.properties,
+            reserved_prop_names=(
                 "instanceName",
                 "moduleName",
                 "argNames",

--- a/xdsl/dialects/hw.py
+++ b/xdsl/dialects/hw.py
@@ -908,7 +908,7 @@ class HWModuleOp(IRDLOperation):
             arg_ssa_iter=self.body.block.args,
             module_type=self.module_type,
         )
-        printer.print_op_properties(
+        printer._print_op_properties(
             self.properties,
             reserved_prop_names=_MODULE_OP_ATTRS_HANDLED_BY_CUSTOM_FORMAT,
             print_keyword=True,
@@ -997,7 +997,7 @@ class HWModuleExternOp(IRDLOperation):
             arg_ssa_iter=arg_ssa_names,
             module_type=self.module_type,
         )
-        printer.print_op_properties(
+        printer._print_op_properties(
             self.properties,
             reserved_prop_names=_MODULE_OP_ATTRS_HANDLED_BY_CUSTOM_FORMAT,
             print_keyword=True,
@@ -1219,7 +1219,7 @@ class InstanceOp(IRDLOperation):
                 ),
                 lambda x: print_output_port(*x),
             )
-        printer.print_op_properties(
+        printer._print_op_properties(
             self.properties,
             reserved_prop_names=(
                 "instanceName",

--- a/xdsl/dialects/hw.py
+++ b/xdsl/dialects/hw.py
@@ -854,7 +854,7 @@ class HWModuleOp(IRDLOperation):
 
     def verify_(self) -> None:
         if self.parameters is not None:
-            # FIXME: once xDSL supports typed properties, check that parameter
+            # FIXME: once xDSL supports typed attributes, check that parameter
             # types are consistent with their default values
             param_names = [param.port_name.data for param in self.parameters.data]
             if len(set(param_names)) != len(param_names):


### PR DESCRIPTION
Attributes are replaced by properties to be compliant with latest MLIR versions (tested with 22.0.0).