### PR TITLE
dialects: make immediates signless in `riscv`

### DIFF
--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -327,15 +327,13 @@ class Registers(ABC):
     FS = (FS0, FS1, FS2, FS3, FS4, FS5, FS6, FS7, FS8, FS9, FS10, FS11)
 
 
-si20 = IntegerType(20, Signedness.SIGNED)
 i5 = IntegerType(5, Signedness.SIGNLESS)
 i12 = IntegerType(12, Signedness.SIGNLESS)
 i20 = IntegerType(20, Signedness.SIGNLESS)
-SImm20Attr = IntegerAttr[Annotated[IntegerType, si20]]
-Imm5Attr = IntegerAttr[Annotated[IntegerType, i5]]
-Imm12Attr = IntegerAttr[Annotated[IntegerType, i12]]
-Imm20Attr = IntegerAttr[Annotated[IntegerType, i20]]
-Imm32Attr = IntegerAttr[Annotated[IntegerType, i32]]
+Imm5Attr: TypeAlias = IntegerAttr[Annotated[IntegerType, i5]]
+Imm12Attr: TypeAlias = IntegerAttr[Annotated[IntegerType, i12]]
+Imm20Attr: TypeAlias = IntegerAttr[Annotated[IntegerType, i20]]
+Imm32Attr: TypeAlias = IntegerAttr[Annotated[IntegerType, i32]]
 
 
 @irdl_attr_definition
@@ -702,17 +700,17 @@ class RdImmJumpOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC):
     The rd register here is not a register storing the result, rather the register where
     the program counter is stored before jumping.
     """
-    immediate = attr_def(base(SImm20Attr) | base(LabelAttr))
+    immediate = attr_def(base(Imm20Attr) | base(LabelAttr))
 
     def __init__(
         self,
-        immediate: int | SImm20Attr | str | LabelAttr,
+        immediate: int | Imm20Attr | str | LabelAttr,
         *,
         rd: IntRegisterType | None = None,
         comment: str | StringAttr | None = None,
     ):
         if isinstance(immediate, int):
-            immediate = IntegerAttr(immediate, si20)
+            immediate = IntegerAttr(immediate, i20)
         elif isinstance(immediate, str):
             immediate = LabelAttr(immediate)
         if isinstance(comment, str):
@@ -731,7 +729,7 @@ class RdImmJumpOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC):
     @classmethod
     def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
         attributes = dict[str, Attribute]()
-        attributes["immediate"] = parse_immediate_value(parser, si20)
+        attributes["immediate"] = parse_immediate_value(parser, i20)
         if parser.parse_optional_punctuation(","):
             attributes["rd"] = parser.parse_attribute()
         return attributes
@@ -2087,7 +2085,7 @@ class JOp(RdImmJumpOperation):
 
     def __init__(
         self,
-        immediate: int | SImm20Attr | str | LabelAttr,
+        immediate: int | Imm20Attr | str | LabelAttr,
         *,
         comment: str | StringAttr | None = None,
     ):

--- a/xdsl/dialects/riscv_snitch.py
+++ b/xdsl/dialects/riscv_snitch.py
@@ -28,11 +28,11 @@ from xdsl.dialects.riscv import (
     RISCVInstruction,
     RISCVRegisterType,
     RsRsIntegerOperation,
-    SImm12Attr,
-    UImm5Attr,
+    Imm12Attr,
+    Imm5Attr,
     parse_immediate_value,
     print_immediate_value,
-    si12,
+    i12,
 )
 from xdsl.dialects.utils import (
     AbstractYieldOperation,
@@ -113,17 +113,17 @@ class ScfgwiOp(RISCVCustomFormatOperation, RISCVInstruction):
     name = "riscv_snitch.scfgwi"
 
     rs1 = operand_def(IntRegisterType)
-    immediate = attr_def(SImm12Attr)
+    immediate = attr_def(Imm12Attr)
 
     def __init__(
         self,
         rs1: Operation | SSAValue,
-        immediate: int | SImm12Attr,
+        immediate: int | Imm12Attr,
         *,
         comment: str | StringAttr | None = None,
     ):
         if isinstance(immediate, int):
-            immediate = IntegerAttr(immediate, si12)
+            immediate = IntegerAttr(immediate, i12)
         if isinstance(comment, str):
             comment = StringAttr(comment)
         super().__init__(
@@ -140,7 +140,7 @@ class ScfgwiOp(RISCVCustomFormatOperation, RISCVInstruction):
     @classmethod
     def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
         attributes = dict[str, Attribute]()
-        attributes["immediate"] = parse_immediate_value(parser, si12)
+        attributes["immediate"] = parse_immediate_value(parser, i12)
         return attributes
 
     def custom_print_attributes(self, printer: Printer) -> set[str]:
@@ -697,7 +697,7 @@ class DMCopyImmOp(RISCVInstruction):
 
     dest = result_def(riscv.IntRegisterType)
     size = operand_def(riscv.IntRegisterType)
-    config = prop_def(UImm5Attr)
+    config = prop_def(Imm5Attr)
 
     traits = traits_def(
         StaticInsnRepresentation(insn=".insn r 0x2b, 0, 2, {0}, {1}, {2}")
@@ -706,7 +706,7 @@ class DMCopyImmOp(RISCVInstruction):
     def __init__(
         self,
         size: SSAValue | Operation,
-        config: int | UImm5Attr,
+        config: int | Imm5Attr,
         result_type: IntRegisterType = riscv.Registers.UNALLOCATED_INT,
     ):
         if isinstance(config, int):
@@ -751,7 +751,7 @@ class DMStatImmOp(RISCVInstruction):
     name = "riscv_snitch.dmstati"
 
     dest = result_def(riscv.IntRegisterType)
-    status = prop_def(UImm5Attr)
+    status = prop_def(Imm5Attr)
 
     traits = traits_def(
         StaticInsnRepresentation(insn=".insn r 0x2b, 0, 4, {0}, {1}, {2}")
@@ -759,7 +759,7 @@ class DMStatImmOp(RISCVInstruction):
 
     def __init__(
         self,
-        status: int | UImm5Attr,
+        status: int | Imm5Attr,
         result_type: IntRegisterType = riscv.Registers.UNALLOCATED_INT,
     ):
         if isinstance(status, int):


### PR DESCRIPTION
We update `riscv` to only expect signless types from immediate arguments.
