### PR TITLE
dialects: (tensor) Added missing traits

### DIFF
--- a/xdsl/dialects/tensor.py
+++ b/xdsl/dialects/tensor.py
@@ -82,7 +82,7 @@ class CastOp(IRDLOperation):
 
     assembly_format = "$source attr-dict `:` type($source) `to` type($dest)"
 
-    traits = traits_def(NoMemoryEffect())
+    traits = traits_def(Pure())
 
     def __init__(self, source: SSAValue | Operation, dest: TensorType[Attribute]):
         super().__init__(operands=(source,), result_types=(dest,))
@@ -122,7 +122,7 @@ class DimOp(IRDLOperation):
     index = operand_def(IndexType)
     result = result_def(IndexType)
 
-    traits = traits_def(Pure())
+    traits = traits_def(NoMemoryEffect())
 
     assembly_format = "attr-dict $source `,` $index `:` type($source)"
 


### PR DESCRIPTION
Some ops were missing traits that were already implemented in xdsl.
One thing to note:
tensor.DimOp has the trait `Pure` which refers to `NoMemoryEffect` and `AlwaysSpeculatable`, but in the mlir docs [DimOp](https://mlir.llvm.org/docs/Dialects/TensorOps/#tensordim-tensordimop) doesn't implement the AlwaysSpeculatable Interface. I wasn't sure if it was noted as `Pure` in xdsl for a specific reason so I didn't change it, but I can change that too.
