### PR TITLE
core: migrate xdsl-opt targets to Multiverse

### DIFF
--- a/xdsl/backend/csl/print_csl.py
+++ b/xdsl/backend/csl/print_csl.py
@@ -6,6 +6,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import IO, Literal, cast
 
+from xdsl.context import Context
 from xdsl.dialects import arith, csl, memref, scf
 from xdsl.dialects.builtin import (
     DYNAMIC_INDEX,
@@ -35,6 +36,7 @@ from xdsl.irdl import Operand
 from xdsl.traits import is_side_effect_free
 from xdsl.utils.comparisons import to_unsigned
 from xdsl.utils.hints import isa
+from xdsl.utils.target import Target
 
 _CSL_KW_SET = {
     "align",
@@ -906,3 +908,11 @@ def print_to_csl(
         divider = True
         ctx.print("// FILE: " + module.sym_name.data)
         ctx.print_block(module.body.block)
+
+
+@dataclass(frozen=True)
+class CSLTarget(Target):
+    name = "csl"
+
+    def emit(self, ctx: Context, module: ModuleOp, output: IO[str]) -> None:
+        print_to_csl(module, output)

--- a/xdsl/backend/llvm/convert.py
+++ b/xdsl/backend/llvm/convert.py
@@ -1,10 +1,15 @@
+from dataclasses import dataclass
+from typing import IO
+
 import llvmlite.ir as ir
 
 from xdsl.backend.llvm.convert_op import convert_op
 from xdsl.backend.llvm.convert_type import convert_type
+from xdsl.context import Context
 from xdsl.dialects import llvm
 from xdsl.dialects.builtin import ModuleOp
 from xdsl.ir import Block, SSAValue
+from xdsl.utils.target import Target
 
 
 def _convert_func(op: llvm.FuncOp, llvm_module: ir.Module):
@@ -66,3 +71,12 @@ def convert_module(module: ModuleOp) -> ir.Module:
                 )
 
     return llvm_module
+
+
+@dataclass(frozen=True)
+class LLVMTarget(Target):
+    name = "llvm"
+
+    def emit(self, ctx: Context, module: ModuleOp, output: IO[str]) -> None:
+        llvm_module = convert_module(module)
+        print(llvm_module, file=output)

--- a/xdsl/backend/mps/print_mps.py
+++ b/xdsl/backend/mps/print_mps.py
@@ -1,6 +1,9 @@
+from dataclasses import dataclass
 from typing import IO
 
+from xdsl.context import Context
 from xdsl.dialects.builtin import ModuleOp
+from xdsl.utils.target import Target
 
 
 def print_to_mps(prog: ModuleOp, output: IO[str]) -> None:
@@ -18,3 +21,11 @@ def print_to_mps(prog: ModuleOp, output: IO[str]) -> None:
         None. The output is written directly to the provided stream.
     """
     raise NotImplementedError("MPS backend not yet implemented")
+
+
+@dataclass(frozen=True)
+class MPSTarget(Target):
+    name = "mps"
+
+    def emit(self, ctx: Context, module: ModuleOp, output: IO[str]) -> None:
+        print_to_mps(module, output)

--- a/xdsl/backend/wgsl/wgsl_printer.py
+++ b/xdsl/backend/wgsl/wgsl_printer.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from functools import singledispatchmethod
-from typing import cast
+from typing import IO, cast
 
+from xdsl.context import Context
 from xdsl.dialects import arith, builtin, gpu, memref
-from xdsl.dialects.builtin import MemRefType
+from xdsl.dialects.builtin import MemRefType, ModuleOp
 from xdsl.ir import Operation, SSAValue
 from xdsl.utils.base_printer import BasePrinter
 from xdsl.utils.hints import isa
+from xdsl.utils.target import Target
 
 
 class WGSLPrinter(BasePrinter):
@@ -233,3 +236,14 @@ class WGSLPrinter(BasePrinter):
         self.print_string("\n")
         with self.indented(2):
             self.print_string(f"let {op_name_hint} = {lhs} - {rhs};")
+
+
+@dataclass(frozen=True)
+class WGSLTarget(Target):
+    name = "wgsl"
+
+    def emit(self, ctx: Context, module: ModuleOp, output: IO[str]) -> None:
+        for op in module.ops:
+            if isinstance(op, gpu.ModuleOp):
+                printer = WGSLPrinter(stream=output)
+                printer.print(op)

--- a/xdsl/dialects/arm/__init__.py
+++ b/xdsl/dialects/arm/__init__.py
@@ -2,11 +2,14 @@
 ARM dialect, based on the ISA [specification](https://developer.arm.com/documentation/102374/0101/Overview).
 """
 
+from dataclasses import dataclass
 from typing import IO
 
 from xdsl.backend.assembly_printer import AssemblyPrinter
+from xdsl.context import Context
 from xdsl.dialects.builtin import ModuleOp
 from xdsl.ir import Dialect
+from xdsl.utils.target import Target
 
 from .ops import CmpRegOp, DSMovOp, DSSMulOp, GetRegisterOp, LabelOp
 from .registers import IntRegisterType
@@ -15,6 +18,14 @@ from .registers import IntRegisterType
 def print_assembly(module: ModuleOp, output: IO[str]) -> None:
     printer = AssemblyPrinter(stream=output)
     printer.print_module(module)
+
+
+@dataclass(frozen=True)
+class ARMAsmTarget(Target):
+    name = "arm-asm"
+
+    def emit(self, ctx: Context, module: ModuleOp, output: IO[str]) -> None:
+        print_assembly(module, output)
 
 
 ARM = Dialect(

--- a/xdsl/dialects/riscv/abstract_ops.py
+++ b/xdsl/dialects/riscv/abstract_ops.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from collections.abc import Set as AbstractSet
+from dataclasses import dataclass
 from io import StringIO
 from typing import IO, Generic, TypeAlias
 
@@ -14,6 +15,7 @@ from xdsl.backend.register_allocatable import (
     RegisterConstraints,
 )
 from xdsl.backend.register_type import RegisterAllocatedMemoryEffect, RegisterType
+from xdsl.context import Context
 from xdsl.dialects.builtin import (
     I32,
     IntegerAttr,
@@ -42,6 +44,7 @@ from xdsl.pattern_rewriter import RewritePattern
 from xdsl.printer import Printer
 from xdsl.traits import HasCanonicalizationPatternsTrait, Pure
 from xdsl.utils.exceptions import VerifyException
+from xdsl.utils.target import Target
 
 from .attrs import (
     I12,
@@ -242,6 +245,14 @@ def riscv_code(module: ModuleOp) -> str:
     stream = StringIO()
     print_assembly(module, stream)
     return stream.getvalue()
+
+
+@dataclass(frozen=True)
+class RISCVAsmTarget(Target):
+    name = "riscv-asm"
+
+    def emit(self, ctx: Context, module: ModuleOp, output: IO[str]) -> None:
+        print_assembly(module, output)
 
 
 # endregion

--- a/xdsl/dialects/wasm/wat.py
+++ b/xdsl/dialects/wasm/wat.py
@@ -1,7 +1,15 @@
+from __future__ import annotations
+
 import abc
 from contextlib import contextmanager
 from dataclasses import dataclass, field
-from typing import Any
+from typing import IO, TYPE_CHECKING, Any
+
+from xdsl.context import Context
+from xdsl.utils.target import Target
+
+if TYPE_CHECKING:
+    from xdsl.dialects.builtin import ModuleOp
 
 
 @dataclass(eq=False, repr=False)
@@ -24,3 +32,17 @@ class WatPrintable(abc.ABC):
     @abc.abstractmethod
     def print_wat(self, printer: WatPrinter) -> None:
         raise NotImplementedError()
+
+
+@dataclass(frozen=True)
+class WatTarget(Target):
+    name = "wat"
+
+    def emit(self, ctx: Context, module: ModuleOp, output: IO[str]) -> None:
+        from xdsl.dialects.wasm import WasmModuleOp
+
+        for op in module.walk():
+            if isinstance(op, WasmModuleOp):
+                printer = WatPrinter(output)
+                op.print_wat(printer)
+                print("", file=output)

--- a/xdsl/dialects/x86/ops.py
+++ b/xdsl/dialects/x86/ops.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from collections.abc import Set as AbstractSet
+from dataclasses import dataclass
 from io import StringIO
 from typing import IO, ClassVar, Generic, Literal, TypeAlias, cast
 
@@ -42,6 +43,7 @@ from xdsl.backend.register_allocatable import (
     RegisterConstraints,
 )
 from xdsl.backend.register_type import RegisterAllocatedMemoryEffect
+from xdsl.context import Context
 from xdsl.dialects.builtin import (
     ArrayAttr,
     IntegerAttr,
@@ -87,6 +89,7 @@ from xdsl.traits import (
     Pure,
 )
 from xdsl.utils.exceptions import VerifyException
+from xdsl.utils.target import Target
 
 from .assembly import (
     AssemblyInstructionArg,
@@ -3705,3 +3708,11 @@ def x86_code(module: ModuleOp) -> str:
     stream = StringIO()
     print_assembly(module, stream)
     return stream.getvalue()
+
+
+@dataclass(frozen=True)
+class X86AsmTarget(Target):
+    name = "x86-asm"
+
+    def emit(self, ctx: Context, module: ModuleOp, output: IO[str]) -> None:
+        print_assembly(module, output)

--- a/xdsl/targets/__init__.py
+++ b/xdsl/targets/__init__.py
@@ -6,4 +6,65 @@ from xdsl.utils.target import Target
 def get_all_targets() -> dict[str, Callable[[], type[Target]]]:
     """Return the list of all available targets."""
 
-    return {}
+    def get_arm_asm():
+        from xdsl.dialects.arm import ARMAsmTarget
+
+        return ARMAsmTarget
+
+    def get_csl():
+        from xdsl.backend.csl.print_csl import CSLTarget
+
+        return CSLTarget
+
+    def get_llvm():
+        from xdsl.backend.llvm.convert import LLVMTarget
+
+        return LLVMTarget
+
+    def get_mlir():
+        from xdsl.targets.mlir import MLIRTarget
+
+        return MLIRTarget
+
+    def get_mps():
+        from xdsl.backend.mps.print_mps import MPSTarget
+
+        return MPSTarget
+
+    def get_riscemu():
+        from xdsl.targets.riscemu import RISCVEmulatorTarget
+
+        return RISCVEmulatorTarget
+
+    def get_riscv_asm():
+        from xdsl.dialects.riscv.abstract_ops import RISCVAsmTarget
+
+        return RISCVAsmTarget
+
+    def get_wat():
+        from xdsl.dialects.wasm.wat import WatTarget
+
+        return WatTarget
+
+    def get_wgsl():
+        from xdsl.backend.wgsl.wgsl_printer import WGSLTarget
+
+        return WGSLTarget
+
+    def get_x86_asm():
+        from xdsl.dialects.x86.ops import X86AsmTarget
+
+        return X86AsmTarget
+
+    return {
+        "arm-asm": get_arm_asm,
+        "csl": get_csl,
+        "llvm": get_llvm,
+        "mlir": get_mlir,
+        "mps": get_mps,
+        "riscemu": get_riscemu,
+        "riscv-asm": get_riscv_asm,
+        "wat": get_wat,
+        "wgsl": get_wgsl,
+        "x86-asm": get_x86_asm,
+    }

--- a/xdsl/targets/mlir.py
+++ b/xdsl/targets/mlir.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import IO
+
+from xdsl.context import Context
+from xdsl.dialects.builtin import ModuleOp
+from xdsl.utils.target import Target
+
+
+@dataclass(frozen=True)
+class MLIRTarget(Target):
+    name = "mlir"
+
+    print_generic_format: bool = False
+    print_properties_as_attributes: bool = False
+    print_debuginfo: bool = False
+    syntax_highlight: bool = False
+
+    def emit(self, ctx: Context, module: ModuleOp, output: IO[str]) -> None:
+        from xdsl.printer import Printer
+        from xdsl.syntax_printer import SyntaxPrinter
+
+        cls = SyntaxPrinter if self.syntax_highlight else Printer
+        printer = cls(
+            stream=output,
+            print_generic_format=self.print_generic_format,
+            print_properties_as_attributes=self.print_properties_as_attributes,
+            print_debuginfo=self.print_debuginfo,
+        )
+        printer.print_op(module)
+        printer.print_metadata(ctx.loaded_dialects)
+        print("\n", file=output)

--- a/xdsl/targets/riscemu.py
+++ b/xdsl/targets/riscemu.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from contextlib import redirect_stdout
+from dataclasses import dataclass
+from typing import IO
+
+from xdsl.context import Context
+from xdsl.dialects.builtin import ModuleOp
+from xdsl.utils.target import Target
+
+
+@dataclass(frozen=True)
+class RISCVEmulatorTarget(Target):
+    name = "riscemu"
+
+    unlimited_regs: bool = True
+    verbosity: int = 0
+
+    def emit(self, ctx: Context, module: ModuleOp, output: IO[str]) -> None:
+        try:
+            from xdsl.interpreters.riscv_emulator import run_riscv
+        except ImportError:
+            print("Please install optional dependencies to run riscv emulation")
+            return
+
+        from xdsl.dialects.riscv import riscv_code
+
+        code = riscv_code(module)
+        with redirect_stdout(output):
+            run_riscv(
+                code,
+                unlimited_regs=self.unlimited_regs,
+                verbosity=self.verbosity,
+            )

--- a/xdsl/xdsl_opt_main.py
+++ b/xdsl/xdsl_opt_main.py
@@ -1,8 +1,8 @@
 import argparse
+import dataclasses
 import inspect
 import sys
 from collections.abc import Callable, Sequence
-from contextlib import redirect_stdout
 from importlib.metadata import version
 from io import StringIO
 from itertools import accumulate
@@ -13,7 +13,6 @@ from xdsl.dialects.builtin import ModuleOp
 from xdsl.ir import Attribute
 from xdsl.passes import ModulePass, PassPipeline
 from xdsl.printer import Printer
-from xdsl.syntax_printer import SyntaxPrinter
 from xdsl.tools.command_line_tool import CommandLineTool
 from xdsl.universe import Universe
 from xdsl.utils.arg_spec import parse_spec
@@ -259,94 +258,6 @@ class xDSLOptMain(CommandLineTool):
 
         Add other/additional targets by overloading this function.
         """
-
-        def _output_arm_asm(prog: ModuleOp, output: IO[str]):
-            from xdsl.dialects.arm import print_assembly
-
-            print_assembly(prog, output)
-
-        def _output_mlir(prog: ModuleOp, output: IO[str]):
-            cls = SyntaxPrinter if self.args.syntax_highlight else Printer
-            printer = cls(
-                stream=output,
-                print_generic_format=self.args.print_op_generic,
-                print_properties_as_attributes=self.args.print_no_properties,
-                print_debuginfo=self.args.print_debuginfo,
-            )
-            printer.print_op(prog)
-            printer.print_metadata(self.ctx.loaded_dialects)
-            print("\n", file=output)
-
-        def _output_riscv_asm(prog: ModuleOp, output: IO[str]):
-            from xdsl.dialects.riscv import print_assembly
-
-            print_assembly(prog, output)
-
-        def _output_x86_asm(prog: ModuleOp, output: IO[str]):
-            from xdsl.dialects.x86.ops import print_assembly
-
-            print_assembly(prog, output)
-
-        def _output_wat(prog: ModuleOp, output: IO[str]):
-            from xdsl.dialects.wasm import WasmModuleOp
-            from xdsl.dialects.wasm.wat import WatPrinter
-
-            for op in prog.walk():
-                if isinstance(op, WasmModuleOp):
-                    printer = WatPrinter(output)
-                    op.print_wat(printer)
-                    print("", file=output)
-
-        def _emulate_riscv(prog: ModuleOp, output: IO[str]):
-            # import only if running riscv emulation
-            try:
-                from xdsl.interpreters.riscv_emulator import run_riscv
-            except ImportError:
-                print("Please install optional dependencies to run riscv emulation")
-                return
-
-            from xdsl.dialects.riscv import riscv_code
-
-            code = riscv_code(prog)
-            with redirect_stdout(output):
-                run_riscv(code, unlimited_regs=True, verbosity=0)
-
-        def _output_csl(prog: ModuleOp, output: IO[str]):
-            from xdsl.backend.csl.print_csl import print_to_csl
-
-            print_to_csl(prog, output)
-
-        def _output_wgsl(prog: ModuleOp, output: IO[str]):
-            from xdsl.backend.wgsl.wgsl_printer import WGSLPrinter
-            from xdsl.dialects import gpu
-
-            for op in prog.ops:
-                if isinstance(op, gpu.ModuleOp):
-                    printer = WGSLPrinter(stream=output)
-                    printer.print(op)
-
-        def _output_air(prog: ModuleOp, output: IO[str]):
-            from xdsl.backend.mps.print_mps import print_to_mps
-
-            print_to_mps(prog, output)
-
-        def _output_llvm(prog: ModuleOp, output: IO[str]):
-            from xdsl.backend.llvm.convert import convert_module
-
-            llvm_module = convert_module(prog)
-            print(llvm_module, file=output)
-
-        self.available_targets["arm-asm"] = _output_arm_asm
-        self.available_targets["csl"] = _output_csl
-        self.available_targets["mlir"] = _output_mlir
-        self.available_targets["riscemu"] = _emulate_riscv
-        self.available_targets["riscv-asm"] = _output_riscv_asm
-        self.available_targets["wat"] = _output_wat
-        self.available_targets["wgsl"] = _output_wgsl
-        self.available_targets["mps"] = _output_air
-        self.available_targets["x86-asm"] = _output_x86_asm
-        self.available_targets["llvm"] = _output_llvm
-
         multiverse = Universe.get_multiverse()
         for target_name, target_factory in multiverse.all_targets.items():
             if target_name not in self.available_targets:
@@ -440,6 +351,16 @@ class xDSLOptMain(CommandLineTool):
         if not sig.parameters:
             factory = cast(Callable[[], type[Target]], target_entry)
             target = factory().from_spec(spec)
+            if spec.name == "mlir":
+                target = dataclasses.replace(
+                    target,
+                    **{
+                        "print_generic_format": self.args.print_op_generic,
+                        "print_properties_as_attributes": self.args.print_no_properties,
+                        "print_debuginfo": self.args.print_debuginfo,
+                        "syntax_highlight": self.args.syntax_highlight,
+                    },
+                )
             target.emit(self.ctx, prog, output)
         else:
             legacy = cast(Callable[[ModuleOp, IO[str]], None], target_entry)


### PR DESCRIPTION
I would like xdsl-opt to be extensible via plugins for targets, similarly to today's dialects and passes. This will bring us one step closer to avoiding opt-like tools in dependent frameworks, for things like codegen, analysis dumps, and interpretation.

Opening this now as a draft PR to make the final state available as I pull out individual changes to review. (should be one PR per commit in this branch)