### PR TITLE
core: add type annotations to delimited helpers

### DIFF
--- a/xdsl/parser/generic_parser.py
+++ b/xdsl/parser/generic_parser.py
@@ -3,7 +3,7 @@ This file contains the definition of `BaseParser`, a recursive descent parser
 that is inherited from the different parsers used in xDSL.
 """
 
-from collections.abc import Callable, Iterable, Iterator
+from collections.abc import Callable, Generator, Iterable
 from contextlib import AbstractContextManager, contextmanager
 from dataclasses import dataclass
 from enum import Enum
@@ -302,7 +302,7 @@ class GenericParser(Generic[TokenKindT]):
         self.raise_error(f"'{text}' expected" + context_msg)
 
     @contextmanager
-    def delimited(self, start: str, end: str) -> Iterator[None]:
+    def delimited(self, start: str, end: str) -> Generator[None, None, None]:
         self.parse_characters(start)
         yield
         self.parse_characters(end)

--- a/xdsl/utils/base_printer.py
+++ b/xdsl/utils/base_printer.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable, Iterator
+from collections.abc import Callable, Generator, Iterable
 from contextlib import AbstractContextManager, contextmanager
 from dataclasses import dataclass, field
 from typing import IO, Any
@@ -69,7 +69,7 @@ class BasePrinter:
             print_fn(elem)
 
     @contextmanager
-    def delimited(self, start: str, end: str) -> Iterator[None]:
+    def delimited(self, start: str, end: str) -> Generator[None, None, None]:
         self.print_string(start)
         yield
         self.print_string(end)


### PR DESCRIPTION
Pyright has a limit to the depth of type inference, and adding these annotations helps removes some spurious issues I've had recently in local development.
