### PR TITLE
bug: (irdl): Fix RangeVarConstraint

### DIFF
--- a/xdsl/irdl/constraints.py
+++ b/xdsl/irdl/constraints.py
@@ -1225,7 +1225,7 @@ class RangeVarConstraint(RangeConstraint[AttributeCovT]):
     ) -> None:
         ctx_attrs = constraint_context.get_range_variable(self.name)
         if ctx_attrs is not None:
-            if attrs != ctx_attrs:
+            if tuple(attrs) != ctx_attrs:
                 raise VerifyException(
                     f"attributes {tuple(str(x) for x in ctx_attrs)} expected from range variable "
                     f"'{self.name}', but got {tuple(str(x) for x in attrs)}"


### PR DESCRIPTION
Fixes how ranges of attributes are compared for equality in RangeVarConstraint.
Previously, `==` was used directly between instances of `Sequence[Attribute]` and `tuple[Attribute, ...]`  which results in lists and tuples containing the same elements being found to be unequal. 