### PR TITLE
dialects: (llvm) add FNegOp

### DIFF
--- a/tests/dialects/test_llvm.py
+++ b/tests/dialects/test_llvm.py
@@ -585,6 +585,13 @@ def test_fabs_op():
     assert op.result.type == builtin.f32
 
 
+def test_fneg_op():
+    val = create_ssa_value(builtin.f32)
+    op = llvm.FNegOp(val)
+    assert op.arg == val
+    assert op.res.type == builtin.f32
+
+
 def test_masked_store_op():
     value = create_ssa_value(builtin.f32)
     ptr = create_ssa_value(llvm.LLVMPointerType())

--- a/tests/filecheck/backend/llvm/convert_op.mlir
+++ b/tests/filecheck/backend/llvm/convert_op.mlir
@@ -575,6 +575,18 @@ builtin.module {
   // CHECK-NEXT:   ret float {{%.+}}
   // CHECK-NEXT: }
 
+  llvm.func @fneg_op(%arg0: f32) -> f32 {
+    %0 = llvm.fneg %arg0 : f32
+    llvm.return %0 : f32
+  }
+
+  // CHECK: define float @"fneg_op"(float %".1")
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {{.[0-9]+}}:
+  // CHECK-NEXT:   {{%.+}} = fneg float %".1"
+  // CHECK-NEXT:   ret float {{%.+}}
+  // CHECK-NEXT: }
+
   llvm.func @helper(%arg0: i32) -> i32 {
     llvm.return %arg0 : i32
   }

--- a/tests/filecheck/dialects/llvm/llvm_intrinsics.mlir
+++ b/tests/filecheck/dialects/llvm/llvm_intrinsics.mlir
@@ -13,6 +13,19 @@
 %fabs_vec = llvm.intr.fabs(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
 // CHECK-NEXT: %fabs_vec = llvm.intr.fabs(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
 
+%fneg_f32 = llvm.fneg %f32 : f32
+// CHECK: %fneg_f32 = llvm.fneg %f32 : f32
+
+%fneg_f64 = llvm.fneg %f64 : f64
+// CHECK-NEXT: %fneg_f64 = llvm.fneg %f64 : f64
+
+%fneg_vec = llvm.fneg %vec_f32 : vector<4xf32>
+// CHECK-NEXT: %fneg_vec = llvm.fneg %vec_f32 : vector<4xf32>
+
+// Verify fneg with fastmath flags
+%fneg_fast = llvm.fneg %f32 {fastmathFlags = #llvm.fastmath<fast>} : f32
+// CHECK-NEXT: %fneg_fast = llvm.fneg %f32 {fastmathFlags = #llvm.fastmath<fast>} : f32
+
 %val = "test.op"() : () -> f32
 %ptr = "test.op"() : () -> !llvm.ptr
 %mask = "test.op"() : () -> i1

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/llvm_intrinsics.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/llvm_intrinsics.mlir
@@ -13,6 +13,18 @@
 %2 = llvm.intr.fabs(%arg2) : (vector<4xf32>) -> vector<4xf32>
 // CHECK: llvm.intr.fabs([[arg2]]) : (vector<4xf32>) -> vector<4xf32>
 
+%3 = llvm.fneg %arg0 : f32
+// CHECK: llvm.fneg [[arg0]] : f32
+
+%4 = llvm.fneg %arg1 : f64
+// CHECK: llvm.fneg [[arg1]] : f64
+
+%5 = llvm.fneg %arg2 : vector<4xf32>
+// CHECK: llvm.fneg [[arg2]] : vector<4xf32>
+
+%6 = llvm.fneg %arg0 {fastmathFlags = #llvm.fastmath<fast>} : f32
+// CHECK: llvm.fneg [[arg0]] {fastmathFlags = #llvm.fastmath<fast>} : f32
+
 %ptr = "test.op"() : () -> !llvm.ptr
 // CHECK: [[ptr:%\d+]] = "test.op"
 %vec_val = "test.op"() : () -> vector<4xf32>

--- a/typings/llvmlite/ir/builder.pyi
+++ b/typings/llvmlite/ir/builder.pyi
@@ -347,7 +347,9 @@ class IRBuilder:
         ...
 
     @_unop("fneg")
-    def fneg(self, arg, name=..., flags=...):  # -> None:
+    def fneg(
+        self, arg: Value, name: str = ..., flags: str | Iterable[str] = ...
+    ) -> Value:
         """
         Floating-point negative:
             name = -arg

--- a/xdsl/backend/llvm/convert_op.py
+++ b/xdsl/backend/llvm/convert_op.py
@@ -155,6 +155,13 @@ def _convert_fabs(
     val_map[op.result] = builder.call(intrinsic, [operand])
 
 
+def _convert_fneg(
+    op: llvm.FNegOp, builder: ir.IRBuilder, val_map: dict[SSAValue, ir.Value]
+):
+    operand = val_map[op.arg]
+    val_map[op.res] = builder.fneg(operand)
+
+
 def _convert_call(
     op: llvm.CallOp, builder: ir.IRBuilder, val_map: dict[SSAValue, ir.Value]
 ):
@@ -293,6 +300,8 @@ def convert_op(
             _convert_cast(op, builder, val_map)
         case llvm.FAbsOp():
             _convert_fabs(op, builder, val_map)
+        case llvm.FNegOp():
+            _convert_fneg(op, builder, val_map)
         case llvm.CallOp():
             _convert_call(op, builder, val_map)
         case llvm.AllocaOp():

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -2183,6 +2183,37 @@ class FAbsOp(IRDLOperation):
 
 
 @irdl_op_definition
+class FNegOp(IRDLOperation):
+    T: ClassVar = VarConstraint("T", AnyFloatConstr | VectorType.constr(AnyFloatConstr))
+
+    name = "llvm.fneg"
+
+    arg = operand_def(T)
+    res = result_def(T)
+
+    fastmathFlags = prop_def(FastMathAttr, default_value=FastMathAttr(None))
+
+    traits = traits_def(Pure(), SameOperandsAndResultType())
+
+    assembly_format = "$arg attr-dict `:` type($arg)"
+
+    irdl_options = (ParsePropInAttrDict(),)
+
+    def __init__(
+        self,
+        arg: Operation | SSAValue,
+        fast_math: FastMathAttr | None = None,
+    ):
+        if fast_math is None:
+            fast_math = FastMathAttr(None)
+        super().__init__(
+            operands=[arg],
+            result_types=[SSAValue.get(arg).type],
+            properties={"fastmathFlags": fast_math},
+        )
+
+
+@irdl_op_definition
 class MaskedStoreOp(IRDLOperation):
     name = "llvm.intr.masked.store"
 
@@ -2239,6 +2270,7 @@ LLVM = Dialect(
         FAddOp,
         FDivOp,
         FMulOp,
+        FNegOp,
         FPExtOp,
         FRemOp,
         FSubOp,


### PR DESCRIPTION
Summary:
- Add `llvm.fneg` operation to the LLVM dialect                                                                                       
- Add backend conversion using `builder.fneg`
- Add type annotation for `fneg` in llvmlite builder stubs

Test plan:
- Unit test in `tests/dialects/test_llvm.py`
- Filecheck roundtrip test in `tests/filecheck/dialects/llvm/llvm_intrinsics.mlir`
- MLIR roundtrip test in `tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/llvm_intrinsics.mlir`
- Backend conversion test in `tests/filecheck/backend/llvm/convert_op.mlir`
