### PR TITLE
dialects: (complex) add folding canonicalization pattern

### DIFF
--- a/tests/filecheck/dialects/complex/canonicalize.mlir
+++ b/tests/filecheck/dialects/complex/canonicalize.mlir
@@ -1,0 +1,102 @@
+// RUN: xdsl-opt %s -p canonicalize | filecheck %s
+
+%f16_0 = complex.constant [0.: f16, 0.: f16] : complex<f16>
+%f16_1 = complex.constant [1.: f16, 3.: f16] : complex<f16>
+%f16_2 = complex.constant [-1.: f16, -3.: f16] : complex<f16>
+%f16_3 = complex.constant [2.: f16, 3.: f16] : complex<f16>
+
+%f32_0 = complex.constant [0.: f32, 0.: f32] : complex<f32>
+%f32_1 = complex.constant [-1.2: f32, -2.2: f32] : complex<f32>
+%f32_2 = complex.constant [1.2: f32, 2.2: f32] : complex<f32>
+%f32_3 = complex.constant [4.0: f32, 5.0: f32] : complex<f32>
+
+"test.op"(%f16_0, %f16_1, %f16_2, %f16_3, %f32_0, %f32_1, %f32_2, %f32_3) : (complex<f16>, complex<f16>, complex<f16>, complex<f16>, complex<f32>, complex<f32>, complex<f32>, complex<f32>) -> ()
+
+// CHECK:       %f16 = complex.constant [0.000000e+00 : f16, 0.000000e+00 : f16] : complex<f16>
+// CHECK-NEXT:  %f16_1 = complex.constant [1.000000e+00 : f16, 3.000000e+00 : f16] : complex<f16>
+// CHECK-NEXT:  %f16_2 = complex.constant [-1.000000e+00 : f16, -3.000000e+00 : f16] : complex<f16>
+// CHECK-NEXT:  %f16_3 = complex.constant [2.000000e+00 : f16, 3.000000e+00 : f16] : complex<f16>
+// CHECK-NEXT:  %f32 = complex.constant [0.000000e+00 : f32, 0.000000e+00 : f32] : complex<f32>
+// CHECK-NEXT:  %f32_1 = complex.constant [-1.200000e+00 : f32, -2.200000e+00 : f32] : complex<f32>
+// CHECK-NEXT:  %f32_2 = complex.constant [1.200000e+00 : f32, 2.200000e+00 : f32] : complex<f32>
+// CHECK-NEXT:  %f32_3 = complex.constant [4.000000e+00 : f32, 5.000000e+00 : f32] : complex<f32>
+// CHECK-NEXT:  "test.op"(%f16, %f16_1, %f16_2, %f16_3, %f32, %f32_1, %f32_2, %f32_3) : (complex<f16>, complex<f16>, complex<f16>, complex<f16>, complex<f32>, complex<f32>, complex<f32>, complex<f32>) -> ()
+
+%addf16 = complex.add %f16_1, %f16_2 : complex<f16>
+%addf16_1 = complex.add %addf16, %f16_3 : complex<f16>
+%addf32 = complex.add %f32_1, %f32_2 : complex<f32>
+%addf32_1 = complex.add %addf32, %f32_3 : complex<f32>
+// CHECK:       %addf16 = complex.constant [0.000000e+00 : f16, 0.000000e+00 : f16] : complex<f16>
+// CHECK-NEXT:  %addf16_1 = complex.constant [2.000000e+00 : f16, 3.000000e+00 : f16] : complex<f16>
+// CHECK-NEXT:  %addf32 = complex.constant [0.000000e+00 : f32, 0.000000e+00 : f32] : complex<f32>
+// CHECK-NEXT:  %addf32_1 = complex.constant [4.000000e+00 : f32, 5.000000e+00 : f32] : complex<f32>
+
+%subf16 = complex.sub %f16_1, %f16_2 : complex<f16>
+%subf16_1 = complex.sub %subf16, %f16_3 : complex<f16>
+%subf32 = complex.sub %f32_1, %f32_2 : complex<f32>
+%subf32_1 = complex.sub %subf32, %f32_3 : complex<f32>
+// CHECK:       %subf16 = complex.constant [2.000000e+00 : f16, 6.000000e+00 : f16] : complex<f16>
+// CHECK-NEXT:  %subf16_1 = complex.constant [0.000000e+00 : f16, 3.000000e+00 : f16] : complex<f16>
+// CHECK-NEXT:  %subf32 = complex.constant [-2.400000e+00 : f32, -4.400000e+00 : f32] : complex<f32>
+// CHECK-NEXT:  %subf32_1 = complex.constant [-6.400000e+00 : f32, -9.400000e+00 : f32] : complex<f32>
+
+%mulf16 = complex.mul %f16_1, %f16_2 : complex<f16>
+%mulf16_1 = complex.mul %mulf16, %f16_3 : complex<f16>
+%mulf32 = complex.mul %f32_1, %f32_2 : complex<f32>
+%mulf32_1 = complex.mul %mulf32, %f32_3 : complex<f32>
+// CHECK:       %mulf16 = complex.constant [8.000000e+00 : f16, -6.000000e+00 : f16] : complex<f16>
+// CHECK-NEXT:  %mulf16_1 = complex.constant [3.400000e+01 : f16, 1.200000e+01 : f16] : complex<f16>
+// CHECK-NEXT:  %mulf32 = complex.constant [3.400000e+00 : f32, -5.280000e+00 : f32] : complex<f32>
+// CHECK-NEXT:  %mulf32_1 = complex.constant [4.000000e+01 : f32, -4.12000036 : f32] : complex<f32>
+
+%divf16 = complex.div %f16_1, %f16_2 : complex<f16>
+%divf16_1 = complex.div %divf16, %f16_3 : complex<f16>
+%divf32 = complex.div %f32_1, %f32_2 : complex<f32>
+%divf32_1 = complex.div %divf32, %f32_3 : complex<f32>
+// CHECK:       %divf16 = complex.constant [-1.000000e+00 : f16, 0.000000e+00 : f16] : complex<f16>
+// CHECK-NEXT:  %divf16_1 = complex.constant [-1.538090e-01 : f16, 2.307130e-01 : f16] : complex<f16>
+// CHECK-NEXT:  %divf32 = complex.constant [-1.000000e+00 : f32, 0.000000e+00 : f32] : complex<f32>
+// CHECK-NEXT:  %divf32_1 = complex.constant [-0.097560972 : f32, 0.121951222 : f32] : complex<f32>
+
+%div16 = complex.div %f16_0, %f16_0 : complex<f16>
+%div16_inf = complex.div %f16_3, %f16_0 : complex<f16> // %f16_3 > 0
+%div16_minus_inf = complex.div %f16_2, %f16_0 : complex<f16> // f16_2 < 0
+// CHECK:       %div16 = complex.constant [0x7e00 : f16, 0x7e00 : f16] : complex<f16>
+// CHECK-NEXT:  %div16_inf = complex.constant [0x7c00 : f16, 0x7c00 : f16] : complex<f16>
+// CHECK-NEXT:  %div16_minus_inf = complex.constant [0xfc00 : f16, 0xfc00 : f16] : complex<f16>
+
+%f16_0_neg = complex.constant [-0.: f16, -0.: f16] : complex<f16>
+%div16_neg = complex.div %f16_0, %f16_0_neg : complex<f16>
+%div16_inf_neg = complex.div %f16_3, %f16_0_neg : complex<f16>
+%div16_minus_inf_neg = complex.div %f16_2, %f16_0_neg : complex<f16>
+// CHECK:       %div16_neg = complex.constant [0x7e00 : f16, 0x7e00 : f16] : complex<f16>
+// CHECK-NEXT:  %div16_inf_neg = complex.constant [0xfc00 : f16, 0xfc00 : f16] : complex<f16>
+// CHECK-NEXT:  %div16_minus_inf_neg = complex.constant [0x7c00 : f16, 0x7c00 : f16] : complex<f16>
+
+%div32 = complex.div %f32_0, %f32_0 : complex<f32>
+%div32_inf = complex.div %f32_2, %f32_0 : complex<f32>
+%div32_minus_inf = complex.div %f32_1, %f32_0 : complex<f32>
+// CHECK:       %div32 = complex.constant [0x7fc00000 : f32, 0x7fc00000 : f32] : complex<f32>
+// CHECK-NEXT:  %div32_inf = complex.constant [0x7f800000 : f32, 0x7f800000 : f32] : complex<f32>
+// CHECK-NEXT:  %div32_minus_inf = complex.constant [0xff800000 : f32, 0xff800000 : f32] : complex<f32>
+
+%f32_0_neg = complex.constant [-0.: f32, -0.: f32] : complex<f32>
+%div32_neg = complex.div %f32_0, %f32_0_neg : complex<f32>
+%div32_inf_neg = complex.div %f32_2, %f32_0_neg : complex<f32>
+%div32_minus_inf_neg = complex.div %f32_1, %f32_0_neg : complex<f32>
+// CHECK:       %div32_neg = complex.constant [0x7fc00000 : f32, 0x7fc00000 : f32] : complex<f32>
+// CHECK-NEXT:  %div32_inf_neg = complex.constant [0xff800000 : f32, 0xff800000 : f32] : complex<f32>
+// CHECK-NEXT:  %div32_minus_inf_neg = complex.constant [0x7f800000 : f32, 0x7f800000 : f32] : complex<f32>
+
+"test.op"(%addf16, %addf16_1, %subf16, %subf16_1, %mulf16, %mulf16_1, %divf16, %divf16_1) : (complex<f16>, complex<f16>, complex<f16>, complex<f16>, complex<f16>, complex<f16>, complex<f16>, complex<f16>) -> ()
+"test.op"(%addf32, %addf32_1, %subf32, %subf32_1, %mulf32, %mulf32_1, %divf32, %divf32_1) : (complex<f32>, complex<f32>, complex<f32>, complex<f32>, complex<f32>, complex<f32>, complex<f32>, complex<f32>) -> ()
+"test.op"(%div16, %div16_inf, %div16_minus_inf) : (complex<f16>, complex<f16>, complex<f16>) -> ()
+"test.op"(%div16_neg, %div16_inf_neg, %div16_minus_inf_neg) : (complex<f16>, complex<f16>, complex<f16>) -> ()
+"test.op"(%div32, %div32_inf, %div32_minus_inf) : (complex<f32>, complex<f32>, complex<f32>) -> ()
+"test.op"(%div32_neg, %div32_inf_neg, %div32_minus_inf_neg) : (complex<f32>, complex<f32>, complex<f32>) -> ()
+// CHECK:       "test.op"(%addf16, %addf16_1, %subf16, %subf16_1, %mulf16, %mulf16_1, %divf16, %divf16_1) : (complex<f16>, complex<f16>, complex<f16>, complex<f16>, complex<f16>, complex<f16>, complex<f16>, complex<f16>) -> ()
+// CHECK-NEXT:  "test.op"(%addf32, %addf32_1, %subf32, %subf32_1, %mulf32, %mulf32_1, %divf32, %divf32_1) : (complex<f32>, complex<f32>, complex<f32>, complex<f32>, complex<f32>, complex<f32>, complex<f32>, complex<f32>) -> ()
+// CHECK-NEXT:  "test.op"(%div16, %div16_inf, %div16_minus_inf) : (complex<f16>, complex<f16>, complex<f16>) -> ()
+// CHECK-NEXT:  "test.op"(%div16_neg, %div16_inf_neg, %div16_minus_inf_neg) : (complex<f16>, complex<f16>, complex<f16>) -> ()
+// CHECK-NEXT:  "test.op"(%div32, %div32_inf, %div32_minus_inf) : (complex<f32>, complex<f32>, complex<f32>) -> ()
+// CHECK-NEXT:  "test.op"(%div32_neg, %div32_inf_neg, %div32_minus_inf_neg) : (complex<f32>, complex<f32>, complex<f32>) -> ()

