### PR TITLE
dialects: (pdl_interp) `get_results` switch from custom print/parse to assembly format

### DIFF
--- a/xdsl/dialects/eqsat_pdl_interp.py
+++ b/xdsl/dialects/eqsat_pdl_interp.py
@@ -75,8 +75,7 @@ class GetResultsOp(IRDLOperation):
     input_op = operand_def(OperationType)
     value = result_def(ValueType | RangeType[ValueType])
 
-    # assembly_format = "($index^)? `of` $input_op `:` type($value) attr-dict"
-    # TODO: Fix bug preventing this assebmly format from working: https://github.com/xdslproject/xdsl/issues/4136.
+    assembly_format = "($index^)? `of` $input_op `:` type($value) attr-dict"
 
     def __init__(
         self,
@@ -91,30 +90,6 @@ class GetResultsOp(IRDLOperation):
             properties={"index": index},
             result_types=[result_type],
         )
-
-    @classmethod
-    def parse(cls, parser: Parser) -> GetResultsOp:
-        index = parser.parse_optional_integer()
-        if index is not None:
-            index = IntegerAttr.from_int_and_width(index, 32)
-        parser.parse_characters("of")
-        input_op = parser.parse_operand()
-        parser.parse_punctuation(":")
-        result_type = parser.parse_type()
-        return GetResultsOp.build(
-            operands=(input_op,),
-            properties={"index": index},
-            result_types=(result_type,),
-        )
-
-    def print(self, printer: Printer):
-        if self.index is not None:
-            printer.print_string(" ", indent=0)
-            self.index.print_without_type(printer)
-        printer.print_string(" of ", indent=0)
-        printer.print_operand(self.input_op)
-        printer.print_string(" : ", indent=0)
-        printer.print_attribute(self.value.type)
 
 
 @irdl_op_definition

--- a/xdsl/dialects/pdl_interp.py
+++ b/xdsl/dialects/pdl_interp.py
@@ -277,8 +277,7 @@ class GetResultsOp(IRDLOperation):
     input_op = operand_def(OperationType)
     value = result_def(ValueType | RangeType[ValueType])
 
-    # assembly_format = "($index^)? `of` $input_op `:` type($value) attr-dict"
-    # TODO: Fix bug preventing this assebmly format from working: https://github.com/xdslproject/xdsl/issues/4136.
+    assembly_format = "($index^)? `of` $input_op `:` type($value) attr-dict"
 
     def __init__(
         self,
@@ -293,30 +292,6 @@ class GetResultsOp(IRDLOperation):
             properties={"index": index},
             result_types=[result_type],
         )
-
-    @classmethod
-    def parse(cls, parser: Parser) -> GetResultsOp:
-        index = parser.parse_optional_integer()
-        if index is not None:
-            index = IntegerAttr.from_int_and_width(index, 32)
-        parser.parse_characters("of")
-        input_op = parser.parse_operand()
-        parser.parse_punctuation(":")
-        result_type = parser.parse_type()
-        return GetResultsOp.build(
-            operands=(input_op,),
-            properties={"index": index},
-            result_types=(result_type,),
-        )
-
-    def print(self, printer: Printer):
-        if self.index is not None:
-            printer.print_string(" ", indent=0)
-            self.index.print_without_type(printer)
-        printer.print_string(" of ", indent=0)
-        printer.print_operand(self.input_op)
-        printer.print_string(" : ", indent=0)
-        printer.print_attribute(self.value.type)
 
 
 @irdl_op_definition


