### PR TITLE
dialects: (riscv) replace ImmAttr types with integer types

### DIFF
--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from collections.abc import Set as AbstractSet
 from io import StringIO
-from typing import IO, Annotated, ClassVar, Generic, Literal, TypeAlias, cast
+from typing import IO, ClassVar, Generic, Literal, TypeAlias, cast
 
 from typing_extensions import Self, TypeVar
 
@@ -52,7 +52,6 @@ from xdsl.irdl import (
     RangeOf,
     VarOpResult,
     attr_def,
-    base,
     irdl_attr_definition,
     irdl_op_definition,
     operand_def,
@@ -338,17 +337,16 @@ class Registers(ABC):
     FS = (FS0, FS1, FS2, FS3, FS4, FS5, FS6, FS7, FS8, FS9, FS10, FS11)
 
 
-ui5 = IntegerType(5, Signedness.UNSIGNED)
-si20 = IntegerType(20, Signedness.SIGNED)
-si12 = IntegerType(12, Signedness.SIGNED)
-i12 = IntegerType(12, Signedness.SIGNLESS)
-i20 = IntegerType(20, Signedness.SIGNLESS)
-UImm5Attr = IntegerAttr[Annotated[IntegerType, ui5]]
-SImm12Attr = IntegerAttr[Annotated[IntegerType, si12]]
-SImm20Attr = IntegerAttr[Annotated[IntegerType, si20]]
-Imm12Attr = IntegerAttr[Annotated[IntegerType, i12]]
-Imm20Attr = IntegerAttr[Annotated[IntegerType, i20]]
-Imm32Attr = IntegerAttr[Annotated[IntegerType, i32]]
+UI5: TypeAlias = IntegerType[Literal[5], Literal[Signedness.UNSIGNED]]
+SI20: TypeAlias = IntegerType[Literal[20], Literal[Signedness.SIGNED]]
+SI12: TypeAlias = IntegerType[Literal[12], Literal[Signedness.SIGNED]]
+I12: TypeAlias = IntegerType[Literal[12], Literal[Signedness.SIGNLESS]]
+I20: TypeAlias = IntegerType[Literal[20], Literal[Signedness.SIGNLESS]]
+ui5: UI5 = IntegerType(5, Signedness.UNSIGNED)
+si20: SI20 = IntegerType(20, Signedness.SIGNED)
+si12: SI12 = IntegerType(12, Signedness.SIGNED)
+i12: I12 = IntegerType(12, Signedness.SIGNLESS)
+i20: I20 = IntegerType(20, Signedness.SIGNLESS)
 
 
 @irdl_attr_definition
@@ -670,7 +668,7 @@ class RdImmIntegerOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC):
     """
 
     rd = result_def(IntRegisterType)
-    immediate = attr_def(base(Imm20Attr) | base(LabelAttr))
+    immediate = attr_def(IntegerAttr[I20] | LabelAttr)
 
     def __init__(
         self,
@@ -722,11 +720,11 @@ class RdImmJumpOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC):
     The rd register here is not a register storing the result, rather the register where
     the program counter is stored before jumping.
     """
-    immediate = attr_def(base(SImm20Attr) | base(LabelAttr))
+    immediate = attr_def(IntegerAttr[SI20] | LabelAttr)
 
     def __init__(
         self,
-        immediate: int | SImm20Attr | str | LabelAttr,
+        immediate: int | IntegerAttr[SI20] | str | LabelAttr,
         *,
         rd: IntRegisterType | None = None,
         comment: str | StringAttr | None = None,
@@ -784,12 +782,12 @@ class RdRsImmIntegerOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC)
 
     rd = result_def(IntRegisterType)
     rs1 = operand_def(IntRegisterType)
-    immediate = attr_def(base(SImm12Attr) | base(LabelAttr))
+    immediate = attr_def(IntegerAttr[SI12] | LabelAttr)
 
     def __init__(
         self,
         rs1: Operation | SSAValue,
-        immediate: int | SImm12Attr | str | LabelAttr,
+        immediate: int | IntegerAttr[SI12] | str | LabelAttr,
         *,
         rd: IntRegisterType = Registers.UNALLOCATED_INT,
         comment: str | StringAttr | None = None,
@@ -841,12 +839,12 @@ class RdRsImmShiftOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC):
 
     rd = result_def(IntRegisterType)
     rs1 = operand_def(IntRegisterType)
