### PR TITLE
core: (Constraints) remove TypedAttributeConstraint

### DIFF
--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -55,7 +55,6 @@ from xdsl.irdl import (
     RangeVarConstraint,
     SameVariadicOperandSize,
     SameVariadicResultSize,
-    TypedAttributeConstraint,  # pyright: ignore[reportDeprecated]
     VarConstraint,
     VarOperand,
     VarOpResult,
@@ -3515,77 +3514,6 @@ def test_renamed_optional_prop(program: str, output: str, generic: str):
     printer.print_op(parsed)
 
     assert generic == stream.getvalue()
-
-
-@pytest.mark.parametrize(
-    "program, generic",
-    [
-        (
-            "test.opt_constant : ()",
-            '"test.opt_constant"() : () -> ()',
-        ),
-        (
-            "%0 = test.opt_constant value 1 : i32 : (i32)",
-            '%0 = "test.opt_constant"() <{value = 1 : i32}> : () -> (i32)',
-        ),
-    ],
-)
-def test_optional_property_with_extractor(program: str, generic: str):
-    with pytest.deprecated_call():
-
-        @irdl_op_definition
-        class OptConstantOp(IRDLOperation):
-            name = "test.opt_constant"
-            T: ClassVar = VarConstraint("T", AnyAttr())
-
-            value = opt_prop_def(TypedAttributeConstraint(IntegerAttr.constr(), T))  # pyright: ignore[reportDeprecated]
-
-            res = opt_result_def(T)
-
-            assembly_format = "(`value` $value^)? attr-dict `:` `(` type($res) `)`"
-
-    ctx = Context()
-    ctx.load_op(OptConstantOp)
-
-    check_roundtrip(program, ctx)
-    check_equivalence(program, generic, ctx)
-
-
-@pytest.mark.parametrize(
-    "program, generic",
-    [
-        (
-            "%0 = test.default_constant",
-            '%0 = "test.default_constant"() <{value = true}> : () -> (i1)',
-        ),
-        (
-            "%0 = test.default_constant value 2 : i32",
-            '%0 = "test.default_constant"() <{value = 2 : i32}> : () -> (i32)',
-        ),
-    ],
-)
-def test_default_property_with_extractor(program: str, generic: str):
-    with pytest.deprecated_call():
-
-        @irdl_op_definition
-        class DefaultConstantOp(IRDLOperation):
-            name = "test.default_constant"
-            T: ClassVar = VarConstraint("T", AnyAttr())
-
-            value = prop_def(
-                TypedAttributeConstraint(IntegerAttr.constr(), T),  # pyright: ignore[reportDeprecated]
-                default_value=BoolAttr.from_bool(True),
-            )
-
-            res = result_def(T)
-
-            assembly_format = "(`value` $value^)? attr-dict"
-
-    ctx = Context()
-    ctx.load_op(DefaultConstantOp)
-
-    check_roundtrip(program, ctx)
-    check_equivalence(program, generic, ctx)
 
 
 @pytest.mark.parametrize(

--- a/xdsl/irdl/constraints.py
+++ b/xdsl/irdl/constraints.py
@@ -192,43 +192,6 @@ TypedAttributeCovT = TypeVar("TypedAttributeCovT", bound=TypedAttribute, covaria
 TypedAttributeT = TypeVar("TypedAttributeT", bound=TypedAttribute)
 
 
-@deprecated("Please use appropriate `AnyOf` constraints instead.")
-@dataclass(frozen=True)
-class TypedAttributeConstraint(AttrConstraint[TypedAttributeCovT]):
-    """
-    Constrains the type of a typed attribute.
-    """
-
-    attr_constraint: AttrConstraint[TypedAttributeCovT]
-    type_constraint: AttrConstraint
-
-    def verify(self, attr: Attribute, constraint_context: ConstraintContext) -> None:
-        if not isinstance(attr, TypedAttribute):
-            raise VerifyException(f"attribute {attr} expected to be a TypedAttribute")
-        self.attr_constraint.verify(attr, constraint_context)
-        self.type_constraint.verify(attr.get_type(), constraint_context)
-
-    def variables(self) -> set[str]:
-        return self.type_constraint.variables() | self.attr_constraint.variables()
-
-    def can_infer(self, var_constraint_names: AbstractSet[str]) -> bool:
-        return self.attr_constraint.can_infer(var_constraint_names)
-
-    def infer(self, context: ConstraintContext) -> TypedAttributeCovT:
-        return self.attr_constraint.infer(context)
-
-    def get_bases(self) -> set[type[Attribute]] | None:
-        return self.attr_constraint.get_bases()
-
-    def mapping_type_vars(
-        self, type_var_mapping: Mapping[TypeVar, AttrConstraint | IntConstraint]
-    ) -> TypedAttributeConstraint[TypedAttributeCovT]:  # pyright: ignore[reportDeprecated]
-        return TypedAttributeConstraint(  # pyright: ignore[reportDeprecated]
-            self.attr_constraint.mapping_type_vars(type_var_mapping),
-            self.type_constraint.mapping_type_vars(type_var_mapping),
-        )
-
-
 @dataclass(frozen=True)
 class VarConstraint(AttrConstraint[AttributeCovT]):
     """


### PR DESCRIPTION
Been deprecated a while.

The tests it was used in seem to test functionality we don't have anymore