### PR TITLE
testing: make multiverse test plugin editable and fix test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ zip-safe = false
 [tool.uv.sources]
 lzstring2 = { git = "https://github.com/superlopuh/lz-string.git" }
 bytesight = { git = "https://github.com/EdmundGoodman/bytesight.git", rev = "e8e8e45ec34316fdc99ee09ea8886c4f63c248be" }
-my_plugin = { path = "tests/my_plugin" }
+my_plugin = { path = "tests/my_plugin", editable = true }
 
 [tool.setuptools.packages]
 find = {}

--- a/tests/dialects/test_universe.py
+++ b/tests/dialects/test_universe.py
@@ -3,7 +3,7 @@ import re
 import pytest
 
 from xdsl.ir import Dialect
-from xdsl.universe import Universe
+from xdsl.universe import XDSL_UNIVERSE, Universe
 
 
 def test_multiverse():
@@ -18,22 +18,26 @@ def test_multiverse():
 
     import my_plugin
 
-    my_plugin.MY_UNIVERSE.all_dialects["scf"] = lambda: Dialect("scf")
+    XDSL_UNIVERSE.all_dialects["plugin_dialect"] = lambda: Dialect("plugin_dialect")
 
     with pytest.raises(
         ValueError,
-        match=re.escape("Duplicate definition of scf in ['my_plugin', 'xdsl']."),
+        match=re.escape(
+            "Duplicate definition of plugin_dialect in ['my_plugin', 'xdsl']."
+        ),
     ):
         Universe.get_multiverse()
 
-    del my_plugin.MY_UNIVERSE.all_dialects["scf"]
+    del XDSL_UNIVERSE.all_dialects["plugin_dialect"]
 
-    my_plugin.MY_UNIVERSE.all_passes["dce"] = lambda: my_plugin.PluginPass
+    XDSL_UNIVERSE.all_passes["plugin-pass"] = lambda: my_plugin.PluginPass
 
     with pytest.raises(
         ValueError,
-        match=re.escape("Duplicate definition of dce in ['my_plugin', 'xdsl']."),
+        match=re.escape(
+            "Duplicate definition of plugin-pass in ['my_plugin', 'xdsl']."
+        ),
     ):
         Universe.get_multiverse()
 
-    del my_plugin.MY_UNIVERSE.all_passes["dce"]
+    del XDSL_UNIVERSE.all_passes["plugin-pass"]

--- a/uv.lock
+++ b/uv.lock
@@ -2069,7 +2069,7 @@ wheels = [
 
 [[package]]
 name = "my-plugin"
-source = { directory = "tests/my_plugin" }
+source = { editable = "tests/my_plugin" }
 dependencies = [
     { name = "xdsl" },
 ]
@@ -3877,7 +3877,7 @@ bench = [
     { name = "viztracer", specifier = ">=1.0.1" },
 ]
 dev = [
-    { name = "my-plugin", directory = "tests/my_plugin" },
+    { name = "my-plugin", editable = "tests/my_plugin" },
     { name = "xdsl", extras = ["dev", "gui", "llvm"] },
 ]
 docs = [


### PR DESCRIPTION
I messed this up when adding this, now the test doesn't depend on arbitrary xDSL passes, and the test tests the current implementation of the plugin, and not the installed version.