### PR TITLE
dialects: (llvm) deprecate LLVMArrayType constructor helper

### DIFF
--- a/tests/backend/llvm/test_convert_type.py
+++ b/tests/backend/llvm/test_convert_type.py
@@ -62,7 +62,7 @@ def test_convert_vector():
 
 
 def test_convert_array():
-    arr_type = LLVMArrayType.from_size_and_type(10, builtin.i32)
+    arr_type = LLVMArrayType(10, builtin.i32)
     assert convert_type(arr_type) == ir.ArrayType(ir.IntType(32), 10)
 
 

--- a/tests/dialects/test_llvm.py
+++ b/tests/dialects/test_llvm.py
@@ -206,7 +206,7 @@ def test_llvm_getelementptr_op():
 
 
 def test_array_type():
-    array_type = llvm.LLVMArrayType.from_size_and_type(10, builtin.i32)
+    array_type = llvm.LLVMArrayType(10, builtin.i32)
 
     assert isinstance(array_type.size, builtin.IntAttr)
     assert array_type.size.data == 10

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass
 from types import EllipsisType
 from typing import ClassVar
 
+from typing_extensions import deprecated
+
 from xdsl.dialects.builtin import (
     I1,
     I32,
@@ -52,6 +54,7 @@ from xdsl.irdl import (
     opt_operand_def,
     opt_prop_def,
     opt_result_def,
+    param_def,
     prop_def,
     region_def,
     result_def,
@@ -176,7 +179,7 @@ class LLVMPointerType(ParametrizedAttribute, TypeAttribute):
 class LLVMArrayType(ParametrizedAttribute, TypeAttribute):
     name = "llvm.array"
 
-    size: IntAttr
+    size: IntAttr = param_def(converter=IntAttr.get)
     type: Attribute
 
     def print_parameters(self, printer: Printer) -> None:
@@ -193,10 +196,9 @@ class LLVMArrayType(ParametrizedAttribute, TypeAttribute):
             type = parse_llvm_type(parser)
         return (size, type)
 
+    @deprecated("Please use LLVMArrayType(size, type)")
     @staticmethod
     def from_size_and_type(size: int | IntAttr, type: Attribute):
-        if isinstance(size, int):
-            size = IntAttr(size)
         return LLVMArrayType(size, type)
 
 

--- a/xdsl/transforms/experimental/hls_convert_stencil_to_ll_mlir.py
+++ b/xdsl/transforms/experimental/hls_convert_stencil_to_ll_mlir.py
@@ -154,11 +154,9 @@ class StencilExternalLoadToHLSExternalLoad(RewritePattern):
 
         stencil_type = LLVMStructType.from_type_list(
             [
-                LLVMArrayType.from_size_and_type(
+                LLVMArrayType(
                     3,
-                    LLVMArrayType.from_size_and_type(
-                        3, LLVMArrayType.from_size_and_type(3, f64)
-                    ),
+                    LLVMArrayType(3, LLVMArrayType(3, f64)),
                 )
             ]
         )

--- a/xdsl/transforms/printf_to_llvm.py
+++ b/xdsl/transforms/printf_to_llvm.py
@@ -99,7 +99,7 @@ class PrintlnOpToPrintfCall(RewritePattern):
         t_type = builtin.TensorType(i8, [len(data)])
 
         return llvm.GlobalOp(
-            llvm.LLVMArrayType.from_size_and_type(len(data), i8),
+            llvm.LLVMArrayType(len(data), i8),
             _key_from_str(val),
             constant=True,
             linkage="internal",


### PR DESCRIPTION
We've since added a helper to make the default init more powerful.