### PR TITLE
dialects: (ematch) Add ematch dialect definitions

### DIFF
--- a/tests/filecheck/dialects/ematch/ops.mlir
+++ b/tests/filecheck/dialects/ematch/ops.mlir
@@ -1,0 +1,49 @@
+// RUN: XDSL_ROUNDTRIP
+// RUN: XDSL_GENERIC_ROUNDTRIP
+
+
+// CHECK:      func.func @main(%val : !pdl.value, %valrange : !pdl.range<value>, %op : !pdl.operation) {
+// CHECK-NEXT:   %class_vals = ematch.get_class_vals %val
+// CHECK-NEXT:   %representative = ematch.get_class_representative %val
+// CHECK-NEXT:   %result = ematch.get_class_result %val
+// CHECK-NEXT:   %results = ematch.get_class_results %valrange
+// CHECK-NEXT:   ematch.union %val : !pdl.value, %val : !pdl.value
+// CHECK-NEXT:   ematch.union %op : !pdl.operation, %valrange : !pdl.range<value>
+// CHECK-NEXT:   ematch.union %valrange : !pdl.range<value>, %valrange : !pdl.range<value>
+// CHECK-NEXT:   %newop = ematch.dedup %op
+// CHECK-NEXT:   func.return
+// CHECK-NEXT: }
+
+// CHECK-GENERIC:     "func.func"() <{sym_name = "main", function_type = (!pdl.value, !pdl.range<value>, !pdl.operation) -> ()}> ({
+// CHECK-GENERIC-NEXT: ^bb0(%val : !pdl.value, %valrange : !pdl.range<value>, %op : !pdl.operation):
+// CHECK-GENERIC-NEXT:   %class_vals = "ematch.get_class_vals"(%val) : (!pdl.value) -> !pdl.range<value>
+// CHECK-GENERIC-NEXT:   %representative = "ematch.get_class_representative"(%val) : (!pdl.value) -> !pdl.value
+// CHECK-GENERIC-NEXT:   %result = "ematch.get_class_result"(%val) : (!pdl.value) -> !pdl.value
+// CHECK-GENERIC-NEXT:   %results = "ematch.get_class_results"(%valrange) : (!pdl.range<value>) -> !pdl.range<value>
+// CHECK-GENERIC-NEXT:   "ematch.union"(%val, %val) : (!pdl.value, !pdl.value) -> ()
+// CHECK-GENERIC-NEXT:   "ematch.union"(%op, %valrange) : (!pdl.operation, !pdl.range<value>) -> ()
+// CHECK-GENERIC-NEXT:   "ematch.union"(%valrange, %valrange) : (!pdl.range<value>, !pdl.range<value>) -> ()
+// CHECK-GENERIC-NEXT:   %newop = "ematch.dedup"(%op) : (!pdl.operation) -> !pdl.operation
+// CHECK-GENERIC-NEXT:   "func.return"() : () -> ()
+// CHECK-GENERIC-NEXT: }) : () -> ()
+
+
+
+func.func @main(%val: !pdl.value, %valrange: !pdl.range<value>, %op: !pdl.operation) -> ()
+{
+    %class_vals = ematch.get_class_vals %val
+    
+    %representative = ematch.get_class_representative %val
+    
+    %result = ematch.get_class_result %val
+    
+    %results = ematch.get_class_results %valrange
+    
+    ematch.union %val : !pdl.value, %val : !pdl.value
+    ematch.union %op : !pdl.operation, %valrange : !pdl.range<value>
+    ematch.union %valrange : !pdl.range<value>, %valrange : !pdl.range<value>
+    
+    %newop = ematch.dedup %op
+    
+    func.return
+}

--- a/xdsl/dialects/__init__.py
+++ b/xdsl/dialects/__init__.py
@@ -103,6 +103,11 @@ def get_all_dialects() -> dict[str, Callable[[], Dialect]]:
 
         return DMP
 
+    def get_ematch():
+        from xdsl.dialects.ematch import EMatch
+
+        return EMatch
+
     def get_emitc():
         from xdsl.dialects.emitc import EmitC
 
@@ -383,6 +388,7 @@ def get_all_dialects() -> dict[str, Callable[[], Dialect]]:
         "csl_wrapper": get_csl_wrapper,
         "dlti": get_dlti,
         "dmp": get_dmp,
+        "ematch": get_ematch,
         "emitc": get_emitc,
         "equivalence": get_equivalence,
         "eqsat_pdl_interp": get_eqsat_pdl_interp,

--- a/xdsl/dialects/__init__.py
+++ b/xdsl/dialects/__init__.py
@@ -104,9 +104,9 @@ def get_all_dialects() -> dict[str, Callable[[], Dialect]]:
         return DMP
 
     def get_ematch():
-        from xdsl.dialects.ematch import EMatch
+        from xdsl.dialects.ematch import Ematch
 
