### PR TITLE
core: Fix location parsing to support nested location aliases

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1000,6 +1000,28 @@ def test_parse_location():
     with pytest.raises(ParseError, match="Unsupported location type."):
         Parser(ctx, "loc(unexpected)").parse_optional_location()
 
+    parser = Parser(ctx, "loc(#loc1)")
+    parser.attribute_aliases["#loc1"] = FileLineColLoc(
+        StringAttr("alias.mlir"), IntAttr(7), IntAttr(9)
+    )
+    attr = parser.parse_optional_location()
+    assert attr == FileLineColLoc(StringAttr("alias.mlir"), IntAttr(7), IntAttr(9))
+
+    parser = Parser(ctx, 'loc("root"(#loc2))')
+    parser.attribute_aliases["#loc2"] = FileLineColLoc(
+        StringAttr("nested.mlir"), IntAttr(3), IntAttr(4)
+    )
+    attr = parser.parse_optional_location()
+    assert attr == NameLoc(
+        StringAttr("root"),
+        FileLineColLoc(StringAttr("nested.mlir"), IntAttr(3), IntAttr(4)),
+    )
+
+    parser = Parser(ctx, "loc(#not_loc)")
+    parser.attribute_aliases["#not_loc"] = IntAttr(42)
+    with pytest.raises(ParseError, match="Expected location alias."):
+        parser.parse_optional_location()
+
     with pytest.raises(ParseError, match="Unexpected location syntax."):
         Parser(ctx, "loc(1)").parse_optional_location()
 

--- a/xdsl/parser/attribute_parser.py
+++ b/xdsl/parser/attribute_parser.py
@@ -1317,6 +1317,12 @@ class AttrParser(BaseParser):
             col = self.parse_integer(False, False)
             return FileLineColLoc(StringAttr(filename), IntAttr(line), IntAttr(col))
 
+        if self._current_token.kind == MLIRTokenKind.HASH_IDENT:
+            attr = self.parse_attribute()
+            if isa(attr, LocationAttr):
+                return attr
+            self.raise_error("Expected location alias.")
+
         if (identifier := self.parse_optional_identifier()) is not None:
             match identifier:
                 case "callsite":


### PR DESCRIPTION
In https://github.com/xdslproject/xdsl/pull/5680, new location types were added like NameLoc, FusedLoc etc. But the parsing logic ignores aliases/nested aliases in locations and hence throws parsing error despite being valid. Here is a minimal reproducer:
```mlir
// RUN: xdsl-opt %s --print-op-generic --print-debuginfo | filecheck %s

#loc_child = loc("child.mlir":3:4)
#loc_root = loc("root"(#loc_child))

"builtin.module"() ({
  "test.op"() : () -> () loc(#loc_child)
  "test.op"() : () -> () loc(#loc_root)
}) : () -> ()

// CHECK: "test.op"() : () -> () loc("child.mlir":3:4)
// CHECK: "test.op"() : () -> () loc("root"("child.mlir":3:4))
``` 
This is the error message -
```python
xdsl.utils.exceptions.ParseError: location_alias.mlir:7:24
#loc_root = loc("root"(#loc_child))
                       ^^^^^^^^^^
                       Unexpected location syntax.
``` 
While the same IR is parsed by MLIR.