### PR TITLE
core: Fix detach_block to clear block pointers

### DIFF
--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -154,6 +154,50 @@ def test_ops_accessor_III():
         region0.detach_block(1)
 
 
+def test_detach_block_clears_pointers():
+    """Test that detach_block clears the block's prev/next pointers."""
+    a = ConstantOp.from_int_and_width(1, i32)
+    b = ConstantOp.from_int_and_width(2, i32)
+    c = ConstantOp.from_int_and_width(3, i32)
+
+    block0 = Block([a])
+    block1 = Block([b])
+    block2 = Block([c])
+
+    region = Region([block0, block1, block2])
+
+    # Verify initial state
+    assert block0.next_block is block1
+    assert block1.prev_block is block0
+    assert block1.next_block is block2
+    assert block2.prev_block is block1
+
+    # Detach middle block
+    detached_block = region.detach_block(block1)
+
+    # Verify detached block's pointers are cleared
+    assert detached_block._prev_block is None  # pyright: ignore[reportPrivateUsage]
+    assert detached_block._next_block is None  # pyright: ignore[reportPrivateUsage]
+    assert detached_block.parent is None
+
+    # Verify region's blocks are properly linked
+    assert block0.next_block is block2
+    assert block2.prev_block is block0
+    assert list(region.blocks) == [block0, block2]
+
+    # Test detaching first block
+    detached_first = region.detach_block(block0)
+    assert detached_first._prev_block is None  # pyright: ignore[reportPrivateUsage]
+    assert detached_first._next_block is None  # pyright: ignore[reportPrivateUsage]
+    assert list(region.blocks) == [block2]
+
+    # Test detaching last (and only) remaining block
+    detached_last = region.detach_block(block2)
+    assert detached_last._prev_block is None  # pyright: ignore[reportPrivateUsage]
+    assert detached_last._next_block is None  # pyright: ignore[reportPrivateUsage]
+    assert list(region.blocks) == []
+
+
 def test_op_operands_assign():
     """Test that we can directly assign `op.operands`."""
     val1, val2 = create_ssa_value(i32), create_ssa_value(i32)

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -2587,6 +2587,10 @@ class Region(_IRNode):
                 block.prev_block
             )
 
+        # Detach linked list from block
+        block._prev_block = None  # pyright: ignore[reportPrivateUsage]
+        block._next_block = None  # pyright: ignore[reportPrivateUsage]
+
         return block
 
     def erase_block(self, block: int | Block, safe_erase: bool = True) -> None:


### PR DESCRIPTION
Clear prev_block and next_block pointers when detaching a block from a region to ensure complete disconnection and avoid unexpected references.
This pull request makes a targeted update to the `detach_block` method in `xdsl/ir/core.py` to ensure proper cleanup of internal linked list pointers when a block is detached.

Linked list cleanup:

* In the `detach_block` method, the private attributes `_prev_block` and `_next_block` of the detached `block` are now explicitly set to `None` to fully disconnect the block from the linked list and prevent potential dangling references.

Fixed #5626 