### PR TITLE
transformations: (convert-x86-scf-to-x86) copy name hints in lowering

### DIFF
--- a/tests/filecheck/transforms/convert-x86-scf-to-x86.mlir
+++ b/tests/filecheck/transforms/convert-x86-scf-to-x86.mlir
@@ -5,17 +5,17 @@
 //  CHECK-NEXT:      %zero = x86.di.mov 0 : () -> !x86.reg<rcx>
 //  CHECK-NEXT:      %step = x86.di.mov 4 : () -> !x86.reg<rdx>
 //  CHECK-NEXT:      %forty = x86.di.mov 40 : () -> !x86.reg<r8>
-//  CHECK-NEXT:      %0 = x86.ds.mov %zero : (!x86.reg<rcx>) -> !x86.reg<r9>
-//  CHECK-NEXT:      %1 = x86.ss.cmp %0, %forty : (!x86.reg<r9>, !x86.reg<r8>) -> !x86.rflags<rflags>
-//  CHECK-NEXT:      x86.c.jl %1 : !x86.rflags<rflags>, ^bb0(%0 : !x86.reg<r9>), ^bb1(%0 : !x86.reg<r9>)
+//  CHECK-NEXT:      %zero_1 = x86.ds.mov %zero : (!x86.reg<rcx>) -> !x86.reg<r9>
+//  CHECK-NEXT:      %0 = x86.ss.cmp %zero_1, %forty : (!x86.reg<r9>, !x86.reg<r8>) -> !x86.rflags<rflags>
+//  CHECK-NEXT:      x86.c.jl %0 : !x86.rflags<rflags>, ^bb0(%zero_1 : !x86.reg<r9>), ^bb1(%zero_1 : !x86.reg<r9>)
 //  CHECK-NEXT:    ^bb1(%offset : !x86.reg<r9>):
 //  CHECK-NEXT:      x86.label "scf_body_0_for"
 //  CHECK-NEXT:      "test.op"(%offset, %src, %dst) : (!x86.reg<r9>, !x86.reg<rax>, !x86.reg<rbx>) -> ()
-//  CHECK-NEXT:      %2 = x86.ds.mov %offset : (!x86.reg<r9>) -> !x86.reg<r9>
-//  CHECK-NEXT:      %3 = x86.r.inc %2 : (!x86.reg<r9>) -> !x86.reg<r9>
-//  CHECK-NEXT:      %4 = x86.ss.cmp %3, %forty : (!x86.reg<r9>, !x86.reg<r8>) -> !x86.rflags<rflags>
-//  CHECK-NEXT:      x86.c.jl %4 : !x86.rflags<rflags>, ^bb1(%3 : !x86.reg<r9>), ^bb0(%3 : !x86.reg<r9>)
-//  CHECK-NEXT:    ^bb0(%5 : !x86.reg<r9>):
+//  CHECK-NEXT:      %offset_1 = x86.ds.mov %offset : (!x86.reg<r9>) -> !x86.reg<r9>
+//  CHECK-NEXT:      %offset_2 = x86.r.inc %offset_1 : (!x86.reg<r9>) -> !x86.reg<r9>
+//  CHECK-NEXT:      %1 = x86.ss.cmp %offset_2, %forty : (!x86.reg<r9>, !x86.reg<r8>) -> !x86.rflags<rflags>
+//  CHECK-NEXT:      x86.c.jl %1 : !x86.rflags<rflags>, ^bb1(%offset_2 : !x86.reg<r9>), ^bb0(%offset_2 : !x86.reg<r9>)
+//  CHECK-NEXT:    ^bb0(%offset_3 : !x86.reg<r9>):
 //  CHECK-NEXT:      x86.label "scf_body_end_0_for"
 //  CHECK-NEXT:      x86_func.ret
 //  CHECK-NEXT:    }
