### PR TITLE
core: expose ScopedDict.local_scope as immutable Mapping

### DIFF
--- a/tests/utils/test_scoped_dict.py
+++ b/tests/utils/test_scoped_dict.py
@@ -9,12 +9,15 @@ def test_simple():
     table[1] = 2
 
     assert table[1] == 2
+    assert table.local_scope == {1: 2}
 
     table[2] = 3
 
     assert table[2] == 3
+    assert table.local_scope == {1: 2, 2: 3}
 
     table[2] = 4
+    assert table.local_scope == {1: 2, 2: 4}
 
     with pytest.raises(KeyError):
         table[3]
@@ -25,12 +28,16 @@ def test_simple():
 
     assert inner[2] == 5
     assert table[2] == 4
+    assert table.local_scope == {1: 2, 2: 4}
+    assert inner.local_scope == {2: 5}
 
     inner[3] = 6
 
     assert 3 not in table
     assert 3 in inner
     assert 4 not in inner
+    assert table.local_scope == {1: 2, 2: 4}
+    assert inner.local_scope == {2: 5, 3: 6}
 
 
 def test_get():

--- a/xdsl/utils/scoped_dict.py
+++ b/xdsl/utils/scoped_dict.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Generic, overload
 
 from typing_extensions import TypeVar
@@ -34,6 +35,10 @@ class ScopedDict(Generic[_Key, _Value]):
         self._local_scope = {} if local_scope is None else local_scope
         self.parent = parent
         self.name = name
+
+    @property
+    def local_scope(self) -> Mapping[_Key, _Value]:
+        return self._local_scope
 
     @overload
     def get(self, key: _Key, default: None = None) -> _Value | None: ...


### PR DESCRIPTION
As noted by @ed741 in #5270, there's a bit of regression in functionality by making ScopedDict more restrictive.