### PR TITLE
[experimental] core: (Constraints) allow constraints to infer other constraints

### DIFF
--- a/tests/filecheck/dialects/vector/vector_transfer_read_verify.mlir
+++ b/tests/filecheck/dialects/vector/vector_transfer_read_verify.mlir
@@ -1,7 +1,7 @@
 // RUN: xdsl-opt --split-input-file --verify-diagnostics %s | filecheck %s
 
 %source, %index, %padding = "test.op"() : () -> (vector<4x3xf32>, index, f32)
-"vector.transfer_read"(%source, %index, %index, %padding) <{in_bounds=[true], operandSegmentSizes = array<i32: 1, 3, 1, 0>, permutation_map = affine_map<() -> (0)>}> : (vector<4x3xf32>, index, index, f32) -> vector<1x1x2x3xf32>
+"vector.transfer_read"(%source, %index, %index, %padding) <{in_bounds=[true], operandSegmentSizes = array<i32: 1, 2, 1, 0>, permutation_map = affine_map<() -> (0)>}> : (vector<4x3xf32>, index, index, f32) -> vector<1x1x2x3xf32>
 // CHECK: operand 'source' at position 0 does not verify:
 // CHECK: Unexpected attribute vector<4x3xf32>
 

--- a/tests/irdl/test_recursive_constraints.py
+++ b/tests/irdl/test_recursive_constraints.py
@@ -1,0 +1,75 @@
+from collections.abc import Mapping
+from collections.abc import Set as AbstractSet
+from dataclasses import dataclass
+from typing import ClassVar
+
+import pytest
+from typing_extensions import TypeVar
+
+from xdsl.dialects.builtin import IntAttr
+from xdsl.irdl import (
+    AnyInt,
+    AttrConstraint,
+    ConstraintContext,
+    IntConstraint,
+    IntVarConstraint,
+    IRDLOperation,
+    irdl_op_definition,
+    result_def,
+)
+from xdsl.utils.exceptions import VerifyException
+
+# Test a constraint that relies on inferring the value of other constaints
+
+
+@dataclass(frozen=True)
+class AddConstraint(IntConstraint):
+    lhs: IntConstraint
+    rhs: IntConstraint
+
+    def verify(self, i: int, constraint_context: ConstraintContext) -> None:
+        if i != self.infer(constraint_context):
+            raise VerifyException()
+
+    def can_infer(self, var_constraint_names: AbstractSet[str]) -> bool:
+        return self.lhs.can_infer(var_constraint_names) and self.rhs.can_infer(
+            var_constraint_names
+        )
+
+    def infer(self, context: ConstraintContext) -> int:
+        return self.lhs.infer(context) + self.rhs.infer(context)
+
+    def mapping_type_vars(
+        self, type_var_mapping: Mapping[TypeVar, AttrConstraint | IntConstraint]
+    ) -> IntConstraint:
+        return AddConstraint(
+            self.lhs.mapping_type_vars(type_var_mapping),
+            self.rhs.mapping_type_vars(type_var_mapping),
+        )
+
+
+# Should function no matter which order the constraints appear in
+@irdl_op_definition
+class RecursiveOp(IRDLOperation):
+    name = "test.recursive"
+
+    A: ClassVar = IntVarConstraint("A", AnyInt())
+    B: ClassVar = IntVarConstraint("B", AnyInt())
+
+    in1 = result_def(IntAttr.constr(AddConstraint(A, B)))
+    in2 = result_def(IntAttr.constr(A))
+    in3 = result_def(IntAttr.constr(B))
+    in4 = result_def(IntAttr.constr(AddConstraint(A, B)))
+
+
+def test_recursive_constraint():
+    op = RecursiveOp(result_types=(IntAttr(3), IntAttr(1), IntAttr(2), IntAttr(3)))
+
+    op.verify()
+
+    op2 = RecursiveOp(result_types=(IntAttr(2), IntAttr(1), IntAttr(2), IntAttr(3)))
+
+    with pytest.raises(
+        VerifyException, match="result 'in1' at position 0 does not verify"
+    ):
+        op2.verify()

