### PR TITLE
frontend: (pyast) add support for implicit return none

### DIFF
--- a/tests/filecheck/frontend/pypdl/pdl.py
+++ b/tests/filecheck/frontend/pypdl/pdl.py
@@ -44,7 +44,6 @@ ctx.register_function(erase_op, pdl.EraseOp)
 @ctx.parse_program
 def constant_replace(matched_operation: arith.ConstantOp):
     erase_op(matched_operation)
-    return
 
 
 # Check that the DSL correctly rewrites on the xDSL data structures

--- a/xdsl/frontend/pyast/code_generation.py
+++ b/xdsl/frontend/pyast/code_generation.py
@@ -414,6 +414,11 @@ class CodeGenerationVisitor(ast.NodeVisitor):
         for stmt in node.body:
             self.visit(stmt)
 
+        # If function does not end with a return statement to be visited, we
+        # must insert a ReturnOp here.
+        if not isinstance(node.body[-1], ast.Return):
+            self.inserter.insert_op(func.ReturnOp())
+
         # When function definition is processed, reset the symbol table and set
         # the insertion point.
         self.symbol_table = None


### PR DESCRIPTION
This allows implicit `return None` in pyast and removes the dummy return statement from `tests/filecheck/frontend/pypdl/pdl.py`.
