### PR TITLE
transformations: (approximate-math-with-bitcast) Add base pass

### DIFF
--- a/tests/filecheck/transforms/approximate-math-with-bitcast.mlir
+++ b/tests/filecheck/transforms/approximate-math-with-bitcast.mlir
@@ -1,0 +1,32 @@
+// RUN: xdsl-opt -p approximate-math-with-bitcast %s | filecheck %s
+
+
+// CHECK-LABEL: @test_log
+func.func @test_log (%x: f32) -> f32 {
+  %a = math.log %x : f32
+//CHECK:      %a = arith.constant 0.693147182 : f32
+//CHECK-NEXT: %a_1 = arith.constant 0x4B000000 : f32
+//CHECK-NEXT: %a_2 = arith.constant 1.06497574e+09 : f32
+//CHECK-NEXT: %a_3 = arith.mulf %a_1, %x : f32
+//CHECK-NEXT: %a_4 = arith.addf %a_2, %a_3 : f32
+//CHECK-NEXT: %a_5 = arith.fptosi %a_4 : f32 to i32
+//CHECK-NEXT: %a_6 = arith.bitcast %a_5 : i32 to f32
+//CHECK-NEXT: %a_7 = arith.mulf %a, %a_6 : f32
+  return %a : f32
+//CHECK-NEXT: return %a_7 : f32
+}
+
+//CHECK-LABEL: @test_exp
+func.func @test_exp (%x: f32) -> f32 {
+  %b = math.exp %x : f32
+// CHECK:      %b = arith.constant 1.44269502 : f32
+// CHECK-NEXT: %b_1 = arith.mulf %b, %x : f32
+// CHECK-NEXT: %b_2 = arith.constant 1.1920929e-07 : f32
+// CHECK-NEXT: %b_3 = arith.constant -1.269550e+02 : f32
+// CHECK-NEXT: %b_4 = arith.bitcast %b_1 : f32 to i32
+// CHECK-NEXT: %b_5 = arith.sitofp %b_4 : i32 to f32
+// CHECK-NEXT: %b_6 = arith.mulf %b_2, %b_5 : f32
+// CHECK-NEXT: %b_7 = arith.addf %b_3, %b_6 : f32
+  return %b : f32
+// CHECK-NEXT: return %b_7 : f32
+}

--- a/xdsl/transforms/__init__.py
+++ b/xdsl/transforms/__init__.py
@@ -315,6 +315,11 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
 
         return eqsat_extract.EqsatExtractPass
 
+    def get_approximate_math_with_bitcast():
+        from xdsl.transforms import approximate_math_with_bitcast
+
+        return approximate_math_with_bitcast.BitcastApproximation
+
     def get_frontend_desymrefy():
         from xdsl.transforms.desymref import FrontendDesymrefyPass
 
@@ -655,6 +660,7 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
         "apply-eqsat-pdl-interp": get_apply_eqsat_pdl_interp,
         "apply-pdl": get_apply_pdl,
         "apply-pdl-interp": get_apply_pdl_interp,
+        "approximate-math-with-bitcast": get_approximate_math_with_bitcast,
         "arith-add-fastmath": get_arith_add_fastmath,
         "canonicalize-dmp": get_canonicalize_dmp,
         "canonicalize": get_canonicalize,