### PR DESCRIPTION
This still errors:
```
Traceback (most recent call last):
  File "/Users/jumerckx/eqsat/xdsl/.venv/bin/xdsl-opt", line 10, in <module>
    sys.exit(main())
             ~~~~^^
  File "/Users/jumerckx/eqsat/xdsl/xdsl/tools/xdsl_opt.py", line 5, in main
    xDSLOptMain().run()
    ~~~~~~~~~~~~~~~~~^^
  File "/Users/jumerckx/eqsat/xdsl/xdsl/xdsl_opt_main.py", line 83, in run
    module = self.parse_chunk(chunk, file_extension, offset)
  File "/Users/jumerckx/eqsat/xdsl/xdsl/tools/command_line_tool.py", line 110, in parse_chunk
    return self.available_frontends[file_extension](chunk)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^
  File "/Users/jumerckx/eqsat/xdsl/xdsl/tools/command_line_tool.py", line 98, in parse_mlir
    ).parse_module(not self.args.no_implicit_module)
      ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jumerckx/eqsat/xdsl/xdsl/parser/core.py", line 134, in parse_module
    if (parsed_op := self.parse_optional_operation()) is not None:
                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/Users/jumerckx/eqsat/xdsl/xdsl/parser/core.py", line 690, in parse_optional_operation
    return self.parse_operation()
           ~~~~~~~~~~~~~~~~~~~~^^
  File "/Users/jumerckx/eqsat/xdsl/xdsl/parser/core.py", line 719, in parse_operation
    op = op_type.parse(self)
  File "/Users/jumerckx/eqsat/xdsl/xdsl/dialects/builtin.py", line 2300, in parse
    region = parser.parse_region()
  File "/Users/jumerckx/eqsat/xdsl/xdsl/parser/core.py", line 608, in parse_region
    region = self.parse_optional_region(arguments)
  File "/Users/jumerckx/eqsat/xdsl/xdsl/parser/core.py", line 562, in parse_optional_region
    self._parse_block_body(block)
    ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^
  File "/Users/jumerckx/eqsat/xdsl/xdsl/parser/core.py", line 224, in _parse_block_body
    while (op := self.parse_optional_operation()) is not None:
                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/Users/jumerckx/eqsat/xdsl/xdsl/parser/core.py", line 690, in parse_optional_operation
    return self.parse_operation()
           ~~~~~~~~~~~~~~~~~~~~^^
  File "/Users/jumerckx/eqsat/xdsl/xdsl/parser/core.py", line 719, in parse_operation
    op = op_type.parse(self)
  File "/Users/jumerckx/eqsat/xdsl/xdsl/dialects/pdl_interp.py", line 859, in parse
    ) = parse_func_op_like(
        ~~~~~~~~~~~~~~~~~~^
        parser, reserved_attr_names=("sym_name", "function_type")
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/Users/jumerckx/eqsat/xdsl/xdsl/dialects/utils/format.py", line 325, in parse_func_op_like
    region = parser.parse_optional_region(entry_args)
  File "/Users/jumerckx/eqsat/xdsl/xdsl/parser/core.py", line 553, in parse_optional_region
    self._parse_block_body(entry_block)
    ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "/Users/jumerckx/eqsat/xdsl/xdsl/parser/core.py", line 224, in _parse_block_body
    while (op := self.parse_optional_operation()) is not None:
                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/Users/jumerckx/eqsat/xdsl/xdsl/parser/core.py", line 690, in parse_optional_operation
    return self.parse_operation()
           ~~~~~~~~~~~~~~~~~~~~^^
  File "/Users/jumerckx/eqsat/xdsl/xdsl/parser/core.py", line 719, in parse_operation
    op = op_type.parse(self)
  File "/Users/jumerckx/eqsat/xdsl/xdsl/irdl/operations.py", line 2166, in parse_with_format
    return assembly_program.parse(parser, cls)
           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "/Users/jumerckx/eqsat/xdsl/xdsl/irdl/declarative_assembly_format.py", line 145, in parse
    stmt.parse(parser, state)
    ~~~~~~~~~~^^^^^^^^^^^^^^^
  File "/Users/jumerckx/eqsat/xdsl/xdsl/irdl/declarative_assembly_format.py", line 1459, in parse
    if ret := self.then_first.parse_optional(parser, state):
              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "/Users/jumerckx/eqsat/xdsl/xdsl/irdl/declarative_assembly_format.py", line 310, in parse_optional
    return self.parse(parser, state)
           ~~~~~~~~~~^^^^^^^^^^^^^^^
  File "/Users/jumerckx/eqsat/xdsl/xdsl/irdl/declarative_assembly_format.py", line 1205, in parse
    attr = self.parse_attr(parser)
  File "/Users/jumerckx/eqsat/xdsl/xdsl/irdl/declarative_assembly_format.py", line 1273, in parse_attr
    return unique_base.parse_with_type(parser, self.unique_type)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jumerckx/eqsat/xdsl/xdsl/dialects/builtin.py", line 960, in parse_with_type
    return IntegerAttr(parser.parse_integer(allow_boolean=(type == i1)), type)
                       ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jumerckx/eqsat/xdsl/xdsl/parser/base_parser.py", line 86, in parse_integer
    return self.expect(
           ~~~~~~~~~~~^
        lambda: self.parse_optional_integer(allow_boolean, allow_negative),
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        "Expected integer literal" + context_msg,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/Users/jumerckx/eqsat/xdsl/xdsl/parser/generic_parser.py", line 176, in expect
    self.raise_error(error_message)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "/Users/jumerckx/eqsat/xdsl/xdsl/parser/generic_parser.py", line 94, in raise_error
    raise ParseError(at_position, msg)
xdsl.utils.exceptions.ParseError: tests/filecheck/transforms/apply-eqsat-pdl-interp/apply_eqsat_pdl_interp_multi_ops.mlir:87:39
    %4 = eqsat_pdl_interp.get_results of %2 : !pdl.range<value>
                                      ^^
                                      Expected integer literal

```
