### PR TITLE
testing: add tests for ValueErrors and improve error message

### DIFF
--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -1376,9 +1376,15 @@ def test_repr():
 def test_insert_arg_unexpected_index():
     """Test that insert_arg raises ValueError for out-of-range index."""
     block = Block(arg_types=[i32])
-    with pytest.raises(ValueError, match="Unexpected index"):
+    with pytest.raises(
+        ValueError,
+        match=r"Cannot insert block argument at index -1, index must be in range \[0, 1\]\.",
+    ):
         block.insert_arg(i32, -1)
-    with pytest.raises(ValueError, match="Unexpected index"):
+    with pytest.raises(
+        ValueError,
+        match=r"Cannot insert block argument at index 5, index must be in range \[0, 1\]\.",
+    ):
         block.insert_arg(i32, 5)
 
 

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -1824,7 +1824,10 @@ class Block(_IRNode, IRWithUses, IRWithName):
         Returns the new argument.
         """
         if index < 0 or index > len(self._args):
-            raise ValueError("Unexpected index")
+            raise ValueError(
+                f"Cannot insert block argument at index {index}, index must be in "
+                f"range [0, {len(self._args)}]."
+            )
         new_arg = BlockArgument(arg_type, self, index)
         for arg in self._args[index:]:
             arg.index += 1


### PR DESCRIPTION
## Description

This PR adds test coverage for several IR manipulation `ValueError` cases as requested in #4793.

While these exceptions are currently excluded from coverage reports via `pyproject.toml`, these tests ensure that core IR integrity remains robust.

### Changes

- **Improved Error Messaging:** Replaced the generic `Unexpected index` error with a more informative message:

```python
raise ValueError(
    f"Cannot insert block argument at index {index}, index must be in "
    f"range [0, {len(self._args)}]."
)

```

- **Added Test Coverage for:**
* [x] `Cannot add region that is already attached on an operation.`
* [x] `Erased SSA value is used by the operation`
* [x] `Cannot detach a toplevel operation`
* [x] `Unexpected index` **(now with the descriptive message)**
* [x] `Attempting to delete an argument of the wrong block`
* [x] `Operation is not a child of the block.`
* [x] `Cannot detach operation from a different block.`
* [x] `Parent pointer of operation does not refer to containing region`
* [x] `Parent pointer of block does not refer to containing region
`


Fixes #4793 