--- a/xdsl/dialects/complex.py
+++ b/xdsl/dialects/complex.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
 import abc
+import math
 from collections.abc import Sequence
 from typing import ClassVar, Generic, cast
 
 from typing_extensions import TypeVar
 
+from xdsl.dialect_interfaces.constant_materialization import (
+    ConstantMaterializationInterface,
+)
 from xdsl.dialects.arith import FastMathFlagsAttr
 from xdsl.dialects.builtin import (
     AnyFloat,
@@ -47,7 +51,7 @@ from xdsl.irdl import (
 )
 from xdsl.parser import AttrParser
 from xdsl.printer import Printer
-from xdsl.traits import ConstantLike, Pure
+from xdsl.traits import ConstantLike, Commutative, Pure
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.hints import isa
 
@@ -176,7 +180,7 @@ class ComplexUnaryRealResultOperation(IRDLOperation, abc.ABC):
             )
 
 
-class ComplexBinaryOp(IRDLOperation, abc.ABC):
+class ComplexBinaryOp(IRDLOperation, HasFolderInterface, abc.ABC):
     """Base class for binary operations on complex numbers."""
 
     T: ClassVar = VarConstraint("T", ComplexTypeConstr)
@@ -204,6 +208,37 @@ class ComplexBinaryOp(IRDLOperation, abc.ABC):
             properties={"fastmath": fastmath},
         )
 
