### PR TITLE
core: only import TypeForm when TYPE_CHECKING below 3.14

### DIFF
--- a/xdsl/irdl/attributes.py
+++ b/xdsl/irdl/attributes.py
@@ -408,6 +408,13 @@ class ConstraintConvertible(Generic[AttributeCovT]):
         """The constraint for this instance."""
 
 
+# Dynamic check due to a regression in Python 3.14, which broke `|` between types and
+# strings, and a bug in Marimo where the correct version of typing_extensions is not
+# installed due to an old (4.11.0) version of typing_extensions already being present in
+# the Pyodide build.
+# When Marimo update their Pyodide we should delete the second branch.
+# We will likely want to support 3.14.0 for a long time, so we can't remove the first
+# branch even if the `|` bug is fixed in a patch update.
 if sys.version_info >= (3, 14, 0):
     IRDLAttrConstraint: TypeAlias = (
         AttrConstraint[AttributeInvT]


### PR DESCRIPTION
This is a hacky fix to the broken notebooks. Marimo haven't updated their pyodide build in a while, and it's not clear when they will. We could migrate more of the notebooks to the wheel build like the ones for the MLIR Summer School, but then xDSL will still be broken in other notebooks created online. I'll try to still find some time to migrate the other notebooks to local wheels, but I don't know when this will be, so I propose to already fix the notebooks today.

Fixes #5426