### PR TITLE
core: ignore `__type_params__` field when creating attributes

### DIFF
--- a/xdsl/irdl/attributes.py
+++ b/xdsl/irdl/attributes.py
@@ -158,7 +158,7 @@ _PARAMETRIZED_ATTRIBUTE_DICT_KEYS = {
     )
     for dict in dict_seq
     for key in dict
-}
+} | {"__type_params__"}  # Forward compatibility for Python 3.12 generics
 
 _IGNORED_PARAM_ATTR_FIELD_TYPES = set(("name", "parameters"))
 


### PR DESCRIPTION
In python 3.12, the `__type_params__` field is used to hold the list of a class' generic arguments. Since xDSL targets 3.10, this is not ignored when inspecting the fields of a class decorated with `@irdl_attr_definition` causing an error.

This feels a little hacky, better suggestions welcome.