### PR TITLE
Zext sext

### DIFF
--- a/tests/filecheck/dialects/riscv/riscv_assembly_emission.mlir
+++ b/tests/filecheck/dialects/riscv/riscv_assembly_emission.mlir
@@ -14,6 +14,12 @@
     // CHECK-NEXT: seqz j_1, j_1
     %snez = riscv.snez %1 : (!riscv.reg<j_1>) -> !riscv.reg<j_1>
     // CHECK-NEXT: snez j_1, j_1
+    %zextb = riscv.zext.b %1 : (!riscv.reg<j_1>) -> !riscv.reg<j_1>
+    // CHECK-NEXT: zext.b j_1, j_1
+    %zextw = riscv.zext.w %1 : (!riscv.reg<j_1>) -> !riscv.reg<j_1>
+    // CHECK-NEXT: zext.w j_1, j_1
+    %sextw = riscv.sext.w %1 : (!riscv.reg<j_1>) -> !riscv.reg<j_1>
+    // CHECK-NEXT: sext.w j_1, j_1
 
     // RV32I/RV64I: Integer Computational Instructions (Section 2.4)
     // Integer Register-Immediate Instructions

--- a/tests/filecheck/dialects/riscv/riscv_ops.mlir
+++ b/tests/filecheck/dialects/riscv/riscv_ops.mlir
@@ -36,6 +36,12 @@
     // CHECK: %{{.*}} = riscv.seqz %{{.*}} : (!riscv.reg) -> !riscv.reg
     %snez = riscv.snez %0 : (!riscv.reg) -> !riscv.reg
     // CHECK: %{{.*}} = riscv.snez %{{.*}} : (!riscv.reg) -> !riscv.reg
+    %zextb = riscv.zext.b %0 : (!riscv.reg) -> !riscv.reg
+    // CHECK: %{{.*}} = riscv.zext.b %{{.*}} : (!riscv.reg) -> !riscv.reg
+    %zextw = riscv.zext.w %0 : (!riscv.reg) -> !riscv.reg
+    // CHECK: %{{.*}} = riscv.zext.w %{{.*}} : (!riscv.reg) -> !riscv.reg
+    %sextw = riscv.sext.w %0 : (!riscv.reg) -> !riscv.reg
+    // CHECK: %{{.*}} = riscv.sext.w %{{.*}} : (!riscv.reg) -> !riscv.reg
     %srliw = riscv.srliw %0, 1: (!riscv.reg) -> !riscv.reg
     // CHECK-NEXT: %{{.*}} = riscv.srliw %0, 1 : (!riscv.reg) -> !riscv.reg
     %sraiw = riscv.sraiw %0, 1: (!riscv.reg) -> !riscv.reg
@@ -464,6 +470,9 @@
 // CHECK-GENERIC-NEXT:      %mv = "riscv.mv"(%0) : (!riscv.reg) -> !riscv.reg
 // CHECK-GENERIC-NEXT:      %seqz = "riscv.seqz"(%0) : (!riscv.reg) -> !riscv.reg
 // CHECK-GENERIC-NEXT:      %snez = "riscv.snez"(%0) : (!riscv.reg) -> !riscv.reg
+// CHECK-GENERIC-NEXT:      %zextb = "riscv.zext.b"(%0) : (!riscv.reg) -> !riscv.reg
+// CHECK-GENERIC-NEXT:      %zextw = "riscv.zext.w"(%0) : (!riscv.reg) -> !riscv.reg
+// CHECK-GENERIC-NEXT:      %sextw = "riscv.sext.w"(%0) : (!riscv.reg) -> !riscv.reg
 // CHECK-GENERIC-NEXT:      %srliw = "riscv.srliw"(%0) {immediate = 1 : ui5} : (!riscv.reg) -> !riscv.reg
 // CHECK-GENERIC-NEXT:      %sraiw = "riscv.sraiw"(%0) {immediate = 1 : si12} : (!riscv.reg) -> !riscv.reg
 // CHECK-GENERIC-NEXT:      %add = "riscv.add"(%0, %1) : (!riscv.reg, !riscv.reg) -> !riscv.reg

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -1829,6 +1829,51 @@ class SnezOp(RdRsIntegerOperation[IntRegisterType]):
     name = "riscv.snez"
 
 
+@irdl_op_definition
+class ZextBOp(RdRsIntegerOperation[IntRegisterType]):
+    """
+    A pseudo instruction that zero-extends the least-significant byte of the source to XLEN by copying the
+    into all of the bits more significant than 31.
+
+    Equivalent to `andi rd, rs1, 255`
+    """
+
+    name = "riscv.zext.b"
+
+    traits = traits_def(Pure())
+
+
+@irdl_op_definition
+class ZextWOp(RdRsIntegerOperation[IntRegisterType]):
+    """
+    A pseudo instruction that zero-extends the least-significant word of the source to XLEN by inserting 0’s
+    into all of the bits more significant than 31.
+
+    Equivalent to `add.uw rd, rs1, 0`
+
+    See external [documentation](https://five-embeddev.com/riscv-bitmanip/1.0.0/bitmanip.html#insns-add_uw)
+    """
+
+    name = "riscv.zext.w"
+
+    traits = traits_def(Pure())
+
+
+@irdl_op_definition
+class SextWOp(RdRsIntegerOperation[IntRegisterType]):
+    """
+    A pseudo instruction that writes the sign-extension of the lower 32 bits of register rs1 into register rd.
+
+    Equivalent to `addiw rd, rs, 0 `
+
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/#_addiw).
+    """
+
+    name = "riscv.sext.w"
+
+    traits = traits_def(Pure())
+
+
 class FMVHasCanonicalizationPatternsTrait(HasCanonicalizationPatternsTrait):
     @classmethod
     def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
@@ -4811,6 +4856,9 @@ RISCV = Dialect(
         MVOp,
         SeqzOp,
         SnezOp,
+        ZextBOp,
+        ZextWOp,
+        SextWOp,
         AddOp,
         SltOp,
         SltuOp,


### PR DESCRIPTION
This PR adds` zext.b, zext.w, sext.w` instructions from RISCV I and B extensions.