### PR TITLE
dialects: (complex) add 'ConstantOp' helper constructors

### DIFF
--- a/tests/dialects/test_complex.py
+++ b/tests/dialects/test_complex.py
@@ -1,7 +1,20 @@
+import pytest
+
 from xdsl.dialects import complex
 from xdsl.dialects.builtin import (
+    AnyFloat,
     ArrayAttr,
+    ComplexType,
+    FloatAttr,
     IntAttr,
+    IntegerAttr,
+    IntegerType,
+    f16,
+    f32,
+    f64,
+    i1,
+    i8,
+    i16,
     i32,
 )
 from xdsl.traits import ConstantLike
@@ -15,3 +28,36 @@ def test_constant_construction():
     constantlike = c1.get_trait(ConstantLike)
     assert constantlike is not None
     assert constantlike.get_constant_value(c1) == ArrayAttr([IntAttr(42), IntAttr(43)])
+
+
+class Test_constant_op_helper_constructors:
+    @pytest.mark.parametrize(
+        "real, imag, type",
+        [
+            (0, 1, i1),
+            (1, 2, i8),
+            (24, 19, i16),
+            (33, 88, i32),
+        ],
+    )
+    def test_from_ints(self, real: int, imag: int, type: IntegerType):
+        cst = complex.ConstantOp.from_ints((real, imag), type)
+        assert cst.value.data[0].type == type
+        assert cst.value == ArrayAttr(
+            [IntegerAttr(real, type), IntegerAttr(imag, type)]
+        )
+        assert cst.result_types[0] == ComplexType(type)
+
+    @pytest.mark.parametrize(
+        "real, imag, type",
+        [
+            (0, 1, f16),
+            (-1, 2.2, f32),
+            (24.45, 19.0, f64),
+        ],
+    )
+    def test_from_floats(self, real: float, imag: float, type: AnyFloat):
+        cst = complex.ConstantOp.from_floats((real, imag), type)
+        assert cst.value.data[0].type == type
+        assert cst.value == ArrayAttr([FloatAttr(real, type), FloatAttr(imag, type)])
+        assert cst.result_types[0] == ComplexType(type)

--- a/xdsl/dialects/complex.py
+++ b/xdsl/dialects/complex.py
@@ -216,6 +216,20 @@ class ConstantOp(IRDLOperation, ConstantLikeInterface):
     def get_constant_value(self) -> Attribute:
         return self.value
 
+    @staticmethod
+    def from_floats(value: tuple[float, float], type: AnyFloat) -> ConstantOp:
+        return ConstantOp(
+            ArrayAttr([FloatAttr(value[0], type), FloatAttr(value[1], type)]),
+            ComplexType(type),
+        )
+
+    @staticmethod
+    def from_ints(value: tuple[int, int], type: IntegerType) -> ConstantOp:
+        return ConstantOp(
+            ArrayAttr([IntegerAttr(value[0], type), IntegerAttr(value[1], type)]),
+            ComplexType(type),
+        )
+
 
 @irdl_op_definition
 class CosOp(ComplexUnaryComplexResultOperation):


### PR DESCRIPTION

It includes helper constructors ```from_floats``` and ```from_ints``` to make the creation of ```ConstantOp``` easier. It's a split-out PR from https://github.com/xdslproject/xdsl/pull/5440.