### PR TITLE
core: (analysis) Allow ModuleOp in DCA visit method

### DIFF
--- a/xdsl/analysis/dead_code_analysis.py
+++ b/xdsl/analysis/dead_code_analysis.py
@@ -12,6 +12,7 @@ from xdsl.analysis.dataflow import (
     LatticeAnchor,
     ProgramPoint,
 )
+from xdsl.dialects.builtin import ModuleOp
 from xdsl.ir import Block, Operation, SSAValue
 
 
@@ -133,7 +134,10 @@ class DeadCodeAnalysis(DataFlowAnalysis):
         if op is None:
             # This analysis only triggers on operations.
             return
-        assert not op.regions, "Cannot yet handle operations with regions"
+        # special cased for the typical case where the analysis is run on a ModuleOp:
+        assert isinstance(op, ModuleOp) or not op.regions, (
+            "Cannot yet handle operations with regions"
+        )
 
         # If parent block is not live, do nothing.
         parent_block = op.parent


### PR DESCRIPTION
The entry of an analysis is typically a module. For this case I've temporarily hardcoded to ensure that no assertion is thrown because of regions.

A similar fix might also be needed later for FuncOp.