### PR TITLE
transformations: (apply-eqsat-pdl-interp) Support e-class analyses

### DIFF
--- a/xdsl/analysis/dataflow.py
+++ b/xdsl/analysis/dataflow.py
@@ -146,9 +146,9 @@ class DataFlowSolver:
     """
 
     context: Context
-    _analyses: list[DataFlowAnalysis] = field(default_factory=lambda: [])
+    _analyses: list[DataFlowAnalysis] = field(default_factory=list["DataFlowAnalysis"])
     _worklist: collections.deque[tuple[ProgramPoint, DataFlowAnalysis]] = field(
-        default_factory=lambda: collections.deque()
+        default_factory=collections.deque[tuple[ProgramPoint, "DataFlowAnalysis"]]
     )
     _analysis_states: dict[LatticeAnchor, dict[type[AnalysisState], AnalysisState]] = (
         field(default_factory=lambda: collections.defaultdict(dict))

--- a/xdsl/interpreters/eqsat_pdl_interp.py
+++ b/xdsl/interpreters/eqsat_pdl_interp.py
@@ -35,7 +35,7 @@ from xdsl.utils.scoped_dict import ScopedDict
 
 @dataclass
 class NonPropagatingDataFlowSolver(DataFlowSolver):
-    propagate: bool = True
+    propagate: bool = field(default=True)
 
     def propagate_if_changed(self, state: AnalysisState, changed: ChangeResult) -> None:
         if not self.propagate:
@@ -134,15 +134,15 @@ class EqsatPDLInterpFunctions(PDLInterpFunctions):
         if op not in self.known_ops:
             self.known_ops[op] = op
 
-    def populate_known_ops(self, module: Operation) -> None:
+    def populate_known_ops(self, outer_op: Operation) -> None:
         """
         Populates the known_ops dictionary by traversing the module.
 
         Args:
-            module: The module to traverse
+            outer_op: The operation containing all operations to be added to known_ops.
         """
         # Walk through all operations in the module
-        for op in module.walk():
+        for op in outer_op.walk():
             # Skip eclasses instances
             if not isinstance(op, eqsat.AnyEClassOp):
                 self.known_ops[op] = op
@@ -558,8 +558,7 @@ class EqsatPDLInterpFunctions(PDLInterpFunctions):
                 results = [analysis.get_lattice_element(r) for r in op.results]
                 if not results:
                     continue
-                assert len(results) == 1
-                result = results[0]
+                (result,) = results
                 # set state for op to bottom (store original state)
                 original_state = result.value
                 result._value = result.value_cls()  # pyright: ignore[reportPrivateUsage]


### PR DESCRIPTION
EqsatPDLInterpFunctions now carries a list of analyses, currently required to be of type `SparseForwardDataFlowAnalysis[Lattice[Any]]`.

When a new operation is inserted (`run_create_operation`), the `visit_operation_impl` of the analysis is run to get the initial analysis value (also for the new e-class encompassing the operation).

When e-classes are merged (`run_replace`), their analysis data is joined with the lattice's `meet` method.

Lastly, invariance maintenance in `repair` follows the description of e-class analyses in egg. Because `visit_operation_impl` `join`s the state that it computes with the existing state, we first set the existing state to uninitialized (`result._value = result.value_cls()`) such that the join operation with the new state simply yields that new state.

In order to run `visit_operation_impl` in several places, it's required to temporarily toggle `solver._is_running`.