### PR TITLE
interpreter: (pdl_interp) use interpreter state for Context

### DIFF
--- a/tests/interpreters/test_eqsat_pdl_interp_interpreter.py
+++ b/tests/interpreters/test_eqsat_pdl_interp_interpreter.py
@@ -23,7 +23,7 @@ def test_populate_known_ops():
     module = ModuleOp([regular_op, eclass_op])
 
     # Create interpreter functions instance
-    interp_functions = EqsatPDLInterpFunctions(Context())
+    interp_functions = EqsatPDLInterpFunctions()
 
     # Call the method under test
     interp_functions.populate_known_ops(module)
@@ -40,7 +40,7 @@ def test_populate_known_ops():
 def test_run_get_result():
     """Test that run_get_result handles EClass operations correctly."""
     interpreter = Interpreter(ModuleOp([]))
-    interpreter.register_implementations(EqsatPDLInterpFunctions(Context()))
+    interpreter.register_implementations(EqsatPDLInterpFunctions())
 
     # Create a test operation with results
     c0 = create_ssa_value(i32)
@@ -66,7 +66,7 @@ def test_run_get_result():
 def test_run_get_result_error_case():
     """Test that run_get_result raises error when result is not used by EClass."""
     interpreter = Interpreter(ModuleOp([]))
-    interpreter.register_implementations(EqsatPDLInterpFunctions(Context()))
+    interpreter.register_implementations(EqsatPDLInterpFunctions())
 
     # Create a test operation with result that is not used by EClass
     c0 = create_ssa_value(i32)
@@ -89,7 +89,7 @@ def test_run_get_result_error_case():
 def test_run_get_results():
     """Test that run_get_results handles EClass operations correctly."""
     interpreter = Interpreter(ModuleOp([]))
-    interpreter.register_implementations(EqsatPDLInterpFunctions(Context()))
+    interpreter.register_implementations(EqsatPDLInterpFunctions())
 
     # Create a test operation with multiple results
     c0 = create_ssa_value(i32)
@@ -115,7 +115,7 @@ def test_run_get_results():
 def test_run_get_results_error_case():
     """Test that run_get_results raises error when result is not used by EClass."""
     interpreter = Interpreter(ModuleOp([]))
-    interpreter.register_implementations(EqsatPDLInterpFunctions(Context()))
+    interpreter.register_implementations(EqsatPDLInterpFunctions())
 
     # Create a test operation with results that are not used by EClass
     c0 = create_ssa_value(i32)
@@ -143,7 +143,7 @@ def test_run_get_results_error_case():
 def test_run_get_result_none_case():
     """Test that run_get_result returns None when result index doesn't exist."""
     interpreter = Interpreter(ModuleOp([]))
-    interpreter.register_implementations(EqsatPDLInterpFunctions(Context()))
+    interpreter.register_implementations(EqsatPDLInterpFunctions())
 
     # Create a test operation with only one result
     c0 = create_ssa_value(i32)
@@ -159,7 +159,7 @@ def test_run_get_result_none_case():
 def test_run_get_results_valuetype_multi_results():
     """Test that run_get_results returns None for ValueType with multiple results."""
     interpreter = Interpreter(ModuleOp([]))
-    interpreter.register_implementations(EqsatPDLInterpFunctions(Context()))
+    interpreter.register_implementations(EqsatPDLInterpFunctions())
 
     # Create a test operation with multiple results
     c0 = create_ssa_value(i32)
@@ -180,7 +180,7 @@ def test_run_get_results_valuetype_multi_results():
 def test_run_get_results_valuetype_no_results():
     """Test that run_get_results returns None for ValueType with no results."""
     interpreter = Interpreter(ModuleOp([]))
-    interpreter.register_implementations(EqsatPDLInterpFunctions(Context()))
+    interpreter.register_implementations(EqsatPDLInterpFunctions())
 
     # Create a test operation with no results
     c0 = create_ssa_value(i32)
