### PR TITLE
dialects: (linalg) add ElementwiseOperation ABC

### DIFF
--- a/tests/interpreters/test_linalg_interpreter.py
+++ b/tests/interpreters/test_linalg_interpreter.py
@@ -193,6 +193,7 @@ def test_linalg_generic_reduction():
 def test_linalg_add():
     interpreter = Interpreter(ModuleOp([]))
     interpreter.register_implementations(LinalgFunctions())
+    interpreter.register_implementations(ArithFunctions())
     op = linalg.AddOp(
         (
             create_ssa_value(TensorType(f32, [2, 2])),
@@ -232,6 +233,7 @@ def test_fill_op():
 def test_linalg_mul():
     interpreter = Interpreter(ModuleOp([]))
     interpreter.register_implementations(LinalgFunctions())
+    interpreter.register_implementations(ArithFunctions())
     op = linalg.MulOp(
         (
             create_ssa_value(TensorType(f32, [2, 2])),
@@ -294,6 +296,7 @@ def test_linalg_matmul():
 def test_linalg_pooling_nchw_max():
     interpreter = Interpreter(ModuleOp([]))
     interpreter.register_implementations(LinalgFunctions())
+    interpreter.register_implementations(ArithFunctions())
     op = linalg.PoolingNchwMaxOp(
         (
             create_ssa_value(TensorType(f32, [1, 1, 4, 4])),

--- a/xdsl/dialects/linalg.py
+++ b/xdsl/dialects/linalg.py
@@ -621,8 +621,22 @@ class NamedOperation(LinalgStructuredOperation, ABC):
         raise NotImplementedError
 
 
+class ElementwiseOperation(NamedOperation, ABC):
+    def get_indexing_maps(self) -> Sequence[AffineMap]:
+        assert all(isinstance(t, ShapedType) for t in self.operand_types), (
+            "Assume that all named linalg pointwise operations have matching shaped "
+            "types."
+        )
+        operand_types = cast(Sequence[ShapedType], self.operand_types)
+        shapes = tuple(t.get_shape() for t in operand_types)
+        assert all(shape == shapes[0] for shape in shapes[1:]), (
+            "All shapes must be equal"
+        )
+        return (AffineMap.identity(len(shapes[0])),) * len(operand_types)
+
+
 @irdl_op_definition
-class AddOp(NamedOperation):
+class AddOp(ElementwiseOperation):
     """
     Adds two tensors elementwise.
 
@@ -664,9 +678,6 @@ class AddOp(NamedOperation):
             YieldOp(result)
 
         return hidden_region
-
-    def get_indexing_maps(self) -> Sequence[AffineMap]:
-        raise NotImplementedError
 
 
 @irdl_op_definition
@@ -758,7 +769,7 @@ class LogOp(NamedOperation):
 
 
 @irdl_op_definition
-class SubOp(NamedOperation):
+class SubOp(ElementwiseOperation):
     """
     Subtracts two tensors elementwise.
 
@@ -802,9 +813,6 @@ class SubOp(NamedOperation):
             YieldOp(result)
 
         return hidden_region
-
-    def get_indexing_maps(self) -> Sequence[AffineMap]:
-        raise NotImplementedError
 
 
 @irdl_op_definition
@@ -957,7 +965,7 @@ class FillOp(NamedOperation):
 
 
 @irdl_op_definition
-class CopyOp(NamedOperation):
+class CopyOp(ElementwiseOperation):
     """
     Copies the tensor elementwise.
 
@@ -1005,7 +1013,7 @@ class CopyOp(NamedOperation):
 
 
 @irdl_op_definition
-class MaxOp(NamedOperation):
+class MaxOp(ElementwiseOperation):
     """
     Takes the max (signed) between two inputs, elementwise.
 
@@ -1052,7 +1060,7 @@ class MaxOp(NamedOperation):
 
 
 @irdl_op_definition
-class MinOp(NamedOperation):
+class MinOp(ElementwiseOperation):
     """
     Takes the max (signed) between two inputs, elementwise.
 
@@ -1099,7 +1107,7 @@ class MinOp(NamedOperation):
 
 
 @irdl_op_definition
-class MulOp(NamedOperation):
+class MulOp(ElementwiseOperation):
     """
     Multiplies two tensors elementwise.
 
@@ -1141,9 +1149,6 @@ class MulOp(NamedOperation):
             YieldOp(result)
 
         return hidden_region
-
-    def get_indexing_maps(self) -> Sequence[AffineMap]:
-        raise NotImplementedError
 
 
 @irdl_op_definition

--- a/xdsl/interpreters/linalg.py
+++ b/xdsl/interpreters/linalg.py
@@ -85,21 +85,7 @@ class LinalgFunctions(InterpreterFunctions):
     def run_add(
         self, interpreter: Interpreter, op: linalg.AddOp, args: tuple[Any, ...]
     ) -> tuple[Any, ...]:
-        (lhs, rhs, res) = (args[0], args[1], args[2])
-        assert isinstance(lhs, ShapedArray)
-        assert isinstance(rhs, ShapedArray)
-        assert isinstance(res, ShapedArray)
-        lhs = cast(ShapedArray[float], lhs)
-        rhs = cast(ShapedArray[float], rhs)
-        res = cast(ShapedArray[float], res)
-        if not all(res.data_ptr[i] == 0.0 for i in range(len(res.data))):
-            raise NotImplementedError()
-        assert lhs.shape == rhs.shape == res.shape
-        for i in range(len(lhs.data)):
-            res.data_ptr[i] = lhs.data_ptr[i] + rhs.data_ptr[i]
-        if len(op.results) > 0:
-            return (res,)
-        return ()
+        return run_linalg_structured_op(interpreter, op, args)
 
     @impl(linalg.FillOp)
     def run_fill(
@@ -122,21 +108,7 @@ class LinalgFunctions(InterpreterFunctions):
     def run_mul(
         self, interpreter: Interpreter, op: linalg.MulOp, args: tuple[Any, ...]
     ) -> tuple[Any, ...]:
-        lhs, rhs, res = args[0], args[1], args[2]
-        assert isinstance(lhs, ShapedArray)
-        assert isinstance(rhs, ShapedArray)
-        assert isinstance(res, ShapedArray)
-        lhs = cast(ShapedArray[float], lhs)
-        rhs = cast(ShapedArray[float], rhs)
-        res = cast(ShapedArray[float], res)
-        if not all(res.data_ptr[i] == 0.0 for i in range(len(res.data))):
-            raise NotImplementedError()
-        assert lhs.shape == rhs.shape == res.shape
-        for i in range(len(lhs.data)):
-            res.data_ptr[i] = lhs.data_ptr[i] * rhs.data_ptr[i]
-        if len(op.results) > 0:
-            return (res,)
-        return ()
+        return run_linalg_structured_op(interpreter, op, args)
 
     @impl(linalg.TransposeOp)
     def run_transpose(


### PR DESCRIPTION
Add an abstract superclass for named elementwise linalg operations, which all have the same indexing maps.

CC @Lishin1215 