### PR TITLE
dialects: (x86) raise error when jumping to numeric labels

### DIFF
--- a/tests/dialects/test_x86.py
+++ b/tests/dialects/test_x86.py
@@ -404,3 +404,34 @@ def test_get_constant_value():
 )
 def test_read_effects(op: type[Operation]):
     assert MemoryReadEffect() in op.traits.traits
+
+
+def test_jmp_numeric_label_not_implemented():
+    label_op = x86.ops.LabelOp("123")
+    op = x86.ops.C_JmpOp(block_values=[], successor=Block([label_op]))
+    with pytest.raises(
+        NotImplementedError,
+        match="Assembly printing for jumps to numeric labels not implemented",
+    ):
+        op.assembly_line_args()
+    label_op.label = x86.attributes.LabelAttr("hello")
+    assert op.assembly_line_args() == ("hello",)
+
+
+def test_conditional_jump_numeric_label_not_implemented():
+    label_op = x86.ops.LabelOp("123")
+    rflags = create_ssa_value(x86.registers.RFLAGS)
+    op = x86.ops.C_JeOp(
+        rflags=rflags,
+        then_values=[],
+        else_values=[],
+        then_block=Block([label_op]),
+        else_block=Block([x86.ops.LabelOp("loop_start")]),
+    )
+    with pytest.raises(
+        NotImplementedError,
+        match="Assembly printing for jumps to numeric labels not implemented",
+    ):
+        op.assembly_line_args()
+    label_op.label = x86.attributes.LabelAttr("hello")
+    assert op.assembly_line_args() == ("hello",)

--- a/xdsl/dialects/x86/ops.py
+++ b/xdsl/dialects/x86/ops.py
@@ -989,7 +989,16 @@ class ConditionalJumpOperation(X86Instruction, X86CustomFormatOperation, ABC):
     def assembly_line_args(self) -> tuple[AssemblyInstructionArg, ...]:
         then_label = self.then_block.first_op
         assert isinstance(then_label, LabelOp)
-        return (then_label.label,)
+        then_label_str = then_label.label.data
+        if then_label_str.isdigit():
+            # x86 Assembly: Numeric jump labels must be annotated with a suffix.
+            # Jumping backward in code requires appending 'b' (e.g., "1b"), and
+            # jumping forward requires appending 'f' (e.g., "1f").
+            # Proper support for generating these labels is currently unimplemented.
+            raise NotImplementedError(
+                "Assembly printing for jumps to numeric labels not implemented"
+            )
+        return (then_label_str,)
 
     def print(self, printer: Printer) -> None:
         printer.print_string(" ")
@@ -2555,7 +2564,16 @@ class C_JmpOp(X86Instruction, X86CustomFormatOperation):
     def assembly_line_args(self) -> tuple[AssemblyInstructionArg, ...]:
         dest_label = self.successor.first_op
         assert isinstance(dest_label, LabelOp)
-        return (dest_label.label,)
+        dest_label_str = dest_label.label.data
+        if dest_label_str.isdigit():
+            # x86 Assembly: Numeric jump labels must be annotated with a suffix.
+            # Jumping backward in code requires appending 'b' (e.g., "1b"), and
+            # jumping forward requires appending 'f' (e.g., "1f").
+            # Proper support for generating these labels is currently unimplemented.
+            raise NotImplementedError(
+                "Assembly printing for jumps to numeric labels not implemented"
+            )
+        return (dest_label_str,)
 
 
 @irdl_op_definition


### PR DESCRIPTION
Technically you need to jump to e.g. 33b (backwards) or 33f (forwards) when jumping to numeric labels, this shouldn't be too difficult to handle but I'd rather implement this logic when we need to, and use non-numeric labels for now.