### PR TITLE
dialects: (x86) infer destination register for RM, push, and pop ops

### DIFF
--- a/xdsl/backend/x86/prologue_epilogue_insertion.py
+++ b/xdsl/backend/x86/prologue_epilogue_insertion.py
@@ -48,9 +48,7 @@ class X86PrologueEpilogueInsertion(ModulePass):
         # Build the prologue at the beginning of the function.
         for reg in used_callee_preserved_registers:
             reg_op = builder.insert(x86.GetRegisterOp(reg))
-            builder.insert(
-                x86.S_PushOp(resp_in=sp_register, source=reg_op, rsp_out=RSP)
-            )
+            builder.insert(x86.S_PushOp(rsp_in=sp_register, source=reg_op))
 
         # Now build the epilogue right before every return operation.
         for block in func.body.blocks:
@@ -59,9 +57,7 @@ class X86PrologueEpilogueInsertion(ModulePass):
                 continue
             builder = Builder(InsertPoint.before(ret_op))
             for reg in reversed(used_callee_preserved_registers):
-                builder.insert(
-                    x86.D_PopOp(rsp_in=sp_register, rsp_out=RSP, destination=reg)
-                )
+                builder.insert(x86.D_PopOp(rsp_in=sp_register, destination=reg))
 
     def apply(self, ctx: Context, op: builtin.ModuleOp) -> None:
         for func in op.walk():

--- a/xdsl/dialects/x86/ops.py
+++ b/xdsl/dialects/x86/ops.py
@@ -400,12 +400,15 @@ class RM_Operation(
         memory_offset: int | IntegerAttr,
         *,
         comment: str | StringAttr | None = None,
-        register_out: R1InvT,
+        register_out: R1InvT | None = None,
     ):
         if isinstance(memory_offset, int):
             memory_offset = IntegerAttr(memory_offset, 64)
         if isinstance(comment, str):
             comment = StringAttr(comment)
+        register_in = SSAValue.get(register_in)
+        if register_out is None:
+            register_out = cast(R1InvT, register_in.type)
 
         super().__init__(
             operands=[register_in, memory],
@@ -569,7 +572,7 @@ class RI_Operation(X86Instruction, X86CustomFormatOperation, ABC, Generic[R1InvT
         immediate: int | IntegerAttr,
         *,
         comment: str | StringAttr | None = None,
-        register_out: R1InvT,
+        register_out: R1InvT | None = None,
     ):
         if isinstance(immediate, int):
             immediate = IntegerAttr(
@@ -577,6 +580,9 @@ class RI_Operation(X86Instruction, X86CustomFormatOperation, ABC, Generic[R1InvT
             )  # the default immediate size is 32 bits
         if isinstance(comment, str):
             comment = StringAttr(comment)
+        register_in = SSAValue.get(register_in)
+        if register_out is None:
+            register_out = cast(R1InvT, register_in.type)
 
         super().__init__(
             operands=[register_in],
@@ -1444,21 +1450,20 @@ class S_PushOp(X86Instruction, X86CustomFormatOperation):
 
     def __init__(
         self,
-        resp_in: Operation | SSAValue,
+        rsp_in: Operation | SSAValue,
         source: Operation | SSAValue,
         *,
         comment: str | StringAttr | None = None,
-        rsp_out: GeneralRegisterType,
     ):
         if isinstance(comment, str):
             comment = StringAttr(comment)
 
         super().__init__(
-            operands=[resp_in, source],
+            operands=[rsp_in, source],
             attributes={
                 "comment": comment,
             },
-            result_types=[rsp_out],
+            result_types=[RSP],
         )
 
     def assembly_line_args(self) -> tuple[AssemblyInstructionArg | None, ...]:
@@ -1485,7 +1490,6 @@ class D_PopOp(X86Instruction, X86CustomFormatOperation):
         *,
         comment: str | StringAttr | None = None,
         destination: X86RegisterType,
-        rsp_out: GeneralRegisterType,
     ):
         if isinstance(comment, str):
             comment = StringAttr(comment)
@@ -1495,7 +1499,7 @@ class D_PopOp(X86Instruction, X86CustomFormatOperation):
             attributes={
                 "comment": comment,
             },
-            result_types=[rsp_out, destination],
+            result_types=[RSP, destination],
         )
 
     def assembly_line_args(self) -> tuple[AssemblyInstructionArg | None, ...]:


### PR DESCRIPTION
Sometimes because it's the same as input, sometimes because it's actually fixed by ABI.