+    @staticmethod
+    def py_operation(
+        lhs: tuple[float, float], rhs: tuple[float, float]
+    ) -> tuple[float, float] | None:
+        """
+        Performs a python function corresponding to this operation.
+
+        If `i := py_operation(lhs, rhs)` is an tuple[float, float], then this operation can be
+        canonicalized to a constant with value `i` when the inputs are constants
+        with values `lhs` and `rhs`.
+        """
+        return None
+
+    def fold(self) -> tuple[ArrayAttr[FloatAttr[AnyFloat]]] | None:
+        lhs = ConstantLike.get_constant_value(self.lhs)
+        rhs = ConstantLike.get_constant_value(self.rhs)
+        if lhs is not None and rhs is not None:
+            if isa(lhs, ArrayAttr[FloatAttr[AnyFloat]]) and isa(
+                rhs, ArrayAttr[FloatAttr[AnyFloat]]
+            ):
+                assert lhs.data[0].type == rhs.data[0].type
+                assert lhs.data[1].type == rhs.data[1].type
+                re_lhs, im_lhs = lhs.data[0].value.data, lhs.data[1].value.data
+                re_rhs, im_rhs = rhs.data[0].value.data, rhs.data[1].value.data
+                res = self.py_operation((re_lhs, im_lhs), (re_rhs, im_rhs))
+                if res is not None:
+                    type = lhs.data[0].type
+                    return (
+                        ArrayAttr([FloatAttr(res[0], type), FloatAttr(res[1], type)]),
+                    )
+
 
 class ComplexCompareOp(IRDLOperation, abc.ABC):
     """Base class for comparison operations on complex numbers."""
