### PR TITLE
core: deprecate IntegerAttr.from_int_and_width

### DIFF
--- a/docs/marimo/irdl.py
+++ b/docs/marimo/irdl.py
@@ -563,7 +563,7 @@ def _(IRDLOperation, IntegerAttr, i32, irdl_op_definition, printer):
         output = result_def(i32)
 
 
-    i32_ssa_var = ConstantOp(IntegerAttr.from_int_and_width(62, 32), i32)
+    i32_ssa_var = ConstantOp(IntegerAttr(62, 32), i32)
     my_addi32 = Addi32Op.build(
         operands=[i32_ssa_var.result, i32_ssa_var.result], result_types=[i32]
     )
@@ -723,7 +723,7 @@ def _(
         res = result_def(i32)
 
 
-    i32_ssa_var_b = ConstantOp(IntegerAttr.from_int_and_width(62, 32), i32)
+    i32_ssa_var_b = ConstantOp(IntegerAttr(62, 32), i32)
     add_op = AddVariadicOp.build(operands=[[i32_ssa_var_b] * 3], result_types=[i32])
     printer.print_op(i32_ssa_var_b)
     print()
@@ -773,7 +773,7 @@ def _(
         irdl_options = (AttrSizedOperandSegments(),)
 
 
-    i32_ssa_var_c = ConstantOp(IntegerAttr.from_int_and_width(62, 32), i32)
+    i32_ssa_var_c = ConstantOp(IntegerAttr(62, 32), i32)
     add_op2 = AddVariadic2Op.build(
         operands=[[i32_ssa_var_c] * 2, [i32_ssa_var_c]],
         result_types=[i32],
@@ -811,7 +811,7 @@ def _(
         res = result_def(i32)
 
 
-    i32_ssa_var_d = ConstantOp(IntegerAttr.from_int_and_width(62, 32), i32)
+    i32_ssa_var_d = ConstantOp(IntegerAttr(62, 32), i32)
     add_op3 = AddVariadic2Op2.build(
         operands=[i32_ssa_var_d, [i32_ssa_var_d]], result_types=[i32]
     )
@@ -971,7 +971,7 @@ def _(
                 raise Exception("expect all input and output types to be equal")
 
 
-    i32_ssa_var_e = ConstantOp(IntegerAttr.from_int_and_width(62, 32), i32)
+    i32_ssa_var_e = ConstantOp(IntegerAttr(62, 32), i32)
     add_op5 = AddiOp.build(operands=[i32_ssa_var_e, i32_ssa_var_e], result_types=[i32])
     # This will pass, since all operands and results have the same type
     add_op5.verify()

--- a/docs/marimo/mlir_interoperation.py
+++ b/docs/marimo/mlir_interoperation.py
@@ -58,8 +58,8 @@ def _():
     from xdsl.ir import Block, Region
 
     # Define two integer constants
-    a = ConstantOp(IntegerAttr.from_int_and_width(1, 32), i32)
-    b = ConstantOp(IntegerAttr.from_int_and_width(2, 32), i32)
+    a = ConstantOp(IntegerAttr(1, 32), i32)
+    b = ConstantOp(IntegerAttr(2, 32), i32)
 
     # Operations on these constants
     c = AddiOp(a, b)

--- a/tests/dialects/test_arith.py
+++ b/tests/dialects/test_arith.py
@@ -495,9 +495,9 @@ def test_extui_incorrect_bitwidth():
 def test_constant_materialization():
     interface = Arith.get_interface(ConstantMaterializationInterface)
     assert interface is not None
-    const = interface.materialize_constant(IntegerAttr.from_int_and_width(42, 32), i32)
+    const = interface.materialize_constant(IntegerAttr(42, 32), i32)
     assert isinstance(const, ConstantOp)
-    assert const.value == IntegerAttr.from_int_and_width(42, 32)
+    assert const.value == IntegerAttr(42, 32)
     assert const.result_types[0] == i32
 
     const = interface.materialize_constant(FloatAttr(42.0, f64), f64)

--- a/tests/dialects/test_equivalence.py
+++ b/tests/dialects/test_equivalence.py
@@ -7,7 +7,7 @@ from xdsl.utils.exceptions import DiagnosticException
 
 
 def test_const_class_construction():
-    value = IntegerAttr.from_int_and_width(42, 64)
+    value = IntegerAttr(42, 64)
     constant_op = arith.ConstantOp(value)
 
     const_class = equivalence.ConstantClassOp(constant_op.result)

--- a/tests/dialects/test_func.py
+++ b/tests/dialects/test_func.py
@@ -68,10 +68,10 @@ def test_func():
 def test_func_II():
     # Create constants and add them, add them in blocks, blocks in
     # a region and create a function
-    a = ConstantOp(IntegerAttr.from_int_and_width(1, 32), i32)
-    b = ConstantOp(IntegerAttr.from_int_and_width(2, 32), i32)
-    c = ConstantOp(IntegerAttr.from_int_and_width(3, 32), i32)
-    d = ConstantOp(IntegerAttr.from_int_and_width(4, 32), i32)
+    a = ConstantOp(IntegerAttr(1, 32), i32)
+    b = ConstantOp(IntegerAttr(2, 32), i32)
+    c = ConstantOp(IntegerAttr(3, 32), i32)
+    d = ConstantOp(IntegerAttr(4, 32), i32)
 
     # Operation to add these constants
     e = AddiOp(a, b)

--- a/tests/dialects/test_pdl.py
+++ b/tests/dialects/test_pdl.py
@@ -108,7 +108,7 @@ def test_build_pattern():
 
     pattern = pdl.PatternOp(1, "pattern", body)
 
-    assert pattern.benefit == IntegerAttr.from_int_and_width(1, 16)
+    assert pattern.benefit == IntegerAttr(1, 16)
     assert pattern.sym_name == StringAttr("pattern")
     assert pattern.body is body
 
@@ -142,9 +142,9 @@ def test_build_pattern():
 
 
 def test_build_result():
-    res = pdl.ResultOp(IntegerAttr.from_int_and_width(1, 32), parent=op_val)
+    res = pdl.ResultOp(IntegerAttr(1, 32), parent=op_val)
 
-    assert res.index == IntegerAttr.from_int_and_width(1, 32)
+    assert res.index == IntegerAttr(1, 32)
     assert res.parent_ == op_val
 
 
@@ -157,18 +157,18 @@ def test_build_resultS():
 
 
 def test_build_results_with_index():
-    res = pdl.ResultsOp(op_val, IntegerAttr.from_int_and_width(1, 32))
+    res = pdl.ResultsOp(op_val, IntegerAttr(1, 32))
 
     assert res.parent_ == op_val
-    assert res.index == IntegerAttr.from_int_and_width(1, 32)
+    assert res.index == IntegerAttr(1, 32)
     assert res.val.type == pdl.RangeType(pdl.ValueType())
 
 
 def test_build_results_with_index_and_type():
-    res = pdl.ResultsOp(op_val, IntegerAttr.from_int_and_width(1, 32), pdl.ValueType())
+    res = pdl.ResultsOp(op_val, IntegerAttr(1, 32), pdl.ValueType())
 
     assert res.parent_ == op_val
-    assert res.index == IntegerAttr.from_int_and_width(1, 32)
+    assert res.index == IntegerAttr(1, 32)
     assert res.val.type == pdl.ValueType()
 
 

--- a/tests/dialects/test_rv32.py
+++ b/tests/dialects/test_rv32.py
@@ -30,15 +30,13 @@ def test_get_constant_value():
     # Test 32-bit LiOp
     li_op = rv32.LiOp(1)
     li_val = get_constant_value(li_op.rd)
-    assert li_val == IntegerAttr.from_int_and_width(1, 32)
+    assert li_val == IntegerAttr(1, 32)
     # LiOp implements ConstantLikeInterface so it also has a get_constant_value method:
     constantlike = li_op.get_trait(ConstantLike)
     assert constantlike is not None
-    assert constantlike.get_constant_value(li_op.rd) == IntegerAttr.from_int_and_width(
-        1, 32
-    )
+    assert constantlike.get_constant_value(li_op.rd) == IntegerAttr(1, 32)
 
     # Test 32-bit zero register
     zero_op = rv32.GetRegisterOp(riscv.Registers.ZERO)
     zero_val = get_constant_value(zero_op.res)
-    assert zero_val == IntegerAttr.from_int_and_width(0, 32)
+    assert zero_val == IntegerAttr(0, 32)

--- a/tests/dialects/test_rv64.py
+++ b/tests/dialects/test_rv64.py
@@ -30,15 +30,13 @@ def test_get_constant_value():
     # Test 64-bit LiOp
     li_op = rv64.LiOp(1)
     li_val = get_constant_value(li_op.rd)
-    assert li_val == IntegerAttr.from_int_and_width(1, 64)
+    assert li_val == IntegerAttr(1, 64)
     # LiOp implements ConstantLikeInterface so it also has a get_constant_value method:
     constantlike = li_op.get_trait(ConstantLike)
     assert constantlike is not None
-    assert constantlike.get_constant_value(li_op.rd) == IntegerAttr.from_int_and_width(
-        1, 64
-    )
+    assert constantlike.get_constant_value(li_op.rd) == IntegerAttr(1, 64)
 
     # Test 64-bit zero register
     zero_op = rv64.GetRegisterOp(riscv.Registers.ZERO)
     zero_val = get_constant_value(zero_op.res)
-    assert zero_val == IntegerAttr.from_int_and_width(0, 64)
+    assert zero_val == IntegerAttr(0, 64)

--- a/tests/pattern_rewriter/test_pattern_rewriter.py
+++ b/tests/pattern_rewriter/test_pattern_rewriter.py
@@ -256,8 +256,8 @@ def test_recursive_rewriter():
             val = op_val.value.data
             if val == 0 or val == 1:
                 return
-            constant_op = ConstantOp(IntegerAttr.from_int_and_width(val - 1, 32), i32)
-            constant_one = ConstantOp(IntegerAttr.from_int_and_width(1, 32), i32)
+            constant_op = ConstantOp(IntegerAttr(val - 1, 32), i32)
+            constant_one = ConstantOp(IntegerAttr(1, 32), i32)
             add_op = AddiOp(constant_op, constant_one)
             rewriter.replace_op(op, [constant_op, constant_one, add_op])
 
@@ -299,8 +299,8 @@ def test_recursive_rewriter_reversed():
             val = op_val.value.data
             if val == 0 or val == 1:
                 return
-            constant_op = ConstantOp(IntegerAttr.from_int_and_width(val - 1, 32), i32)
-            constant_one = ConstantOp(IntegerAttr.from_int_and_width(1, 32), i32)
+            constant_op = ConstantOp(IntegerAttr(val - 1, 32), i32)
+            constant_one = ConstantOp(IntegerAttr(1, 32), i32)
             add_op = AddiOp(constant_op, constant_one)
             rewriter.replace_op(op, [constant_op, constant_one, add_op])
 
@@ -1880,9 +1880,9 @@ builtin.module {
     class Rewrite(RewritePattern):
         @op_type_rewrite_pattern
         def match_and_rewrite(self, matched_op: test.TestOp, rewriter: PatternRewriter):
-            if matched_op.attributes.get(
-                "erroneous", IntegerAttr.from_int_and_width(0, 1)
-            ) == IntegerAttr.from_int_and_width(1, 1):
+            if matched_op.attributes.get("erroneous", IntegerAttr(0, 1)) == IntegerAttr(
+                1, 1
+            ):
                 raise ValueError("Expected operation to not be erroneous!")
             return
 

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -107,10 +107,10 @@ def test_ops_accessor_II():
 def test_ops_accessor_III():
     # Create constants and add them, add them in blocks, blocks in
     # a region and create a function
-    a = ConstantOp(IntegerAttr.from_int_and_width(1, 32), i32)
-    b = ConstantOp(IntegerAttr.from_int_and_width(2, 32), i32)
-    c = ConstantOp(IntegerAttr.from_int_and_width(3, 32), i32)
-    d = ConstantOp(IntegerAttr.from_int_and_width(4, 32), i32)
+    a = ConstantOp(IntegerAttr(1, 32), i32)
+    b = ConstantOp(IntegerAttr(2, 32), i32)
+    c = ConstantOp(IntegerAttr(3, 32), i32)
+    d = ConstantOp(IntegerAttr(4, 32), i32)
 
     # Operation to add these constants
     e = AddiOp(a, b)

--- a/tests/test_traits.py
+++ b/tests/test_traits.py
@@ -324,9 +324,7 @@ def test_symbol_op_interface():
         sym_name = attr_def(IntegerAttr)
         traits = traits_def(SymbolOpInterface())
 
-    op1 = SymNameWrongTypeOp(
-        attributes={"sym_name": IntegerAttr.from_int_and_width(1, 32)}
-    )
+    op1 = SymNameWrongTypeOp(attributes={"sym_name": IntegerAttr(1, 32)})
 
     with pytest.raises(
         VerifyException,

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -887,7 +887,7 @@ class CmpiOp(ComparisonOperation):
         super().__init__(
             operands=[operand1, operand2],
             result_types=[IntegerType(1)],
-            properties={"predicate": IntegerAttr.from_int_and_width(arg, 64)},
+            properties={"predicate": IntegerAttr(arg, 64)},
         )
 
     @classmethod
@@ -989,7 +989,7 @@ class CmpfOp(ComparisonOperation):
             operands=[operand1, operand2],
             result_types=[IntegerType(1)],
             properties={
-                "predicate": IntegerAttr.from_int_and_width(arg, 64),
+                "predicate": IntegerAttr(arg, 64),
                 "fastmath": fastmath,
             },
         )

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -924,6 +924,7 @@ class IntegerAttr(
                 value = normalized_value
         super().__init__(IntAttr(value), value_type)
 
+    @deprecated("Please use IntegerAttr(value, width) instead")
     @staticmethod
     def from_int_and_width(
         value: int, width: IntCovT

--- a/xdsl/dialects/comb.py
+++ b/xdsl/dialects/comb.py
@@ -304,7 +304,7 @@ class ICmpOp(IRDLOperation, ABC):
             }
             arg = ICmpOp._get_comparison_predicate(arg, cmpi_comparison_operations)
         if not isinstance(arg, IntegerAttr):
-            arg = IntegerAttr.from_int_and_width(arg, 64)
+            arg = IntegerAttr(arg, 64)
 
         attrs: dict[str, Attribute] = {"predicate": arg}
         if has_two_state_semantics:

--- a/xdsl/dialects/eqsat_pdl_interp.py
+++ b/xdsl/dialects/eqsat_pdl_interp.py
@@ -15,6 +15,8 @@ from xdsl.dialects.builtin import (
     StringAttr,
     SymbolRefAttr,
     UnitAttr,
+    i16,
+    i32,
 )
 from xdsl.dialects.pdl import (
     AnyPDLTypeConstr,
@@ -58,7 +60,7 @@ class GetResultOp(IRDLOperation):
 
     def __init__(self, index: int | IntegerAttr[I32], input_op: SSAValue) -> None:
         if isinstance(index, int):
-            index = IntegerAttr.from_int_and_width(index, 32)
+            index = IntegerAttr(index, i32)
         super().__init__(
             operands=[input_op], properties={"index": index}, result_types=[ValueType()]
         )
@@ -85,7 +87,7 @@ class GetResultsOp(IRDLOperation):
         result_type: ValueType | RangeType[ValueType],
     ) -> None:
         if isinstance(index, int):
-            index = IntegerAttr.from_int_and_width(index, 32)
+            index = IntegerAttr(index, i32)
         super().__init__(
             operands=[input_op],
             properties={"index": index},
@@ -96,7 +98,7 @@ class GetResultsOp(IRDLOperation):
     def parse(cls, parser: Parser) -> GetResultsOp:
         index = parser.parse_optional_integer()
         if index is not None:
-            index = IntegerAttr.from_int_and_width(index, 32)
+            index = IntegerAttr(index, 32)
         parser.parse_characters("of")
         input_op = parser.parse_operand()
         parser.parse_punctuation(":")
@@ -365,7 +367,7 @@ class RecordMatchOp(IRDLOperation):
         if isinstance(root_kind, str):
             root_kind = StringAttr(root_kind)
         if isinstance(benefit, int):
-            benefit = IntegerAttr.from_int_and_width(benefit, 16)
+            benefit = IntegerAttr(benefit, i16)
         super().__init__(
             operands=[inputs, matched_ops],
             properties={

--- a/xdsl/dialects/experimental/dmp.py
+++ b/xdsl/dialects/experimental/dmp.py
@@ -456,7 +456,7 @@ class GridSlice2dAttr(DomainDecompositionStrategy):
     diagonals: builtin.BoolAttr
 
     def __init__(self, topo: tuple[int, ...]):
-        super().__init__(RankTopoAttr(topo), builtin.BoolAttr.from_int_and_width(0, 1))
+        super().__init__(RankTopoAttr(topo), builtin.BoolAttr.from_bool(False))
 
     def _verify(self):
         assert len(self.topology.as_tuple()) >= 2, (
@@ -502,7 +502,7 @@ class GridSlice3dAttr(DomainDecompositionStrategy):
     diagonals: builtin.BoolAttr
 
     def __init__(self, topo: tuple[int, ...]):
-        super().__init__(RankTopoAttr(topo), builtin.BoolAttr.from_int_and_width(0, 1))
+        super().__init__(RankTopoAttr(topo), builtin.BoolAttr.from_bool(False))
 
     def _verify(self):
         assert len(self.topology.as_tuple()) >= 3, (

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -1161,9 +1161,7 @@ class AllocaOp(IRDLOperation):
         elem_type: Attribute,
         alignment: int = 32,
     ):
-        props: dict[str, Attribute] = {
-            "alignment": IntegerAttr.from_int_and_width(alignment, 64)
-        }
+        props: dict[str, Attribute] = {"alignment": IntegerAttr(alignment, 64)}
         ptr_type = LLVMPointerType()
         props["elem_type"] = elem_type
 
@@ -1251,7 +1249,7 @@ class InlineAsmOp(IRDLOperation):
         props: dict[str, Attribute | None] = {
             "asm_string": StringAttr(asm_string),
             "constraints": StringAttr(constraints),
-            "asm_dialect": IntegerAttr.from_int_and_width(asm_dialect, 64),
+            "asm_dialect": IntegerAttr(asm_dialect, 64),
             "has_side_effects": UnitAttr() if has_side_effects else None,
             "is_align_stack": UnitAttr() if is_align_stack else None,
             "tail_call_kind": tail_call_kind,
@@ -1700,7 +1698,7 @@ class FuncOp(IRDLOperation):
         if isinstance(sym_name, str):
             sym_name = StringAttr(sym_name)
         if isinstance(visibility, int):
-            visibility = IntegerAttr.from_int_and_width(visibility, 64)
+            visibility = IntegerAttr(visibility, 64)
         if body is None:
             body = Region([])
         if isinstance(sym_visibility, str):
@@ -1740,18 +1738,18 @@ class FuncOp(IRDLOperation):
     @staticmethod
     def _parse_llvm_visibility(parser: Parser) -> IntegerAttr[IntegerType]:
         if parser.parse_optional_keyword("hidden"):
-            return IntegerAttr.from_int_and_width(1, 64)
+            return IntegerAttr(1, 64)
         elif parser.parse_optional_keyword("protected"):
-            return IntegerAttr.from_int_and_width(2, 64)
-        return IntegerAttr.from_int_and_width(0, 64)
+            return IntegerAttr(2, 64)
+        return IntegerAttr(0, 64)
 
     @staticmethod
     def _parse_llvm_unnamed_addr(parser: Parser) -> IntegerAttr[IntegerType]:
         if parser.parse_optional_keyword("local_unnamed_addr"):
-            return IntegerAttr.from_int_and_width(1, 64)
+            return IntegerAttr(1, 64)
         elif parser.parse_optional_keyword("unnamed_addr"):
-            return IntegerAttr.from_int_and_width(2, 64)
-        return IntegerAttr.from_int_and_width(0, 64)
+            return IntegerAttr(2, 64)
+        return IntegerAttr(0, 64)
 
     @staticmethod
     def _get_return_type(

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -209,7 +209,7 @@ class AllocOp(IRDLOperation):
             dynamic_sizes = []
 
         if isinstance(alignment, int):
-            alignment = IntegerAttr.from_int_and_width(alignment, 64)
+            alignment = IntegerAttr(alignment, 64)
 
         return cls(
             tuple(SSAValue.get(ds) for ds in dynamic_sizes),
@@ -346,7 +346,7 @@ class AllocaOp(IRDLOperation):
             dynamic_sizes = []
 
         if isinstance(alignment, int):
-            alignment = IntegerAttr.from_int_and_width(alignment, 64)
+            alignment = IntegerAttr(alignment, 64)
 
         return AllocaOp.build(
             operands=[dynamic_sizes, []],
@@ -448,7 +448,7 @@ class GlobalOp(IRDLOperation):
         alignment: int | IntegerAttr[IntegerType] | None = None,
     ) -> GlobalOp:
         if isinstance(alignment, int):
-            alignment = IntegerAttr.from_int_and_width(alignment, 64)
+            alignment = IntegerAttr(alignment, 64)
 
         return GlobalOp.build(
             properties={

--- a/xdsl/dialects/pdl_interp.py
+++ b/xdsl/dialects/pdl_interp.py
@@ -27,6 +27,8 @@ from xdsl.dialects.builtin import (
     SymbolRefAttr,
     UnitAttr,
     VectorType,
+    i16,
+    i32,
 )
 from xdsl.dialects.pdl import (
     AnyPDLType,
@@ -109,7 +111,7 @@ class GetOperandOp(IRDLOperation):
 
     def __init__(self, index: int | IntegerAttr[I32], input_op: SSAValue) -> None:
         if isinstance(index, int):
-            index = IntegerAttr.from_int_and_width(index, 32)
+            index = IntegerAttr(index, i32)
         super().__init__(
             operands=[input_op], properties={"index": index}, result_types=[ValueType()]
         )
@@ -137,7 +139,7 @@ class GetOperandsOp(IRDLOperation):
         result_type: ValueType | RangeType[ValueType],
     ) -> None:
         if isinstance(index, int):
-            index = IntegerAttr.from_int_and_width(index, 32)
+            index = IntegerAttr(index, i32)
         super().__init__(
             operands=[input_op],
             properties={"index": index},
@@ -148,7 +150,7 @@ class GetOperandsOp(IRDLOperation):
     def parse(cls, parser: Parser) -> GetOperandsOp:
         index = parser.parse_optional_integer()
         if index is not None:
-            index = IntegerAttr.from_int_and_width(index, 32)
+            index = IntegerAttr(index, 32)
         parser.parse_characters("of")
         input_op = parser.parse_operand()
         parser.parse_punctuation(":")
@@ -242,7 +244,7 @@ class CheckOperandCountOp(IRDLOperation):
         compareAtLeast: bool = False,
     ) -> None:
         if isinstance(count, int):
-            count = IntegerAttr.from_int_and_width(count, 32)
+            count = IntegerAttr(count, i32)
         properties = dict[str, Attribute](count=count)
         if compareAtLeast:
             properties["compareAtLeast"] = UnitAttr()
@@ -278,7 +280,7 @@ class CheckResultCountOp(IRDLOperation):
         compareAtLeast: bool = False,
     ) -> None:
         if isinstance(count, int):
-            count = IntegerAttr.from_int_and_width(count, 32)
+            count = IntegerAttr(count, i32)
         properties = dict[str, Attribute](count=count)
         if compareAtLeast:
             properties["compareAtLeast"] = UnitAttr()
@@ -324,7 +326,7 @@ class GetResultOp(IRDLOperation):
 
     def __init__(self, index: int | IntegerAttr[I32], input_op: SSAValue) -> None:
         if isinstance(index, int):
-            index = IntegerAttr.from_int_and_width(index, 32)
+            index = IntegerAttr(index, i32)
         super().__init__(
             operands=[input_op], properties={"index": index}, result_types=[ValueType()]
         )
@@ -351,7 +353,7 @@ class GetResultsOp(IRDLOperation):
         result_type: ValueType | RangeType[ValueType],
     ) -> None:
         if isinstance(index, int):
-            index = IntegerAttr.from_int_and_width(index, 32)
+            index = IntegerAttr(index, i32)
         super().__init__(
             operands=[input_op],
             properties={"index": index},
@@ -362,7 +364,7 @@ class GetResultsOp(IRDLOperation):
     def parse(cls, parser: Parser) -> GetResultsOp:
         index = parser.parse_optional_integer()
         if index is not None:
-            index = IntegerAttr.from_int_and_width(index, 32)
+            index = IntegerAttr(index, 32)
         parser.parse_characters("of")
         input_op = parser.parse_operand()
         parser.parse_punctuation(":")
@@ -658,7 +660,7 @@ class RecordMatchOp(IRDLOperation):
         if isinstance(root_kind, str):
             root_kind = StringAttr(root_kind)
         if isinstance(benefit, int):
-            benefit = IntegerAttr.from_int_and_width(benefit, 16)
+            benefit = IntegerAttr(benefit, i16)
         super().__init__(
             operands=[inputs, matched_ops],
             properties={


### PR DESCRIPTION
Can just use init instead.
