### PR TITLE
core: enable standard locations parsing & printing

### DIFF
--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -89,6 +89,16 @@ def test_print_op_location():
 
     assert_print_op(add, expected, print_debuginfo=True)
 
+    add.location = UnknownLoc()
+
+    assert_print_op(add, expected, print_debuginfo=True)
+
+    add.location = FileLineColLoc(StringAttr("one"), IntAttr(2), IntAttr(3))
+
+    expected = """%0 = "test.op"() : () -> i32 loc("one":2:3)"""
+
+    assert_print_op(add, expected, print_debuginfo=True)
+
 
 @irdl_op_definition
 class UnitAttrOp(IRDLOperation):
@@ -452,14 +462,21 @@ def test_print_block_argument():
 
 def test_print_block_argument_location():
     """Print a block argument with location."""
-    block = Block(arg_types=[i32, i32])
+    block = Block(arg_types=[i32, i32, i32])
 
+    block.args[1].location = UnknownLoc()
+    block.args[2].location = FileLineColLoc(StringAttr("one"), IntAttr(2), IntAttr(3))
     io = StringIO()
     p = Printer(stream=io, print_debuginfo=True)
     p.print_block_argument(block.args[0])
     p.print_string(", ")
     p.print_block_argument(block.args[1])
-    assert io.getvalue() == """%0 : i32 loc(unknown), %1 : i32 loc(unknown)"""
+    p.print_string(", ")
+    p.print_block_argument(block.args[2])
+    assert (
+        io.getvalue()
+        == """%0 : i32 loc(unknown), %1 : i32 loc(unknown), %2 : i32 loc("one":2:3)"""
+    )
 
 
 def test_print_block():

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -843,6 +843,9 @@ class BlockArgument(SSAValue[AttributeCovT], Generic[AttributeCovT]):
     index: int
     """The index of the variable in the block arguments."""
 
+    location: Attribute | None = None
+    """Location attached to the block argument"""
+
     @property
     def owner(self) -> Block:
         return self.block
@@ -1069,6 +1072,9 @@ class Operation(_IRNode):
 
     regions: tuple[Region, ...] = field(default=())
     """Regions arguments of the operation."""
+
+    location: Attribute | None = field(default=None)
+    """Location attached to the operation"""
 
     parent: Block | None = field(default=None)
     """The block containing this operation."""

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -245,7 +245,7 @@ class Printer(BasePrinter):
             self.print_attribute(arg.type)
             if self.print_debuginfo:
                 self.print_string(" ")
-                self.print_attribute(UnknownLoc())
+                self.print_attribute(arg.location if arg.location else UnknownLoc())
 
     def print_region(
         self,
@@ -585,7 +585,7 @@ class Printer(BasePrinter):
         self.print_function_type(op.operand_types, op.result_types)
         if self.print_debuginfo:
             self.print_string(" ")
-            self.print_attribute(UnknownLoc())
+            self.print_attribute(op.location if op.location else UnknownLoc())
 
     def enter_scope(self) -> None:
         self._next_valid_name_id.append(self._next_valid_name_id[-1])


### PR DESCRIPTION
This patch extends existing location support by
(a) implementing MLIR's `CallSiteLoc`, `FusedLoc` and `NameLoc` in the builtin dialect, and
(b) adding a `location` field to `Operation` and `BlockArgument` to store the parsed/set location.
With these changes, xdsl should be able to parse, utilize and print MLIR modules containing these standard locations.