### PR TITLE
core: update insertion_point when setting PatternRewriter.current_operation

### DIFF
--- a/xdsl/interpreters/eqsat_pdl_interp.py
+++ b/xdsl/interpreters/eqsat_pdl_interp.py
@@ -597,6 +597,7 @@ class EqsatPDLInterpFunctions(PDLInterpFunctions):
         rewriter = PDLInterpFunctions.get_rewriter(interpreter)
         for rewriter_op, root, args in self.pending_rewrites:
             rewriter.current_operation = root
+            rewriter.insertion_point = InsertPoint.before(root)
 
             self.is_matching = False
             interpreter.call_op(rewriter_op, args)

--- a/xdsl/interpreters/pdl_interp.py
+++ b/xdsl/interpreters/pdl_interp.py
@@ -18,6 +18,7 @@ from xdsl.interpreter import (
 from xdsl.ir import Attribute, Operation, OpResult, SSAValue
 from xdsl.irdl import IRDLOperation
 from xdsl.pattern_rewriter import PatternRewriter
+from xdsl.rewriter import InsertPoint
 from xdsl.utils.exceptions import InterpretationError
 from xdsl.utils.hints import isa
 
@@ -444,7 +445,9 @@ class PDLInterpFunctions(InterpreterFunctions):
             assert len(args) == 1
             root_op = args[0]
             assert isinstance(root_op, Operation)
-            self.get_rewriter(interpreter).current_operation = root_op
+            rewriter = self.get_rewriter(interpreter)
+            rewriter.current_operation = root_op
+            rewriter.insertion_point = InsertPoint.before(root_op)
 
         return interpreter.run_ssacfg_region(op.body, args, op.sym_name.data)
 


### PR DESCRIPTION
I had a go locally to try and forbid setting the `insertion_point` property directly, but that doesn't quite work. I think this is one more argument for removing `current_operation` altogether once the `matched_op` methods are deprecated.

UPDATE: now instead of automating setting the insert_point, just update it in the two places where it was missing. We'll just deprecate `current_operation` in the future so this is the future-proof way to do it.