### PR TITLE
CI: collect code coverage for 3.13 instead of 3.10

### DIFF
--- a/.github/workflows/ci-mlir.yml
+++ b/.github/workflows/ci-mlir.yml
@@ -91,7 +91,8 @@ jobs:
         attempt_delay: 10000
         attempt_limit: 10
         with: |
-          fail_ci_if_error: true
+          # Temporary setting to not fail the CI job while we debug recent codecov issues
+          fail_ci_if_error: false
           verbose: true
           root_dir: xdsl
           files: coverage.xml


### PR DESCRIPTION
It's the fastest Python we currently support.