### PR TITLE
CI: deploy to website from main only, not PRs

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -45,6 +45,7 @@ jobs:
         path: ./site
 
   deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: build
     permissions:
       pages: write


### PR DESCRIPTION
Recent PRs have been failing after being merged for this reason