### PR TITLE
installation: Fix pylint compatibility

### DIFF
--- a/xdsl/irdl/attributes.py
+++ b/xdsl/irdl/attributes.py
@@ -74,7 +74,6 @@ from .constraints import (  # noqa: TID251
 _DataElement = TypeVar("_DataElement", bound=Hashable, covariant=True)
 
 
-@dataclass(frozen=True)
 class GenericData(Data[_DataElement], ABC):
     """
     A Data with type parameters.


### PR DESCRIPTION
Removes `@dataclass` annotation from class that sub-types what is already a dataclass but doesn't add any new fields. 
For reasons beyond my understanding this breaks pylint, by causing it to misunderstand the correct number of constructor arguments for classes such as `IntAttr`. This in turn causes projects depending on xdsl to fail pylint's type checking.