--- a/xdsl/irdl/constraints.py
+++ b/xdsl/irdl/constraints.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from collections.abc import Set as AbstractSet
 from dataclasses import dataclass, field
 from typing import (
@@ -28,6 +28,18 @@ if TYPE_CHECKING:
     from xdsl.irdl import IRDLAttrConstraint
 
 
+class InferVariableError(Exception):
+    """
+    Thrown when a variable was expected to be instantiated for inference,
+    but has not been set yet.
+    """
+
+    variable: str
+
+
+T = TypeVar("T")
+
+
 @dataclass
 class ConstraintContext:
     """
@@ -45,6 +57,12 @@ class ConstraintContext:
     _int_variables: dict[str, int] = field(default_factory=dict[str, int])
     """The assignment of constraint int variables."""
 
+    _has_changed: bool = False
+
+    _constraints: list[tuple[Callable[[Any, ConstraintContext], None], Any]] = field(
+        default_factory=list[tuple[Callable[[Any, "ConstraintContext"], None], Any]]
+    )
+
     def get_variable(self, key: str) -> Attribute | None:
         return self._variables.get(key)
 
@@ -56,12 +74,40 @@ class ConstraintContext:
 
     def set_attr_variable(self, key: str, attr: Attribute):
         self._variables[key] = attr
+        self._has_changed = True
 
     def set_range_variable(self, key: str, attrs: tuple[Attribute, ...]):
         self._range_variables[key] = attrs
+        self._has_changed = True
 
     def set_int_variable(self, key: str, i: int):
         self._int_variables[key] = i
+        self._has_changed = True
+
+    def add_constraint(
+        self, verify: Callable[[T, ConstraintContext], None], to_verify: T
+    ):
+        self._constraints.append((verify, to_verify))
+
+    def _verify_constraint(
+        self, verify: Callable[[T, ConstraintContext], None], to_verify: T
+    ):
+        try:
+            verify(to_verify, self)
+            return False
+        except InferVariableError:
+            return True
+
+    def solve_constraints(self):
+        while True:
+            self._has_changed = False
+            self._constraints[:] = [
+                (x, y) for (x, y) in self._constraints if self._verify_constraint(x, y)
+            ]
+            if not self._constraints:
+                return
+            if not self._has_changed:
+                raise VerifyException("Constraint variable resolution did not converge")
 
     @property
     def attr_variables(self) -> AbstractSet[str]:
@@ -263,6 +309,8 @@ class VarConstraint(AttrConstraint[AttributeCovT]):
 
     def infer(self, context: ConstraintContext) -> AttributeCovT:
         v = context.get_variable(self.name)
+        if v is None:
+            raise InferVariableError(self.name)
         return cast(AttributeCovT, v)
 
     def can_infer(self, var_constraint_names: AbstractSet[str]) -> bool:
@@ -1015,7 +1063,8 @@ class IntVarConstraint(IntConstraint):
         context: ConstraintContext,
     ) -> int:
         v = context.get_int_variable(self.name)
-        assert isinstance(v, int)
+        if v is None:
+            raise InferVariableError(self.name)
         return v
 
     def mapping_type_vars(
@@ -1250,6 +1299,8 @@ class RangeVarConstraint(RangeConstraint[AttributeCovT]):
         self, context: ConstraintContext, *, length: int | None
     ) -> Sequence[AttributeCovT]:
         v = context.get_range_variable(self.name)
+        if v is None:
+            raise InferVariableError(self.name)
         return cast(Sequence[AttributeCovT], v)
 
     def mapping_type_vars(

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -181,12 +181,12 @@ class FormatProgram:
             state.operands, state.operand_types, op_def.operands, strict=True
         ):
             length = len(operand) if isinstance(operand, Sequence) else 1
-            operand_def.constr.verify_length(length, ctx)
+            ctx.add_constraint(operand_def.constr.verify_length, length)
             if operand_type is None:
                 continue
             if isinstance(operand_type, Attribute):
                 operand_type = (operand_type,)
-            operand_def.constr.verify(operand_type, ctx)
+            ctx.add_constraint(operand_def.constr.verify, operand_type)
 
         for result_type, (_, result_def) in zip(
             state.result_types, op_def.results, strict=True
@@ -195,7 +195,7 @@ class FormatProgram:
                 continue
             if isinstance(result_type, Attribute):
                 result_type = (result_type,)
-            result_def.constr.verify(result_type, ctx)
+            ctx.add_constraint(result_def.constr.verify, result_type)
 
         for prop_name, prop_def in op_def.properties.items():
             if isinstance(prop_def, OptionalDef) and prop_def.default_value is None:
@@ -203,7 +203,7 @@ class FormatProgram:
             attr = state.properties.get(prop_name, prop_def.default_value)
             if attr is None:
                 continue
-            prop_def.constr.verify(attr, ctx)
+            ctx.add_constraint(prop_def.constr.verify, attr)
 
         for attr_name, attr_def in op_def.attributes.items():
             if isinstance(attr_def, OptionalDef) and attr_def.default_value is None:
@@ -211,7 +211,9 @@ class FormatProgram:
             attr = state.attributes.get(attr_name, attr_def.default_value)
             if attr is None:
                 continue
-            attr_def.constr.verify(attr, ctx)
+            ctx.add_constraint(attr_def.constr.verify, attr)
+
+        ctx.solve_constraints()
 
     def resolve_operand_types(
         self, state: ParsingState, op_def: OpDef

--- a/xdsl/irdl/operations.py
+++ b/xdsl/irdl/operations.py
@@ -1179,7 +1179,6 @@ class OpDef:
 
     def verify(self, op: Operation):
         """Given an IRDL definition, verify that an operation satisfies its invariants."""
-
         # Mapping from type variables to their concrete types.
         constraint_context = ConstraintContext()
 
@@ -1203,7 +1202,9 @@ class OpDef:
                 raise VerifyException(
                     f"property '{prop_name}' expected in operation '{op.name}'"
                 )
-            attr_def.constr.verify(op.properties[prop_name], constraint_context)
+            constraint_context.add_constraint(
+                attr_def.constr.verify, op.properties[prop_name]
+            )
 
         for prop_name in op.properties.keys():
             if prop_name not in self.properties:
@@ -1221,7 +1222,11 @@ class OpDef:
                 raise VerifyException(
                     f"attribute '{attr_name}' expected in operation '{op.name}'"
                 )
-            attr_def.constr.verify(op.attributes[attr_name], constraint_context)
+            constraint_context.add_constraint(
+                attr_def.constr.verify, op.attributes[attr_name]
+            )
+
+        constraint_context.solve_constraints()
 
         # Verify traits.
         for trait in self.traits:
@@ -1464,6 +1469,32 @@ def irdl_op_verify_regions(
                 ) from e
 
 
+def _verify_arg_at_position(
+    args: tuple[
+        RangeConstraint,
+        str,
+        Sequence[Attribute],
+        Literal[VarIRConstruct.OPERAND, VarIRConstruct.RESULT],
+        int,
+    ],
+    constraint_context: ConstraintContext,
+):
+    constr, arg_name, arg_types, construct, idx = args
+    length = len(arg_types)
+    try:
+        constr.verify(arg_types, constraint_context)
+    except VerifyException as e:
+        if length == 0:
+            pos = f"expected at position {idx}"
+        elif length == 1:
+            pos = f"at position {idx}"
+        else:
+            pos = f"at positions {idx} to {idx + length - 1}"
+        raise VerifyException(
+            f"{get_construct_name(construct)} '{arg_name}' {pos} does not verify:\n{e}"
+        ) from e
+
+
 def irdl_op_verify_arg_list(
     op: Operation,
     op_def: OpDef,
@@ -1484,21 +1515,11 @@ def irdl_op_verify_arg_list(
             arg_types = (args.type,)
         else:
             arg_types = args.types
-        length = len(arg_types)
-        try:
-            arg_def.constr.verify(arg_types, constraint_context)
-        except VerifyException as e:
-            if length == 0:
-                pos = f"expected at position {idx}"
-            elif length == 1:
-                pos = f"at position {idx}"
-            else:
-                pos = f"at positions {idx} to {idx + length - 1}"
-            raise VerifyException(
-                f"{get_construct_name(construct)} '{arg_name}' {pos} does not "
-                f"verify:\n{e}"
-            ) from e
-        idx += length
+        constraint_context.add_constraint(
+            _verify_arg_at_position,
+            (arg_def.constr, arg_name, arg_types, construct, idx),
+        )
+        idx += len(arg_types)
 
 
 @overload


### PR DESCRIPTION
Allows constraints to depend on other constraints.

Remember @PapyChacal suggesting to me that this could be done this way, by just looping through all the constraints until you either finish or make no progress. I know we considered other solutions in the past, like explicitly marking that a constraint should verify "later", or trying to figure out a dependency tree of verification.

I am not sure there is any use case that needs more than 1 iteration, and I'm not even sure if this feature is desirable, but I nerdsniped myself into coding it up. Is there an easy way to test the performance impact? Happy to discuss any alternate implementations/just not doing this.