### PR TITLE
CI: fail CI if codecov failed

### DIFF
--- a/.github/workflows/ci-mlir.yml
+++ b/.github/workflows/ci-mlir.yml
@@ -79,7 +79,7 @@ jobs:
       if: matrix.python-version == '3.13'
       uses: Wandalen/wretry.action@v3
       with:
-        action: codecov/codecov-action@v5
+        action: codecov/codecov-action@v4
         attempt_delay: 10000
         attempt_limit: 10
         with: |


### PR DESCRIPTION
A revert of the "fix" in #5404.