-        return EMatch
+        return Ematch
 
     def get_emitc():
         from xdsl.dialects.emitc import EmitC

--- a/xdsl/dialects/ematch.py
+++ b/xdsl/dialects/ematch.py
@@ -140,7 +140,7 @@ class DedupOp(IRDLOperation):
         )
 
 
-EMatch = Dialect(
+Ematch = Dialect(
     "ematch",
     [
         GetClassValsOp,

--- a/xdsl/dialects/ematch.py
+++ b/xdsl/dialects/ematch.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from xdsl.dialects.pdl import (
+    OperationType,
+    RangeType,
+    ValueType,
+)
+from xdsl.ir import (
+    Dialect,
+    SSAValue,
+)
+from xdsl.irdl import (
+    IRDLOperation,
+    irdl_op_definition,
+    operand_def,
+    result_def,
+)
+
+
+@irdl_op_definition
+class GetClassValsOp(IRDLOperation):
+    """
+    Take a value and return all values in its equivalence class.
+
+    If the value is an equivalence.class result, return the operands of the class,
+    otherwise return a range containing the value itself.
+    """
+
+    name = "ematch.get_class_vals"
+    value = operand_def(ValueType)
+    result = result_def(RangeType[ValueType])
+
+    assembly_format = "$value attr-dict"
+
+    def __init__(self, value: SSAValue) -> None:
+        super().__init__(
+            operands=[value],
+            result_types=[RangeType(ValueType())],
+        )
+
+
+@irdl_op_definition
+class GetClassRepresentativeOp(IRDLOperation):
+    """
+    Get one of the values in the equivalence class of v.
+    """
+
+    name = "ematch.get_class_representative"
+    value = operand_def(ValueType)
+    result = result_def(ValueType)
+
+    assembly_format = "$value attr-dict"
+
+    def __init__(self, value: SSAValue) -> None:
+        super().__init__(
+            operands=[value],
+            result_types=[ValueType()],
+        )
+
+
+@irdl_op_definition
+class GetClassResultOp(IRDLOperation):
+    """
+    Get the equivalence.class result corresponding to the equivalence class of v.
+    """
+
+    name = "ematch.get_class_result"
+    value = operand_def(ValueType)
+    result = result_def(ValueType)
+
+    assembly_format = "$value attr-dict"
+
+    def __init__(self, value: SSAValue) -> None:
+        super().__init__(
+            operands=[value],
+            result_types=[ValueType()],
+        )
+
+
+@irdl_op_definition
+class GetClassResultsOp(IRDLOperation):
+    """
+    Get the equivalence.class results corresponding to the equivalence classes
+    of a range of values.
+    """
+
+    name = "ematch.get_class_results"
+    values = operand_def(RangeType[ValueType])
+    result = result_def(RangeType[ValueType])
+
+    assembly_format = "$values attr-dict"
+
+    def __init__(self, values: SSAValue) -> None:
+        super().__init__(
+            operands=[values],
+            result_types=[RangeType(ValueType())],
+        )
+
+
+@irdl_op_definition
+class UnionOp(IRDLOperation):
+    """
+    Merge two values, an operation and a value range, or two value ranges
+    into equivalence class(es).
+
+    Supported operand type combinations:
+    - (value, value): merge two values
+    - (operation, range<value>): merge operation results with values
+    - (range<value>, range<value>): merge two value ranges
+    """
+
+    name = "ematch.union"
+    lhs = operand_def(ValueType | OperationType | RangeType[ValueType])
+    rhs = operand_def(ValueType | RangeType[ValueType])
+
+    assembly_format = "$lhs `:` type($lhs) `,` $rhs `:` type($rhs) attr-dict"
+
+    def __init__(self, lhs: SSAValue, rhs: SSAValue) -> None:
+        super().__init__(operands=[lhs, rhs])
+
+
+@irdl_op_definition
+class DedupOp(IRDLOperation):
+    """
+    Check if the operation already exists in the hashcons.
+
+    If so, remove the new one and return the existing one.
+    """
+
+    name = "ematch.dedup"
+    input_op = operand_def(OperationType)
+    result_op = result_def(OperationType)
+
+    assembly_format = "$input_op attr-dict"
+
+    def __init__(self, input_op: SSAValue) -> None:
+        super().__init__(
+            operands=[input_op],
+            result_types=[OperationType()],
+        )
+
+
+EMatch = Dialect(
+    "ematch",
+    [
+        GetClassValsOp,
+        GetClassRepresentativeOp,
+        GetClassResultOp,
+        GetClassResultsOp,
+        UnionOp,
+        DedupOp,
+    ],
+)


### PR DESCRIPTION
This can replace the existing eqsat_pdl_interp overrides. I'll also update the dialect name from `tamatch` to `ematch` in Tamagoyaki?
