### PR TITLE
dialects: (pdl_interp) Add default empty region to foreach constructor

### DIFF
--- a/xdsl/dialects/pdl_interp.py
+++ b/xdsl/dialects/pdl_interp.py
@@ -1428,7 +1428,17 @@ class ForEachOp(IRDLOperation):
     region = region_def()
     successor = successor_def()
 
-    def __init__(self, values: SSAValue, successor: Block, region: Region) -> None:
+    def __init__(
+        self,
+        values: SSAValue,
+        successor: Block,
+        region: Region | type[Region.DEFAULT] = Region.DEFAULT,
+    ) -> None:
+        if not isinstance(region, Region):
+            assert isa(values.type, RangeType[AnyPDLType])
+            val_type = values.type.element_type
+            region = Region(Block(arg_types=(val_type,)))
+
         super().__init__(operands=[values], successors=[successor], regions=[region])
 
     @classmethod


### PR DESCRIPTION
mimicking how things are done in func.func

This is covered by the test in https://github.com/xdslproject/xdsl/pull/5608, or should there be a dedicated test for this?
