### PR TITLE
dialects: (x86) standardise signedness of immediates

### DIFF
--- a/tests/dialects/test_x86.py
+++ b/tests/dialects/test_x86.py
@@ -1,7 +1,7 @@
 import pytest
 
 from xdsl.dialects import x86
-from xdsl.dialects.builtin import IntegerAttr, i32
+from xdsl.dialects.builtin import IntegerAttr
 from xdsl.dialects.x86.ops import (
     DM_LeaOp,
     DM_MovOp,
@@ -37,6 +37,7 @@ from xdsl.dialects.x86.ops import (
     RM_SubOp,
     RM_XorOp,
     SM_CmpOp,
+    si32,
 )
 from xdsl.ir import Block, Operation
 from xdsl.traits import MemoryReadEffect
@@ -353,11 +354,11 @@ def test_get_constant_value():
     unknown_value = create_ssa_value(U)
     assert get_constant_value(unknown_value) is None
     known_value = x86.DI_MovOp(42, destination=U).destination
-    assert get_constant_value(known_value) == IntegerAttr(42, i32)
+    assert get_constant_value(known_value) == IntegerAttr(42, si32)
     moved_once = x86.DS_MovOp(known_value, destination=U).destination
-    assert get_constant_value(moved_once) == IntegerAttr(42, i32)
+    assert get_constant_value(moved_once) == IntegerAttr(42, si32)
     moved_twice = x86.DS_MovOp(known_value, destination=U).destination
-    assert get_constant_value(moved_twice) == IntegerAttr(42, i32)
+    assert get_constant_value(moved_twice) == IntegerAttr(42, si32)
 
     block = Block(arg_types=(U,))
     assert get_constant_value(block.args[0]) is None


### PR DESCRIPTION
Memory offset are signed 64 bits, immediates are signed 32 bits, shuffle are unsigned 8 bits.

I'm not totally happy with this, as my impression is that x86 is much more flexible, but at least it's now consistent.

This also opens the door to declarative assembly format.