### PR TITLE
dialects: (scf) fix WhileOp crash when regions contain multiple blocks

### DIFF
--- a/tests/filecheck/dialects/scf/scf_ops.mlir
+++ b/tests/filecheck/dialects/scf/scf_ops.mlir
@@ -133,6 +133,46 @@ builtin.module {
   // CHECK-NEXT:    func.return
   // CHECK-NEXT:  }
 
+  func.func @while_multiblock(%arg0: i32) {
+    %res = scf.while (%arg1 = %arg0) : (i32) -> i32 {
+      %cond = "test.op"() : () -> i1
+      "test.termop"(%cond) [^bb1, ^bb2] : (i1) -> ()
+    ^bb1:
+      scf.condition(%cond) %arg1 : i32
+    ^bb2:
+      scf.condition(%cond) %arg1 : i32
+    } do {
+    ^bb0(%arg2: i32):
+      %cond2 = "test.op"() : () -> i1
+      "test.termop"(%cond2) [^bb1, ^bb2] : (i1) -> ()
+    ^bb1:
+      scf.yield %arg2 : i32
+    ^bb2:
+      scf.yield %arg2 : i32
+    }
+    func.return
+  }
+
+  // CHECK:      func.func @while_multiblock(%{{.*}}: i32) {
+  // CHECK-NEXT:   %{{.*}} = scf.while (%{{.*}} = %{{.*}}) : (i32) -> i32 {
+  // CHECK-NEXT:     %{{.*}} = "test.op"() : () -> i1
+  // CHECK-NEXT:     "test.termop"(%{{.*}}) [^bb{{\d+}}, ^bb{{\d+}}] : (i1) -> ()
+  // CHECK-NEXT:   ^bb{{\d+}}:
+  // CHECK-NEXT:     scf.condition(%{{.*}}) %{{.*}} : i32
+  // CHECK-NEXT:   ^bb{{\d+}}:
+  // CHECK-NEXT:     scf.condition(%{{.*}}) %{{.*}} : i32
+  // CHECK-NEXT:   } do {
+  // CHECK-NEXT:   ^bb{{\d+}}(%{{.*}} : i32):
+  // CHECK-NEXT:     %{{.*}} = "test.op"() : () -> i1
+  // CHECK-NEXT:     "test.termop"(%{{.*}}) [^bb{{\d+}}, ^bb{{\d+}}] : (i1) -> ()
+  // CHECK-NEXT:   ^bb{{\d+}}:
+  // CHECK-NEXT:     scf.yield %{{.*}} : i32
+  // CHECK-NEXT:   ^bb{{\d+}}:
+  // CHECK-NEXT:     scf.yield %{{.*}} : i32
+  // CHECK-NEXT:   }
+  // CHECK-NEXT:   func.return
+  // CHECK-NEXT: }
+
   func.func @for() {
     %lb = arith.constant 0 : index
     %ub = arith.constant 42 : index

--- a/xdsl/dialects/scf.py
+++ b/xdsl/dialects/scf.py
@@ -84,17 +84,17 @@ class WhileOp(IRDLOperation):
     # TODO verify dependencies between scf.condition, scf.yield and the regions
     def verify_(self):
         for idx, arg in enumerate(self.arguments):
-            if self.before_region.block.args[idx].type != arg.type:
+            if self.before_region.blocks[0].args[idx].type != arg.type:
                 raise Exception(
                     f"Block arguments with wrong type, expected {arg.type}, "
-                    f"got {self.before_region.block.args[idx].type}"
+                    f"got {self.before_region.blocks[0].args[idx].type}"
                 )
 
         for idx, res in enumerate(self.res):
-            if self.after_region.block.args[idx].type != res.type:
+            if self.after_region.blocks[0].args[idx].type != res.type:
                 raise Exception(
                     f"Block arguments with wrong type, expected {res.type}, "
-                    f"got {self.after_region.block.args[idx].type}"
+                    f"got {self.after_region.blocks[0].args[idx].type}"
                 )
 
     @staticmethod
@@ -105,7 +105,7 @@ class WhileOp(IRDLOperation):
 
     def print(self, printer: Printer):
         printer.print_string(" (")
-        block_args = self.before_region.block.args
+        block_args = self.before_region.blocks[0].args
         printer.print_list(
             zip(block_args, self.arguments, strict=True),
             lambda pair: self._print_pair(printer, pair),


### PR DESCRIPTION
This pull request introduces a new test case for multi-block `scf.while` loops and refactors the way regions and block arguments are accessed in the `xdsl` SCF dialect implementation. The main focus is to improve correctness and consistency when handling regions that may contain multiple blocks.

**Testing improvements:**

* Added a new test function, `@while_multiblock`, to `scf_ops.mlir` that exercises an `scf.while` loop with multiple blocks in both the before and after regions, along with corresponding `CHECK` statements to validate its structure.

**Codebase consistency and correctness:**

* Refactored the `verify_` method in `xdsl/dialects/scf.py` to use `blocks[0]` instead of `block` when accessing region block arguments, ensuring compatibility with regions that may have multiple blocks.
* Updated the `print` method in `xdsl/dialects/scf.py` to access block arguments via `blocks[0]`, aligning with the above change for consistency.

fixed #5644 