@@ -230,6 +265,19 @@ class AbsOp(ComplexUnaryRealResultOperation):
 class AddOp(ComplexBinaryOp):
     name = "complex.add"
 
+    traits = traits_def(Pure(), Commutative())
+
+    traits = traits_def(
+        Pure(),
+        Commutative(),
+    )
+
+    @staticmethod
+    def py_operation(
+        lhs: tuple[float, float], rhs: tuple[float, float]
+    ) -> tuple[float, float]:
+        return (lhs[0] + rhs[0], lhs[1] + rhs[1])
+
 
 @irdl_op_definition
 class AngleOp(ComplexUnaryRealResultOperation):
@@ -242,7 +290,7 @@ class Atan2Op(ComplexBinaryOp):
 
 
 @irdl_op_definition
-class BitcastOp(IRDLOperation):
+class BitcastOp(IRDLOperation, HasFolderInterface):
     """
     compute between complex and and equal arith types
     """
@@ -314,7 +362,7 @@ class ConstantOp(IRDLOperation, HasFolderInterface):
 
     assembly_format = "$value attr-dict `:` type($complex)"
 
-    def __init__(self, value: ArrayAttr, result_type: ComplexType):
+    def __init__(self, value: ArrayAttr | ComplexNumberAttr, result_type: ComplexType):
         super().__init__(properties={"value": value}, result_types=[result_type])
 
     def fold(self) -> tuple[Attribute]:
