### PR TITLE
backend: fix register allocation for operations with multiple outputs

### DIFF
--- a/tests/backend/riscv/test_register_allocation.py
+++ b/tests/backend/riscv/test_register_allocation.py
@@ -141,23 +141,3 @@ def test_count_reg_types():
         "riscv.reg": {"a0", "a1"},
         "riscv.freg": {"fa0"},
     }
-
-
-def test_multiple_outputs():
-    class AllocatableTestOp(TestOp, riscv.RISCVRegallocOperation):
-        pass
-
-    available_registers = RiscvRegisterStack(allow_infinite=True)
-    register_allocator = RegisterAllocatorLivenessBlockNaive(available_registers)
-
-    op = AllocatableTestOp(
-        result_types=(
-            riscv.IntRegisterType.unallocated(),
-            riscv.IntRegisterType.unallocated(),
-        )
-    )
-
-    op.allocate_registers(register_allocator)
-
-    # Check allocated registers are unique
-    assert len(op.result_types) == len(set(op.result_types))


### PR DESCRIPTION
Currently, the default behaviour for RISCV's register allocation for operations will allocate an output, then free the result before allocating the next output. This can lead to all outputs being allocated to the same register.

This PR ensures all outputs are allocated before they are freed so outputs can't be allocated to the same register.