### PR TITLE
dialects: (linalg) use properties in linalg named ops

### DIFF
--- a/tests/filecheck/dialects/linalg/linalg_ops.mlir
+++ b/tests/filecheck/dialects/linalg/linalg_ops.mlir
@@ -194,7 +194,7 @@ linalg.generic {indexing_maps = [affine_map<(d0, d1) -> ()>, affine_map<(d0, d1)
 // CHECK-GENERIC-NEXT:    %{{.*}} %{{.*}} = "test.op"() : () -> (memref<64x9216xf32>, memref<9216x4096xf32>)
 // CHECK-GENERIC-NEXT:    %{{.*}} = "test.op"() : () -> memref<64x4096xf32>
 
-// CHECK-GENERIC-NEXT:    "linalg.matmul"(%{{.*}} %{{.*}} %{{.*}} <{indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>], operandSegmentSizes = array<i32: 2, 1>}> ({
+// CHECK-GENERIC-NEXT:    "linalg.matmul"(%{{.*}} %{{.*}} %{{.*}} <{operandSegmentSizes = array<i32: 2, 1>, indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>]}> ({
 // CHECK-GENERIC-NEXT:    ^{{.*}}(%{{.*}} : f32, %{{.*}} : f32, %{{.*}} : f32):
 // CHECK-GENERIC-NEXT:      %{{.*}} = "arith.mulf"(%{{.*}}, %{{.*}} : (f32, f32) -> f32
 // CHECK-GENERIC-NEXT:      %{{.*}} = "arith.addf"(%{{.*}}, %{{.*}} : (f32, f32) -> f32
@@ -204,7 +204,7 @@ linalg.generic {indexing_maps = [affine_map<(d0, d1) -> ()>, affine_map<(d0, d1)
 // CHECK-GENERIC-NEXT:    %{{.*}} %{{.*}} = "test.op"() : () -> (memref<64x9216xi32>, memref<9216x4096xi32>)
 // CHECK-GENERIC-NEXT:    %{{.*}} = "test.op"() : () -> memref<64x4096xi32>
 
-// CHECK-GENERIC-NEXT:    "linalg.matmul"(%{{.*}} %{{.*}} %{{.*}} <{indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>], operandSegmentSizes = array<i32: 2, 1>}> ({
+// CHECK-GENERIC-NEXT:    "linalg.matmul"(%{{.*}} %{{.*}} %{{.*}} <{operandSegmentSizes = array<i32: 2, 1>, indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>]}> ({
 // CHECK-GENERIC-NEXT:    ^{{.*}}(%{{.*}} : i32, %{{.*}} : i32, %{{.*}} : i32):
 // CHECK-GENERIC-NEXT:      %{{.*}} = "arith.muli"(%{{.*}}, %{{.*}} : (i32, i32) -> i32
 // CHECK-GENERIC-NEXT:      %{{.*}} = "arith.addi"(%{{.*}}, %{{.*}} : (i32, i32) -> i32

--- a/tests/interpreters/test_linalg_interpreter.py
+++ b/tests/interpreters/test_linalg_interpreter.py
@@ -300,10 +300,8 @@ def test_linalg_pooling_nchw_max():
         ),
         (create_ssa_value(TensorType(f32, [1, 1, 3, 3])),),
         (TensorType(f32, [1, 1, 3, 3]),),
-        {
-            "dilations": DenseIntOrFPElementsAttr.from_list(TensorType(i64, [2]), [1]),
-            "strides": DenseIntOrFPElementsAttr.from_list(TensorType(i64, [2]), [1]),
-        },
+        strides=DenseIntOrFPElementsAttr.from_list(TensorType(i64, [2]), [1]),
+        dilations=DenseIntOrFPElementsAttr.from_list(TensorType(i64, [2]), [1]),
     )
     a = ShapedArray(TypedPtr.new_float32(list(range(1, 17))), [1, 1, 4, 4])
     b = ShapedArray(
@@ -333,10 +331,8 @@ def test_linalg_pooling_nchw_max_strides_two():
         ),
         (create_ssa_value(TensorType(f32, [1, 1, 2, 2])),),
         (TensorType(f32, [1, 1, 2, 2]),),
-        {
-            "dilations": DenseIntOrFPElementsAttr.from_list(TensorType(i64, [2]), [1]),
-            "strides": DenseIntOrFPElementsAttr.from_list(TensorType(i64, [2]), [2]),
-        },
+        dilations=DenseIntOrFPElementsAttr.from_list(TensorType(i64, [2]), [1]),
+        strides=DenseIntOrFPElementsAttr.from_list(TensorType(i64, [2]), [2]),
     )
     a = ShapedArray(
         TypedPtr.new_float32([1, 1, 2, 4, 5, 6, 7, 8, 3, 2, 1, 0, 1, 2, 3, 4]),
@@ -366,10 +362,8 @@ def test_linalg_conv_2d_nchw_fchw():
         ),
         (create_ssa_value(TensorType(f32, [1, 1, 3, 3])),),
         (TensorType(f32, [1, 1, 3, 3]),),
-        {
-            "dilations": DenseIntOrFPElementsAttr.from_list(TensorType(i64, [2]), [1]),
-            "strides": DenseIntOrFPElementsAttr.from_list(TensorType(i64, [2]), [1]),
-        },
+        dilations=DenseIntOrFPElementsAttr.from_list(TensorType(i64, [2]), [1]),
+        strides=DenseIntOrFPElementsAttr.from_list(TensorType(i64, [2]), [1]),
     )
     a = ShapedArray(TypedPtr.new_float32(list(range(25))), [1, 1, 5, 5])
     b = ShapedArray(


### PR DESCRIPTION
This got out of sync, the next PR will update the MLIR interop test to catch this error. I wanted to do it in two steps to first demonstrate that the xDSL side of things is consistent before changing the test.