### PR TITLE
documentation: Fix Parameterized spelling and doc string.

### DIFF
--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -115,7 +115,7 @@ class Attribute(ABC):
     def __post_init__(self):
         self._verify()
         if not isinstance(self, Data | ParametrizedAttribute):
-            raise TypeError("Attributes should only be Data or ParameterizedAttribute")
+            raise TypeError("Attributes should only be Data or ParametrizedAttribute")
 
     def _verify(self):
         self.verify()

--- a/xdsl/irdl/attributes.py
+++ b/xdsl/irdl/attributes.py
@@ -123,7 +123,7 @@ def param_def(
     converter: Callable[[Any], AttributeInvT] | None = None,
     init: Literal[True] = True,
 ) -> AttributeInvT:
-    """Defines a property of an operation."""
+    """Defines a parameter of a ParametrizedAttribute."""
     return cast(AttributeInvT, _ParameterDef(constraint, converter))
 
 

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -1252,14 +1252,14 @@ class UniqueBaseAttributeVariable(AttributeVariable):
             unique_base = cast(type[Data[Any]], unique_base)
             return unique_base.new(unique_base.parse_parameter(parser))
         else:
-            raise ValueError("Attributes must be Data or ParameterizedAttribute.")
+            raise ValueError("Attributes must be Data or ParametrizedAttribute.")
 
     def print_attr(self, printer: Printer, attr: Attribute) -> None:
         if isinstance(attr, ParametrizedAttribute):
             return attr.print_parameters(printer)
         if isinstance(attr, Data):
             return attr.print_parameter(printer)
-        raise ValueError("Attributes must be Data or ParameterizedAttribute!")
+        raise ValueError("Attributes must be Data or ParametrizedAttribute!")
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Fixes a doc string and makes use of Parametrized spelling more consistent. 