### PR TITLE
dialects: (llvm) change ReturnOp to take an SSAValue operand

### DIFF
--- a/tests/dialects/test_llvm.py
+++ b/tests/dialects/test_llvm.py
@@ -273,6 +273,29 @@ def test_implicit_void_func_return():
     assert isinstance(func_type.output, llvm.LLVMVoidType)
 
 
+def test_return_op_with_value():
+    const = arith.ConstantOp.from_int_and_width(42, 32)
+    val = const.result
+
+    op = llvm.ReturnOp(val)
+
+    assert op.arg == val
+    assert op.operands[0] == val
+    assert len(op.operands) == 1
+
+
+def test_return_op_with_none():
+    op_none = llvm.ReturnOp(None)
+    assert op_none.arg is None
+    assert len(op_none.operands) == 0
+
+
+def test_return_op_empty():
+    op_empty = llvm.ReturnOp()
+    assert op_empty.arg is None
+    assert len(op_empty.operands) == 0
+
+
 def test_calling_conv():
     cconv = llvm.CallingConventionAttr("cc 11")
     cconv.verify()

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -1700,8 +1700,8 @@ class ReturnOp(IRDLOperation):
 
     traits = traits_def(IsTerminator(), NoMemoryEffect())
 
-    def __init__(self, value: Attribute | None = None):
-        super().__init__(attributes={"value": value})
+    def __init__(self, value: SSAValue | None = None):
+        super().__init__(operands=[value])
 
 
 @irdl_op_definition


### PR DESCRIPTION
The `llvm.return` operation was previously incorrectly initialized with an `Attribute`. This commit changes the `__init__` method to accept an `SSAValue` instead, allowing it to return dynamic values computed by other operations.
