### PR TITLE
transformations: (convert_pdl_to_pdl_interp) add `_generate_rewriter_for_apply_native_rewrite` and `_generate_rewriter_for_attribute`

### DIFF
--- a/tests/transforms/test_convert_pdl_to_pdl_interp.py
+++ b/tests/transforms/test_convert_pdl_to_pdl_interp.py
@@ -3743,7 +3743,7 @@ def test_generate_rewriter_for_attribute_without_constant():
     )
 
     # Verify no ops were created
-    assert len(list(rewriter_block.ops)) == 0
+    assert not rewriter_block.ops
 
     # Verify no mapping was added
     assert attr_op.output not in rewrite_values

--- a/xdsl/transforms/convert_pdl_to_pdl_interp/conversion.py
+++ b/xdsl/transforms/convert_pdl_to_pdl_interp/conversion.py
@@ -1417,7 +1417,7 @@ class MatcherGenerator:
             arguments, name=op.constraint_name, result_types=result_types
         )
         self.rewriter_builder.insert(interp_op)
-        for old_res, new_res in zip(op.results, interp_op.results):
+        for old_res, new_res in zip(op.results, interp_op.results, strict=True):
             rewrite_values[old_res] = new_res
 
     def _generate_rewriter_for_attribute(
@@ -1426,7 +1426,7 @@ class MatcherGenerator:
         rewrite_values: dict[SSAValue, SSAValue],
         map_rewrite_value: Callable[[SSAValue], SSAValue],
     ):
-        if op.value:
+        if op.value is not None:
             new_attr_op = pdl_interp.CreateAttributeOp(op.value)
             self.rewriter_builder.insert(new_attr_op)
             rewrite_values[op.output] = new_attr_op.attribute


### PR DESCRIPTION
This is the first of a stack of commits that defining the helper functions that generate the pdl_interp rewriter code.
The tests all call these internal helpers, once they're in I've got a commit that refactors the tests to use the public method that ends up calling those.
