### PR TITLE
testing: use unittest.mock instead of manual override for pyclip_copy

### DIFF
--- a/tests/interactive/test_app.py
+++ b/tests/interactive/test_app.py
@@ -1,4 +1,5 @@
 from typing import Any, cast
+from unittest.mock import patch
 
 import pytest
 from textual.screen import Screen
@@ -16,7 +17,6 @@ from xdsl.dialects.builtin import (
     ModuleOp,
     UnrealizedConversionCastOp,
 )
-from xdsl.interactive import _pasteboard
 from xdsl.interactive.add_arguments_screen import AddArguments
 from xdsl.interactive.app import InputApp
 from xdsl.interactive.passes import get_condensed_pass_list, get_new_registered_context
@@ -197,13 +197,11 @@ builtin.module {
         )
 
         # Test that the current pipeline command is correctly copied
-        def callback(x: str):
-            assert (
-                x == "xdsl-opt -p 'convert-func-to-riscv-func,convert-arith-to-riscv'"
+        with patch("xdsl.interactive.app.pyclip_copy") as mock_copy:
+            await pilot.click("#copy_query_button")
+            mock_copy.assert_called_once_with(
+                "xdsl-opt -p 'convert-func-to-riscv-func,convert-arith-to-riscv'"
             )
-
-        _pasteboard._test_pyclip_callback = callback  # pyright: ignore[reportPrivateUsage]
-        await pilot.click("#copy_query_button")
 
         current_pipeline = app.pass_pipeline
         # press "Remove Last Pass" button

--- a/xdsl/interactive/_pasteboard.py
+++ b/xdsl/interactive/_pasteboard.py
@@ -3,18 +3,8 @@ We use pyclip to copy text to the local pasteboard, but pyclip does not have typ
 annotations. We add our own mirror of the copy function here.
 """
 
-from collections.abc import Callable
-
-_test_pyclip_callback: Callable[[str], None] | None = None
-"""Used in tests."""
-
 
 def pyclip_copy(text: str) -> None:
-    global _test_pyclip_callback
-    if _test_pyclip_callback is not None:
-        _test_pyclip_callback(text)
-        return
-
     import pyclip  # pyright: ignore[reportMissingTypeStubs]
 
     pyclip.copy(text)  # pyright: ignore[reportUnknownMemberType]


### PR DESCRIPTION
I wasn't aware of the mocking helpers when I added this.