### PR TITLE
CI: don't provide path for MLIR CI

### DIFF
--- a/.github/workflows/ci-mlir.yml
+++ b/.github/workflows/ci-mlir.yml
@@ -26,14 +26,13 @@ jobs:
     steps:
     - uses: actions/checkout@v5
       with:
-        path: xdsl
         fetch-depth: 2
 
     - name: Install uv
       uses: astral-sh/setup-uv@v7
       with:
         enable-cache: true
-        cache-dependency-glob: "xdsl/uv.lock"
+        cache-dependency-glob: "uv.lock"
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v6
@@ -41,14 +40,10 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install the package locally and nbval
-      run: |
-        # Change directory so that xdsl-opt can be found during installation.
-        cd xdsl
-        make venv
+      run: make venv
 
     - name: Test with pytest and generate code coverage
       run: |
-        cd xdsl
         if [ "$COLLECT_COVERAGE" = "true" ]; then
           uv run pytest -W error --cov
         else
@@ -57,7 +52,6 @@ jobs:
 
     - name: Execute lit tests
       run: |
-        cd xdsl
         # Add mlir-opt to the path
         export PATH=$PATH:${GITHUB_WORKSPACE}/llvm-project/build/bin/
         if [ "$COLLECT_COVERAGE" = "true" ]; then
@@ -70,7 +64,6 @@ jobs:
 
     - name: Test MLIR dependent examples/tutorials
       run: |
-        cd xdsl
         # Add mlir-opt to the path
         export PATH=$PATH:${GITHUB_WORKSPACE}/llvm-project/build/bin/
         make tests-marimo
@@ -78,7 +71,6 @@ jobs:
     - name: Combine coverage data
       if: matrix.python-version == '3.13'
       run: |
-        cd xdsl
         uv run coverage combine --append
         uv run coverage report
         uv run coverage xml
@@ -94,7 +86,6 @@ jobs:
           # Temporary setting to not fail the CI job while we debug recent codecov issues
           fail_ci_if_error: false
           verbose: true
-          root_dir: xdsl
           files: coverage.xml
           codecov_yml_path: codecov.yml
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
I think this was necessary for codecov at some point but now that it's broken anyway I propose to simplify this CI action.