### PR TITLE
Liop rv32 rv64

### DIFF
--- a/xdsl/dialects/__init__.py
+++ b/xdsl/dialects/__init__.py
@@ -253,6 +253,16 @@ def get_all_dialects() -> dict[str, Callable[[], Dialect]]:
 
         return RISCV
 
+    def get_RV32():
+        from xdsl.dialects.rv32 import RV32
+
+        return RV32
+
+    def get_RV64():
+        from xdsl.dialects.rv64 import RV64
+
+        return RV64
+
     def get_riscv_func():
         from xdsl.dialects.riscv_func import RISCV_Func
 
@@ -417,6 +427,8 @@ def get_all_dialects() -> dict[str, Callable[[], Dialect]]:
         "printf": get_printf,
         "ptr_xdsl": get_ptr_xdsl,
         "riscv": get_riscv,
+        "rv32": get_RV32,
+        "rv64": get_RV64,
         "riscv_debug": get_riscv_debug,
         "riscv_func": get_riscv_func,
         "riscv_scf": get_riscv_scf,

--- a/xdsl/dialects/rv32.py
+++ b/xdsl/dialects/rv32.py
@@ -2,7 +2,7 @@
 RISC-V 32-bit (RV32) dialect operations and types.
 
 This module defines the RV32-specific variant of RISC-V operations,
