### PR TITLE
dialects: (builtin) accept Iterable of Operation in ModuleOp init

### DIFF
--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -2260,7 +2260,7 @@ class ModuleOp(IRDLOperation):
 
     def __init__(
         self,
-        ops: list[Operation] | Region,
+        ops: Iterable[Operation] | Region,
         attributes: Mapping[str, Attribute] | None = None,
         sym_name: StringAttr | None = None,
     ):


### PR DESCRIPTION
list is invariant which makes pyright complain when passing a list of arguments.