### PR TITLE
transform: (approximate-math-with-bitcast) Pass fastmath flags through

### DIFF
--- a/tests/filecheck/transforms/approximate-math-with-bitcast.mlir
+++ b/tests/filecheck/transforms/approximate-math-with-bitcast.mlir
@@ -18,15 +18,15 @@ func.func @test_log (%x: f32) -> f32 {
 
 //CHECK-LABEL: @test_exp
 func.func @test_exp (%x: f32) -> f32 {
-  %b = math.exp %x : f32
+  %b = math.exp %x fastmath<fast>: f32
 // CHECK:      %b = arith.constant 1.44269502 : f32
-// CHECK-NEXT: %b_1 = arith.mulf %b, %x : f32
+// CHECK-NEXT: %b_1 = arith.mulf %b, %x fastmath<fast> : f32
 // CHECK-NEXT: %b_2 = arith.constant 1.1920929e-07 : f32
 // CHECK-NEXT: %b_3 = arith.constant -1.269550e+02 : f32
 // CHECK-NEXT: %b_4 = arith.bitcast %b_1 : f32 to i32
 // CHECK-NEXT: %b_5 = arith.sitofp %b_4 : i32 to f32
-// CHECK-NEXT: %b_6 = arith.mulf %b_2, %b_5 : f32
-// CHECK-NEXT: %b_7 = arith.addf %b_3, %b_6 : f32
+// CHECK-NEXT: %b_6 = arith.mulf %b_2, %b_5 fastmath<fast> : f32
+// CHECK-NEXT: %b_7 = arith.addf %b_3, %b_6 fastmath<fast> : f32
   return %b : f32
 // CHECK-NEXT: return %b_7 : f32
 }

--- a/xdsl/transforms/approximate_math_with_bitcast.py
+++ b/xdsl/transforms/approximate_math_with_bitcast.py
@@ -35,8 +35,8 @@ class MakeBase2(RewritePattern):
                 rewriter.replace_matched_op(
                     [
                         c := arith.ConstantOp(ln2),
-                        newlog := math.Log2Op(op.operand),
-                        mul := arith.MulfOp(c, newlog),
+                        newlog := math.Log2Op(op.operand, op.fastmath),
+                        mul := arith.MulfOp(c, newlog, op.fastmath),
                     ],
                     mul.results,
                 )
@@ -46,8 +46,8 @@ class MakeBase2(RewritePattern):
                 rewriter.replace_matched_op(
                     [
                         c := arith.ConstantOp(log2e),
-                        inner := arith.MulfOp(c, op.operand),
-                        e := math.Exp2Op(inner),
+                        inner := arith.MulfOp(c, op.operand, op.fastmath),
+                        e := math.Exp2Op(inner, op.fastmath),
                     ],
                     e.results,
                 )
@@ -90,8 +90,8 @@ class MakeApprox(RewritePattern):
                     [
                         a := arith.ConstantOp(builtin.FloatAttr(L, t)),
                         b := arith.ConstantOp(builtin.FloatAttr(L * (B - 0.045), t)),
-                        ax := arith.MulfOp(a, x),
-                        axpb := arith.AddfOp(b, ax),
+                        ax := arith.MulfOp(a, x, op.fastmath),
+                        axpb := arith.AddfOp(b, ax, op.fastmath),
                         asint := arith.FPToSIOp(axpb, int_t),
                         res := arith.BitcastOp(asint, t),
                     ],
@@ -105,8 +105,8 @@ class MakeApprox(RewritePattern):
                         b := arith.ConstantOp(builtin.FloatAttr(-B + 0.045, t)),
                         xi := arith.BitcastOp(x, int_t),
                         xif := arith.SIToFPOp(xi, t),
-                        ax := arith.MulfOp(a, xif),
-                        axpb := arith.AddfOp(b, ax),
+                        ax := arith.MulfOp(a, xif, op.fastmath),
+                        axpb := arith.AddfOp(b, ax, op.fastmath),
                     ],
                     axpb.results,
                 )


### PR DESCRIPTION
This PR just makes sure that fastmath flags from the original op are preserved when approximating.