@@ -201,7 +201,7 @@ def test_run_get_results_valuetype_no_results():
 def test_run_get_defining_op():
     """Test that run_get_defining_op handles regular operations correctly."""
     interpreter = Interpreter(ModuleOp([]))
-    interp_functions = EqsatPDLInterpFunctions(Context())
+    interp_functions = EqsatPDLInterpFunctions()
     interpreter.register_implementations(interp_functions)
 
     # Create a test operation and its result
@@ -224,7 +224,7 @@ def test_run_get_defining_op():
 def test_run_get_defining_op_eclass_not_visited():
     """Test that run_get_defining_op handles EClassOp when not visited."""
     interpreter = Interpreter(ModuleOp([]))
-    interp_functions = EqsatPDLInterpFunctions(Context())
+    interp_functions = EqsatPDLInterpFunctions()
     interpreter.register_implementations(interp_functions)
 
     # Create test operations
@@ -257,7 +257,7 @@ def test_run_get_defining_op_eclass_not_visited():
 def test_run_get_defining_op_eclass_visited():
     """Test that run_get_defining_op handles EClassOp when visited."""
     interpreter = Interpreter(ModuleOp([]))
-    interp_functions = EqsatPDLInterpFunctions(Context())
+    interp_functions = EqsatPDLInterpFunctions()
     interpreter.register_implementations(interp_functions)
 
     # Create test operations with multiple operands
@@ -296,7 +296,7 @@ def test_run_get_defining_op_eclass_visited():
 def test_run_get_defining_op_eclass_error_multiple_gdo():
     """Test that run_get_defining_op raises error for multiple get_defining_op in block."""
     interpreter = Interpreter(ModuleOp([]))
-    interp_functions = EqsatPDLInterpFunctions(Context())
+    interp_functions = EqsatPDLInterpFunctions()
     interpreter.register_implementations(interp_functions)
 
     # Create test operations
@@ -330,9 +330,9 @@ def test_run_get_defining_op_eclass_error_multiple_gdo():
 def test_run_create_operation_new_operation():
     """Test that run_create_operation creates new operation and EClass when no existing match."""
     interpreter = Interpreter(ModuleOp([]))
-    ctx = Context()
+    interp_functions = EqsatPDLInterpFunctions()
+    ctx = interp_functions.get_ctx(interpreter)
     ctx.register_dialect("test", lambda: test.Test)
-    interp_functions = EqsatPDLInterpFunctions(ctx)
     interpreter.register_implementations(interp_functions)
 
     # Set up a mock rewriter
@@ -384,9 +384,9 @@ def test_run_create_operation_new_operation():
 def test_run_create_operation_existing_operation_in_use_by_eclass():
     """Test that run_create_operation returns existing operation when it's still in use."""
     interpreter = Interpreter(ModuleOp([]))
-    ctx = Context()
+    interp_functions = EqsatPDLInterpFunctions()
+    ctx = interp_functions.get_ctx(interpreter)
     ctx.register_dialect("test", lambda: test.Test)
-    interp_functions = EqsatPDLInterpFunctions(ctx)
     interpreter.register_implementations(interp_functions)
 
     # Set up a mock rewriter
@@ -438,9 +438,9 @@ def test_run_create_operation_existing_operation_in_use_by_eclass():
 def test_run_create_operation_existing_operation_in_use():
     """Test that run_create_operation returns existing operation when it's still in use but not by an eclass."""
     interpreter = Interpreter(ModuleOp([]))
-    ctx = Context()
+    interp_functions = EqsatPDLInterpFunctions()
+    ctx = interp_functions.get_ctx(interpreter)
     ctx.register_dialect("test", lambda: test.Test)
-    interp_functions = EqsatPDLInterpFunctions(ctx)
     interpreter.register_implementations(interp_functions)
 
     # Set up a mock rewriter
@@ -493,9 +493,9 @@ def test_run_create_operation_existing_operation_not_in_use():
     """Test that run_create_operation reuses an operation not currently
     in use by wrapping it in a new eclass."""
     interpreter = Interpreter(ModuleOp([]))