-using 5-bit shift immediates for 32-bit architectures.
+using 5-bit immediates for 32-bit architectures.
 """
 
 from __future__ import annotations

--- a/xdsl/dialects/rv32.py
+++ b/xdsl/dialects/rv32.py
@@ -1,0 +1,117 @@
+"""
+RISC-V 32-bit (RV32) dialect operations and types.
+
+This module defines the RV32-specific variant of RISC-V operations,
+using 5-bit shift immediates for 32-bit architectures.
+"""
+
+from __future__ import annotations
+
+from abc import ABC
+from collections.abc import Sequence
+from collections.abc import Set as AbstractSet
+
+from xdsl.dialects.builtin import I32, IntegerAttr, StringAttr, i32
+from xdsl.dialects.riscv import (
+    AssemblyInstructionArg,
+    IntRegisterType,
+    LabelAttr,
+    LiOpHasCanonicalizationPatternTrait,
+    Registers,
+    RISCVCustomFormatOperation,
+    RISCVInstruction,
+    parse_immediate_value,
+    print_immediate_value,
+)
+from xdsl.interfaces import ConstantLikeInterface
+from xdsl.ir import (
+    Attribute,
+    Dialect,
+)
+from xdsl.irdl import (
+    attr_def,
+    irdl_op_definition,
+    result_def,
+    traits_def,
+)
+from xdsl.parser import Parser
+from xdsl.printer import Printer
+from xdsl.traits import (
+    Pure,
+)
+
+
+@irdl_op_definition
+class LiOp(RISCVCustomFormatOperation, RISCVInstruction, ConstantLikeInterface, ABC):
+    """
+    Loads a 32-bit immediate into rd.
+
+    This is an assembler pseudo-instruction.
+
+    See external [documentation](https://github.com/riscv-non-isa/riscv-asm-manual/blob/main/src/asm-manual.adoc).
+    """
+
+    name = "rv32.li"
+
+    rd = result_def(IntRegisterType)
+    immediate = attr_def(IntegerAttr[I32] | LabelAttr)
+
+    traits = traits_def(Pure(), LiOpHasCanonicalizationPatternTrait())
+
+    def __init__(
+        self,
+        immediate: int | IntegerAttr[I32] | str | LabelAttr,
+        *,
+        rd: IntRegisterType = Registers.UNALLOCATED_INT,
+        comment: str | StringAttr | None = None,
+    ):
+        if isinstance(immediate, int):
+            immediate = IntegerAttr(immediate, i32)
+        elif isinstance(immediate, str):
+            immediate = LabelAttr(immediate)
+        if isinstance(comment, str):
+            comment = StringAttr(comment)
+
+        super().__init__(
+            result_types=[rd],
+            attributes={
+                "immediate": immediate,
+                "comment": comment,
+            },
+        )
+
+    def assembly_line_args(self) -> tuple[AssemblyInstructionArg, ...]:
+        return self.rd, self.immediate
+
+    def get_constant_value(self):
+        return self.immediate
+
+    @classmethod
+    def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
+        attributes = dict[str, Attribute]()
+        attributes["immediate"] = parse_immediate_value(parser, i32)
+        return attributes
+
+    def custom_print_attributes(self, printer: Printer) -> AbstractSet[str]:
+        printer.print_string(" ")
+        print_immediate_value(printer, self.immediate)
+        return {"immediate", "fastmath"}
+
+    @classmethod
+    def parse_op_type(
+        cls, parser: Parser
+    ) -> tuple[Sequence[Attribute], Sequence[Attribute]]:
+        parser.parse_punctuation(":")
+        res_type = parser.parse_attribute()
+        return (), (res_type,)
+
+    def print_op_type(self, printer: Printer) -> None:
+        printer.print_string(" : ")
+        printer.print_attribute(self.rd.type)
+
+
+RV32 = Dialect(
+    "rv32",
+    [LiOp],
+    [],
+)

--- a/xdsl/dialects/rv64.py
+++ b/xdsl/dialects/rv64.py
@@ -1,8 +1,8 @@
 """
-RISC-V 32-bit (RV32) dialect operations and types.
+RISC-V 64-bit (RV64) dialect operations and types.
 
-This module defines the RV32-specific variant of RISC-V operations,
-using 5-bit shift immediates for 32-bit architectures.
+This module defines the RV64-specific variant of RISC-V operations,
+using 6-bit immediates for 64-bit architectures.
 """
 
 from __future__ import annotations

--- a/xdsl/dialects/rv64.py
+++ b/xdsl/dialects/rv64.py
@@ -1,0 +1,117 @@
+"""
+RISC-V 32-bit (RV32) dialect operations and types.
+
+This module defines the RV32-specific variant of RISC-V operations,
+using 5-bit shift immediates for 32-bit architectures.
+"""
+
+from __future__ import annotations
+
+from abc import ABC
+from collections.abc import Sequence
+from collections.abc import Set as AbstractSet
+
+from xdsl.dialects.builtin import I64, IntegerAttr, StringAttr, i64
+from xdsl.dialects.riscv import (
+    AssemblyInstructionArg,
+    IntRegisterType,
+    LabelAttr,
+    LiOpHasCanonicalizationPatternTrait,
+    Registers,
+    RISCVCustomFormatOperation,
+    RISCVInstruction,
+    parse_immediate_value,
+    print_immediate_value,
+)
+from xdsl.interfaces import ConstantLikeInterface
+from xdsl.ir import (
+    Attribute,
+    Dialect,
+)
+from xdsl.irdl import (
+    attr_def,
+    irdl_op_definition,
+    result_def,
+    traits_def,
+)
+from xdsl.parser import Parser
+from xdsl.printer import Printer
+from xdsl.traits import (
+    Pure,
+)
+
+
+@irdl_op_definition
+class LiOp(RISCVCustomFormatOperation, RISCVInstruction, ConstantLikeInterface, ABC):
+    """
+    Loads a 64-bit immediate into rd.
+
+    This is an assembler pseudo-instruction.
+
+    See external [documentation](https://github.com/riscv-non-isa/riscv-asm-manual/blob/main/src/asm-manual.adoc).
+    """
+
+    name = "rv64.li"
+
+    rd = result_def(IntRegisterType)
+    immediate = attr_def(IntegerAttr[I64] | LabelAttr)
+
+    traits = traits_def(Pure(), LiOpHasCanonicalizationPatternTrait())
+
+    def __init__(
+        self,
+        immediate: int | IntegerAttr[I64] | str | LabelAttr,
+        *,
+        rd: IntRegisterType = Registers.UNALLOCATED_INT,
+        comment: str | StringAttr | None = None,
+    ):
+        if isinstance(immediate, int):
+            immediate = IntegerAttr(immediate, i64)
+        elif isinstance(immediate, str):
+            immediate = LabelAttr(immediate)
+        if isinstance(comment, str):
+            comment = StringAttr(comment)
+
+        super().__init__(
+            result_types=[rd],
+            attributes={
+                "immediate": immediate,
+                "comment": comment,
+            },
+        )
+
+    def assembly_line_args(self) -> tuple[AssemblyInstructionArg, ...]:
+        return self.rd, self.immediate
+
+    def get_constant_value(self):
+        return self.immediate
+
+    @classmethod
+    def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
+        attributes = dict[str, Attribute]()
+        attributes["immediate"] = parse_immediate_value(parser, i64)
+        return attributes
+
+    def custom_print_attributes(self, printer: Printer) -> AbstractSet[str]:
+        printer.print_string(" ")
+        print_immediate_value(printer, self.immediate)
+        return {"immediate", "fastmath"}
+
+    @classmethod
+    def parse_op_type(
+        cls, parser: Parser
+    ) -> tuple[Sequence[Attribute], Sequence[Attribute]]:
+        parser.parse_punctuation(":")
+        res_type = parser.parse_attribute()
+        return (), (res_type,)
+
+    def print_op_type(self, printer: Printer) -> None:
+        printer.print_string(" : ")
+        printer.print_attribute(self.rd.type)
+
+
+RV64 = Dialect(
+    "rv64",
+    [LiOp],
+    [],
+)


### PR DESCRIPTION
This PR introduces `rv32`, `rv64` dialects and `LiOp` for these dialects.