### PR TITLE
dialects: (x86) drop `() -> ` in get register ops

### DIFF
--- a/tests/filecheck/backend/x86/prologue_epilogue_insertion.mlir
+++ b/tests/filecheck/backend/x86/prologue_epilogue_insertion.mlir
@@ -2,23 +2,23 @@
 
 // CHECK: func @main
 x86_func.func @main() {
-  // CHECK-NEXT: %{{.*}} = x86.get_register : () -> !x86.reg<rsp>
-  // CHECK-NEXT: %{{.*}} = x86.get_register : () -> !x86.reg<r14>
+  // CHECK-NEXT: %{{.*}} = x86.get_register : !x86.reg<rsp>
+  // CHECK-NEXT: %{{.*}} = x86.get_register : !x86.reg<r14>
   // CHECK-NEXT: %{{.*}} = x86.s.push %{{.*}}, %{{.*}} : (!x86.reg<rsp>, !x86.reg<r14>) -> !x86.reg<rsp>
-  // CHECK-NEXT: %{{.*}} = x86.get_register : () -> !x86.reg<r15>
+  // CHECK-NEXT: %{{.*}} = x86.get_register : !x86.reg<r15>
   // CHECK-NEXT: %{{.*}} = x86.s.push %{{.*}}, %{{.*}} : (!x86.reg<rsp>, !x86.reg<r15>) -> !x86.reg<rsp>
 
-  // CHECK-NEXT: %r12 = x86.get_register : () -> !x86.reg<r12>
-  // CHECK-NEXT: %r13 = x86.get_register : () -> !x86.reg<r13>
+  // CHECK-NEXT: %r12 = x86.get_register : !x86.reg<r12>
+  // CHECK-NEXT: %r13 = x86.get_register : !x86.reg<r13>
   // CHECK-NEXT: %r14 = x86.rs.add %r12, %r13 : (!x86.reg<r12>, !x86.reg<r13>) -> !x86.reg<r14>
-  // CHECK-NEXT: %r8 = x86.get_register : () -> !x86.reg<r8>
+  // CHECK-NEXT: %r8 = x86.get_register : !x86.reg<r8>
   // CHECK-NEXT: %r15 = x86.ds.mov %r8 : (!x86.reg<r8>) -> !x86.reg<r15>
   // CHECK-NEXT: %rflags = x86.ss.cmp %r8, %r15 : (!x86.reg<r8>, !x86.reg<r15>) -> !x86.rflags<rflags>
   // CHECK-NEXT: x86.c.jne %rflags : !x86.rflags<rflags>, ^then(%r8 : !x86.reg<r8>), ^else(%r15 : !x86.reg<r15>)
-  %r12 = x86.get_register() : () -> !x86.reg<r12>
-  %r13 = x86.get_register() : () -> !x86.reg<r13>
+  %r12 = x86.get_register : !x86.reg<r12>
+  %r13 = x86.get_register : !x86.reg<r13>
   %r14 = x86.rs.add %r12,%r13: (!x86.reg<r12>, !x86.reg<r13>) -> !x86.reg<r14>
-  %r8 = x86.get_register() : () -> !x86.reg<r8>
+  %r8 = x86.get_register : !x86.reg<r8>
   %r15 = x86.ds.mov %r8 : (!x86.reg<r8>) -> !x86.reg<r15>
   %rflags = x86.ss.cmp %r8, %r15 : (!x86.reg<r8>, !x86.reg<r15>) -> !x86.rflags<rflags>
   x86.c.jne %rflags : !x86.rflags<rflags>, ^then(%r8 : !x86.reg<r8>), ^else(%r15 : !x86.reg<r15>)
@@ -44,7 +44,7 @@ x86_func.func @main() {
 
 // CHECK: func @simple
 x86_func.func @simple(%0 : !x86.reg<rdi>, %1 : !x86.reg<rsi>) -> !x86.reg<rax> {
-  // CHECK-NOT: %{{.*}} = x86.get_register : () -> !x86.reg<rsp>
+  // CHECK-NOT: %{{.*}} = x86.get_register : !x86.reg<rsp>
   // CHECK-NOT: %{{.*}} = x86.s.push %{{.*}}, %{{.*}} : (!x86.reg<rsp>, !x86.reg<{{.*}}>) -> !x86.reg<rsp>
   // CHECK-NEXT: %2 = x86.ds.mov %0 : (!x86.reg<rdi>) -> !x86.reg<r8>
   // CHECK-NEXT: %3 = x86.ds.mov %1 : (!x86.reg<rsi>) -> !x86.reg<r9>

--- a/tests/filecheck/dialects/x86/x86_assembly_emission.mlir
+++ b/tests/filecheck/dialects/x86/x86_assembly_emission.mlir
@@ -2,11 +2,11 @@
 
 // CHECK-NEXT: .intel_syntax noprefix
 
-%0 = x86.get_register : () -> !x86.reg<rax>
-%1 = x86.get_register : () -> !x86.reg<rdx>
-%2 = x86.get_register : () -> !x86.reg<rcx>
-%rsp = x86.get_register : () -> !x86.reg<rsp>
-%rax = x86.get_register : () -> !x86.reg<rax>
+%0 = x86.get_register : !x86.reg<rax>
+%1 = x86.get_register : !x86.reg<rdx>
+%2 = x86.get_register : !x86.reg<rcx>
+%rsp = x86.get_register : !x86.reg<rsp>
+%rax = x86.get_register : !x86.reg<rax>
 
 %rs_add = x86.rs.add %0, %1 : (!x86.reg<rax>, !x86.reg<rdx>) -> !x86.reg<rax>
 // CHECK-NEXT: add rax, rdx
@@ -168,8 +168,8 @@ x86.label "label"
 // CHECK-NEXT: label:
 
 x86_func.func @funcyasm() {
-    %3 = x86.get_register : () -> !x86.reg<rax>
-    %4 = x86.get_register : () -> !x86.reg<rdx>
+    %3 = x86.get_register : !x86.reg<rax>
+    %4 = x86.get_register : !x86.reg<rdx>
     %rflags = x86.ss.cmp %3, %4 : (!x86.reg<rax>, !x86.reg<rdx>) -> !x86.rflags<rflags>
     // CHECK: cmp rax, rdx
 
@@ -338,9 +338,9 @@ x86_func.func @funcyasm() {
     // CHECK-NEXT: jmp then
 }
 
-%xmm0 = x86.get_avx_register : () -> !x86.ssereg<xmm0>
-%xmm1 = x86.get_avx_register : () -> !x86.ssereg<xmm1>
-%xmm2 = x86.get_avx_register : () -> !x86.ssereg<xmm2>
+%xmm0 = x86.get_avx_register : !x86.ssereg<xmm0>
+%xmm1 = x86.get_avx_register : !x86.ssereg<xmm1>
+%xmm2 = x86.get_avx_register : !x86.ssereg<xmm2>
 
 %rrr_vfmadd231pd_sse = x86.rss.vfmadd231pd %xmm0, %xmm1, %xmm2 : (!x86.ssereg<xmm0>, !x86.ssereg<xmm1>, !x86.ssereg<xmm2>) -> !x86.ssereg<xmm0>
 // CHECK: vfmadd231pd xmm0, xmm1, xmm2
@@ -359,9 +359,9 @@ x86_func.func @funcyasm() {
 %rm_vbroadcastsd_sse = x86.dm.vbroadcastsd %1, 8 : (!x86.reg<rdx>) -> !x86.ssereg<xmm0>
 // CHECK-NEXT: vbroadcastsd xmm0, [rdx+8]
 
-%ymm0 = x86.get_avx_register : () -> !x86.avx2reg<ymm0>
-%ymm1 = x86.get_avx_register : () -> !x86.avx2reg<ymm1>
-%ymm2 = x86.get_avx_register : () -> !x86.avx2reg<ymm2>
+%ymm0 = x86.get_avx_register : !x86.avx2reg<ymm0>
+%ymm1 = x86.get_avx_register : !x86.avx2reg<ymm1>
+%ymm2 = x86.get_avx_register : !x86.avx2reg<ymm2>
 
 %rrr_vfmadd231pd_avx2 = x86.rss.vfmadd231pd %ymm0, %ymm1, %ymm2 : (!x86.avx2reg<ymm0>, !x86.avx2reg<ymm1>, !x86.avx2reg<ymm2>) -> !x86.avx2reg<ymm0>
 // CHECK: vfmadd231pd ymm0, ymm1, ymm2
@@ -384,10 +384,10 @@ x86_func.func @funcyasm() {
 %ds_vpbroadcastq_avx2 = x86.ds.vpbroadcastq %rax : (!x86.reg<rax>) -> !x86.avx2reg<ymm0>
 // CHECK-NEXT: vpbroadcastq ymm0, rax
 
-%zmm0 = x86.get_avx_register : () -> !x86.avx512reg<zmm0>
-%zmm1 = x86.get_avx_register : () -> !x86.avx512reg<zmm1>
-%zmm2 = x86.get_avx_register : () -> !x86.avx512reg<zmm2>
-%k1 = x86.get_mask_register: () -> !x86.avx512maskreg<k1>
+%zmm0 = x86.get_avx_register : !x86.avx512reg<zmm0>
+%zmm1 = x86.get_avx_register : !x86.avx512reg<zmm1>
+%zmm2 = x86.get_avx_register : !x86.avx512reg<zmm2>
+%k1 = x86.get_mask_register: !x86.avx512maskreg<k1>
 
 %rrr_vfmadd231pd_avx512 = x86.rss.vfmadd231pd %zmm0, %zmm1, %zmm2 : (!x86.avx512reg<zmm0>, !x86.avx512reg<zmm1>, !x86.avx512reg<zmm2>) -> !x86.avx512reg<zmm0>
 // CHECK: vfmadd231pd zmm0, zmm1, zmm2

--- a/tests/filecheck/dialects/x86/x86_ops_invalid.mlir
+++ b/tests/filecheck/dialects/x86/x86_ops_invalid.mlir
@@ -1,8 +1,8 @@
 // RUN: xdsl-opt --verify-diagnostics --split-input-file %s | filecheck %s
 
 x86_func.func @funcyasm() {
-    %3 = x86.get_register : () -> !x86.reg<rax>
-    %4 = x86.get_register : () -> !x86.reg<rdx>
+    %3 = x86.get_register : !x86.reg<rax>
+    %4 = x86.get_register : !x86.reg<rdx>
     %rflags = x86.ss.cmp %3, %4 : (!x86.reg<rax>, !x86.reg<rdx>) -> !x86.rflags<rflags>
     x86.fallthrough ^fallthrough()
     // CHECK: Operation does not verify: Fallthrough op successor must immediately follow its parent.

--- a/xdsl/dialects/x86/ops.py
+++ b/xdsl/dialects/x86/ops.py
@@ -3607,7 +3607,6 @@ class DSSI_ShufpsOp(
 class GetAnyRegisterOperation(
     X86AsmOperation,
     X86RegallocOperation,
-    X86CustomFormatOperation,
     ABC,
     Generic[R1InvT],
 ):
@@ -3616,6 +3615,8 @@ class GetAnyRegisterOperation(
     """
 
     result: OpResult[R1InvT] = result_def(R1InvT)
+
+    assembly_format = "attr-dict `:` type($result)"
 
     def __init__(
         self,


### PR DESCRIPTION
It's not pretty and not consistent with riscv.