### PR TITLE
core: deprecate PatternRewriter.inline_block_before/after_matched_op

### DIFF
--- a/docs/Toy/toy/rewrites/inline_toy.py
+++ b/docs/Toy/toy/rewrites/inline_toy.py
@@ -7,6 +7,7 @@ from xdsl.pattern_rewriter import (
     RewritePattern,
     op_type_rewrite_pattern,
 )
+from xdsl.rewriter import InsertPoint
 from xdsl.traits import CallableOpInterface, SymbolTable
 from xdsl.transforms.dead_code_elimination import dce
 
@@ -46,7 +47,7 @@ class InlineFunctions(RewritePattern):
             rewriter.erase_block_argument(impl_block.args[-1])
 
         # Inline function definition before matched op
-        rewriter.inline_block_before_matched_op(impl_block)
+        rewriter.inline_block(impl_block, InsertPoint.before(op))
 
         # Get return from function definition
         return_op = op.prev_op

--- a/tests/pattern_rewriter/test_pattern_rewriter.py
+++ b/tests/pattern_rewriter/test_pattern_rewriter.py
@@ -811,7 +811,9 @@ def test_inline_block_before_matched_op():
         @op_type_rewrite_pattern
         def match_and_rewrite(self, matched_op: test.TestOp, rewriter: PatternRewriter):
             if matched_op.regs and matched_op.regs[0].blocks:
-                rewriter.inline_block_before_matched_op(matched_op.regs[0].blocks[0])
+                rewriter.inline_block(
+                    matched_op.regs[0].blocks[0], InsertPoint.before(matched_op)
+                )
 
     rewrite_and_compare(
         prog,

--- a/xdsl/backend/riscv/lowering/convert_snitch_stream_to_snitch.py
+++ b/xdsl/backend/riscv/lowering/convert_snitch_stream_to_snitch.py
@@ -183,7 +183,7 @@ class LowerStreamingRegionOp(RewritePattern):
         for arg in reversed(block.args):
             rewriter.erase_block_argument(arg)
 
-        rewriter.inline_block_before_matched_op(block)
+        rewriter.inline_block(block, InsertPoint.before(op))
 
         rewriter.replace_matched_op(snitch.SsrDisableOp())
 

--- a/xdsl/backend/riscv/riscv_scf_to_asm.py
+++ b/xdsl/backend/riscv/riscv_scf_to_asm.py
@@ -92,7 +92,7 @@ class LowerRiscvScfToLabels(RewritePattern):
             rewriter.insert_op_after_matched_op(get_target_register)
 
         # Extract ops from the body and insert them after the loop header.
-        rewriter.inline_block_after_matched_op(body)
+        rewriter.inline_block(body, InsertPoint.after(op))
 
         rewriter.erase_op(op)
 

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -260,6 +260,7 @@ class PatternRewriter(Builder, PatternRewriterListener):
         self.has_done_action = True
         Rewriter.inline_block(block, insertion_point, arg_values=arg_values)
 
+    @deprecated("Please use `inline_block(block, InsertPoint.before(op))`")
     def inline_block_before_matched_op(
         self, block: Block, arg_values: Sequence[SSAValue] = ()
     ):
@@ -271,6 +272,7 @@ class PatternRewriter(Builder, PatternRewriterListener):
             block, InsertPoint.before(self.current_operation), arg_values=arg_values
         )
 
+    @deprecated("Please use `inline_block(block, InsertPoint.after(op))`")
     def inline_block_after_matched_op(
         self, block: Block, arg_values: Sequence[SSAValue] = ()
     ):


### PR DESCRIPTION
PR 2/4 deprecating `matched_op` helper functions.