### PR TITLE
documentation: Fix mlir_introduction notebook exercise

### DIFF
--- a/docs/marimo/mlir_introduction.py
+++ b/docs/marimo/mlir_introduction.py
@@ -453,10 +453,15 @@ def _(lmo, mo):
 
 
 @app.cell
-def _(mo, to_mlir, write_editor, write_listlang):
+def _(mo, parse_mlir, to_mlir, write_editor, write_listlang):
     write_mlir = to_mlir(write_listlang)
 
-    write_check = "✅ " if str(write_mlir) == str(write_editor.value) else "❌"
+    try:
+        user = parse_mlir(write_editor.value)
+    except:
+        user = ""
+
+    write_check = "✅ " if str(write_mlir) == str(user) else "❌"
 
     write_hint = """/// details | Need a hint?
     * Make sure the names are correct


### PR DESCRIPTION
The exercise was requiring users to pass a `builtin.module`, which should not be the case.
The workaround is to parse their input and then extract the `builtin.module`