### PR TITLE
dialects: (riscv) remove label immediate for shift constants

### DIFF
--- a/xdsl/dialects/riscv/abstract_ops.py
+++ b/xdsl/dialects/riscv/abstract_ops.py
@@ -731,7 +731,7 @@ class ImmShiftOpHasCanonicalizationPatternsTrait(HasCanonicalizationPatternsTrai
         return (ShiftbyZero(),)
 
 
-class RdRsImmShiftOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC):
+class RdRsImmShiftOperation(RISCVInstruction, ABC):
     """
     A base class for RISC-V operations that have one destination register, one source
     register and one immediate operand.
@@ -747,21 +747,23 @@ class RdRsImmShiftOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC):
 
     rd = result_def(IntRegisterType)
     rs1 = operand_def(IntRegisterType)
-    immediate = attr_def(IntegerAttr[UI5] | LabelAttr)
+    immediate = attr_def(IntegerAttr[UI5])
     traits = traits_def(ImmShiftOpHasCanonicalizationPatternsTrait())
+
+    assembly_format = (
+        "$rs1 `,` $immediate attr-dict `:` `(` type($rs1) `)` `->` type($rd)"
+    )
 
     def __init__(
         self,
         rs1: Operation | SSAValue,
-        immediate: int | IntegerAttr[UI5] | str | LabelAttr,
+        immediate: int | IntegerAttr[UI5],
         *,
         rd: IntRegisterType = Registers.UNALLOCATED_INT,
         comment: str | StringAttr | None = None,
     ):
         if isinstance(immediate, int):
             immediate = IntegerAttr(immediate, ui5)
-        elif isinstance(immediate, str):
-            immediate = LabelAttr(immediate)
 
         if isinstance(comment, str):
             comment = StringAttr(comment)
@@ -776,17 +778,6 @@ class RdRsImmShiftOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC):
 
     def assembly_line_args(self) -> tuple[AssemblyInstructionArg, ...]:
         return self.rd, self.rs1, self.immediate
-
-    @classmethod
-    def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
-        attributes = dict[str, Attribute]()
-        attributes["immediate"] = parse_immediate_value(parser, ui5)
-        return attributes
-
-    def custom_print_attributes(self, printer: Printer) -> AbstractSet[str]:
-        printer.print_string(", ")
-        print_immediate_value(printer, self.immediate)
-        return {"immediate"}
 
 
 class RdRsImmBitManipOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC):

--- a/xdsl/transforms/canonicalization_patterns/riscv.py
+++ b/xdsl/transforms/canonicalization_patterns/riscv.py
@@ -299,9 +299,7 @@ class XoriImmediate(RewritePattern):
 class ShiftLeftImmediate(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: riscv.SlliOp, rewriter: PatternRewriter) -> None:
-        if (rs1 := get_constant_value(op.rs1)) is not None and isinstance(
-            op.immediate, IntegerAttr
-        ):
+        if (rs1 := get_constant_value(op.rs1)) is not None:
             rd = op.rd.type
             rewriter.replace_op(
                 op,
@@ -312,9 +310,7 @@ class ShiftLeftImmediate(RewritePattern):
 class ShiftRightImmediate(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: riscv.SrliOp, rewriter: PatternRewriter) -> None:
-        if (rs1 := get_constant_value(op.rs1)) is not None and isinstance(
-            op.immediate, IntegerAttr
-        ):
+        if (rs1 := get_constant_value(op.rs1)) is not None:
             rd = op.rd.type
             rewriter.replace_op(
                 op,
@@ -332,7 +328,7 @@ class ShiftbyZero(RewritePattern):
         self, op: riscv.SlliOp | riscv.SrliOp | riscv.SraiOp, rewriter: PatternRewriter
     ) -> None:
         # check if the shift amount is zero
-        if isinstance(op.immediate, IntegerAttr) and op.immediate.value.data == 0:
+        if op.immediate.value.data == 0:
             rewriter.replace_op(op, riscv.MVOp(op.rs1, rd=op.rd.type))
 
 


### PR DESCRIPTION
It's not supported by most assemblers, we'll do a review of the remaining ops and whether these should also accept labels for their immediates.