@@ -365,6 +413,39 @@ class CreateOp(IRDLOperation):
 class DivOp(ComplexBinaryOp):
     name = "complex.div"
 
+    traits = traits_def(
+        Pure(),
+    )
+
+    @staticmethod
+    def py_operation(
+        lhs: tuple[float, float], rhs: tuple[float, float]
+    ) -> tuple[float, float]:
+        re_lhs, im_lhs = lhs[0], lhs[1]
+        re_rhs, im_rhs = rhs[0], rhs[1]
+        # 0.0 == -0.0 -> True
+        if re_rhs == 0.0 and im_rhs == 0.0:
+            if re_lhs == 0.0:
+                real = float("nan")
+            else:
+                if math.copysign(re_lhs, re_rhs) > 0:
+                    positive = True if re_lhs > 0 else False
+                else:
+                    positive = True if re_lhs < 0 else False
+                real = float("inf") if positive else float("-inf")
+            if im_lhs == 0.0:
+                imag = float("nan")
+            else:
+                if math.copysign(im_lhs, im_rhs) > 0:
+                    positive = True if im_lhs > 0 else False
+                else:
+                    positive = True if im_lhs < 0 else False
+                imag = float("inf") if positive else float("-inf")
+        else:
+            real = (re_lhs * re_rhs + im_lhs * im_rhs) / (re_rhs**2 + im_rhs**2)
+            imag = (im_lhs * re_rhs - re_lhs * im_rhs) / (re_rhs**2 + im_rhs**2)
+        return (real, imag)
+
 
 @irdl_op_definition
 class EqualOp(ComplexCompareOp):
@@ -399,6 +480,19 @@ class Log1pOp(ComplexUnaryComplexResultOperation):
 @irdl_op_definition
 class MulOp(ComplexBinaryOp):
     name = "complex.mul"
+
+    traits = traits_def(
+        Pure(),
+        Commutative(),
+    )
+
+    @staticmethod
+    def py_operation(
+        lhs: tuple[float, float], rhs: tuple[float, float]
+    ) -> tuple[float, float]:
+        re_lhs, im_lhs = lhs[0], lhs[1]
+        re_rhs, im_rhs = rhs[0], rhs[1]
+        return (re_lhs * re_rhs - im_lhs * im_rhs, re_lhs * im_rhs + im_lhs * re_rhs)
 
 
 @irdl_op_definition
@@ -445,6 +539,16 @@ class SqrtOp(ComplexUnaryComplexResultOperation):
 class SubOp(ComplexBinaryOp):
     name = "complex.sub"
 
+    traits = traits_def(
+        Pure(),
+    )
+
+    @staticmethod
+    def py_operation(
+        lhs: tuple[float, float], rhs: tuple[float, float]
+    ) -> tuple[float, float]:
+        return (lhs[0] - rhs[0], lhs[1] - rhs[1])
+
 
 @irdl_op_definition
 class TanOp(ComplexUnaryComplexResultOperation):
