### PR TITLE
dialects: (linalg) expand LinalgStructuredOperation with missing fields

### DIFF
--- a/xdsl/dialects/linalg.py
+++ b/xdsl/dialects/linalg.py
@@ -225,9 +225,6 @@ class GenericOp(LinalgStructuredOperation):
             regions=[body],
         )
 
-    def get_body(self) -> Region:
-        return self.body
-
     def get_indexing_maps(self) -> Sequence[AffineMap]:
         return tuple(attr.data for attr in self.indexing_maps)
 


### PR DESCRIPTION
Fields missing to do useful things like tiling, interpreting, etc in a generic way, present on the MLIR counterpart.

CC @Lishin1215 