### PR TITLE
transformations: (riscv-lowering-parallel-mov) Add helper to insert MvOp

### DIFF
--- a/xdsl/transforms/riscv_lower_parallel_mov.py
+++ b/xdsl/transforms/riscv_lower_parallel_mov.py
@@ -5,7 +5,7 @@ from typing import cast
 
 from xdsl.context import Context
 from xdsl.dialects import riscv
-from xdsl.dialects.builtin import ModuleOp, SSAValue
+from xdsl.dialects.builtin import ModuleOp
 from xdsl.ir import Operation, SSAValue, SSAValues
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (


### PR DESCRIPTION
This PR extracts the common logic of creating a mvop and inserting it into its own helper.

See https://github.com/xdslproject/xdsl/pull/5512#discussion_r2658968103