@@ -454,6 +558,14 @@ class TanOp(ComplexUnaryComplexResultOperation):
 @irdl_op_definition
 class TanhOp(ComplexUnaryComplexResultOperation):
     name = "complex.tanh"
+
+
+class ComplexConstantMaterializationInterface(ConstantMaterializationInterface):
+    def materialize_constant(self, value: Attribute, type: Attribute) -> Operation:
+        return cast(
+            Operation,
+            ConstantOp.build(properties={"value": value}, result_types=(type,)),
+        )
 
 
 Complex = Dialect(
@@ -490,5 +602,8 @@ Complex = Dialect(
     ],
     [
         ComplexNumberAttr,
+    ],
+    [
+        ComplexConstantMaterializationInterface(),
     ],
 )

--- a/xdsl/dialects/complex.py
+++ b/xdsl/dialects/complex.py
@@ -290,7 +290,7 @@ class Atan2Op(ComplexBinaryOp):
 
 
 @irdl_op_definition
-class BitcastOp(IRDLOperation, HasFolderInterface):
+class BitcastOp(IRDLOperation):
     """
     compute between complex and and equal arith types
     """
@@ -362,7 +362,7 @@ class ConstantOp(IRDLOperation, HasFolderInterface):
 
     assembly_format = "$value attr-dict `:` type($complex)"
 
-    def __init__(self, value: ArrayAttr | ComplexNumberAttr, result_type: ComplexType):
+    def __init__(self, value: ArrayAttr, result_type: ComplexType):
         super().__init__(properties={"value": value}, result_types=[result_type])
 
     def fold(self) -> tuple[Attribute]:

