### PR TITLE
dialects: (complex) refactor 'BitcastOp'

### DIFF
--- a/tests/filecheck/dialects/complex/invalid.mlir
+++ b/tests/filecheck/dialects/complex/invalid.mlir
@@ -1,0 +1,23 @@
+// RUN: xdsl-opt --split-input-file %s --verify-diagnostics | filecheck %s
+
+%i64 = "test.op"() : () -> i64
+%0 = complex.bitcast %i64 : i64 to f64
+//CHECK: Expected ('i64', 'f64') to be bitcast between complex and equal arith types
+
+// -----
+
+%f64 = "test.op"() : () -> f64
+%0 = complex.bitcast %f64 : f64 to i32
+//CHECK: Expected ('f64', 'i32') to be bitcast between complex and equal arith types
+
+// -----
+
+%f64 = "test.op"() : () -> f64
+%0 = complex.bitcast %f64 : f64 to f32
+//CHECK: Expected ('f64', 'f32') to be bitcast between complex and equal arith types
+
+// -----
+
+%complex = "test.op"() : () -> (complex<f32>)
+%0 = complex.bitcast %complex : complex<f32> to i32
+//CHECK: Expected ('complex<f32>', 'i32') to be bitcast between complex and equal arith types

--- a/xdsl/dialects/complex.py
+++ b/xdsl/dialects/complex.py
@@ -11,6 +11,7 @@ from xdsl.dialects.builtin import (
     ArrayAttr,
     ArrayOfConstraint,
     ComplexType,
+    FixedBitwidthType,
     FloatAttr,
     IntegerAttr,
     IntegerType,
@@ -20,6 +21,7 @@ from xdsl.interfaces import ConstantLikeInterface
 from xdsl.ir import Attribute, Dialect, Operation, SSAValue
 from xdsl.irdl import (
     AnyOf,
+    BaseAttr,
     EqIntConstraint,
     IRDLOperation,
     RangeOf,
@@ -33,6 +35,7 @@ from xdsl.irdl import (
 )
 from xdsl.traits import Pure
 from xdsl.utils.exceptions import VerifyException
+from xdsl.utils.hints import isa
 
 ComplexTypeConstr = ComplexType.constr(AnyFloat)
 
@@ -168,9 +171,17 @@ class Atan2Op(ComplexBinaryOp):
 
 @irdl_op_definition
 class BitcastOp(IRDLOperation):
+    """
+    compute between complex and and equal arith types
+    """
+
     name = "complex.bitcast"
-    operand = operand_def()
-    result = result_def()
+    operand = operand_def(
+        ComplexType.constr(AnyFloatConstr) | AnyFloatConstr | BaseAttr(IntegerType)
+    )
+    result = result_def(
+        ComplexType.constr(AnyFloatConstr) | AnyFloatConstr | BaseAttr(IntegerType)
+    )
 
     traits = traits_def(Pure())
 
@@ -178,6 +189,29 @@ class BitcastOp(IRDLOperation):
 
     def __init__(self, operand: SSAValue | Operation, result_type: Attribute):
         super().__init__(operands=[operand], result_types=[result_type])
+
+    def verify_(self) -> None:
+        in_type = self.operand.type
+        res_type = self.result.type
+
+        # We allow this to be legal as it can be folded away
+        if in_type == res_type:
+            return
+
+        if in_complex := isa(in_type, ComplexType[AnyFloat]):
+            in_bitwidth = in_type.element_type.bitwidth * 2
+        else:
+            in_bitwidth = cast(FixedBitwidthType, in_type).bitwidth
+
+        if out_complex := isa(res_type, ComplexType[AnyFloat]):
+            out_bitwidth = res_type.element_type.bitwidth * 2
+        else:
+            out_bitwidth = cast(FixedBitwidthType, res_type).bitwidth
+
+        if not ((in_bitwidth == out_bitwidth) and (in_complex != out_complex)):
+            raise VerifyException(
+                f"Expected ('{in_type}', '{res_type}') to be bitcast between complex and equal arith types"
+            )
 
 
 @irdl_op_definition


### PR DESCRIPTION
Conversions (e.g., complex(f32) to i64) could be useful 
for handling interop between the ```arith``` and ```complex``` dialects.

It's a split-out PR from  @https://github.com/xdslproject/xdsl/pull/5440.