@@ -36,31 +36,31 @@ x86_func.func @copy10(%src : !x86.reg<rax>, %dst : !x86.reg<rbx>) {
 //  CHECK-NEXT:      %zero_outer = x86.di.mov 0 : () -> !x86.reg<rcx>
 //  CHECK-NEXT:      %step_outer = x86.di.mov 4 : () -> !x86.reg<rdx>
 //  CHECK-NEXT:      %forty_outer = x86.di.mov 40 : () -> !x86.reg<r8>
-//  CHECK-NEXT:      %0 = x86.ds.mov %zero_outer : (!x86.reg<rcx>) -> !x86.reg<r9>
-//  CHECK-NEXT:      %1 = x86.ss.cmp %0, %forty_outer : (!x86.reg<r9>, !x86.reg<r8>) -> !x86.rflags<rflags>
-//  CHECK-NEXT:      x86.c.jl %1 : !x86.rflags<rflags>, ^bb0(%0 : !x86.reg<r9>), ^bb1(%0 : !x86.reg<r9>)
+//  CHECK-NEXT:      %zero_outer_1 = x86.ds.mov %zero_outer : (!x86.reg<rcx>) -> !x86.reg<r9>
+//  CHECK-NEXT:      %0 = x86.ss.cmp %zero_outer_1, %forty_outer : (!x86.reg<r9>, !x86.reg<r8>) -> !x86.rflags<rflags>
+//  CHECK-NEXT:      x86.c.jl %0 : !x86.rflags<rflags>, ^bb0(%zero_outer_1 : !x86.reg<r9>), ^bb1(%zero_outer_1 : !x86.reg<r9>)
 //  CHECK-NEXT:    ^bb1(%offset_outer : !x86.reg<r9>):
 //  CHECK-NEXT:      x86.label "scf_body_1_for"
 //  CHECK-NEXT:      %zero_inner = x86.di.mov 0 : () -> !x86.reg<r10>
 //  CHECK-NEXT:      %step_inner = x86.di.mov 2 : () -> !x86.reg<r11>
 //  CHECK-NEXT:      %forty_inner = x86.di.mov 40 : () -> !x86.reg<r12>
-//  CHECK-NEXT:      %2 = x86.ds.mov %zero_inner : (!x86.reg<r10>) -> !x86.reg<r13>
-//  CHECK-NEXT:      %3 = x86.ss.cmp %2, %forty_inner : (!x86.reg<r13>, !x86.reg<r12>) -> !x86.rflags<rflags>
-//  CHECK-NEXT:      x86.c.jl %3 : !x86.rflags<rflags>, ^bb2(%2 : !x86.reg<r13>), ^bb3(%2 : !x86.reg<r13>)
+//  CHECK-NEXT:      %zero_inner_1 = x86.ds.mov %zero_inner : (!x86.reg<r10>) -> !x86.reg<r13>
+//  CHECK-NEXT:      %1 = x86.ss.cmp %zero_inner_1, %forty_inner : (!x86.reg<r13>, !x86.reg<r12>) -> !x86.rflags<rflags>
+//  CHECK-NEXT:      x86.c.jl %1 : !x86.rflags<rflags>, ^bb2(%zero_inner_1 : !x86.reg<r13>), ^bb3(%zero_inner_1 : !x86.reg<r13>)
 //  CHECK-NEXT:    ^bb3(%offset_inner : !x86.reg<r13>):
 //  CHECK-NEXT:      x86.label "scf_body_0_for"
 //  CHECK-NEXT:      "test.op"(%src, %dst, %offset_outer, %offset_inner) : (!x86.reg<rax>, !x86.reg<rbx>, !x86.reg<r9>, !x86.reg<r13>) -> ()
-//  CHECK-NEXT:      %4 = x86.ds.mov %offset_inner : (!x86.reg<r13>) -> !x86.reg<r13>
-//  CHECK-NEXT:      %5 = x86.r.inc %4 : (!x86.reg<r13>) -> !x86.reg<r13>
-//  CHECK-NEXT:      %6 = x86.ss.cmp %5, %forty_inner : (!x86.reg<r13>, !x86.reg<r12>) -> !x86.rflags<rflags>
-//  CHECK-NEXT:      x86.c.jl %6 : !x86.rflags<rflags>, ^bb3(%5 : !x86.reg<r13>), ^bb2(%5 : !x86.reg<r13>)
-//  CHECK-NEXT:    ^bb2(%7 : !x86.reg<r13>):
+//  CHECK-NEXT:      %offset_inner_1 = x86.ds.mov %offset_inner : (!x86.reg<r13>) -> !x86.reg<r13>
+//  CHECK-NEXT:      %offset_inner_2 = x86.r.inc %offset_inner_1 : (!x86.reg<r13>) -> !x86.reg<r13>
+//  CHECK-NEXT:      %2 = x86.ss.cmp %offset_inner_2, %forty_inner : (!x86.reg<r13>, !x86.reg<r12>) -> !x86.rflags<rflags>
+//  CHECK-NEXT:      x86.c.jl %2 : !x86.rflags<rflags>, ^bb3(%offset_inner_2 : !x86.reg<r13>), ^bb2(%offset_inner_2 : !x86.reg<r13>)
+//  CHECK-NEXT:    ^bb2(%offset_inner_3 : !x86.reg<r13>):
 //  CHECK-NEXT:      x86.label "scf_body_end_0_for"
-//  CHECK-NEXT:      %8 = x86.ds.mov %offset_outer : (!x86.reg<r9>) -> !x86.reg<r9>
-//  CHECK-NEXT:      %9 = x86.r.inc %8 : (!x86.reg<r9>) -> !x86.reg<r9>
-//  CHECK-NEXT:      %10 = x86.ss.cmp %9, %forty_outer : (!x86.reg<r9>, !x86.reg<r8>) -> !x86.rflags<rflags>
-//  CHECK-NEXT:      x86.c.jl %10 : !x86.rflags<rflags>, ^bb1(%9 : !x86.reg<r9>), ^bb0(%9 : !x86.reg<r9>)
-//  CHECK-NEXT:    ^bb0(%11 : !x86.reg<r9>):
+//  CHECK-NEXT:      %offset_outer_1 = x86.ds.mov %offset_outer : (!x86.reg<r9>) -> !x86.reg<r9>
+//  CHECK-NEXT:      %offset_outer_2 = x86.r.inc %offset_outer_1 : (!x86.reg<r9>) -> !x86.reg<r9>
+//  CHECK-NEXT:      %3 = x86.ss.cmp %offset_outer_2, %forty_outer : (!x86.reg<r9>, !x86.reg<r8>) -> !x86.rflags<rflags>
+//  CHECK-NEXT:      x86.c.jl %3 : !x86.rflags<rflags>, ^bb1(%offset_outer_2 : !x86.reg<r9>), ^bb0(%offset_outer_2 : !x86.reg<r9>)
+//  CHECK-NEXT:    ^bb0(%offset_outer_3 : !x86.reg<r9>):
 //  CHECK-NEXT:      x86.label "scf_body_end_1_for"
 //  CHECK-NEXT:      x86_func.ret
 //  CHECK-NEXT:    }

--- a/xdsl/transforms/convert_x86_scf_to_x86.py
+++ b/xdsl/transforms/convert_x86_scf_to_x86.py
@@ -124,6 +124,10 @@ class LowerX86ScfForPattern(RewritePattern):
             ),
         )
 
+        mv_op.destination.name_hint = iv.name_hint
+        inc_op.register_out.name_hint = iv.name_hint
+        end_block.args[0].name_hint = iv.name_hint
+
         rewriter.inline_region(op.body, BlockInsertPoint.before(end_block))
 
         # Move lb to new register to initialize the iv.
@@ -142,6 +146,8 @@ class LowerX86ScfForPattern(RewritePattern):
             ),
             InsertPoint.at_end(init_block),
         )
+
+        mv_op.destination.name_hint = op.lb.name_hint
 
         # Insert label at the start of the first body block.
         rewriter.insert_op(


### PR DESCRIPTION
I forgot to do this initially, which makes it more difficult to change the lowering as the numered value names are not stable.