### PR TITLE
backend: split out base classes for asm printing and regalloc

### DIFF
--- a/tests/backend/riscv/test_register_allocation.py
+++ b/tests/backend/riscv/test_register_allocation.py
@@ -73,7 +73,9 @@ def test_default_reserved_registers():
 
 def test_allocate_with_inout_constraints():
     @irdl_op_definition
-    class MyInstructionOp(riscv.RISCVAsmOperation, IRDLOperation):
+    class MyInstructionOp(
+        riscv.RISCVAsmOperation, riscv.RISCVRegallocOperation, IRDLOperation
+    ):
         name = "riscv.my_instruction"
 
         rs0 = operand_def()

--- a/xdsl/dialects/arm/ops.py
+++ b/xdsl/dialects/arm/ops.py
@@ -15,13 +15,13 @@ from xdsl.irdl import (
 from .registers import IntRegisterType
 
 
-class ARMOperation(IRDLOperation, OneLineAssemblyPrintable, ABC):
+class ARMAsmOperation(IRDLOperation, OneLineAssemblyPrintable, ABC):
     """
     Base class for operations that can be a part of ARM assembly printing.
     """
 
 
-class ARMInstruction(ARMOperation, ABC):
+class ARMInstruction(ARMAsmOperation, ABC):
     """
     Base class for operations that can be a part of x86 assembly printing. Must
     represent an instruction in the x86 instruction set.
@@ -92,7 +92,7 @@ class DSMovOp(ARMInstruction):
 
 
 @irdl_op_definition
-class GetRegisterOp(ARMOperation):
+class GetRegisterOp(ARMAsmOperation):
     """
     This instruction allows us to create an SSAValue for a given register name.
     """
@@ -150,7 +150,7 @@ class DSSMulOp(ARMInstruction):
 
 
 @irdl_op_definition
-class LabelOp(ARMOperation):
+class LabelOp(ARMAsmOperation):
     """
     The label operation is used to emit text labels (e.g. loop:) that are used
     as branch, unconditional jump targets and symbol offsets.

--- a/xdsl/dialects/arm_func.py
+++ b/xdsl/dialects/arm_func.py
@@ -45,7 +45,7 @@ class FuncOpCallableInterface(CallableOpInterface):
 
 
 @irdl_op_definition
-class FuncOp(arm.ops.ARMOperation):
+class FuncOp(arm.ops.ARMAsmOperation):
     """ARM function definition operation"""
 
     name = "arm_func.func"

--- a/xdsl/dialects/arm_neon.py
+++ b/xdsl/dialects/arm_neon.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from typing import ClassVar
 
 from xdsl.backend.assembly_printer import reg
-from xdsl.dialects.arm.ops import ARMInstruction, ARMOperation
+from xdsl.dialects.arm.ops import ARMAsmOperation, ARMInstruction
 from xdsl.dialects.arm.registers import ARMRegisterType, IntRegisterType
 from xdsl.dialects.builtin import (
     IntegerAttr,
@@ -169,7 +169,7 @@ def variadic_neon_reg_arg(
 
 
 @irdl_op_definition
-class GetRegisterOp(ARMOperation):
+class GetRegisterOp(ARMAsmOperation):
     """
     This instruction allows us to create an SSAValue for a given register name.
     """

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -357,14 +357,21 @@ class LabelAttr(Data[str]):
             printer.print_string_literal(self.data)
 
 
-class RISCVAsmOperation(
-    HasRegisterConstraints, IRDLOperation, OneLineAssemblyPrintable, ABC
-):
+class RISCVAsmOperation(IRDLOperation, OneLineAssemblyPrintable, ABC):
     """
     Base class for operations that can be a part of RISC-V assembly printing.
     """
 
+
+class RISCVRegallocOperation(HasRegisterConstraints, IRDLOperation, ABC):
+    """
+    Base class for operations that can take part in register allocation.
+    """
+
     def get_register_constraints(self) -> RegisterConstraints:
+        # The default register constraints are that all operands are "in", and all
+        # results are "out" registers.
+        # If some registers are "inout" then this function must be overridden.
         return RegisterConstraints(self.operands, self.results, ())
 
 
@@ -453,7 +460,7 @@ AssemblyInstructionArg: TypeAlias = (
 )
 
 
-class RISCVInstruction(RISCVAsmOperation, ABC):
+class RISCVInstruction(RISCVAsmOperation, RISCVRegallocOperation, ABC):
     """
     Base class for operations that can be a part of RISC-V assembly printing. Must
     represent an instruction in the RISC-V instruction set, and have the following format:
@@ -3519,7 +3526,7 @@ class EcallOp(NullaryOperation):
 
 
 @irdl_op_definition
-class LabelOp(RISCVCustomFormatOperation, RISCVAsmOperation):
+class LabelOp(RISCVCustomFormatOperation, RISCVAsmOperation, RISCVRegallocOperation):
     """
     The label operation is used to emit text labels (e.g. loop:) that are used
     as branch, unconditional jump targets and symbol offsets.
@@ -3574,7 +3581,9 @@ class LabelOp(RISCVCustomFormatOperation, RISCVAsmOperation):
 
 
 @irdl_op_definition
-class DirectiveOp(RISCVCustomFormatOperation, RISCVAsmOperation):
+class DirectiveOp(
+    RISCVCustomFormatOperation, RISCVAsmOperation, RISCVRegallocOperation
+):
     """
     The directive operation is used to emit assembler directives (e.g. .word; .equ; etc.)
     without any associated region of assembly code.
@@ -3761,7 +3770,7 @@ class CustomAssemblyInstructionOp(RISCVCustomFormatOperation, RISCVInstruction):
 
 
 @irdl_op_definition
-class CommentOp(RISCVCustomFormatOperation, RISCVAsmOperation):
+class CommentOp(RISCVCustomFormatOperation, RISCVAsmOperation, RISCVRegallocOperation):
     name = "riscv.comment"
     comment = attr_def(StringAttr)
 
@@ -3810,7 +3819,11 @@ class WfiOp(NullaryOperation):
 
 
 class GetAnyRegisterOperation(
-    RISCVCustomFormatOperation, RISCVAsmOperation, ABC, Generic[RDInvT]
+    RISCVCustomFormatOperation,
+    RISCVAsmOperation,
+    RISCVRegallocOperation,
+    ABC,
+    Generic[RDInvT],
 ):
     """
     This instruction allows us to create an SSAValue with for a given register name. This

--- a/xdsl/dialects/riscv_snitch.py
+++ b/xdsl/dialects/riscv_snitch.py
@@ -26,6 +26,7 @@ from xdsl.dialects.riscv import (
     RISCVAsmOperation,
     RISCVCustomFormatOperation,
     RISCVInstruction,
+    RISCVRegallocOperation,
     RISCVRegisterType,
     RsRsIntegerOperation,
     SImm12Attr,
@@ -150,7 +151,9 @@ class ScfgwiOp(RISCVCustomFormatOperation, RISCVInstruction):
 
 
 @irdl_op_definition
-class FrepYieldOp(AbstractYieldOperation[Attribute], RISCVAsmOperation):
+class FrepYieldOp(
+    AbstractYieldOperation[Attribute], RISCVAsmOperation, RISCVRegallocOperation
+):
     name = "riscv_snitch.frep_yield"
 
     traits = lazy_traits_def(
@@ -162,7 +165,7 @@ class FrepYieldOp(AbstractYieldOperation[Attribute], RISCVAsmOperation):
 
 
 @irdl_op_definition
-class ReadOp(RISCVAsmOperation):
+class ReadOp(RISCVAsmOperation, RISCVRegallocOperation):
     name = "riscv_snitch.read"
 
     T: ClassVar = VarConstraint("T", AnyAttr())
@@ -191,7 +194,7 @@ class ReadOp(RISCVAsmOperation):
 
 
 @irdl_op_definition
-class WriteOp(RISCVAsmOperation):
+class WriteOp(RISCVAsmOperation, RISCVRegallocOperation):
     name = "riscv_snitch.write"
 
     T: ClassVar = VarConstraint("T", AnyAttr())
@@ -542,7 +545,7 @@ class FrepInnerOp(FRepOperation):
 
 
 @irdl_op_definition
-class GetStreamOp(RISCVAsmOperation):
+class GetStreamOp(RISCVAsmOperation, RISCVRegallocOperation):
     name = "riscv_snitch.get_stream"
 
     stream = result_def(

--- a/xdsl/dialects/x86/ops.py
+++ b/xdsl/dialects/x86/ops.py
@@ -117,20 +117,23 @@ R3InvT = TypeVar("R3InvT", bound=X86RegisterType)
 R4InvT = TypeVar("R4InvT", bound=X86RegisterType)
 
 
-class X86AsmOperation(
-    IRDLOperation, HasRegisterConstraints, OneLineAssemblyPrintable, ABC
-):
+class X86AsmOperation(IRDLOperation, OneLineAssemblyPrintable, ABC):
     """
     Base class for operations that can be a part of x86 assembly printing.
     """
 
+
+class X86RegallocOperation(IRDLOperation, HasRegisterConstraints, ABC):
+    """
+    Base class for operations that can take part in register allocation.
+    """
+
     traits = traits_def(RegisterAllocatedMemoryEffect())
 
-    @abstractmethod
-    def assembly_line(self) -> str | None:
-        raise NotImplementedError()
-
     def get_register_constraints(self) -> RegisterConstraints:
+        # The default register constraints are that all operands are "in", and all
+        # results are "out" registers.
+        # If some registers are "inout" then this function must be overridden.
         return RegisterConstraints(self.operands, self.results, ())
 
 
@@ -218,7 +221,7 @@ class X86CustomFormatOperation(IRDLOperation, ABC):
         printer.print_operation_type(self)
 
 
-class X86Instruction(X86AsmOperation):
+class X86Instruction(X86AsmOperation, X86RegallocOperation):
     """
     Base class for operations that can be a part of x86 assembly printing. Must
     represent an instruction in the x86 instruction set.
@@ -2399,7 +2402,7 @@ class M_ImulOp(X86Instruction, X86CustomFormatOperation):
 
 
 @irdl_op_definition
-class LabelOp(X86AsmOperation, X86CustomFormatOperation):
+class LabelOp(X86AsmOperation, X86RegallocOperation, X86CustomFormatOperation):
     """
     The label operation is used to emit text labels (e.g. loop:) that are used
     as branch, unconditional jump targets and symbol offsets.
@@ -2452,7 +2455,7 @@ class LabelOp(X86AsmOperation, X86CustomFormatOperation):
 
 
 @irdl_op_definition
-class DirectiveOp(X86AsmOperation, X86CustomFormatOperation):
+class DirectiveOp(X86AsmOperation, X86RegallocOperation, X86CustomFormatOperation):
     """
     The directive operation is used to represent a directive in the assembly code. (e.g. .globl; .type etc)
     """
@@ -2603,7 +2606,7 @@ class C_JmpOp(X86Instruction, X86CustomFormatOperation):
 
 
 @irdl_op_definition
-class FallthroughOp(X86AsmOperation, X86CustomFormatOperation):
+class FallthroughOp(X86AsmOperation, X86RegallocOperation, X86CustomFormatOperation):
     """
     Continue execution into the next block.
     The successor of this operation must be immediately after this operation's parent.
@@ -3588,7 +3591,11 @@ class DSSI_ShufpsOp(
 
 
 class GetAnyRegisterOperation(
-    X86AsmOperation, X86CustomFormatOperation, ABC, Generic[R1InvT]
+    X86AsmOperation,
+    X86RegallocOperation,
+    X86CustomFormatOperation,
+    ABC,
+    Generic[R1InvT],
 ):
     """
     This instruction allows us to create an SSAValue for a given register name.


### PR DESCRIPTION
A bit of separation of concerns in the dialects. My proposed structure is an ABC per concern, and than an "instruction" ABC to provide some helpers for common functionality. The two main things going on right now are assembly printing and register allocation (in an upcoming PR better memory effects helpers also). In main, these are mixed together in a single ASMOperation, whereas I think these should be split out.