### PR TITLE
transformations: (lower-riscv-func) avoid GreedyRewritePatternApplier

### DIFF
--- a/xdsl/transforms/lower_riscv_func.py
+++ b/xdsl/transforms/lower_riscv_func.py
@@ -6,7 +6,6 @@ from xdsl.dialects.builtin import ModuleOp
 from xdsl.ir import Operation
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
-    GreedyRewritePatternApplier,
     PatternRewriter,
     PatternRewriteWalker,
     RewritePattern,
@@ -86,10 +85,4 @@ class LowerRISCVFunc(ModulePass):
             PatternRewriteWalker(
                 InsertExitSyscallOp(), apply_recursively=False
             ).rewrite_module(op)
-        PatternRewriteWalker(
-            GreedyRewritePatternApplier(
-                [
-                    LowerSyscallOp(),
-                ]
-            )
-        ).rewrite_module(op)
+        PatternRewriteWalker(LowerSyscallOp()).rewrite_module(op)


### PR DESCRIPTION
Unnecessary for single rewrite pattern.