### PR TITLE
core: don't initialize MLIRToken typealias

### DIFF
--- a/xdsl/utils/mlir_lexer.py
+++ b/xdsl/utils/mlir_lexer.py
@@ -303,7 +303,7 @@ class MLIRLexer(Lexer[MLIRTokenKind]):
         """
         Return a token with the given kind, and the start position.
         """
-        return MLIRToken(kind, Span(start_pos, self.pos, self.input))
+        return Token(kind, Span(start_pos, self.pos, self.input))
 
     def lex(self) -> MLIRToken:
         """
@@ -499,19 +499,19 @@ class MLIRLexer(Lexer[MLIRTokenKind]):
         lit = StringLiteral(start_pos, self.pos, self.input)
 
         if lit.text == '""':
-            return MLIRToken(MLIRTokenKind.STRING_LIT, lit)  # empty string literal
+            return Token(MLIRTokenKind.STRING_LIT, lit)  # empty string literal
 
         if "\\" not in lit.text:
             # If there are no escape sequences, directly return a STRING_LIT
-            return MLIRToken(MLIRTokenKind.STRING_LIT, lit)
+            return Token(MLIRTokenKind.STRING_LIT, lit)
 
         bytes_contents = lit.bytes_contents
 
         if bytes_contents.isascii():
             # If the bytes contents are ASCII, return a STRING_LIT
-            return MLIRToken(MLIRTokenKind.STRING_LIT, lit)
+            return Token(MLIRTokenKind.STRING_LIT, lit)
 
-        return MLIRToken(MLIRTokenKind.BYTES_LIT, lit)
+        return Token(MLIRTokenKind.BYTES_LIT, lit)
 
     _hexdigits_star_regex = re.compile(r"[0-9a-fA-F]*")
     _digits_star_regex = re.compile(r"[0-9]*")


### PR DESCRIPTION
It turns out that this has an overhead, lexing a microbenchmark speeds up by 10% for me.

```
~/Developer/xdslproject/xdsl sasha/misc/mlir-token *165 !1 ❯ uv run benchmarks/lexer.py Lexer.constant_100 timeit                                                  15:51:52
Test Lexer.constant_100 ran in: 0.000939 ± 1.83e-05s
~/Developer/xdslproject/xdsl sasha/misc/mlir-token *165 !1 ❯ uv run benchmarks/lexer.py Lexer.constant_100 timeit                                                  15:51:58
Test Lexer.constant_100 ran in: 0.00103 ± 3.33e-05s
```
