### PR TITLE
core: use ConstantLike + HasFolderInterface for constant op results

### DIFF
--- a/tests/dialects/test_arith.py
+++ b/tests/dialects/test_arith.py
@@ -130,26 +130,21 @@ class Test_integer_arith_construction:
 
 
 def test_constant_construction():
-    c1 = ConstantOp(IntegerAttr(1, i32))
+    attr1 = IntegerAttr(1, i32)
+    c1 = ConstantOp(attr1)
     assert c1.value.type == i32
-    constantlike1 = c1.get_trait(ConstantLike)
-    assert constantlike1 is not None
-    assert constantlike1.get_constant_value(c1) == IntegerAttr(1, i32)
+    assert ConstantLike.get_constant_value(c1.result) == attr1
 
-    c3 = ConstantOp(FloatAttr(1.0, f32))
-    assert c3.value.type == f32
-    constantlike3 = c3.get_trait(ConstantLike)
-    assert constantlike3 is not None
-    assert constantlike3.get_constant_value(c3) == FloatAttr(1.0, f32)
+    attr2 = FloatAttr(1.0, f32)
+    c2 = ConstantOp(attr2)
+    assert c2.value.type == f32
+    assert ConstantLike.get_constant_value(c2.result) == attr2
 
     value_type = TensorType(i32, [2, 2])
