### PR TITLE
core: split dialect interfaces into own files

### DIFF
--- a/tests/dialects/test_arith.py
+++ b/tests/dialects/test_arith.py
@@ -1,6 +1,8 @@
 import pytest
 
-from xdsl.dialect_interfaces import ConstantMaterializationInterface
+from xdsl.dialect_interfaces.constant_materialization import (
+    ConstantMaterializationInterface,
+)
 from xdsl.dialects.arith import (
     AddfOp,
     AddiOp,

--- a/tests/test_dialect_interfaces.py
+++ b/tests/test_dialect_interfaces.py
@@ -1,6 +1,7 @@
 import pytest
 
-from xdsl.dialect_interfaces import DialectInterface, OpAsmDialectInterface
+from xdsl.dialect_interfaces import DialectInterface
+from xdsl.dialect_interfaces.op_asm import OpAsmDialectInterface
 from xdsl.ir import Dialect
 
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -6,7 +6,7 @@ from typing import cast
 import pytest
 
 from xdsl.context import Context
-from xdsl.dialect_interfaces import OpAsmDialectInterface
+from xdsl.dialect_interfaces.op_asm import OpAsmDialectInterface
 from xdsl.dialects.builtin import (
     DYNAMIC_INDEX,
     ArrayAttr,

--- a/xdsl/dialect_interfaces/__init__.py
+++ b/xdsl/dialect_interfaces/__init__.py
@@ -1,0 +1,14 @@
+from abc import ABC
+
+
+class DialectInterface(ABC):
+    """
+    A base class for dialects' interfaces.
+    They usually define functionality which is dialect specific to some transformation.
+
+    For example DialectInlinerInterface defines which dialect operations can be inlined and how.
+    Dialects will implement this interface and the inlining transformation will query them through the base interface.
+
+    The design logic tries to follow MLIR's dialect interfaces closely
+    https://mlir.llvm.org/docs/Interfaces/#dialect-interfaces
+    """

--- a/xdsl/dialect_interfaces/constant_materialization.py
+++ b/xdsl/dialect_interfaces/constant_materialization.py
@@ -1,0 +1,31 @@
+from abc import ABC, abstractmethod
+
+from xdsl.dialect_interfaces import DialectInterface
+from xdsl.ir import Attribute, Operation
+
+
+class ConstantMaterializationInterface(DialectInterface, ABC):
+    """
+    An interface for dialects that support constant materialization.
+
+    A dialect that implements this interface should provide the `materialize_constant` method,
+    which creates a constant operation of the dialect given a value and a type.
+
+    This is useful for transformations that need to create constants in a dialect-specific way.
+    """
+
+    @abstractmethod
+    def materialize_constant(
+        self, value: Attribute, type: Attribute
+    ) -> Operation | None:
+        """
+        Materializes a constant operation in the dialect.
+
+        Args:
+            value (Attribute): The attribute representing the constant value.
+            type (Attribute): The type of the constant.
+
+        Returns:
+            Operation: The created constant operation.
+        """
+        raise NotImplementedError("Dialect does not implement materialize_constant")

--- a/xdsl/dialect_interfaces/op_asm.py
+++ b/xdsl/dialect_interfaces/op_asm.py
@@ -1,51 +1,6 @@
-from abc import ABC, abstractmethod
 from collections.abc import Iterable
-from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    from xdsl.ir import Attribute, Operation
-
-
-class DialectInterface:
-    """
-    A base class for dialects' interfaces.
-    They usually define functionality which is dialect specific to some transformation.
-
-    For example DialectInlinerInterface defines which dialect operations can be inlined and how.
-    Dialects will implement this interface and the inlining transformation will query them through the base interface.
-
-    The design logic tries to follow MLIR's dialect interfaces closely
-    https://mlir.llvm.org/docs/Interfaces/#dialect-interfaces
-    """
-
-    pass
-
-
-class ConstantMaterializationInterface(DialectInterface, ABC):
-    """
-    An interface for dialects that support constant materialization.
-
-    A dialect that implements this interface should provide the `materialize_constant` method,
-    which creates a constant operation of the dialect given a value and a type.
-
-    This is useful for transformations that need to create constants in a dialect-specific way.
-    """
-
-    @abstractmethod
-    def materialize_constant(
-        self, value: "Attribute", type: "Attribute"
-    ) -> "Operation | None":
-        """
-        Materializes a constant operation in the dialect.
-
-        Args:
-            value (Attribute): The attribute representing the constant value.
-            type (Attribute): The type of the constant.
-
-        Returns:
-            Operation: The created constant operation.
-        """
-        raise NotImplementedError("Dialect does not implement materialize_constant")
+from xdsl.dialect_interfaces import DialectInterface
 
 
 class OpAsmDialectInterface(DialectInterface):

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -4,7 +4,9 @@ import abc
 from collections.abc import Mapping, Sequence
 from typing import ClassVar, Literal, cast
 
-from xdsl.dialect_interfaces import ConstantMaterializationInterface
+from xdsl.dialect_interfaces.constant_materialization import (
+    ConstantMaterializationInterface,
+)
 from xdsl.dialects.builtin import (
     AnyFloat,
     AnyFloatConstr,

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -21,7 +21,7 @@ from typing import (
 from immutabledict import immutabledict
 from typing_extensions import Self, TypeVar, deprecated, override
 
-from xdsl.dialect_interfaces import OpAsmDialectInterface
+from xdsl.dialect_interfaces.op_asm import OpAsmDialectInterface
 from xdsl.ir import (
     Attribute,
     AttributeCovT,

--- a/xdsl/dialects/test.py
+++ b/xdsl/dialects/test.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 
-from xdsl.dialect_interfaces import OpAsmDialectInterface
+from xdsl.dialect_interfaces.op_asm import OpAsmDialectInterface
 from xdsl.ir import (
     Attribute,
     Block,

--- a/xdsl/folder.py
+++ b/xdsl/folder.py
@@ -3,7 +3,9 @@ from dataclasses import dataclass
 
 from xdsl.builder import Builder
 from xdsl.context import Context
-from xdsl.dialect_interfaces import ConstantMaterializationInterface
+from xdsl.dialect_interfaces.constant_materialization import (
+    ConstantMaterializationInterface,
+)
 from xdsl.ir import Attribute, Operation, SSAValue, TypeAttribute
 from xdsl.pattern_rewriter import PatternRewriter
 from xdsl.traits import HasFolder

--- a/xdsl/parser/attribute_parser.py
+++ b/xdsl/parser/attribute_parser.py
@@ -10,7 +10,7 @@ from immutabledict import immutabledict
 
 import xdsl.parser as affine_parser
 from xdsl.context import Context
-from xdsl.dialect_interfaces import OpAsmDialectInterface
+from xdsl.dialect_interfaces.op_asm import OpAsmDialectInterface
 from xdsl.dialects.builtin import (
     DYNAMIC_INDEX,
     AffineMapAttr,

--- a/xdsl/parser/core.py
+++ b/xdsl/parser/core.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from typing import Literal, overload
 
 from xdsl.context import Context
-from xdsl.dialect_interfaces import OpAsmDialectInterface
+from xdsl.dialect_interfaces.op_asm import OpAsmDialectInterface
 from xdsl.dialects.builtin import DictionaryAttr, ModuleOp
 from xdsl.ir import (
     Attribute,

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -9,7 +9,7 @@ from typing import Any, cast
 
 from typing_extensions import TypeVar, deprecated
 
-from xdsl.dialect_interfaces import OpAsmDialectInterface
+from xdsl.dialect_interfaces.op_asm import OpAsmDialectInterface
 from xdsl.dialects.builtin import (
     DYNAMIC_INDEX,
     AnyFloat,

--- a/xdsl/transforms/constant_fold_interp.py
+++ b/xdsl/transforms/constant_fold_interp.py
@@ -7,7 +7,9 @@ from dataclasses import dataclass
 from typing import Any, cast
 
 from xdsl.context import Context
-from xdsl.dialect_interfaces import ConstantMaterializationInterface
+from xdsl.dialect_interfaces.constant_materialization import (
+    ConstantMaterializationInterface,
+)
 from xdsl.dialects import builtin
 from xdsl.dialects.builtin import IntegerAttr, IntegerType
 from xdsl.interpreter import Interpreter


### PR DESCRIPTION
I'm about to add the inlining interface and helpers which is quite a lot of code. I think this might make sense to do this for traits and interfaces also, in the future.