### PR TITLE
dialects: (bigint) add `bigint.truncate_to_int` op

### DIFF
--- a/tests/filecheck/dialects/bigint/ops.mlir
+++ b/tests/filecheck/dialects/bigint/ops.mlir
@@ -18,6 +18,11 @@
 %cwithdict = bigint.constant 1 {my_attr}
 
 
+// CHECK-NEXT:  %trunc1 = bigint.truncate_to_int %a : i32
+// CHECK-NEXT:  %trunc2 = bigint.truncate_to_int %a {my_attr} : i64
+%trunc1 = bigint.truncate_to_int %a : i32
+%trunc2 = bigint.truncate_to_int %a {my_attr} : i64
+
 // CHECK-NEXT:   %sum = bigint.add %a, %b : !bigint.bigint
 // CHECK-NEXT:   %diff = bigint.sub %a, %b : !bigint.bigint
 // CHECK-NEXT:   %prod = bigint.mul %a, %b : !bigint.bigint

--- a/xdsl/dialects/bigint.py
+++ b/xdsl/dialects/bigint.py
@@ -3,7 +3,7 @@
 import abc
 from collections.abc import Sequence
 
-from xdsl.dialects.builtin import IntAttr, f64, i1
+from xdsl.dialects.builtin import IntAttr, IntegerType, f64, i1
 from xdsl.ir import (
     Attribute,
     Dialect,
@@ -97,6 +97,24 @@ class ConstantOp(IRDLOperation):
 
     def fold(self) -> Sequence[SSAValue | Attribute] | None:
         return (self.value,)
+
+
+@irdl_op_definition
+class TruncateToIntOp(IRDLOperation):
+    name = "bigint.truncate_to_int"
+    result = result_def(IntegerType)
+    value = operand_def(bigint)
+
+    traits = traits_def(Pure())
+
+    assembly_format = "$value attr-dict `:` type($result)"
+
+    def __init__(
+        self,
+        value: Operation | SSAValue,
+        type: IntegerType = IntegerType(64),
+    ):
+        super().__init__(operands=[value], result_types=[type])
 
 
 @irdl_op_definition
@@ -354,6 +372,7 @@ BigInt = Dialect(
     "bigint",
     [
         ConstantOp,
+        TruncateToIntOp,
         AddOp,
         SubOp,
         MulOp,


### PR DESCRIPTION
Adds a new operation to cast/convert/truncate arbitrary-precision `!bigint.bigint` to standard `IntegerType`s (`i32`/etc), for example for use with `arith` operations.