-    ctx = Context()
+    interp_functions = EqsatPDLInterpFunctions()
+    ctx = interp_functions.get_ctx(interpreter)
     ctx.register_dialect("test", lambda: test.Test)
-    interp_functions = EqsatPDLInterpFunctions(ctx)
     interpreter.register_implementations(interp_functions)
 
     # Set up a mock rewriter
@@ -546,7 +546,7 @@ def test_run_create_operation_existing_operation_not_in_use():
 def test_run_finalize_empty_stack():
     """Test that run_finalize handles empty backtrack stack correctly."""
     interpreter = Interpreter(ModuleOp([]))
-    interp_functions = EqsatPDLInterpFunctions(Context())
+    interp_functions = EqsatPDLInterpFunctions()
     interpreter.register_implementations(interp_functions)
 
     # Test finalize with empty backtrack stack - should return empty values
@@ -556,7 +556,7 @@ def test_run_finalize_empty_stack():
 
 def test_backtrack_stack_manipulation():
     """Test that backtrack stack operations work correctly."""
-    interp_functions = EqsatPDLInterpFunctions(Context())
+    interp_functions = EqsatPDLInterpFunctions()
 
     # Verify initial state
     assert len(interp_functions.backtrack_stack) == 0
@@ -581,7 +581,7 @@ def test_backtrack_stack_manipulation():
 def test_run_finalize_with_backtrack_stack():
     """Test that run_finalize handles non-empty backtrack stack correctly."""
     interpreter = Interpreter(ModuleOp([]))
-    interp_functions = EqsatPDLInterpFunctions(Context())
+    interp_functions = EqsatPDLInterpFunctions()
     interpreter.register_implementations(interp_functions)
 
     # Import necessary classes
@@ -636,8 +636,7 @@ def test_run_finalize_with_backtrack_stack():
 def test_run_replace():
     """Test that run_replace correctly merges EClass operations."""
     interpreter = Interpreter(ModuleOp([]))
-    ctx = Context()
-    interp_functions = EqsatPDLInterpFunctions(ctx)
+    interp_functions = EqsatPDLInterpFunctions()
 
     from xdsl.builder import ImplicitBuilder
     from xdsl.ir import Block, Region
@@ -690,8 +689,7 @@ def test_run_replace():
 def test_run_replace_same_eclass():
     """Test that run_replace handles replacing with same EClass correctly."""
     interpreter = Interpreter(ModuleOp([]))
-    ctx = Context()
-    interp_functions = EqsatPDLInterpFunctions(ctx)
+    interp_functions = EqsatPDLInterpFunctions()
 
     # Create test operation
     c0 = create_ssa_value(i32)
@@ -723,8 +721,7 @@ def test_run_replace_same_eclass():
 def test_run_replace_error_not_eclass_original():
     """Test that run_replace raises error when original operation result is not used by EClass."""
     interpreter = Interpreter(ModuleOp([]))
-    ctx = Context()
-    interp_functions = EqsatPDLInterpFunctions(ctx)
+    interp_functions = EqsatPDLInterpFunctions()
 
     # Create test operation without EClass usage
     c0 = create_ssa_value(i32)
@@ -755,8 +752,7 @@ def test_run_replace_error_not_eclass_original():
 def test_run_replace_error_not_eclass_replacement():
     """Test that run_replace raises error when replacement value is not from EClass."""
     interpreter = Interpreter(ModuleOp([]))
-    ctx = Context()
-    interp_functions = EqsatPDLInterpFunctions(ctx)
+    interp_functions = EqsatPDLInterpFunctions()
 
     # Create test operation with EClass usage
     c0 = create_ssa_value(i32)
@@ -818,7 +814,9 @@ def test_rebuilding():
     ctx.register_dialect("arith", lambda: arith.Arith)
     rewriter = PatternRewriter(c_b.owner)
 
-    interp_functions = EqsatPDLInterpFunctions(ctx)
+    interpreter = Interpreter(ModuleOp([]))
+    interp_functions = EqsatPDLInterpFunctions()
+    ctx = interp_functions.get_ctx(interpreter)
     interp_functions.rewriter = rewriter
 
     interp_functions.populate_known_ops(testmodule)
