### PR TITLE
dialects: (riscv) make `get_constant_value` agnostic

### DIFF
--- a/tests/dialects/test_riscv.py
+++ b/tests/dialects/test_riscv.py
@@ -1,7 +1,7 @@
 import pytest
 
 from xdsl.context import Context
-from xdsl.dialects import riscv, rv32
+from xdsl.dialects import riscv, rv32, rv64
 from xdsl.dialects.builtin import (
     IntAttr,
     IntegerAttr,
@@ -275,6 +275,7 @@ def test_asm_section():
 
 
 def test_get_constant_value():
+    # Test 32-bit LiOp
     li_op = rv32.LiOp(1)
     li_val = get_constant_value(li_op.rd)
     assert li_val == IntegerAttr.from_int_and_width(1, 32)
@@ -284,6 +285,17 @@ def test_get_constant_value():
     assert constantlike.get_constant_value(li_op) == IntegerAttr.from_int_and_width(
         1, 32
     )
+
+    # Test 64-bit LiOp
+    li_op_64 = rv64.LiOp(1)
+    li_val_64 = get_constant_value(li_op_64.rd)
+    assert li_val_64 == IntegerAttr.from_int_and_width(1, 64)
+    constantlike = li_op_64.get_trait(ConstantLike)
+    assert constantlike is not None
+    assert constantlike.get_constant_value(li_op_64) == IntegerAttr.from_int_and_width(
+        1, 64
+    )
+
     zero_op = riscv.GetRegisterOp(riscv.Registers.ZERO)
     zero_val = get_constant_value(zero_op.res)
     assert zero_val == IntegerAttr.from_int_and_width(0, 32)

--- a/tests/filecheck/backend/riscv/canonicalize.mlir
+++ b/tests/filecheck/backend/riscv/canonicalize.mlir
@@ -26,8 +26,6 @@ builtin.module {
   %c1 = rv32.li 1 : !riscv.reg
   %c2 = rv32.li 2 : !riscv.reg
   %c3 = rv32.li 3 : !riscv.reg
-  %c0_64 = rv64.li 5 : !riscv.reg
-  %c1_64 = rv64.li 2 : !riscv.reg
 
   // Don't optimise out unused immediates
   "test.op"(%zero, %c0, %c1, %c2, %c3) : (!riscv.reg<zero>, !riscv.reg, !riscv.reg, !riscv.reg, !riscv.reg) -> ()
@@ -73,12 +71,6 @@ builtin.module {
 
   %add_immediate_constant = riscv.addi %c2, 1 : (!riscv.reg) -> !riscv.reg<a0>
   "test.op"(%add_immediate_constant) : (!riscv.reg<a0>) -> ()
-
-  %multiply_immediate_immediate_64 = riscv.mul %c0_64, %c1_64 : (!riscv.reg, !riscv.reg) -> !riscv.reg
-  "test.op"(%multiply_immediate_immediate_64) : (!riscv.reg) -> ()
-
-  %sub_immediate_immediate_64 = riscv.sub %c0_64, %c1_64 : (!riscv.reg, !riscv.reg) -> !riscv.reg
-  "test.op"(%sub_immediate_immediate_64) : (!riscv.reg) -> ()
 
   // Unchanged
   %sub_lhs_immediate = riscv.sub %c2, %i2 : (!riscv.reg, !riscv.reg) -> !riscv.reg<a0>
@@ -242,12 +234,6 @@ builtin.module {
 
 // CHECK-NEXT:   %add_immediate_constant = rv32.li 3 : !riscv.reg<a0>
 // CHECK-NEXT:   "test.op"(%add_immediate_constant) : (!riscv.reg<a0>) -> ()
-
-// CHECK-NEXT:   %multiply_immediate_immediate = rv32.li 10 : !riscv.reg
-// CHECK-NEXT:   "test.op"(%multiply_immediate_immediate) : (!riscv.reg) -> ()
-
-// CHECK-NEXT:   %sub_immediate_immediate = rv32.li 3 : !riscv.reg
-// CHECK-NEXT:   "test.op"(%sub_immediate_immediate) : (!riscv.reg) -> ()
 
   // Unchanged
 // CHECK-NEXT:   %sub_lhs_immediate = riscv.sub %c2, %i2 : (!riscv.reg, !riscv.reg) -> !riscv.reg<a0>


### PR DESCRIPTION
Breaking down PR #5589, this PR makes the `get_constant_value` agnostic of input type.