### PR TITLE
core: add simplification of AffineExpr (no modulo or division)

### DIFF
--- a/tests/test_affine_builtins.py
+++ b/tests/test_affine_builtins.py
@@ -1,5 +1,5 @@
 import re
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 
 import pytest
 from typing_extensions import TypeVar
@@ -9,6 +9,7 @@ from xdsl.ir.affine import (
     AffineBinaryOpKind,
     AffineExpr,
     AffineMap,
+    SimpleAffineExprFlattener,
 )
 
 
@@ -535,10 +536,11 @@ def test_traversal():
         assert nodes[i] is node
 
 
-def test_from_flat_form():
-    d0, d1, d2 = (AffineExpr.dimension(i) for i in range(3))
-    s0, s1, s2 = (AffineExpr.symbol(i) for i in range(3))
+d0, d1, d2 = (AffineExpr.dimension(i) for i in range(3))
+s0, s1, s2 = (AffineExpr.symbol(i) for i in range(3))
 
+
+def test_from_flat_form():
     # Empty case
     assert AffineExpr.from_flat_form([0], 0, 0, []) == AffineExpr.constant(0)
     # One dimension
@@ -565,3 +567,111 @@ def test_from_flat_form():
         )
         == d1 + d2 * 2 + s1 + s2 * 2 + s0 * 2 + 1
     )
+
+
+@pytest.mark.parametrize(
+    "expr,expected",
+    [
+        # Simple cases: constants, dimensions, symbols
+        (AffineExpr.constant(0), AffineExpr.constant(0)),
+        (AffineExpr.constant(42), AffineExpr.constant(42)),
+        (d0, d0),
+        (d1, d1),
+        (s0, s0),
+        (s2, s2),
+        # Already-simplified sums
+        (d0 + 3, d0 + 3),
+        (2 * d1 + s0, 2 * d1 + s0),
+        # Expressions with redundant zeros
+        (d0 * 0, AffineExpr.constant(0)),
+        (0 * s1, AffineExpr.constant(0)),
+        (AffineExpr.constant(0) + d1, d1),
+        (d0 + 0, d0),
+        (0 + d2, d2),
+        # Combining constants
+        (
+            AffineBinaryOpExpr(
+                AffineBinaryOpKind.Add, AffineExpr.constant(2), AffineExpr.constant(3)
+            ),
+            AffineExpr.constant(5),
+        ),
+        (
+            AffineBinaryOpExpr(
+                AffineBinaryOpKind.Mul,
+                AffineBinaryOpExpr(
+                    AffineBinaryOpKind.Add,
+                    AffineExpr.constant(1),
+                    AffineExpr.constant(2),
+                ),
+                AffineExpr.constant(3),
+            ),
+            AffineExpr.constant(9),
+        ),
+        ((d0 + 2) + 3, d0 + 5),
+        # Multiplying by 1 or 0
+        (d1 * 1, d1),
+        (1 * s0, s0),
+        ((d1 + 2) * 1, d1 + 2),
+        ((d2 + 7) * 0, AffineExpr.constant(0)),
+        # Grouping like terms (if supported by simplify)
+        (d0 + d0, 2 * d0),
+        (2 * d0 + 3 * d0, 5 * d0),
+        (d0 + s1 + d0, 2 * d0 + s1),
+        # More complex: terms cancel
+        (d0 - d0, AffineExpr.constant(0)),
+        (2 * d1 - d1, d1),
+        ((d0 + 2) - 2, d0),
+        # Deeply nested expressions
+        ((d0 + (AffineExpr.constant(1) + 2)), d0 + 3),
+        (((d0 + 2) + (d0 + 3)), 2 * d0 + 5),
+        # To be added in upcoming PRs adding div and mod support
+        # # Exact multiples of floordiv are cancelled out
+        # ((2 * d0 + 4 * s1) // 2, d0 + 2 * s1),
+        # # Exact multiples of ceildiv are cancelled out
+        # ((2 * d0 + 4 * s1).ceil_div(2), d0 + 2 * s1),
+        # # Greatest common denominators of floordiv are cancelled out
+        # ((2 * d0 + 4 * s1) // 6, (d0 + 2 * s1) // 3),
+        # # Greatest common denominators of ceildiv are cancelled out
+        # ((2 * d0 + 4 * s1).ceil_div(6), (d0 + 2 * s1).ceil_div(3)),
+        # # Division is aggregated
+        # (d0 // 2 + d0 // 2, d0 // 2 * 2),
+        # # Factors and modulo cancel
+        # ((2 * d0 + 4 * s1) % 2, AffineExpr.constant(0)),
+        # # Modulo is converted into the manual computation (x % k == x - (x // k * k))
+        # ((2 * d0 + 4 * s1) % 3, (2 * d0 + 4 * s1) + ((2 * d0 + 4 * s1) // 3 * -3)),
+        # # This sometimes cancels out
+        # (d0 % 3 + d0 // 3 * 3, d0),
+        # # GCD cancel in the fraction
+        # ((2 * d0 + 4 * s1) % 6, (2 * d0 + 4 * s1) + ((d0 + 2 * s1) // 3 * -6)),
+        # # Modulos with same expressions are aggregated
+        # (d0 % 2 - d0 % 2, AffineExpr.constant(0)),
+    ],
+)
+def test_affine_expr_simplify(expr: AffineExpr, expected: AffineExpr):
+    assert str(expr.simplify(3, 3)) == str(expected)
+    assert expr.simplify(3, 3) == expected
+    # Eval on some numbers to catch errors in simplification test
+    assert expr.eval((1, 2, 3), (5, 7, 11)) == expected.eval((1, 2, 3), (5, 7, 11))
+    assert expr.eval((11, 7, 5), (3, 2, 1)) == expected.eval((11, 7, 5), (3, 2, 1))
+
+
+@pytest.mark.parametrize(
+    "expr",
+    [
+        (lambda: AffineBinaryOpExpr(AffineBinaryOpKind.Mul, d0, s0)),
+        # To be added in upcoming PRs adding div and mod support
+        # (lambda: AffineBinaryOpExpr(AffineBinaryOpKind.FloorDiv, d0, s0)),
+        # (lambda: AffineBinaryOpExpr(AffineBinaryOpKind.Mod, d0, s0)),
+    ],
+)
+def test_affine_expr_simplify_semi_affine_raises(expr: Callable[[], AffineExpr]):
+    with pytest.raises(
+        NotImplementedError,
+        match="Simplification of semi-affine expressions is not implemented yet.",
+    ):
+        expr().simplify(num_dims=3, num_symbols=3)
+    with pytest.raises(
+        NotImplementedError,
+        match="Semi-affine map flattening not implemented",
+    ):
+        SimpleAffineExprFlattener(3, 3).simplify(expr())

