### PR TITLE
dialects: (builtin) Fix printer for FloatData

### DIFF
--- a/tests/filecheck/dialects/builtin/attrs.mlir
+++ b/tests/filecheck/dialects/builtin/attrs.mlir
@@ -4,6 +4,14 @@
 "builtin.module"() ({
   // CHECK: func.func
   "func.func"() ({
+    // CHECK-NEXT: test = #builtin.int<0>
+    "test.op"() {test = #builtin.int<0>} : () -> ()
+    // CHECK-NEXT: test = #builtin.int<5444517870735015415413993718908291383295>
+    "test.op"() {test = #builtin.int<5444517870735015415413993718908291383295>} : () -> ()
+    // CHECK-NEXT: test = #builtin.float_data<-0.4>
+    "test.op"() {test = #builtin.float_data<-0.4>} : () -> ()
+    // CHECK-NEXT: test = #builtin.float_data<2.1>
+    "test.op"() {test = #builtin.float_data<2.100000e+00>} : () -> ()
     // CHECK-NEXT: test = true
     "test.op"() {test = true} : () -> ()
     // CHECK-NEXT: test = false

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -1122,7 +1122,8 @@ class FloatData(Data[float]):
             return float(parser.parse_number())
 
     def print_parameter(self, printer: Printer) -> None:
-        printer.print_string(f"{self.data}")
+        with printer.in_angle_brackets():
+            printer.print_string(f"{self.data}")
 
     def __eq__(self, other: object):
         # avoid triggering `float('nan') != float('nan')` inequality


### PR DESCRIPTION
Printing and Parsing FloatData does not round trip since printing does not use angle brackets.
This PR fixes this and adds a couple tests for FloatData and IntAttr.
Bug appears to originate from #1724 
