### PR TITLE
dialects : (riscv) add seqz and snez pseudo-instructions

### DIFF
--- a/tests/filecheck/dialects/riscv/riscv_assembly_emission.mlir
+++ b/tests/filecheck/dialects/riscv/riscv_assembly_emission.mlir
@@ -10,6 +10,10 @@
     // CHECK-NEXT: add j_2, zero, j_1
     %mv = riscv.mv %0 : (!riscv.reg<zero>) -> !riscv.reg<j_2>
     // CHECK-NEXT: mv j_2, zero
+    %seqz = riscv.seqz %1 : (!riscv.reg<j_1>) -> !riscv.reg<j_1>
+    // CHECK-NEXT: seqz j_1, j_1
+    %snez = riscv.snez %1 : (!riscv.reg<j_1>) -> !riscv.reg<j_1>
+    // CHECK-NEXT: snez j_1, j_1
 
     // RV32I/RV64I: Integer Computational Instructions (Section 2.4)
     // Integer Register-Immediate Instructions

--- a/tests/filecheck/dialects/riscv/riscv_ops.mlir
+++ b/tests/filecheck/dialects/riscv/riscv_ops.mlir
@@ -32,6 +32,10 @@
     // CHECK-NEXT: %{{.*}} = riscv.auipc 1 : () -> !riscv.reg
     %mv = riscv.mv %0 : (!riscv.reg) -> !riscv.reg
     // CHECK: %{{.*}} = riscv.mv %{{.*}} : (!riscv.reg) -> !riscv.reg
+    %seqz = riscv.seqz %0 : (!riscv.reg) -> !riscv.reg
+    // CHECK: %{{.*}} = riscv.seqz %{{.*}} : (!riscv.reg) -> !riscv.reg
+    %snez = riscv.snez %0 : (!riscv.reg) -> !riscv.reg
+    // CHECK: %{{.*}} = riscv.snez %{{.*}} : (!riscv.reg) -> !riscv.reg
     %srliw = riscv.srliw %0, 1: (!riscv.reg) -> !riscv.reg
     // CHECK-NEXT: %{{.*}} = riscv.srliw %0, 1 : (!riscv.reg) -> !riscv.reg
     %sraiw = riscv.sraiw %0, 1: (!riscv.reg) -> !riscv.reg
@@ -458,6 +462,8 @@
 // CHECK-GENERIC-NEXT:      %lui = "riscv.lui"() {immediate = 1 : i20} : () -> !riscv.reg
 // CHECK-GENERIC-NEXT:      %auipc = "riscv.auipc"() {immediate = 1 : i20} : () -> !riscv.reg
 // CHECK-GENERIC-NEXT:      %mv = "riscv.mv"(%0) : (!riscv.reg) -> !riscv.reg
+// CHECK-GENERIC-NEXT:      %seqz = "riscv.seqz"(%0) : (!riscv.reg) -> !riscv.reg
+// CHECK-GENERIC-NEXT:      %snez = "riscv.snez"(%0) : (!riscv.reg) -> !riscv.reg
 // CHECK-GENERIC-NEXT:      %srliw = "riscv.srliw"(%0) {immediate = 1 : ui5} : (!riscv.reg) -> !riscv.reg
 // CHECK-GENERIC-NEXT:      %sraiw = "riscv.sraiw"(%0) {immediate = 1 : si12} : (!riscv.reg) -> !riscv.reg
 // CHECK-GENERIC-NEXT:      %add = "riscv.add"(%0, %1) : (!riscv.reg, !riscv.reg) -> !riscv.reg

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -1807,6 +1807,28 @@ class MVOp(RdRsIntegerOperation[IntRegisterType]):
     )
 
 
+@irdl_op_definition
+class SeqzOp(RdRsIntegerOperation[IntRegisterType]):
+    """
+    A pseudo instruction that sets the destination register to 1 if the source register is equal to zero.
+
+    Equivalent to `sltiu rd, rs, 1
+    """
+
+    name = "riscv.seqz"
+
+
+@irdl_op_definition
+class SnezOp(RdRsIntegerOperation[IntRegisterType]):
+    """
+    A pseudo instruction that sets the destination register to 1 if the source register is not equal to zero.
+
+    Equivalent to `sltu rd, x0, rs1 `
+    """
+
+    name = "riscv.snez"
+
+
 class FMVHasCanonicalizationPatternsTrait(HasCanonicalizationPatternsTrait):
     @classmethod
     def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
@@ -4787,6 +4809,8 @@ RISCV = Dialect(
         LuiOp,
         AuipcOp,
         MVOp,
+        SeqzOp,
+        SnezOp,
         AddOp,
         SltOp,
         SltuOp,


### PR DESCRIPTION
This PR adds the pseudo-instructions seqz and snez from the RISC-V I extension.