### PR TITLE
backend: (riscv) add option to force infinite registers during register allocation

### DIFF
--- a/tests/filecheck/transforms/test-riscv-force-infinite.mlir
+++ b/tests/filecheck/transforms/test-riscv-force-infinite.mlir
@@ -1,0 +1,15 @@
+// RUN: xdsl-opt --split-input-file -p "riscv-allocate-registers{allocation_strategy=LivenessBlockNaive force_infinite=true}" %s | filecheck %s
+
+// check that infinite registers are used
+riscv_func.func @main() {
+    %0, %1 = "test.op"() : () -> (!riscv.reg, !riscv.reg)
+    %2, %3 = riscv.parallel_mov %0, %1 [32, 32] : (!riscv.reg, !riscv.reg) -> (!riscv.reg, !riscv.reg)
+    riscv_func.return
+}
+// CHECK:       builtin.module {
+// CHECK-NEXT:    riscv_func.func @main() {
+// CHECK-NEXT:      %0, %1 = "test.op"() : () -> (!riscv.reg<j_0>, !riscv.reg<j_1>)
+// CHECK-NEXT:      %2, %3 = riscv.parallel_mov %0, %1 [32, 32] : (!riscv.reg<j_0>, !riscv.reg<j_1>) -> (!riscv.reg<j_0>, !riscv.reg<j_1>)
+// CHECK-NEXT:      riscv_func.return
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/xdsl/transforms/riscv_allocate_registers.py
+++ b/xdsl/transforms/riscv_allocate_registers.py
@@ -28,6 +28,11 @@ class RISCVAllocateRegistersPass(ModulePass):
     Whether to allow using infinite registers during register allocation.
     """
 
+    force_infinite: bool = False
+    """
+    Only use infinite registers during register allocation.
+    """
+
     def apply(self, ctx: Context, op: ModuleOp) -> None:
         allocator_strategies = {
             "LivenessBlockNaive": RegisterAllocatorLivenessBlockNaive,
@@ -42,7 +47,8 @@ class RISCVAllocateRegistersPass(ModulePass):
         for inner_op in op.walk():
             if isinstance(inner_op, riscv_func.FuncOp):
                 register_stack = RiscvRegisterStack.get(
-                    allow_infinite=self.allow_infinite
+                    allow_infinite=self.allow_infinite | self.force_infinite,
+                    allocatable_registers=() if self.force_infinite else None,
                 )
                 allocator = allocator_strategies[self.allocation_strategy](
                     register_stack


### PR DESCRIPTION
This PR adds an argument to the RISC-V register allocation pass to only use infinite registers for allocation. 