@@ -892,13 +890,15 @@ def test_rebuilding_parents_already_equivalent():
     b.name_hint = "b"
     c_ab.name_hint = "c_ab"
 
-    ctx = Context()
+    rewriter = PatternRewriter(c_ab.owner)
+
+    interpreter = Interpreter(ModuleOp(()))
+    interp_functions = EqsatPDLInterpFunctions()
+    ctx = EqsatPDLInterpFunctions.get_ctx(interpreter)
     ctx.register_dialect("func", lambda: func.Func)
     ctx.register_dialect("eqsat", lambda: eqsat.EqSat)
     ctx.register_dialect("test", lambda: test.Test)
-    rewriter = PatternRewriter(c_ab.owner)
 
-    interp_functions = EqsatPDLInterpFunctions(ctx)
     interp_functions.rewriter = rewriter
 
     interp_functions.populate_known_ops(testmodule)
@@ -926,7 +926,7 @@ def test_rebuilding_parents_already_equivalent():
 def test_run_get_defining_op_block_argument():
     """Test that run_get_defining_op returns None for block arguments."""
     interpreter = Interpreter(ModuleOp([]))
-    interp_functions = EqsatPDLInterpFunctions(Context())
+    interp_functions = EqsatPDLInterpFunctions()
     interpreter.register_implementations(interp_functions)
 
     # Create a block argument
@@ -969,7 +969,7 @@ def test_run_get_defining_op_block_argument():
 def test_run_choose_not_visited():
     """Test that run_choose handles ChooseOp when not visited (coming from run_finalize)."""
     interpreter = Interpreter(ModuleOp([]))
-    interp_functions = EqsatPDLInterpFunctions(Context())
+    interp_functions = EqsatPDLInterpFunctions()
     interpreter.register_implementations(interp_functions)
 
     # Create blocks for choices and default
@@ -1010,7 +1010,7 @@ def test_run_choose_not_visited():
 def test_run_choose_visited():
     """Test that run_choose handles ChooseOp when visited (creating new backtrack point)."""
     interpreter = Interpreter(ModuleOp([]))
-    interp_functions = EqsatPDLInterpFunctions(Context())
+    interp_functions = EqsatPDLInterpFunctions()
     interpreter.register_implementations(interp_functions)
 
     # Create blocks for choices and default
@@ -1057,7 +1057,7 @@ def test_run_choose_visited():
 def test_run_choose_default_dest():
     """Test that run_choose goes to default destination when index equals len(choices)."""
     interpreter = Interpreter(ModuleOp([]))
-    interp_functions = EqsatPDLInterpFunctions(Context())
+    interp_functions = EqsatPDLInterpFunctions()
     interpreter.register_implementations(interp_functions)
 
     # Create blocks for choices and default
@@ -1100,7 +1100,7 @@ def test_run_choose_default_dest():
 def test_run_choose_error_wrong_op():
     """Test that run_choose raises error when expected ChooseOp is not at top of backtrack stack."""
     interpreter = Interpreter(ModuleOp([]))
-    interp_functions = EqsatPDLInterpFunctions(Context())
+    interp_functions = EqsatPDLInterpFunctions()
     interpreter.register_implementations(interp_functions)
 
     # Create blocks for choices and default
@@ -1133,8 +1133,7 @@ def test_run_choose_error_wrong_op():
 
 def test_eclass_union_different_constants_fails():
     """Test that eclass_union of two ConstantEClassOp with different constant values fails."""
-    ctx = Context()
-    interp_functions = EqsatPDLInterpFunctions(ctx)
+    interp_functions = EqsatPDLInterpFunctions()
 
     from xdsl.builder import ImplicitBuilder
     from xdsl.dialects.builtin import IntegerAttr
@@ -1166,8 +1165,7 @@ def test_eclass_union_different_constants_fails():
 
 def test_eclass_union_constant_with_regular():
     """Test that eclass_union of ConstantEClassOp with regular EClassOp results in ConstantEClassOp containing both operands."""
