### PR TITLE
core: handle self-replacement in replace_all_uses_with

### DIFF
--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -1145,6 +1145,17 @@ def test_dialect_name():
     assert MyOperation.dialect_name() == "dialect"
 
 
+def test_replace_all_uses_with_self():
+    """Replacing an SSA value with itself should be a no-op (fixes #5721)."""
+    a = create_ssa_value(i32)
+    b = test.TestOp((a,))
+
+    a.replace_all_uses_with(a)
+
+    # The use should still be intact and pointing to a
+    assert set(u.operation for u in a.uses) == {b}
+
+
 def test_replace_by_if():
     a = create_ssa_value(i32)
     b = test.TestOp((a,))

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -768,6 +768,8 @@ class SSAValue(IRWithUses, IRWithName, ABC, Generic[AttributeCovT]):
 
     def replace_all_uses_with(self, value: SSAValue) -> None:
         """Replace the value by another value in all its uses."""
+        if value is self:
+            return
         for use in tuple(self.uses):
             use.operation.operands[use.index] = value
         # carry over name if possible


### PR DESCRIPTION
## Bug
Fixes #5721 — Calling `replace_all_uses_with(self)` (replacing an SSA value with itself) triggers an assertion error (`unexpected error in xdsl`). The loop reassigns each use to the same value, so the use list is never cleared, and the `assert self.first_use is None` at the end fails.

## Fix
Add an early return when `value is self`, making self-replacement a no-op. This mirrors how MLIR/LLVM handles the same case in `replaceAllUsesWith`.

## Testing
Added `test_replace_all_uses_with_self` in `tests/test_ir.py` that verifies self-replacement does not raise and preserves the existing use chain.

Happy to address any feedback.

Greetings, saschabuehrle