### PR TITLE
misc: (RangeConstaint) add verifies

### DIFF
--- a/xdsl/irdl/constraints.py
+++ b/xdsl/irdl/constraints.py
@@ -1071,6 +1071,19 @@ class RangeConstraint(ABC, Generic[AttributeCovT]):
         """
         ...
 
+    def verifies(
+        self,
+        attrs: Sequence[Attribute],
+    ) -> TypeGuard[AttributeCovT]:
+        """
+        A helper method to check whether a given attribute matches `self`.
+        """
+        try:
+            self.verify(attrs, ConstraintContext())
+            return True
+        except VerifyException:
+            return False
+
     @abstractmethod
     def verify_length(self, length: int, constraint_context: ConstraintContext) -> None:
         """


### PR DESCRIPTION
Mirrors the `AttrConstraint.verifies` function. I would find it handy for testing. Doesn't seem to be a test for `AttrConstraint.verifies` and I'm unsure what would be a good test for this, but could probably cook one up if wanted.