-    ctx = Context()
-    interp_functions = EqsatPDLInterpFunctions(ctx)
+    interp_functions = EqsatPDLInterpFunctions()
 
     from xdsl.builder import ImplicitBuilder
     from xdsl.dialects.builtin import IntegerAttr
@@ -1226,8 +1224,7 @@ def test_eclass_union_constant_with_regular():
 def test_run_replace_no_uses_returns_empty():
     """Test that run_replace returns empty tuple when input_op has no uses."""
     interpreter = Interpreter(ModuleOp([]))
-    ctx = Context()
-    interp_functions = EqsatPDLInterpFunctions(ctx)
+    interp_functions = EqsatPDLInterpFunctions()
 
     from xdsl.builder import ImplicitBuilder
     from xdsl.ir import Block, Region
@@ -1267,9 +1264,9 @@ def test_run_replace_no_uses_returns_empty():
 def test_run_create_operation_folding():
     """Test that run_create_operation handles folding operations correctly."""
     interpreter = Interpreter(ModuleOp([]))
-    ctx = Context()
+    interp_functions = EqsatPDLInterpFunctions()
+    ctx = EqsatPDLInterpFunctions.get_ctx(interpreter)
     ctx.register_dialect("arith", lambda: arith.Arith)
-    interp_functions = EqsatPDLInterpFunctions(ctx)
     interpreter.register_implementations(interp_functions)
 
     from xdsl.builder import ImplicitBuilder

--- a/tests/interpreters/test_pdl_interp_interpreter.py
+++ b/tests/interpreters/test_pdl_interp_interpreter.py
@@ -1,7 +1,6 @@
 import pytest
 
 from xdsl.builder import ImplicitBuilder