-    immediate = attr_def(base(UImm5Attr) | base(LabelAttr))
+    immediate = attr_def(IntegerAttr[UI5] | LabelAttr)
 
     def __init__(
         self,
         rs1: Operation | SSAValue,
-        immediate: int | UImm5Attr | str | LabelAttr,
+        immediate: int | IntegerAttr[UI5] | str | LabelAttr,
         *,
         rd: IntRegisterType = Registers.UNALLOCATED_INT,
         comment: str | StringAttr | None = None,
@@ -901,12 +899,12 @@ class RdRsImmJumpOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC):
     The rd register here is not a register storing the result, rather the register where
     the program counter is stored before jumping.
     """
-    immediate = attr_def(base(SImm12Attr) | base(LabelAttr))
+    immediate = attr_def(IntegerAttr[SI12] | LabelAttr)
 
     def __init__(
         self,
         rs1: Operation | SSAValue,
-        immediate: int | SImm12Attr | str | LabelAttr,
+        immediate: int | IntegerAttr[SI12] | str | LabelAttr,
         *,
         rd: IntRegisterType | None = None,
         comment: str | StringAttr | None = None,
@@ -1014,13 +1012,13 @@ class RsRsOffIntegerOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC)
 
     rs1 = operand_def(IntRegisterType)
     rs2 = operand_def(IntRegisterType)
-    offset = attr_def(base(SImm12Attr) | base(LabelAttr))
+    offset = attr_def(IntegerAttr[SI12] | LabelAttr)
 
     def __init__(
         self,
         rs1: Operation | SSAValue,
         rs2: Operation | SSAValue,
-        offset: int | SImm12Attr | LabelAttr,
+        offset: int | IntegerAttr[SI12] | LabelAttr,
         *,
         comment: str | StringAttr | None = None,
     ):
@@ -1064,13 +1062,13 @@ class RsRsImmIntegerOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC)
 
     rs1 = operand_def(IntRegisterType)
     rs2 = operand_def(IntRegisterType)
-    immediate = attr_def(SImm12Attr)
+    immediate = attr_def(IntegerAttr[SI12])
 
     def __init__(
         self,
         rs1: Operation | SSAValue,
         rs2: Operation | SSAValue,
-        immediate: int | Imm12Attr | str | LabelAttr,
+        immediate: int | IntegerAttr[SI12] | str | LabelAttr,
         *,
         comment: str | StringAttr | None = None,
     ):
@@ -2211,7 +2209,7 @@ class JOp(RdImmJumpOperation):
 
     def __init__(
         self,
-        immediate: int | SImm20Attr | str | LabelAttr,
+        immediate: int | IntegerAttr[SI20] | str | LabelAttr,
         *,
         comment: str | StringAttr | None = None,
     ):
@@ -3487,13 +3485,13 @@ class LiOp(RISCVCustomFormatOperation, RISCVInstruction, ConstantLikeInterface, 
     name = "riscv.li"
 
     rd = result_def(IntRegisterType)
-    immediate = attr_def(base(Imm32Attr) | base(LabelAttr))
+    immediate = attr_def(IntegerAttr[I32] | LabelAttr)
 
     traits = traits_def(Pure(), LiOpHasCanonicalizationPatternTrait())
 
     def __init__(
         self,
-        immediate: int | Imm32Attr | str | LabelAttr,
+        immediate: int | IntegerAttr[I32] | str | LabelAttr,
         *,
         rd: IntRegisterType = Registers.UNALLOCATED_INT,
         comment: str | StringAttr | None = None,
@@ -4075,13 +4073,13 @@ class RsRsImmFloatOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC):
 
     rs1 = operand_def(IntRegisterType)
     rs2 = operand_def(FloatRegisterType)
-    immediate = attr_def(Imm12Attr)
+    immediate = attr_def(IntegerAttr[I12])
 
     def __init__(
         self,
         rs1: Operation | SSAValue,
         rs2: Operation | SSAValue,
-        immediate: int | Imm12Attr | str | LabelAttr,
+        immediate: int | IntegerAttr[I12] | str | LabelAttr,
         *,
         comment: str | StringAttr | None = None,
     ):
@@ -4124,12 +4122,12 @@ class RdRsImmFloatOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC):
 
     rd = result_def(FloatRegisterType)
     rs1 = operand_def(IntRegisterType)
-    immediate = attr_def(base(Imm12Attr) | base(LabelAttr))
+    immediate = attr_def(IntegerAttr[I12] | LabelAttr)
 
     def __init__(
         self,
         rs1: Operation | SSAValue,
-        immediate: int | Imm12Attr | str | LabelAttr,
+        immediate: int | IntegerAttr[I12] | str | LabelAttr,
         *,
         rd: FloatRegisterType = Registers.UNALLOCATED_FLOAT,
         comment: str | StringAttr | None = None,

--- a/xdsl/dialects/riscv_func.py
+++ b/xdsl/dialects/riscv_func.py
@@ -7,13 +7,14 @@ from xdsl.backend.register_type import RegisterType
 from xdsl.dialects import riscv
 from xdsl.dialects.builtin import (
     I8,
+    I32,
     FunctionType,
     IntegerAttr,
-    IntegerType,
     StringAttr,
     SymbolNameConstraint,
     SymbolRefAttr,
     i8,
+    i32,
 )
 from xdsl.dialects.utils import (
     parse_func_op_like,
@@ -48,17 +49,17 @@ from xdsl.utils.exceptions import DiagnosticException, VerifyException
 class SyscallOp(IRDLOperation):
     name = "riscv_func.syscall"
     args = var_operand_def(riscv.IntRegisterType)
-    syscall_num = attr_def(IntegerAttr[IntegerType])
+    syscall_num = attr_def(IntegerAttr[I32])
     result = opt_result_def(riscv.IntRegisterType)
 
     def __init__(
         self,
-        num: int | IntegerAttr,
+        num: int | IntegerAttr[I32],
         has_result: bool = False,
         operands: list[SSAValue | Operation] = [],
     ):
         if isinstance(num, int):
-            num = IntegerAttr.from_int_and_width(num, 32)
+            num = IntegerAttr(num, i32)
         super().__init__(
             operands=[operands],
             attributes={"syscall_num": num},

--- a/xdsl/dialects/riscv_snitch.py
+++ b/xdsl/dialects/riscv_snitch.py
@@ -13,11 +13,12 @@ from xdsl.dialects import riscv, snitch
 from xdsl.dialects.builtin import (
     IntegerAttr,
     IntegerType,
-    Signedness,
     StringAttr,
     UnrealizedConversionCastOp,
 )
 from xdsl.dialects.riscv import (
+    SI12,
+    UI5,
     AssemblyInstructionArg,
     FastMathFlagsAttr,
     FloatRegisterType,
@@ -29,11 +30,10 @@ from xdsl.dialects.riscv import (
     RISCVRegallocOperation,
     RISCVRegisterType,
     RsRsIntegerOperation,
-    SImm12Attr,
-    UImm5Attr,
     parse_immediate_value,
     print_immediate_value,
     si12,
+    ui5,
 )
 from xdsl.dialects.utils import (
     AbstractYieldOperation,
@@ -114,12 +114,12 @@ class ScfgwiOp(RISCVCustomFormatOperation, RISCVInstruction):
     name = "riscv_snitch.scfgwi"
 
     rs1 = operand_def(IntRegisterType)
-    immediate = attr_def(SImm12Attr)
+    immediate = attr_def(IntegerAttr[SI12])
 
     def __init__(
         self,
         rs1: Operation | SSAValue,
-        immediate: int | SImm12Attr,
+        immediate: int | IntegerAttr[SI12],
         *,
         comment: str | StringAttr | None = None,
     ):
@@ -714,7 +714,7 @@ class DMCopyImmOp(RISCVInstruction):
 
     dest = result_def(riscv.IntRegisterType)
     size = operand_def(riscv.IntRegisterType)
-    config = prop_def(UImm5Attr)
+    config = prop_def(IntegerAttr[UI5])
 
     assembly_format = (
         "$size `,` $config attr-dict `:` functional-type(operands, results)"
@@ -727,11 +727,11 @@ class DMCopyImmOp(RISCVInstruction):
     def __init__(
         self,
         size: SSAValue | Operation,
-        config: int | UImm5Attr,
+        config: int | IntegerAttr[UI5],
         result_type: IntRegisterType = riscv.Registers.UNALLOCATED_INT,
     ):
         if isinstance(config, int):
-            config = IntegerAttr(config, IntegerType(5, signedness=Signedness.UNSIGNED))
+            config = IntegerAttr(config, ui5)
         super().__init__(
             operands=[size],
             properties={"config": config},
@@ -747,7 +747,7 @@ class DMStatImmOp(RISCVInstruction):
     name = "riscv_snitch.dmstati"
 
     dest = result_def(riscv.IntRegisterType)
-    status = prop_def(UImm5Attr)
+    status = prop_def(IntegerAttr[UI5])
 
     assembly_format = "$status attr-dict `:` `(` `)` `->` type($dest)"
 
@@ -757,11 +757,11 @@ class DMStatImmOp(RISCVInstruction):
 
     def __init__(
         self,
-        status: int | UImm5Attr,
+        status: int | IntegerAttr[UI5],
         result_type: IntRegisterType = riscv.Registers.UNALLOCATED_INT,
     ):
         if isinstance(status, int):
-            status = IntegerAttr(status, IntegerType(5, signedness=Signedness.UNSIGNED))
+            status = IntegerAttr(status, ui5)
         super().__init__(
             properties={"status": status},
             result_types=[result_type],

--- a/xdsl/transforms/canonicalization_patterns/riscv.py
+++ b/xdsl/transforms/canonicalization_patterns/riscv.py
@@ -1,5 +1,5 @@
 from xdsl.dialects import riscv, riscv_snitch
-from xdsl.dialects.builtin import IntegerAttr
+from xdsl.dialects.builtin import I32, IntegerAttr, i32
 from xdsl.dialects.utils import FastMathFlag
 from xdsl.ir import OpResult, SSAValue
 from xdsl.pattern_rewriter import (
@@ -649,9 +649,9 @@ class LoadImmediate0(RewritePattern):
             )
 
 
-def get_constant_value(value: SSAValue) -> riscv.Imm32Attr | None:
+def get_constant_value(value: SSAValue) -> IntegerAttr[I32] | None:
     if value.type == riscv.Registers.ZERO:
-        return IntegerAttr.from_int_and_width(0, 32)
+        return IntegerAttr(0, i32)
 
     if not isinstance(value, OpResult):
         return


### PR DESCRIPTION
Standardises things a little bit, there's no need to have a special convention just for riscv.
