### PR TITLE
dialects: (tensor) Fixed nofold attr to optional arg 

### DIFF
--- a/xdsl/dialects/tensor.py
+++ b/xdsl/dialects/tensor.py
@@ -772,8 +772,8 @@ class PadOp(IRDLOperation):
         region: Region,
         static_low: Sequence[int] | DenseArrayBase,
         static_high: Sequence[int] | DenseArrayBase,
-        nofold: UnitAttr,
         result_type: TensorType[Attribute],
+        nofold: UnitAttr | None = None,
         attributes: dict[str, Attribute] | None = None,
     ):
         if not isinstance(static_low, DenseArrayBase):


### PR DESCRIPTION
Tensor PadOp has an optional attribute `nofold`, but the constructor for PadOp did not have the option to have it not be set since it needed a None typehint and default argument.
