### PR TITLE
transforms: (approximate-math-with-bitcast) Add support for math.log1p

### DIFF
--- a/tests/filecheck/transforms/approximate-math-with-bitcast.mlir
+++ b/tests/filecheck/transforms/approximate-math-with-bitcast.mlir
@@ -16,6 +16,23 @@ func.func @test_log (%x: f32) -> f32 {
 //CHECK-NEXT: return %a_7 : f32
 }
 
+// CHECK-LABEL: @test_log1p
+func.func @test_log1p (%x: f32) -> f32 {
+  %a = math.log1p %x : f32
+// CHECK:      %a = arith.constant 1.000000e+00 : f32
+// CHECK-NEXT: %a_1 = arith.addf %a, %x : f32
+// CHECK-NEXT: %a_2 = arith.constant 0.693147182 : f32
+// CHECK-NEXT: %a_3 = arith.constant 0x4B000000 : f32
+// CHECK-NEXT: %a_4 = arith.constant 1.06497574e+09 : f32
+// CHECK-NEXT: %a_5 = arith.mulf %a_3, %a_1 : f32
+// CHECK-NEXT: %a_6 = arith.addf %a_4, %a_5 : f32
+// CHECK-NEXT: %a_7 = arith.fptosi %a_6 : f32 to i32
+// CHECK-NEXT: %a_8 = arith.bitcast %a_7 : i32 to f32
+// CHECK-NEXT: %a_9 = arith.mulf %a_2, %a_8 : f32
+  return %a : f32
+// CHECK-NEXT: func.return %a_9 : f32
+}
+
 //CHECK-LABEL: @test_exp
 func.func @test_exp (%x: f32) -> f32 {
   %b = math.exp %x fastmath<fast>: f32

--- a/xdsl/transforms/__init__.py
+++ b/xdsl/transforms/__init__.py
@@ -318,7 +318,7 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
     def get_approximate_math_with_bitcast():
         from xdsl.transforms import approximate_math_with_bitcast
 
-        return approximate_math_with_bitcast.BitcastApproximation
+        return approximate_math_with_bitcast.ApproximateMathWithBitcastPass
 
     def get_frontend_desymrefy():
         from xdsl.transforms.desymref import FrontendDesymrefyPass

--- a/xdsl/transforms/approximate_math_with_bitcast.py
+++ b/xdsl/transforms/approximate_math_with_bitcast.py
@@ -29,31 +29,42 @@ class MakeBase2(RewritePattern):
 
         match op:
             # rewrite ln(A) -> log2(A) * ln(2)
-            case math.LogOp() if self.log:
+            case math.LogOp(operand=x, fastmath=ff) if self.log:
                 ln2 = builtin.FloatAttr(pmath.log(2), t)
 
                 rewriter.replace_matched_op(
                     [
                         c := arith.ConstantOp(ln2),
-                        newlog := math.Log2Op(op.operand, op.fastmath),
-                        mul := arith.MulfOp(c, newlog, op.fastmath),
+                        newlog := math.Log2Op(x, ff),
+                        mul := arith.MulfOp(c, newlog, ff),
                     ],
                     mul.results,
                 )
-            # rewrite eexp(%a) to exp2(%a * log2(e))
-            case math.ExpOp() if self.exp:
+            # rewrite log1p(A) -> ln(A + 1)
+            case math.Log1pOp(operand=x, fastmath=ff) if self.log and isa(
+                x.type, builtin.AnyFloat
+            ):
+                rewriter.replace_matched_op(
+                    [
+                        one := arith.ConstantOp(builtin.FloatAttr(1.0, x.type)),
+                        xp1 := arith.AddfOp(one, x, ff),
+                        res := math.LogOp(xp1, ff),
+                    ],
+                    res.results,
+                )
+            # rewrite expe(%a) to exp2(%a * log2(e))
+            case math.ExpOp(operand=x, fastmath=ff) if self.exp:
                 log2e = builtin.FloatAttr(pmath.log2(pmath.e), t)
                 rewriter.replace_matched_op(
                     [
                         c := arith.ConstantOp(log2e),
-                        inner := arith.MulfOp(c, op.operand, op.fastmath),
-                        e := math.Exp2Op(inner, op.fastmath),
+                        inner := arith.MulfOp(c, x, ff),
+                        e := math.Exp2Op(inner, ff),
                     ],
                     e.results,
                 )
             # TODO: math.powf
             # TODO: math.log10
-            # TODO: math.log1p
             # TODO: math.fpowi?
             case _:
                 pass
@@ -85,19 +96,19 @@ class MakeApprox(RewritePattern):
 
         match op:
             # log2(%a) -> fp(L * (B - eps + A))
-            case math.Log2Op(operand=x) if self.log:
+            case math.Log2Op(operand=x, fastmath=ff) if self.log:
                 rewriter.replace_matched_op(
                     [
                         a := arith.ConstantOp(builtin.FloatAttr(L, t)),
                         b := arith.ConstantOp(builtin.FloatAttr(L * (B - 0.045), t)),
-                        ax := arith.MulfOp(a, x, op.fastmath),
-                        axpb := arith.AddfOp(b, ax, op.fastmath),
+                        ax := arith.MulfOp(a, x, ff),
+                        axpb := arith.AddfOp(b, ax, ff),
                         asint := arith.FPToSIOp(axpb, int_t),
                         res := arith.BitcastOp(asint, t),
                     ],
                     res.results,
                 )
-            case math.Exp2Op(operand=x) if self.exp:
+            case math.Exp2Op(operand=x, fastmath=ff) if self.exp:
                 # 2^%x -> int(%x) * 1/L - B + eps
                 rewriter.replace_matched_op(
                     [
@@ -105,8 +116,8 @@ class MakeApprox(RewritePattern):
                         b := arith.ConstantOp(builtin.FloatAttr(-B + 0.045, t)),
                         xi := arith.BitcastOp(x, int_t),
                         xif := arith.SIToFPOp(xi, t),
-                        ax := arith.MulfOp(a, xif, op.fastmath),
-                        axpb := arith.AddfOp(b, ax, op.fastmath),
+                        ax := arith.MulfOp(a, xif, ff),
+                        axpb := arith.AddfOp(b, ax, ff),
                     ],
                     axpb.results,
                 )
@@ -115,7 +126,7 @@ class MakeApprox(RewritePattern):
 
 
 @dataclass(frozen=True)
-class BitcastApproximation(ModulePass):
+class ApproximateMathWithBitcastPass(ModulePass):
     r"""
     This pass applies approximations for some math operations (currently log and exp)
     and converts them to bitcasting-based approximations.


### PR DESCRIPTION
Adds a simple pattern to convert `log1p(%x)` to `log(%x + 1)` so that the other rewrite patterns can match 