-from xdsl.context import Context
 from xdsl.dialects import pdl, pdl_interp, test
 from xdsl.dialects.builtin import (
     ArrayAttr,
@@ -31,7 +30,7 @@ from xdsl.utils.test_value import create_ssa_value
 
 def test_getters():
     interpreter = Interpreter(ModuleOp([]))
-    interpreter.register_implementations(PDLInterpFunctions(Context()))
+    interpreter.register_implementations(PDLInterpFunctions())
 
     c0 = create_ssa_value(i32)
     c1 = create_ssa_value(i32)
@@ -120,7 +119,7 @@ def test_getters():
 
 def test_check_operation_name():
     interpreter = Interpreter(ModuleOp([]))
-    pdl_interp_functions = PDLInterpFunctions(Context())
+    pdl_interp_functions = PDLInterpFunctions()
     interpreter.register_implementations(pdl_interp_functions)
 
     truedest = Block()
@@ -158,7 +157,7 @@ def test_check_operation_name():
 
 def test_check_operand_count():
     interpreter = Interpreter(ModuleOp([]))
-    pdl_interp_functions = PDLInterpFunctions(Context())
+    pdl_interp_functions = PDLInterpFunctions()
     interpreter.register_implementations(pdl_interp_functions)
 
     truedest = Block()
@@ -220,7 +219,7 @@ def test_check_operand_count():
 
 def test_check_result_count():
     interpreter = Interpreter(ModuleOp([]))
-    pdl_interp_functions = PDLInterpFunctions(Context())
+    pdl_interp_functions = PDLInterpFunctions()
     interpreter.register_implementations(pdl_interp_functions)
 
     truedest = Block()
@@ -282,7 +281,7 @@ def test_check_result_count():
 
 def test_check_attribute():
     interpreter = Interpreter(ModuleOp([]))
-    pdl_interp_functions = PDLInterpFunctions(Context())
+    pdl_interp_functions = PDLInterpFunctions()
     interpreter.register_implementations(pdl_interp_functions)
 
     truedest = Block()
@@ -314,7 +313,7 @@ def test_check_attribute():
 
 def test_check_type():
     interpreter = Interpreter(ModuleOp([]))
-    pdl_interp_functions = PDLInterpFunctions(Context())
+    pdl_interp_functions = PDLInterpFunctions()
     interpreter.register_implementations(pdl_interp_functions)
 
     truedest = Block()
@@ -346,7 +345,7 @@ def test_check_type():
 
 def test_is_not_null():
     interpreter = Interpreter(ModuleOp([]))
-    pdl_interp_functions = PDLInterpFunctions(Context())
+    pdl_interp_functions = PDLInterpFunctions()
     interpreter.register_implementations(pdl_interp_functions)
 
     truedest = Block()
@@ -379,7 +378,7 @@ def test_is_not_null():
 
 def test_are_equal():
     interpreter = Interpreter(ModuleOp([]))
-    pdl_interp_functions = PDLInterpFunctions(Context())
+    pdl_interp_functions = PDLInterpFunctions()
     interpreter.register_implementations(pdl_interp_functions)
 
     truedest = Block()
@@ -414,7 +413,7 @@ def test_are_equal():
 
 def test_create_attribute():
     interpreter = Interpreter(ModuleOp([]))
-    interpreter.register_implementations(PDLInterpFunctions(Context()))
+    interpreter.register_implementations(PDLInterpFunctions())
 
     # Create test attribute
     test_attr = StringAttr("test")
@@ -429,9 +428,9 @@ def test_create_attribute():
 
 def test_create_operation():
     interpreter = Interpreter(ModuleOp([]))
-    ctx = Context()
+    implementations = PDLInterpFunctions()
+    ctx = PDLInterpFunctions.get_ctx(interpreter)
     ctx.register_dialect("test", lambda: test.Test)
-    implementations = PDLInterpFunctions(ctx)
     interpreter.register_implementations(implementations)
 
     testmodule = ModuleOp(Region([Block()]))
@@ -487,9 +486,9 @@ def test_create_operation():
 
 def test_replace():
     interpreter = Interpreter(ModuleOp([]))
-    ctx = Context()
+    pdl_interp_functions = PDLInterpFunctions()
+    ctx = PDLInterpFunctions.get_ctx(interpreter)
     ctx.register_dialect("test", lambda: test.Test)
-    pdl_interp_functions = PDLInterpFunctions(ctx)
     interpreter.register_implementations(pdl_interp_functions)
 
     testmodule = ModuleOp(Region([Block()]))
@@ -527,9 +526,9 @@ def test_replace():
 
 def test_replace_with_range():
     interpreter = Interpreter(ModuleOp([]))
-    ctx = Context()
+    pdl_interp_functions = PDLInterpFunctions()
+    ctx = PDLInterpFunctions.get_ctx(interpreter)
     ctx.register_dialect("test", lambda: test.Test)
-    pdl_interp_functions = PDLInterpFunctions(ctx)
     interpreter.register_implementations(pdl_interp_functions)
 
     testmodule = ModuleOp(Region([Block()]))
@@ -570,9 +569,9 @@ def test_replace_with_range():
 
 def test_replace_with_range_invalid():
     interpreter = Interpreter(ModuleOp([]))
-    ctx = Context()
+    pdl_interp_functions = PDLInterpFunctions()
+    ctx = PDLInterpFunctions.get_ctx(interpreter)
     ctx.register_dialect("test", lambda: test.Test)
-    pdl_interp_functions = PDLInterpFunctions(ctx)
     interpreter.register_implementations(pdl_interp_functions)
 
     testmodule = ModuleOp(Region([Block()]))
@@ -624,9 +623,9 @@ def test_func():
     testmodule.verify()
 
     interpreter = Interpreter(testmodule)
-    ctx = Context()
+    pdl_interp_functions = PDLInterpFunctions()
+    ctx = PDLInterpFunctions.get_ctx(interpreter)
     ctx.register_dialect("test", lambda: test.Test)
-    pdl_interp_functions = PDLInterpFunctions(ctx)
     interpreter.register_implementations(pdl_interp_functions)
     with pytest.raises(InterpretationError):
         interpreter.call_op("matcher", (op,))
@@ -636,7 +635,7 @@ def test_func():
 
 def test_switch_operation_name():
     interpreter = Interpreter(ModuleOp([]))
-    pdl_interp_functions = PDLInterpFunctions(Context())
+    pdl_interp_functions = PDLInterpFunctions()
     interpreter.register_implementations(pdl_interp_functions)
 
     case1 = Block()
@@ -687,7 +686,7 @@ def test_switch_operation_name():
 
 def test_create_type():
     interpreter = Interpreter(ModuleOp([]))
-    interpreter.register_implementations(PDLInterpFunctions(Context()))
+    interpreter.register_implementations(PDLInterpFunctions())
 
     # Test create_type operation
     create_type_op = pdl_interp.CreateTypeOp(i32)
@@ -698,7 +697,7 @@ def test_create_type():
 
 def test_create_types():
     interpreter = Interpreter(ModuleOp([]))
-    interpreter.register_implementations(PDLInterpFunctions(Context()))
+    interpreter.register_implementations(PDLInterpFunctions())
 
     # Test create_types operation
     type_attrs = ArrayAttr([i32, i64])
@@ -710,7 +709,7 @@ def test_create_types():
 
 def test_switch_attribute():
     interpreter = Interpreter(ModuleOp([]))
-    pdl_interp_functions = PDLInterpFunctions(Context())
+    pdl_interp_functions = PDLInterpFunctions()
     interpreter.register_implementations(pdl_interp_functions)
 
     case1 = Block()
@@ -767,7 +766,7 @@ def test_switch_attribute():
 def test_get_defining_op_block_argument():
     """Test that get_defining_op returns None for block arguments."""
     interpreter = Interpreter(ModuleOp([]))
-    interpreter.register_implementations(PDLInterpFunctions(Context()))
+    interpreter.register_implementations(PDLInterpFunctions())
 
     # Create a block argument
     block_arg = Block((), arg_types=(i32,)).args[0]
@@ -795,9 +794,9 @@ def test_apply_constraint():
             return True, (x + 42,)
 
     interpreter = Interpreter(ModuleOp([]))
-    ctx = Context()
+    pdl_interp_functions = PDLInterpFunctions()
+    ctx = pdl_interp_functions.get_ctx(interpreter)
     ctx.register_dialect("test", lambda: test.Test)
-    pdl_interp_functions = PDLInterpFunctions(ctx)
     interpreter.register_implementations(pdl_interp_functions)
     interpreter.register_implementations(TestImplFunctions())
 

--- a/xdsl/interpreters/eqsat_pdl_interp.py
+++ b/xdsl/interpreters/eqsat_pdl_interp.py
@@ -339,7 +339,9 @@ class EqsatPDLInterpFunctions(PDLInterpFunctions):
         args = (*updated_operands, *args[len(op.input_operands) :])
         (new_op,) = super().run_create_operation(interpreter, op, args).values
         if cast(Operation, new_op).get_attr_or_prop("unsound") is None and (
-            values := Folder(self.ctx).replace_with_fold(new_op, self.rewriter)
+            values := Folder(
+                EqsatPDLInterpFunctions.get_ctx(interpreter)
+            ).replace_with_fold(new_op, self.rewriter)
         ):
             assert len(values) == 1, (
                 "pdl_interp.create_operation currently only supports creating operations with a single result."

--- a/xdsl/interpreters/pdl_interp.py
+++ b/xdsl/interpreters/pdl_interp.py
@@ -50,9 +50,23 @@ class PDLInterpFunctions(InterpreterFunctions):
     Note that the return type of a native constraint must be `tuple[bool, PythonValues]`.
     """
 
-    ctx: Context
-
     _rewriter: PatternRewriter | None = field(default=None)
+
+    @staticmethod
+    def get_ctx(interpreter: Interpreter) -> Context:
+        return interpreter.get_data(
+            PDLInterpFunctions,
+            "ctx",
+            lambda: Context(),
+        )
+
+    @staticmethod
+    def set_ctx(interpreter: Interpreter, ctx: Context) -> None:
+        interpreter.set_data(
+            PDLInterpFunctions,
+            "ctx",
+            ctx,
+        )
 
     @property
     def rewriter(self) -> PatternRewriter:
@@ -364,7 +378,8 @@ class PDLInterpFunctions(InterpreterFunctions):
     ) -> tuple[Any, ...]:
         # Get operation name
         op_name = op.constraint_name.data
-        op_type = self.ctx.get_optional_op(op_name)
+        ctx = self.get_ctx(interpreter)
+        op_type = ctx.get_optional_op(op_name)
         if op_type is None:
             raise InterpretationError(
                 f"Could not find op type for name {op_name} in context"

--- a/xdsl/transforms/apply_eqsat_pdl.py
+++ b/xdsl/transforms/apply_eqsat_pdl.py
@@ -94,7 +94,7 @@ class ApplyEqsatPDLPass(ModulePass):
             pattern for pattern in pdl_module.ops if isinstance(pattern, pdl.PatternOp)
         )
 
-        implementations = EqsatPDLInterpFunctions(ctx)
+        implementations = EqsatPDLInterpFunctions()
         implementations.populate_known_ops(op)
 
         matchers_module = builtin.ModuleOp([])
@@ -104,6 +104,7 @@ class ApplyEqsatPDLPass(ModulePass):
         rewriters_builder = Builder(InsertPoint.at_end(rewriters_module.body.block))
 
         interpreter = Interpreter(matchers_module)
+        EqsatPDLInterpFunctions.set_ctx(interpreter, ctx)
         interpreter.register_implementations(implementations)
 
         rewrite_patterns: list[PDLInterpRewritePattern] = []
@@ -174,7 +175,8 @@ class ApplyEqsatPDLPass(ModulePass):
 
         # Initialize interpreter and implementations
         interpreter = Interpreter(pdl_interp_module)
-        implementations = EqsatPDLInterpFunctions(ctx)
+        implementations = EqsatPDLInterpFunctions()
+        implementations.set_ctx(interpreter, ctx)
         implementations.populate_known_ops(op)
         interpreter.register_implementations(implementations)
         rewrite_pattern = PDLInterpRewritePattern(matcher, interpreter, implementations)

--- a/xdsl/transforms/apply_eqsat_pdl_interp.py
+++ b/xdsl/transforms/apply_eqsat_pdl_interp.py
@@ -27,7 +27,8 @@ def apply_eqsat_pdl_interp(
 
     # Initialize interpreter and implementations once
     interpreter = Interpreter(pdl_interp_module)
-    implementations = EqsatPDLInterpFunctions(ctx)
+    implementations = EqsatPDLInterpFunctions()
+    EqsatPDLInterpFunctions.set_ctx(interpreter, ctx)
     implementations.populate_known_ops(op)
     interpreter.register_implementations(implementations)
     rewrite_pattern = PDLInterpRewritePattern(matcher, interpreter, implementations)

--- a/xdsl/transforms/apply_pdl_interp.py
+++ b/xdsl/transforms/apply_pdl_interp.py
@@ -69,7 +69,8 @@ class ApplyPDLInterpPass(ModulePass):
                 break
         assert matcher is not None, "matcher function not found"
         interpreter = Interpreter(pdl_interp_module)
-        implementations = PDLInterpFunctions(ctx)
+        implementations = PDLInterpFunctions()
+        PDLInterpFunctions.set_ctx(interpreter, ctx)
         interpreter.register_implementations(implementations)
         rewrite_pattern = PDLInterpRewritePattern(matcher, interpreter, implementations)
         PatternRewriteWalker(rewrite_pattern).rewrite_module(op)


### PR DESCRIPTION
This is PR 1/2 of moving state from PDLInterpFunctions to the interpreter, I'll move the rewriter in the next PR.

We created this API to be able to share state between interpreter functions in a sort of controlled way. It's not yet super ergonomic, and I'd like to figure out a way to do it more nicely in the future, but it already works.