### PR TITLE
[WIP] riscv allocate infinite registers for ForOp case 

### DIFF
--- a/tests/filecheck/backend/riscv/register-allocation/allocate-inf-reg.mlir
+++ b/tests/filecheck/backend/riscv/register-allocation/allocate-inf-reg.mlir
@@ -1,0 +1,26 @@
+// RUN: xdsl-opt --split-input-file -p "riscv-allocate-infinite-registers" %s | filecheck %s
+
+builtin.module {
+  riscv_func.func @main() {
+    %0 = riscv.li 6 : !riscv.reg<j_0>
+    %1 = riscv.li 5 : !riscv.reg<j_1>
+    %2 = riscv.add %0, %1 : (!riscv.reg<j_0>, !riscv.reg<j_1>) -> !riscv.reg<j_2>
+    %3 = riscv_scf.for %4 : !riscv.reg<j_0>  = %0 to %1 step %2 iter_args(%5 = %2) -> (!riscv.reg<j_2>) {
+      riscv_scf.yield %5 : !riscv.reg<j_2>
+    }
+    riscv_func.return
+  }
+}
+
+// CHECK:       builtin.module {
+// CHECK-NEXT:    riscv_func.func @main() {
+// CHECK-NEXT:      %0 = riscv.li 6 : !riscv.reg<t0>
+// CHECK-NEXT:      %1 = riscv.li 5 : !riscv.reg<s0>
+// CHECK-NEXT:      %2 = riscv.add %0, %1 : (!riscv.reg<t0>, !riscv.reg<s0>) -> !riscv.reg<t1>
+// CHECK-NEXT:      %3 = riscv_scf.for %4 : !riscv.reg<t0>  = %0 to %1 step %2 iter_args(%5 = %2) -> (!riscv.reg<t1>) {
+// CHECK-NEXT:        %6 = riscv.mv %5 : (!riscv.reg<t1>) -> !riscv.reg<t1>
+// CHECK-NEXT:        riscv_scf.yield %6 : !riscv.reg<t1>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      riscv_func.return
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/xdsl/transforms/__init__.py
+++ b/xdsl/transforms/__init__.py
@@ -505,6 +505,11 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
 
         return riscv_allocate_registers.RISCVAllocateRegistersPass
 
+    def get_test_riscv_allocate_registers():
+        from xdsl.transforms import test_riscv_allocate_registers
+
+        return test_riscv_allocate_registers.TestRiscvAllocateRegistersPass
+
     def get_riscv_lower_parallel_mov():
         from xdsl.transforms import riscv_lower_parallel_mov
 
@@ -772,6 +777,7 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
         "test-add-timers-to-top-level-funcs": get_test_add_timers_to_top_level_funcs,
         "test-constant-folding": get_test_constant_folding,
         "test-lower-linalg-to-snitch": get_test_lower_linalg_to_snitch,
+        "test-riscv-allocate-registers": get_test_riscv_allocate_registers,
         "test-specialised-constant-folding": get_test_specialised_constant_folding,
         "test-transform-dialect-erase-schedule": get_test_transform_dialect_erase_schedule,
         "test-vectorize-matmul": get_test_vectorize_matmul,

--- a/xdsl/transforms/test_riscv_allocate_registers.py
+++ b/xdsl/transforms/test_riscv_allocate_registers.py
@@ -1,0 +1,22 @@
+from dataclasses import dataclass
+
+from xdsl.context import Context
+from xdsl.dialects import builtin
+from xdsl.passes import ModulePass, PassPipeline
+from xdsl.transforms import riscv_allocate_infinite_registers, riscv_allocate_registers
+
+
+@dataclass(frozen=True)
+class TestRiscvAllocateRegistersPass(ModulePass):
+    name = "test-riscv-allocate-registers"
+
+    def apply(self, ctx: Context, op: builtin.ModuleOp) -> None:
+        pipeline = PassPipeline(
+            (
+                riscv_allocate_registers.RISCVAllocateRegistersPass(
+                    force_infinite=True
+                ),
+                riscv_allocate_infinite_registers.RISCVAllocateInfiniteRegistersPass(),
+            )
+        )
+        pipeline.apply(ctx, op)


### PR DESCRIPTION
This draft PR is intended to show a failing case of current infinite register allocation, and is not intended to be merged

Currently, allocating the ForOp does not allocate some values, complaining that some values need to be the same type.