-    c5 = ConstantOp(DenseIntOrFPElementsAttr.from_list(value_type, [1, 2, 3, 4]))
-    assert c5.value.type == value_type
-    constantlike5 = c5.get_trait(ConstantLike)
-    assert constantlike5 is not None
-    assert constantlike5.get_constant_value(c5) == DenseIntOrFPElementsAttr.from_list(
-        value_type, [1, 2, 3, 4]
-    )
+    attr3 = DenseIntOrFPElementsAttr.from_list(value_type, [1, 2, 3, 4])
+    c3 = ConstantOp(attr3)
+    assert c3.value.type == value_type
+    assert ConstantLike.get_constant_value(c3.result) == attr3
 
 
 @pytest.mark.parametrize(

--- a/tests/dialects/test_complex.py
+++ b/tests/dialects/test_complex.py
@@ -22,13 +22,13 @@ from xdsl.traits import ConstantLike
 
 
 def test_constant_construction():
+    value = ArrayAttr([IntAttr(42), IntAttr(43)])
     c1 = complex.ConstantOp(
-        value=ArrayAttr([IntAttr(42), IntAttr(43)]),
+        value=value,
         result_type=complex.ComplexType(i32),
     )
-    constantlike = c1.get_trait(ConstantLike)
-    assert constantlike is not None
-    assert constantlike.get_constant_value(c1) == ArrayAttr([IntAttr(42), IntAttr(43)])
+
+    assert ConstantLike.get_constant_value(c1.complex) == value
 
 
 class Test_constant_op_helper_constructors:

--- a/tests/dialects/test_equivalence.py
+++ b/tests/dialects/test_equivalence.py
@@ -7,18 +7,17 @@ from xdsl.utils.exceptions import DiagnosticException
 
 
 def test_const_class_construction():
-    constant_op = arith.ConstantOp(IntegerAttr.from_int_and_width(42, 64))
+    value = IntegerAttr.from_int_and_width(42, 64)
+    constant_op = arith.ConstantOp(value)
 
     const_class = equivalence.ConstantClassOp(constant_op.result)
     trait = const_class.get_trait(ConstantLike)
     assert trait is not None
-    assert trait.get_constant_value(const_class) == IntegerAttr.from_int_and_width(
-        42, 64
-    )
+    assert ConstantLike.get_constant_value(constant_op.result) == value
 
     non_constant_op = test.TestOp(result_types=(i32,))
     with pytest.raises(
         DiagnosticException,
-        match="The argument of a ConstantClass must be a constant-like operation.",
+        match="The argument of a ConstantClass must be a `ConstantLike` operation implementing `HasFolderInterface`.",
     ):
         equivalence.ConstantClassOp(non_constant_op.results[0])

--- a/tests/dialects/test_riscv.py
+++ b/tests/dialects/test_riscv.py
@@ -276,25 +276,18 @@ def test_asm_section():
 
 def test_get_constant_value():
     # Test 32-bit LiOp
-    li_op = rv32.LiOp(1)
-    li_val = get_constant_value(li_op.rd)
-    assert li_val == IntegerAttr.from_int_and_width(1, 32)
-    # LiOp implements ConstantLikeInterface so it also has a get_constant_value method:
-    constantlike = li_op.get_trait(ConstantLike)
-    assert constantlike is not None
-    assert constantlike.get_constant_value(li_op) == IntegerAttr.from_int_and_width(
-        1, 32
-    )
+    one_32 = IntegerAttr.from_int_and_width(1, 32)
+    li_op_32 = rv32.LiOp(1)
+    li_val_32 = get_constant_value(li_op_32.rd)
+    assert li_val_32 == one_32
+    assert ConstantLike.get_constant_value(li_op_32.rd) == one_32
 
     # Test 64-bit LiOp
-    li_op_64 = rv64.LiOp(1)
-    li_val_64 = get_constant_value(li_op_64.rd)
-    assert li_val_64 == IntegerAttr.from_int_and_width(1, 64)
-    constantlike = li_op_64.get_trait(ConstantLike)
-    assert constantlike is not None
-    assert constantlike.get_constant_value(li_op_64) == IntegerAttr.from_int_and_width(
-        1, 64
-    )
+    one_rv64 = IntegerAttr.from_int_and_width(1, 64)
+    li_op_rv64 = rv64.LiOp(1)
+    li_val_rv64 = get_constant_value(li_op_rv64.rd)
+    assert li_val_rv64 == one_rv64
+    assert ConstantLike.get_constant_value(li_op_rv64.rd) == one_rv64
 
     zero_op = riscv.GetRegisterOp(riscv.Registers.ZERO)
     zero_val = get_constant_value(zero_op.res)

--- a/tests/dialects/test_smt.py
+++ b/tests/dialects/test_smt.py
@@ -52,16 +52,12 @@ def test_constant_bool():
     op = ConstantBoolOp(True)
     assert op.value is True
     assert op.value_attr == IntegerAttr(-1, 1)
-    constantlike = op.get_trait(ConstantLike)
-    assert constantlike is not None
-    assert constantlike.get_constant_value(op) == IntegerAttr(-1, 1)
+    assert ConstantLike.get_constant_value(op.result) == IntegerAttr(-1, 1)
 
     op = ConstantBoolOp(False)
     assert op.value is False
     assert op.value_attr == IntegerAttr(0, 1)
-    constantlike = op.get_trait(ConstantLike)
-    assert constantlike is not None
-    assert constantlike.get_constant_value(op) == IntegerAttr(0, 1)
+    assert ConstantLike.get_constant_value(op.result) == IntegerAttr(0, 1)
 
 
 def test_bv_type():
@@ -189,23 +185,17 @@ def test_bv_constant_op():
     op = BvConstantOp(bv_attr)
     assert op.value == bv_attr
     assert op.result.type == BitVectorType(32)
-    constantlike = op.get_trait(ConstantLike)
-    assert constantlike is not None
-    assert constantlike.get_constant_value(op) == bv_attr
+    assert ConstantLike.get_constant_value(op.result) == bv_attr
 
     op2 = BvConstantOp(42, 32)
     assert op2.value == bv_attr
     assert op2.result.type == BitVectorType(32)
-    constantlike2 = op2.get_trait(ConstantLike)
-    assert constantlike2 is not None
-    assert constantlike2.get_constant_value(op2) == bv_attr
+    assert ConstantLike.get_constant_value(op2.result) == bv_attr
 
     op3 = BvConstantOp(42, BitVectorType(32))
     assert op3.value == bv_attr
     assert op3.result.type == BitVectorType(32)
-    constantlike3 = op3.get_trait(ConstantLike)
-    assert constantlike3 is not None
-    assert constantlike3.get_constant_value(op3) == bv_attr
+    assert ConstantLike.get_constant_value(op3.result) == bv_attr
 
 
 @pytest.mark.parametrize("op_type", [BVNotOp, BVNegOp])

--- a/xdsl/dialects/rv32.py
+++ b/xdsl/dialects/rv32.py
@@ -23,7 +23,7 @@ from xdsl.dialects.riscv import (
     print_immediate_value,
 )
 from xdsl.dialects.riscv.ops import LiOpHasCanonicalizationPatternTrait
-from xdsl.interfaces import ConstantLikeInterface
+from xdsl.interfaces import HasFolderInterface
 from xdsl.ir import (
     Attribute,
     Dialect,
@@ -37,12 +37,13 @@ from xdsl.irdl import (
 from xdsl.parser import Parser
 from xdsl.printer import Printer
 from xdsl.traits import (
+    ConstantLike,
     Pure,
 )
 
 
 @irdl_op_definition
-class LiOp(RISCVCustomFormatOperation, RISCVInstruction, ConstantLikeInterface, ABC):
+class LiOp(RISCVCustomFormatOperation, RISCVInstruction, HasFolderInterface, ABC):
     """
     Loads a 32-bit immediate into rd.
 
@@ -56,7 +57,7 @@ class LiOp(RISCVCustomFormatOperation, RISCVInstruction, ConstantLikeInterface, 
     rd = result_def(IntRegisterType)
     immediate = attr_def(IntegerAttr[I32] | LabelAttr)
 
-    traits = traits_def(Pure(), LiOpHasCanonicalizationPatternTrait())
+    traits = traits_def(Pure(), LiOpHasCanonicalizationPatternTrait(), ConstantLike())
 
     def __init__(
         self,
@@ -83,8 +84,8 @@ class LiOp(RISCVCustomFormatOperation, RISCVInstruction, ConstantLikeInterface, 
     def assembly_line_args(self) -> tuple[AssemblyInstructionArg, ...]:
         return self.rd, self.immediate
 
-    def get_constant_value(self):
-        return self.immediate
+    def fold(self) -> tuple[IntegerAttr[I32] | LabelAttr]:
+        return (self.immediate,)
 
     @classmethod
     def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:

--- a/xdsl/interfaces.py
+++ b/xdsl/interfaces.py
@@ -16,7 +16,6 @@ from xdsl.ir import Attribute, Operation, SSAValue
 from xdsl.irdl import traits_def
 from xdsl.pattern_rewriter import RewritePattern
 from xdsl.traits import (
-    ConstantLike,
     HasCanonicalizationPatternsTrait,
     HasFolder,
 )
@@ -56,35 +55,6 @@ class HasCanonicalizationPatternsInterface(Operation, abc.ABC):
         raise NotImplementedError()
 
 
-class _ConstantLikeInterfaceTrait(ConstantLike):
-    """
-    Gets the constant value from the operation's implementation
-    of `ConstantLikeInterface`.
-    """
-
-    def verify(self, op: Operation) -> None:
-        return
-
-    @classmethod
-    def get_constant_value(cls, op: Operation) -> Attribute:
-        op = cast(ConstantLikeInterface, op)
-        return op.get_constant_value()
-
-
-class ConstantLikeInterface(Operation, abc.ABC):
-    """
-    An operation subclassing this interface must implement the
-    `get_constant_value` method, which returns the constant value of this operation.
-    Wraps `ConstantLikeTrait`.
-    """
-
-    traits = traits_def(_ConstantLikeInterfaceTrait())
-
-    @abc.abstractmethod
-    def get_constant_value(self) -> Attribute:
-        raise NotImplementedError()
-
-
 class _HasFolderInterfaceTrait(HasFolder):
     """
     Gets the fold results from the operation's implementation
@@ -108,13 +78,6 @@ class HasFolderInterface(Operation, abc.ABC):
     """
 
     traits = traits_def(_HasFolderInterfaceTrait())
-
-    def get_constant(self, operand: SSAValue) -> Attribute | None:
-        if (
-            isinstance(operand_op := operand.owner, Operation)
-            and (t := operand_op.get_trait(ConstantLike)) is not None
-        ):
-            return t.get_constant_value(operand_op)
 
     @abc.abstractmethod
     def fold(self) -> Sequence[SSAValue | Attribute] | None:

--- a/xdsl/transforms/canonicalization_patterns/riscv.py
+++ b/xdsl/transforms/canonicalization_patterns/riscv.py
@@ -1,9 +1,10 @@
-from typing import cast
+from typing import Literal, cast
 
 from xdsl.dialects import riscv, riscv_snitch, rv32
-from xdsl.dialects.builtin import I32, I64, IntegerAttr, i32
+from xdsl.dialects.builtin import I32, I64, IntegerAttr, IntegerType, Signedness, i32
 from xdsl.dialects.utils import FastMathFlag
 from xdsl.ir import OpResult, SSAValue
+from xdsl.irdl import irdl_to_attr_constraint
 from xdsl.pattern_rewriter import (
     PatternRewriter,
     RewritePattern,
@@ -645,7 +646,14 @@ class LoadImmediate0(RewritePattern):
             )
 
 
-def get_constant_value(value: SSAValue) -> IntegerAttr[I32] | IntegerAttr[I64] | None:
+_I32_I64_CONSTRAINT = irdl_to_attr_constraint(
+    IntegerAttr[IntegerType[Literal[32, 64], Literal[Signedness.SIGNLESS]]]
+)
+
+
+def get_constant_value(
+    value: SSAValue,
+) -> IntegerAttr[I32] | IntegerAttr[I64] | None:
     if value.type == riscv.Registers.ZERO:
         return IntegerAttr(0, i32)
 
@@ -655,8 +663,7 @@ def get_constant_value(value: SSAValue) -> IntegerAttr[I32] | IntegerAttr[I64] |
     if isinstance(value.op, riscv.MVOp):
         return get_constant_value(value.op.rs)
 
-    constant_like = value.op.get_trait(ConstantLike)
-    if constant_like is not None:
-        result = constant_like.get_constant_value(value.op)
-        if isinstance(result, IntegerAttr):
-            return cast(IntegerAttr[I32] | IntegerAttr[I64], result)
+    if (
+        result := ConstantLike.get_constant_value(value)
+    ) is not None and _I32_I64_CONSTRAINT.verifies(result):
+        return cast(IntegerAttr[I32] | IntegerAttr[I64], result)


### PR DESCRIPTION
This more closely resembles the MLIR API, where ConstantLike is a trait, and ops have optional folders.