### PR TITLE
dialects: (Vector) disallow 0d extraction/insertion

### DIFF
--- a/tests/filecheck/dialects/vector/invalid.mlir
+++ b/tests/filecheck/dialects/vector/invalid.mlir
@@ -25,7 +25,7 @@ func.func @insert_vector_type(%a: f32, %b: vector<4x8x16xf32>) {
 // -----
 
 func.func @insert_0d(%a: vector<f32>, %b: vector<4x8x16xf32>) {
-  // CHECK: Expected position attribute rank (2) + source rank (0) to match dest vector rank (3).
+  // CHECK: Cannot insert 0d vector.
   %1 = vector.insert %a, %b[2, 6] : vector<f32> into vector<4x8x16xf32>
   func.return
 }
@@ -59,5 +59,13 @@ func.func @extract_position_rank_overflow_generic(%arg0: vector<4x8x16xf32>) {
 func.func @extract_0d(%arg0: vector<f32>) {
   // CHECK: Expected position attribute rank (1) to match source vector rank (0).
   %1 = vector.extract %arg0[0] : f32 from vector<f32>
+  func.return
+}
+
+// -----
+
+func.func @extract_0d(%arg0: vector<f32>) {
+  // CHECK: Cannot extract 0d vector.
+  %1 = vector.extract %arg0[0] : vector<f32> from vector<4xf32>
   func.return
 }

--- a/tests/filecheck/dialects/vector/vector_ops.mlir
+++ b/tests/filecheck/dialects/vector/vector_ops.mlir
@@ -121,12 +121,10 @@ func.func @insert_val_idx(%a: f32, %b: vector<16xf32>, %c: vector<8x16xf32>,
 }
 
 // CHECK-LABEL: @insert_0d
-func.func @insert_0d(%a: f32, %b: vector<f32>, %c: vector<2x3xf32>) -> (vector<f32>, vector<2x3xf32>) {
+func.func @insert_0d(%a: f32, %b: vector<f32>) -> vector<f32> {
   // CHECK-NEXT: vector.insert %{{.*}}, %{{.*}}[] : f32 into vector<f32>
   %1 = vector.insert %a,  %b[] : f32 into vector<f32>
-  // CHECK-NEXT: vector.insert %{{.*}}, %{{.*}}[0, 1] : vector<f32> into vector<2x3xf32>
-  %2 = vector.insert %b,  %c[0, 1] : vector<f32> into vector<2x3xf32>
-  return %1, %2 : vector<f32>, vector<2x3xf32>
+  return %1 : vector<f32>
 }
 
 // CHECK-LABEL: @insert_poison_idx

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/vector/insert.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/vector/insert.mlir
@@ -28,10 +28,8 @@ func.func @insert_val_idx(%a: f32, %b: vector<16xf32>, %c: vector<8x16xf32>,
 }
 
 // CHECK-LABEL: @insert_0d
-func.func @insert_0d(%a: f32, %b: vector<f32>, %c: vector<2x3xf32>) -> (vector<f32>, vector<2x3xf32>) {
+func.func @insert_0d(%a: f32, %b: vector<f32>) -> vector<f32> {
   // CHECK-NEXT: vector.insert %{{.*}}, %{{.*}}[] : f32 into vector<f32>
   %1 = vector.insert %a,  %b[] : f32 into vector<f32>
-  // CHECK-NEXT: vector.insert %{{.*}}, %{{.*}}[0, 1] : vector<f32> into vector<2x3xf32>
-  %2 = vector.insert %b,  %c[0, 1] : vector<f32> into vector<2x3xf32>
-  return %1, %2 : vector<f32>, vector<2x3xf32>
+  return %1 : vector<f32>
 }

--- a/xdsl/dialects/vector.py
+++ b/xdsl/dialects/vector.py
@@ -48,12 +48,15 @@ from xdsl.ir import (
 from xdsl.ir.affine import AffineConstantExpr, AffineDimExpr, AffineMap
 from xdsl.irdl import (
     AnyAttr,
+    AtLeast,
     AttrConstraint,
     AttrSizedOperandSegments,
     ConstraintContext,
     IntConstraint,
     IRDLOperation,
+    MessageConstraint,
     ParsePropInAttrDict,
+    RangeOf,
     VarConstraint,
     base,
     irdl_attr_definition,
@@ -601,7 +604,16 @@ class ExtractOp(IRDLOperation):
     vector = operand_def(_V)
     dynamic_position = var_operand_def(IndexTypeConstr)
 
-    result = result_def(VectorType.constr(_T) | _T)
+    result = result_def(
+        VectorType.constr(
+            _T,
+            shape=MessageConstraint(
+                ArrayAttr.constr(RangeOf(base(IntAttr)).of_length(AtLeast(1))),
+                "Cannot extract 0d vector.",
+            ),
+        )
+        | _T
+    )
 
     traits = traits_def(Pure())
 
@@ -727,7 +739,16 @@ class InsertOp(IRDLOperation):
 
     static_position = prop_def(DenseArrayBase.constr(i64))
 
-    source = operand_def(VectorType.constr(_T) | _T)
+    source = operand_def(
+        VectorType.constr(
+            _T,
+            shape=MessageConstraint(
+                ArrayAttr.constr(RangeOf(base(IntAttr)).of_length(AtLeast(1))),
+                "Cannot insert 0d vector.",
+            ),
+        )
+        | _T
+    )
     dest = operand_def(_V)
     dynamic_position = var_operand_def(IndexTypeConstr)
 


### PR DESCRIPTION
Part of updating to llvm 21
https://github.com/llvm/llvm-project/commit/e9e25f02e6e10c75224aad646bdd1705f1d9d8b1

Can either merge this in before or as part of the eventual switch over.