--- a/xdsl/dialects/complex.py
+++ b/xdsl/dialects/complex.py
@@ -219,25 +219,24 @@ class ComplexBinaryOp(IRDLOperation, HasFolderInterface, abc.ABC):
         canonicalized to a constant with value `i` when the inputs are constants
         with values `lhs` and `rhs`.
         """
-        return None
 
     def fold(self) -> tuple[ArrayAttr[FloatAttr[AnyFloat]]] | None:
         lhs = ConstantLike.get_constant_value(self.lhs)
         rhs = ConstantLike.get_constant_value(self.rhs)
-        if lhs is not None and rhs is not None:
-            if isa(lhs, ArrayAttr[FloatAttr[AnyFloat]]) and isa(
-                rhs, ArrayAttr[FloatAttr[AnyFloat]]
-            ):
-                assert lhs.data[0].type == rhs.data[0].type
-                assert lhs.data[1].type == rhs.data[1].type
-                re_lhs, im_lhs = lhs.data[0].value.data, lhs.data[1].value.data
-                re_rhs, im_rhs = rhs.data[0].value.data, rhs.data[1].value.data
-                res = self.py_operation((re_lhs, im_lhs), (re_rhs, im_rhs))
-                if res is not None:
-                    type = lhs.data[0].type
-                    return (
-                        ArrayAttr([FloatAttr(res[0], type), FloatAttr(res[1], type)]),
-                    )
+        if (
+            lhs is not None
+            and rhs is not None
+            and isa(lhs, ArrayAttr[FloatAttr])
+            and isa(rhs, ArrayAttr[FloatAttr])
+        ):
+            assert lhs.data[0].type == rhs.data[0].type
+            assert lhs.data[1].type == rhs.data[1].type
+            re_lhs, im_lhs = lhs.data[0].value.data, lhs.data[1].value.data
+            re_rhs, im_rhs = rhs.data[0].value.data, rhs.data[1].value.data
+            res = self.py_operation((re_lhs, im_lhs), (re_rhs, im_rhs))
+            if res is not None:
+                type = lhs.data[0].type
+                return (ArrayAttr([FloatAttr(res[0], type), FloatAttr(res[1], type)]),)
 
 
 class ComplexCompareOp(IRDLOperation, abc.ABC):
@@ -421,8 +420,8 @@ class DivOp(ComplexBinaryOp):
     def py_operation(
         lhs: tuple[float, float], rhs: tuple[float, float]
     ) -> tuple[float, float]:
-        re_lhs, im_lhs = lhs[0], lhs[1]
-        re_rhs, im_rhs = rhs[0], rhs[1]
+        re_lhs, im_lhs = lhs
+        re_rhs, im_rhs = rhs
         # 0.0 == -0.0 -> True
         if re_rhs == 0.0 and im_rhs == 0.0:
             inf = float("inf")
@@ -484,8 +483,8 @@ class MulOp(ComplexBinaryOp):
     def py_operation(
         lhs: tuple[float, float], rhs: tuple[float, float]
     ) -> tuple[float, float]:
-        re_lhs, im_lhs = lhs[0], lhs[1]
-        re_rhs, im_rhs = rhs[0], rhs[1]
+        re_lhs, im_lhs = lhs
+        re_rhs, im_rhs = rhs
         return (re_lhs * re_rhs - im_lhs * im_rhs, re_lhs * im_rhs + im_lhs * re_rhs)
 
 

--- a/xdsl/dialects/complex.py
+++ b/xdsl/dialects/complex.py
@@ -51,7 +51,7 @@ from xdsl.irdl import (
 )
 from xdsl.parser import AttrParser
 from xdsl.printer import Printer
-from xdsl.traits import ConstantLike, Commutative, Pure
+from xdsl.traits import Commutative, ConstantLike, Pure
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.hints import isa
 
@@ -425,22 +425,16 @@ class DivOp(ComplexBinaryOp):
         re_rhs, im_rhs = rhs[0], rhs[1]
         # 0.0 == -0.0 -> True
         if re_rhs == 0.0 and im_rhs == 0.0:
+            inf = float("inf")
             if re_lhs == 0.0:
                 real = float("nan")
             else:
-                if math.copysign(re_lhs, re_rhs) > 0:
-                    positive = True if re_lhs > 0 else False
-                else:
-                    positive = True if re_lhs < 0 else False
-                real = float("inf") if positive else float("-inf")
+                real = math.copysign(inf, re_lhs) / math.copysign(1.0, re_rhs)
             if im_lhs == 0.0:
                 imag = float("nan")
             else:
-                if math.copysign(im_lhs, im_rhs) > 0:
-                    positive = True if im_lhs > 0 else False
-                else:
-                    positive = True if im_lhs < 0 else False
-                imag = float("inf") if positive else float("-inf")
+                # Positive infinity if signs match, negative otherwise
+                imag = math.copysign(inf, im_lhs) / math.copysign(1.0, im_rhs)
         else:
             real = (re_lhs * re_rhs + im_lhs * im_rhs) / (re_rhs**2 + im_rhs**2)
             imag = (im_lhs * re_rhs - re_lhs * im_rhs) / (re_rhs**2 + im_rhs**2)
@@ -562,10 +556,7 @@ class TanhOp(ComplexUnaryComplexResultOperation):
 
 class ComplexConstantMaterializationInterface(ConstantMaterializationInterface):
     def materialize_constant(self, value: Attribute, type: Attribute) -> Operation:
-        return cast(
-            Operation,
-            ConstantOp.build(properties={"value": value}, result_types=(type,)),
-        )
+        return ConstantOp.build(properties={"value": value}, result_types=(type,))
 
 
 Complex = Dialect(


### PR DESCRIPTION

This PR folds complex floating point binary ops whose operands are both ```complex.constant```s.
The complex binary ops that support folding are ```add```, ```sub```, ```mul```, ```div```.

It's a split-out PR from @https://github.com/xdslproject/xdsl/pull/5440.