--- a/xdsl/ir/affine/affine_expr.py
+++ b/xdsl/ir/affine/affine_expr.py
@@ -116,6 +116,19 @@ class AffineExpr(ABC):
 
         return expr
 
+    def simplify(self, num_dims: int, num_symbols: int) -> AffineExpr:
+        """
+        Simplify the affine expression by flattening it and reconstructing it.
+        """
+        if not self.is_pure_affine():
+            # Simplify semi-affine expressions separately
+            raise NotImplementedError(
+                "Simplification of semi-affine expressions is not implemented yet."
+            )
+
+        flattener = SimpleAffineExprFlattener(num_dims, num_symbols)
+        return flattener.simplify(self)
+
     def compose(self, map: AffineMap) -> AffineExpr:
         """
         Compose with an AffineMap.
@@ -478,3 +491,182 @@ class AffineConstantExpr(AffineExpr):
 
     def __str__(self) -> str:
         return f"{self.value}"
+
+
+class SimpleAffineExprFlattener:
+    """
+    This class is used to flatten a pure affine expression (AffineExpr, which is in a
+    tree form) into a sum of products (with respect to constants) when possible, thereby
+    simplifying the expression. For modulo, floordiv, or ceildiv expressions, an
+    additional identifier, called a local identifier, is introduced to rewrite the
+    expression as a sum of product affine expression. Each local identifier is always,
+    by construction, a floordiv of a pure add/mul affine function of dimensional,
+    symbolic, and other local identifiers, in a non-mutually recursive way. Thus, every
+    local identifier can ultimately always be recovered as an affine function of
+    dimensional and symbolic identifiers (involving floordiv's); note, however, that by
+    AffineExpr construction, some floordiv combinations are converted to mod's.
+    The result of the flattening is a flattened expression and a set of
+    constraints involving just the local variables.
+
+    For example, `d2 + (d0 + d1) // 4` is flattened to `d2 + q` where `q` is
+    the local variable introduced, with `localVarCst` containing
+    `4*q <= d0 + d1 <= 4*q + 3`.
+
+    The simplification performed includes the accumulation of contributions for
+    each dimensional and symbolic identifier together, the simplification of
+    floordiv/ceildiv/mod expressions, and other simplifications that in turn
+    happen as a result. A simplification that this flattening naturally performs
+    is simplifying the numerator and denominator of floordiv/ceildiv, and
+    folding a modulo expression to zero, if possible. Three examples are below:
+
+    ```
+    (d0 + 3 * d1) + d0) - 2 * d1) - d0    simplified to     d0 + d1
+    (d0 - d0 % 4 + 4) % 4                 simplified to     0
+    (3*d0 + 2*d1 + d0) // 2 + d1          simplified to     2*d0 + 2*d1
+    ```
+
+    The way the flattening works for the second example is as follows: `d0 % 4` is
+    replaced by `d0 - 4*q` with `q` being introduced; the expression then simplifies
+    to: `(d0 - (d0 - 4q) + 4) = 4q + 4`, modulo of which with respect to 4
+    simplifies to zero. Note that an affine expression may not always be
+    expressible purely as a sum of products involving just the original
+    dimensional and symbolic identifiers due to the presence of
+    modulo/floordiv/ceildiv expressions that may not be eliminated after
+    simplification; in such cases, the final expression can be reconstructed by
+    replacing the local identifiers with their corresponding explicit form
+    stored in `localExprs` (note that each of the explicit forms itself would
+    have been simplified).
+
+    The expression walk method here performs a linear time post-order walk that
+    performs the above simplifications through visit methods, with partial
+    results being stored in `operandExprStack`. When a parent expr is visited,
+    the flattened expressions corresponding to its two operands would already be
+    on the stack—the parent expression looks at the two flattened expressions
+    and combines the two. It pops off the operand expressions and pushes the
+    combined result (although this is done in-place on its LHS operand expr).
+    When the walk is completed, the flattened form of the top-level expression
+    would be left on the stack.
+
+    A flattener can be repeatedly used for multiple affine expressions that bind
+    to the same operands, for example, for all result expressions of an
+    AffineMap or AffineValueMap. In such cases, using it for multiple
+    expressions is more efficient than creating a new flattener for each
+    expression since common identical div and mod expressions appearing across
+    different expressions are mapped to the same local identifier (same column
+    position in `localVarCst`).
+    """
+
+    # Flattend expression layout: [dims, symbols, locals, constant]
+    # Stack that holds the LHS and RHS operands while visiting a binary op expr.
+    operand_expr_stack: list[list[int]]
+    """
+    Flattend expression layout: [dims, symbols, locals, constant]
+    Stack that holds the LHS and RHS operands while visiting a binary op expr.
+    """
+    num_dims: int
+    num_symbols: int
+    local_exprs: list[AffineExpr]
+
+    def __init__(self, num_dims: int, num_symbols: int) -> None:
+        self.operand_expr_stack = []
+        self.num_dims = num_dims
+        self.num_symbols = num_symbols
+        self.local_exprs = []
+
+    def visit_mul_expr(self, expr: AffineBinaryOpExpr) -> None:
+        """
+        In pure affine t = expr * c, we multiply each coefficient of lhs with c.
+        In case of semi affine multiplication expressions, `t = expr * symbolic_expr`,
+        introduce a local variable `p (= expr * symbolic_expr)`, and the affine expression
+        `expr * symbolic_expr`` is added to `localExprs`.
+        """
+        assert len(self.operand_expr_stack) >= 2
+        rhs = self.operand_expr_stack.pop()
+        lhs = self.operand_expr_stack.pop()
+
+        if not isinstance(expr.rhs, AffineConstantExpr):
+            # Flatten semi-affine multiplication expressions by introducing a local
+            # variable in place of the product; the affine expression
+            # corresponding to the quantifier is added to `localExprs`.
+            raise NotImplementedError("Semi-affine map flattening not implemented")
+
+        rhs_const = rhs[self.get_constant_index()]
+        self.operand_expr_stack.append([l * rhs_const for l in lhs])
+
+    def visit_add_expr(self, expr: AffineBinaryOpExpr) -> None:
+        assert len(self.operand_expr_stack) >= 2
+        rhs = self.operand_expr_stack.pop()
+        lhs = self.operand_expr_stack.pop()
+        assert len(lhs) == len(rhs)
+        self.operand_expr_stack.append([l + r for l, r in zip(lhs, rhs, strict=True)])
+
+    def visit_dim_expr(self, expr: AffineDimExpr) -> None:
+        row = [0] * self.get_num_cols()
+        assert expr.position < self.num_dims, "Inconsistent number of dims"
+        row[self.get_dim_start_index() + expr.position] = 1
+        self.operand_expr_stack.append(row)
+
+    def visit_symbol_expr(self, expr: AffineSymExpr) -> None:
+        # Equivalent to SimpleAffineExprFlattener::visitSymbolExpr
+        row = [0] * self.get_num_cols()
+        assert expr.position < self.num_symbols, "Inconsistent number of symbols"
+        row[self.get_symbol_start_index() + expr.position] = 1
+        self.operand_expr_stack.append(row)
+
+    def visit_constant_expr(self, expr: AffineConstantExpr) -> None:
+        # Equivalent to SimpleAffineExprFlattener::visitConstantExpr
+        row = [0] * self.get_num_cols()
+        row[self.get_constant_index()] = expr.value
+        self.operand_expr_stack.append(row)
+
+    def visit_div_expr(self, expr: AffineBinaryOpExpr, *, is_ceil: bool) -> None:
+        raise NotImplementedError("Simplifying div expr not yet implemented")
+
+    def visit_mod_expr(self, expr: AffineBinaryOpExpr) -> None:
+        raise NotImplementedError("Simplifying mod expr not yet implemented")
+
+    def simplify(self, expr: AffineExpr):
+        for inner in expr.post_order():
+            match inner:
+                case AffineBinaryOpExpr():
+                    match inner.kind:
+                        case AffineBinaryOpKind.Mul:
+                            self.visit_mul_expr(inner)
+                        case AffineBinaryOpKind.Add:
+                            self.visit_add_expr(inner)
+                        case AffineBinaryOpKind.Mod:
+                            self.visit_mod_expr(inner)
+                        case AffineBinaryOpKind.FloorDiv:
+                            self.visit_div_expr(inner, is_ceil=False)
+                        case AffineBinaryOpKind.CeilDiv:
+                            self.visit_div_expr(inner, is_ceil=True)
+                case AffineDimExpr():
+                    self.visit_dim_expr(inner)
+                case AffineConstantExpr():
+                    self.visit_constant_expr(inner)
+                case AffineSymExpr():
+                    self.visit_symbol_expr(inner)
+                case _:
+                    raise ValueError("Unreachable")
+
+        return AffineExpr.from_flat_form(
+            self.operand_expr_stack.pop(),
+            self.num_dims,
+            self.num_symbols,
+            self.local_exprs,
+        )
+
+    def get_num_cols(self) -> int:
+        return self.num_dims + self.num_symbols + len(self.local_exprs) + 1
+
+    def get_constant_index(self) -> int:
+        return self.get_num_cols() - 1
+
+    def get_local_var_start_index(self) -> int:
+        return self.num_dims + self.num_symbols
+
+    def get_symbol_start_index(self) -> int:
+        return self.num_dims
+
+    def get_dim_start_index(self) -> int:
+        return 0


### PR DESCRIPTION
Mod and division are a bit more involved, these simplifications are hopefully fairly easy to understand.