### PR TITLE
dialects: (hw) allow nested arrays to be unpacked by array_get

### DIFF
--- a/tests/filecheck/dialects/hw/hw_ops.mlir
+++ b/tests/filecheck/dialects/hw/hw_ops.mlir
@@ -30,6 +30,10 @@
   %element = hw.array_get %array[%index] : !hw.array<2xi19>, i1
 
   // CHECK: %{{.*}} = hw.array_get %{{.*}}[%{{.*}}] : !hw.array<2xi19>, i1
+  %nested = "test.op"() : () -> !hw.array<2x!hw.array<4xi64>>
+  %first_index = arith.constant 1 : i1
+  %take_out = hw.array_get %nested[%first_index] : !hw.array<2x!hw.array<4xi64>>, i1
+  // CHECK: %{{.*}} = hw.array_get %{{.*}}[%{{.*}}] : !hw.array<2x!hw.array<4xi64>>, i1
 
   %ic = hw.bitcast %test : (!hw.array<6xi7>) -> !hw.array<7xi6>
   // CHECK: %ic = hw.bitcast %test : (!hw.array<6xi7>) -> !hw.array<7xi6>

--- a/xdsl/dialects/hw.py
+++ b/xdsl/dialects/hw.py
@@ -1430,7 +1430,7 @@ class ArrayGetOp(IRDLOperation):
     name = "hw.array_get"
     input = operand_def(ArrayType)
     index = operand_def(IntegerType)
-    result = result_def(IntegerType)
+    result = result_def(IntegerType | ArrayType)
 
     def __init__(self, input: Operation | SSAValue, index: Operation | SSAValue):
         typ = SSAValue.get(input, type=ArrayType).type


### PR DESCRIPTION
I noticed that `xdsl` is not happy about nested hw arrays 
```mlir
  %nested = "test.op"() : () -> !hw.array<2x!hw.array<4xi64>>
  %first_index = "arith.constant"() <{value = true}> : () -> i1
  %take_out = "hw.array_get"(%nested, %first_index) : (!hw.array<2x!hw.array<4xi64>>, i1) -> !hw.array<4xi64>
//  ^^^^^^^^^^^^^^^^^^^^^^^^^^-------------------------------------------------
//  | Operation does not verify: result 'result' at position 0 does not verify:
//  | !hw.array<4xi64> should be of base attribute integer_type
//  ---------------------------------------------------------------------------
```
even though circt-opt is perfectly happy about it:
`circt-opt /home/josse/xdsl/tests/filecheck/dialects/hw/hw_ops.mlir --allow-unregistered-dialect
`
```mlir
...
  %5 = "test.op"() : () -> !hw.array<2xarray<4xi64>>
  %true = arith.constant true
  %6 = hw.array_get %5[%true] : !hw.array<2xarray<4xi64>>, i1
...
```