### PR TITLE
core: Fix typing of SSAValue.types property

### DIFF
--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -911,7 +911,7 @@ class SSAValues(tuple[SSAValueCovT, ...], Generic[SSAValueCovT]):
     """
 
     @property
-    def types(self):
+    def types(self: tuple[SSAValue[AttributeInvT], ...]) -> tuple[AttributeInvT, ...]:
         return tuple(o.type for o in self)
 
     @overload


### PR DESCRIPTION
Currently, `SSAValues.types` type checks as `tuple[Attribute, ...]`. This is because it is taking the bound type rather than using the inner type.

This PR fixes the type hint by exposing the inner type to the return type.