### PR TITLE
CI: (mlir) re-enable python 3.14 testing

### DIFF
--- a/.github/workflows/ci-mlir.yml
+++ b/.github/workflows/ci-mlir.yml
@@ -18,7 +18,7 @@ jobs:
     container: ghcr.io/xdslproject/llvm:21.1.1
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     env:
       LLVM_SYMBOLIZER_PATH: /usr/lib/llvm-11/bin/llvm-symbolizer


### PR DESCRIPTION
Want to see if the CI works after updating the container