--- a/xdsl/transforms/approximate_math_with_bitcast.py
+++ b/xdsl/transforms/approximate_math_with_bitcast.py
@@ -1,0 +1,161 @@
+import math as pmath
+from dataclasses import dataclass
+
+from xdsl.context import Context
+from xdsl.dialects import arith, builtin, math
+from xdsl.ir import Operation
+from xdsl.passes import ModulePass
+from xdsl.pattern_rewriter import (
+    GreedyRewritePatternApplier,
+    PatternRewriter,
+    PatternRewriteWalker,
+    RewritePattern,
+)
+from xdsl.utils.hints import isa
+
+
+@dataclass
+class MakeBase2(RewritePattern):
+    log: bool
+    exp: bool
+
+    def match_and_rewrite(self, op: Operation, rewriter: PatternRewriter):
+        if len(op.results) != 1:
+            return
+
+        t = op.results[0].type
+        if not isa(t, builtin.AnyFloat):
+            return
+
+        match op:
+            # rewrite ln(A) -> log2(A) * ln(2)
+            case math.LogOp() if self.log:
+                ln2 = builtin.FloatAttr(pmath.log(2), t)
+
+                rewriter.replace_matched_op(
+                    [
+                        c := arith.ConstantOp(ln2),
+                        newlog := math.Log2Op(op.operand),
+                        mul := arith.MulfOp(c, newlog),
+                    ],
+                    mul.results,
+                )
+            # rewrite eexp(%a) to exp2(%a * log2(e))
+            case math.ExpOp() if self.exp:
+                log2e = builtin.FloatAttr(pmath.log2(pmath.e), t)
+                rewriter.replace_matched_op(
+                    [
+                        c := arith.ConstantOp(log2e),
+                        inner := arith.MulfOp(c, op.operand),
+                        e := math.Exp2Op(inner),
+                    ],
+                    e.results,
+                )
+            # TODO: math.powf
+            # TODO: math.log10
+            # TODO: math.log1p
+            # TODO: math.fpowi?
+            case _:
+                pass
+
+
+LBs = {
+    builtin.f16: (2**10, 14),
+    builtin.f32: (2**23, 127),
+    builtin.f64: (2**52, 1023),
+}
+
+
+@dataclass
+class MakeApprox(RewritePattern):
+    log: bool
+    exp: bool
+
+    def match_and_rewrite(self, op: Operation, rewriter: PatternRewriter, /):
+        if len(op.results) == 0:
+            return
+
+        t = op.results[0].type
+        if not isa(t, builtin.AnyFloat):
+            return
+
+        L, B = LBs[t] if t in LBs else (1, 1)
+
+        int_t = builtin.IntegerType(t.bitwidth)
+
+        match op:
+            # log2(%a) -> fp(L * (B - eps + A))
+            case math.Log2Op(operand=x) if self.log:
+                rewriter.replace_matched_op(
+                    [
+                        a := arith.ConstantOp(builtin.FloatAttr(L, t)),
+                        b := arith.ConstantOp(builtin.FloatAttr(L * (B - 0.045), t)),
+                        ax := arith.MulfOp(a, x),
+                        axpb := arith.AddfOp(b, ax),
+                        asint := arith.FPToSIOp(axpb, int_t),
+                        res := arith.BitcastOp(asint, t),
+                    ],
+                    res.results,
+                )
+            case math.Exp2Op(operand=x) if self.exp:
+                # 2^%x -> int(%x) * 1/L - B + eps
+                rewriter.replace_matched_op(
+                    [
+                        a := arith.ConstantOp(builtin.FloatAttr(1 / L, t)),
+                        b := arith.ConstantOp(builtin.FloatAttr(-B + 0.045, t)),
+                        xi := arith.BitcastOp(x, int_t),
+                        xif := arith.SIToFPOp(xi, t),
+                        ax := arith.MulfOp(a, xif),
+                        axpb := arith.AddfOp(b, ax),
+                    ],
+                    axpb.results,
+                )
+            case _:
+                pass
+
+
+@dataclass(frozen=True)
+class BitcastApproximation(ModulePass):
+    r"""
+    This pass applies approximations for some math operations (currently log and exp)
+    and converts them to bitcasting-based approximations.
+
+    These are intended for environments that don't need high accuracy, and do not have
+    specialized hardware support for expf and log in hardware.
+
+    It makes use of the fact that IEEE floating-point numbers are encoded as three base-2
+    numbers:
+
+        s eeeeeeee mmmmmmmmmmmmmmmmmmmmmmm
+
+    With the final floating-point number being $$x = (-1)^s * 2^{e-B} * (1 + m/L)$$.
+    Hence, $$e$$ encodes the $$\lfloor log2(x)\rfloor$$ of x, and can be accessed by
+    bit-casting and left-shifting.
+
+    The following approximations are enabled through this:
+
+    1) $$\log_2(x) \approx bc-int(x)/L - B + \varepsilon$$
+    2) $$2^x       \approx bc-float(L(B-\varepsilon + x))$$
+
+    With $$\varepsilon$$ being a tunable constant that we initialize to 0.045 for simplicity
+
+    This pass first applies some rewrites to convert suitable arithmetic into base-2 format,
+    and then applies the above approximations.
+
+    Inidividual rewrites can be controlled via pass arguments.
+    """
+
+    name = "approximate-math-with-bitcast"
+
+    log: bool = True
+    exp: bool = True
+
+    def apply(self, ctx: Context, op: builtin.ModuleOp) -> None:
+        PatternRewriteWalker(
+            GreedyRewritePatternApplier(
+                [
+                    MakeBase2(self.log, self.exp),
+                    MakeApprox(self.log, self.exp),
+                ]
+            )
+        ).rewrite_module(op)


### PR DESCRIPTION
This PR adds bit-cast based approximations for exp and log.

The pass consists of two rewrite-patterns:
1. Convert exp and log operations to base-2
2. Approximate base-2 logs and exps with the approximations outlined in <paper that may be published soon>

# Pass docstring:

This pass applies approximations for some math operations (currently `log` and `exp`) and converts them to bitcasting-based approximations.

These are intended for environments that don't need high accuracy, and do not have specialised hardware support for `expf` and `log` in hardware.

It makes use of the fact that IEEE floating-point numbers are encoded as three base-2 numbers:

    s eeeeeeee mmmmmmmmmmmmmmmmmmmmmmm

With the final floating-point number being $$x = (-1)^s \times 2^{e-B} \times (1 + m/L)$$. Hence, $$e$$ encodes the $$\lfloor \log_2\rfloor$$ of x, and can be accessed by bit-casting and left-shifting.

The following approximations are enabled through this:
 1) $$\log_2(x) \approx \text{bc-int}(x)/L - B + \varepsilon$$
 2) $$2^x       \approx \text{bc-float}(L(B-\varepsilon + x))$$

With $$\varepsilon$$ being a tunable constant that we initialise to 0.045 for simplicity

This pass first applies some rewrites to convert suitable arithmetic into base-2 format, and then applies the above approximations.

Individual rewrites can be controlled via pass arguments.
