### PR TITLE
dialects: (stencil)  Add support for buffer-semantic reductions

### DIFF
--- a/tests/filecheck/dialects/csl/csl-stencil-ops.mlir
+++ b/tests/filecheck/dialects/csl/csl-stencil-ops.mlir
@@ -64,7 +64,7 @@ builtin.module {
 // CHECK-GENERIC-NEXT:   ^bb0(%a: !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>, %b: !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>):
 // CHECK-GENERIC-NEXT:     %0 = "stencil.load"(%a) : (!stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>) -> !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
 // CHECK-GENERIC-NEXT:     %pref = "csl_stencil.prefetch"(%0) <{topo = #dmp.topo<1022x510>, swaps = [#csl_stencil.exchange<to [1, 0]>, #csl_stencil.exchange<to [-1, 0]>, #csl_stencil.exchange<to [0, 1]>, #csl_stencil.exchange<to [0, -1]>], num_chunks = 2 : i64}> : (!stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>) -> tensor<4x510xf32>
-// CHECK-GENERIC-NEXT:     %1 = "stencil.apply"(%0, %pref) <{operandSegmentSizes = array<i32: 2, 0>}> ({
+// CHECK-GENERIC-NEXT:     %1 = "stencil.apply"(%0, %pref) <{operandSegmentSizes = array<i32: 2, 0, 0>}> ({
 // CHECK-GENERIC-NEXT:     ^bb1(%2: !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %3: tensor<4x510xf32>):
 // CHECK-GENERIC-NEXT:       %4 = "arith.constant"() <{value = 1.666600e-01 : f32}> : () -> f32
 // CHECK-GENERIC-NEXT:       %5 = "csl_stencil.access"(%3) <{offset = #stencil.index<[1, 0]>, offset_mapping = #stencil.index<[0, 1]>}> : (tensor<4x510xf32>) -> tensor<510xf32>

--- a/tests/filecheck/dialects/stencil/invalid.mlir
+++ b/tests/filecheck/dialects/stencil/invalid.mlir
@@ -13,7 +13,7 @@ builtin.module {
 builtin.module {
   func.func @buffered_and_stored_1d(%in: !stencil.field<[-4,68]xf64>, %out: !stencil.field<[0,1024]xf64>) {
     %int = "stencil.load"(%in) : (!stencil.field<[-4,68]xf64>) -> !stencil.temp<[-1,68]xf64>
-    %outt = "stencil.apply"(%int) <{operandSegmentSizes = array<i32: 1, 0>}> ({
+    %outt = "stencil.apply"(%int) <{operandSegmentSizes = array<i32: 1, 0, 0>}> ({
     ^bb0(%intb: !stencil.temp<[-1,68]xf64>):
       %v = "stencil.access"(%intb) {"offset" = #stencil.index<[-1]>} : (!stencil.temp<[-1,68]xf64>) -> f64
       "stencil.return"(%v) : (f64) -> ()
@@ -31,7 +31,7 @@ builtin.module {
 builtin.module {
   func.func @buffer_types_mismatch_1d(%in: !stencil.field<[-4,68]xf64>, %out: !stencil.field<[0,1024]xf64>) {
     %int = "stencil.load"(%in) : (!stencil.field<[-4,68]xf64>) -> !stencil.temp<[-1,68]xf64>
-    %outt = "stencil.apply"(%int) <{operandSegmentSizes = array<i32: 1, 0>}> ({
+    %outt = "stencil.apply"(%int) <{operandSegmentSizes = array<i32: 1, 0, 0>}> ({
     ^bb0(%intb: !stencil.temp<[-1,68]xf64>):
       %v = "stencil.access"(%intb) {"offset" = #stencil.index<[-1]>} : (!stencil.temp<[-1,68]xf64>) -> f64
       "stencil.return"(%v) : (f64) -> ()
@@ -71,7 +71,7 @@ builtin.module {
 builtin.module {
   func.func @apply_no_return_1d(%in: !stencil.field<[-4,68]xf64>) {
     %int = "stencil.load"(%in) : (!stencil.field<[-4,68]xf64>) -> !stencil.temp<?xf64>
-    "stencil.apply"(%int) <{operandSegmentSizes = array<i32: 1, 0>}> ({
+    "stencil.apply"(%int) <{operandSegmentSizes = array<i32: 1, 0, 0>}> ({
     ^bb0(%intb: !stencil.temp<?xf64>):
       %v = "stencil.access"(%intb) {"offset" = #stencil.index<[-1]>} : (!stencil.temp<?xf64>) -> f64
       "stencil.return"() : () -> ()
@@ -88,7 +88,7 @@ builtin.module {
   func.func @access_bad_temp_1d(%in: !stencil.field<[-4,68]xf64>, %bigin: !stencil.field<[-4,68]x[-4,68]xf64>, %out: !stencil.field<[-4,68]xf64>) {
     %int = "stencil.load"(%in) : (!stencil.field<[-4,68]xf64>) -> !stencil.temp<?xf64>
     %bigint = "stencil.load"(%bigin) : (!stencil.field<[-4,68]x[-4,68]xf64>) -> !stencil.temp<?x?xf64>
-    %outt = "stencil.apply"(%int, %bigint) <{operandSegmentSizes = array<i32: 2, 0>}> ({
+    %outt = "stencil.apply"(%int, %bigint) <{operandSegmentSizes = array<i32: 2, 0, 0>}> ({
     ^bb0(%intb: !stencil.temp<?xf64>, %bigintb: !stencil.temp<?x?xf64>):
       %v = "stencil.access"(%bigintb) {"offset" = #stencil.index<[-1]>} : (!stencil.temp<?x?xf64>) -> f64
       "stencil.return"(%v) : (f64) -> ()
@@ -105,7 +105,7 @@ builtin.module {
 builtin.module {
   func.func @access_bad_offset_1d(%in: !stencil.field<[-4,68]xf64>, %out: !stencil.field<[-4,68]xf64>) {
     %int = "stencil.load"(%in) : (!stencil.field<[-4,68]xf64>) -> !stencil.temp<?xf64>
-    %outt = "stencil.apply"(%int) <{operandSegmentSizes = array<i32: 1, 0>}> ({
+    %outt = "stencil.apply"(%int) <{operandSegmentSizes = array<i32: 1, 0, 0>}> ({
     ^bb0(%intb: !stencil.temp<?xf64>):
       %v = "stencil.access"(%intb) {"offset" = #stencil.index<[-1, 1]>} : (!stencil.temp<?xf64>) -> f64
       "stencil.return"(%v) : (f64) -> ()
@@ -134,7 +134,7 @@ builtin.module {
 builtin.module {
   func.func @wrong_return_arity_1d(%in: !stencil.field<[-4,68]xf64>, %bigin: !stencil.field<[-4,68]x[-4,68]xf64>, %out: !stencil.field<[-4,68]xf64>) {
     %int = "stencil.load"(%in) : (!stencil.field<[-4,68]xf64>) -> !stencil.temp<?xf64>
-    %outt1, %outt2 = "stencil.apply"(%int) <{operandSegmentSizes = array<i32: 1, 0>}> ({
+    %outt1, %outt2 = "stencil.apply"(%int) <{operandSegmentSizes = array<i32: 1, 0, 0>}> ({
     ^bb0(%intb: !stencil.temp<?xf64>):
       %v = "stencil.access"(%intb) {"offset" = #stencil.index<[-1]>} : (!stencil.temp<?xf64>) -> f64
       "stencil.return"(%v) : (f64) -> ()
@@ -151,7 +151,7 @@ builtin.module {
 builtin.module {
   func.func @wrong_return_types_1d(%in: !stencil.field<[-4,68]xf64>, %bigin: !stencil.field<[-4,68]x[-4,68]xf64>, %out: !stencil.field<[-4,68]xf64>) {
     %int = "stencil.load"(%in) : (!stencil.field<[-4,68]xf64>) -> !stencil.temp<?xf64>
-    %outt1, %outt2 = "stencil.apply"(%int) <{operandSegmentSizes = array<i32: 1, 0>}> ({
+    %outt1, %outt2 = "stencil.apply"(%int) <{operandSegmentSizes = array<i32: 1, 0, 0>}> ({
     ^bb0(%intb: !stencil.temp<?xf64>):
       %v = "stencil.access"(%intb) {"offset" = #stencil.index<[-1]>} : (!stencil.temp<?xf64>) -> f64
       "stencil.return"(%v, %v) : (f64, f64) -> ()
@@ -168,7 +168,7 @@ builtin.module {
 builtin.module {
   func.func @different_apply_bounds(%in: !stencil.field<[-4,68]xf64>, %bigin: !stencil.field<[-4,68]x[-4,68]xf64>, %out: !stencil.field<[-4,68]xf64>) {
     %int = "stencil.load"(%in) : (!stencil.field<[-4,68]xf64>) -> !stencil.temp<?xf64>
-    %outt1, %outt2 = "stencil.apply"(%int) <{operandSegmentSizes = array<i32: 1, 0>}> ({
+    %outt1, %outt2 = "stencil.apply"(%int) <{operandSegmentSizes = array<i32: 1, 0, 0>}> ({
     ^bb0(%intb: !stencil.temp<?xf64>):
       %v = "stencil.access"(%intb) {"offset" = #stencil.index<[-1]>} : (!stencil.temp<?xf64>) -> f64
       "stencil.return"(%v, %v) : (f64, f64) -> ()

--- a/tests/filecheck/dialects/stencil/stencil_ops.mlir
+++ b/tests/filecheck/dialects/stencil/stencil_ops.mlir
@@ -256,11 +256,11 @@ builtin.module {
 
       // reduction (side effect)
       %c0 = arith.constant 0.000000e+00 : f64
-      "stencil.reduce"(%7, %c0) ({
+      stencil.reduce %7 init %c0 {
       ^bb0(%acc : f64, %elem : f64):
         %sum = arith.addf %acc, %elem : f64
-        "stencil.yield"(%sum) : (f64) -> ()
-      }) : (f64, f64) -> ()
+        stencil.yield %sum : f64
+      } : f64
 
       %8 = stencil.store_result %7 : !stencil.result<f64>
       stencil.return %8 : !stencil.result<f64>
@@ -274,53 +274,11 @@ builtin.module {
 // CHECK-NEXT:      stencil.apply(%2 = %0 : !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) outs (%1 : !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) reductions (%red : !llvm.ptr) {
 // CHECK-NEXT:        %3 = stencil.access %2[0, 0, 0] : !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
 // CHECK-NEXT:        %c0 = arith.constant 0.000000e+00 : f64
-// CHECK-NEXT:        "stencil.reduce"(%3, %c0) ({
+// CHECK-NEXT:        stencil.reduce %3 init %c0 {
 // CHECK-NEXT:        ^bb0(%acc: f64, %elem: f64):
 // CHECK-NEXT:          %sum = arith.addf %acc, %elem : f64
-// CHECK-NEXT:          "stencil.yield"(%sum) : (f64) -> ()
-// CHECK-NEXT:        }) : (f64, f64) -> ()
-// CHECK-NEXT:        %4 = stencil.store_result %3 : !stencil.result<f64>
-// CHECK-NEXT:        stencil.return %4 : !stencil.result<f64>
-// CHECK-NEXT:      } to <[0, 0, 0], [64, 64, 64]>
-// CHECK-NEXT:      func.return
-// CHECK-NEXT:    }
-// CHECK-NEXT:  }
-
-// -----
-
-builtin.module {
-  func.func @stencil_copy_bufferized_with_reduction(%0: !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>, %1: !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>, %red: !llvm.ptr) {
-    stencil.apply(%6 = %0 : !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>)
-      outs (%1 : !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>)
-      reductions (%red : !llvm.ptr) {
-
-      %7 = stencil.access %6[0, 0, 0] : !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
-
-      // reduction (side effect)
-      %c0 = arith.constant 0.000000e+00 : f64
-      "stencil.reduce"(%7, %c0) ({
-      ^bb0(%acc : f64, %elem : f64):
-        %sum = arith.addf %acc, %elem : f64
-        "stencil.yield"(%sum) : (f64) -> ()
-      }) : (f64, f64) -> ()
-
-      %8 = stencil.store_result %7 : !stencil.result<f64>
-      stencil.return %8 : !stencil.result<f64>
-    } to <[0, 0, 0], [64, 64, 64]>
-    func.return
-  }
-}
-
-// CHECK:       builtin.module {
-// CHECK-NEXT:    func.func @stencil_copy_bufferized_with_reduction(%0: !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>, %1: !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>, %red: !llvm.ptr) {
-// CHECK-NEXT:      stencil.apply(%2 = %0 : !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) outs (%1 : !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) reductions (%red : !llvm.ptr) {
-// CHECK-NEXT:        %3 = stencil.access %2[0, 0, 0] : !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
-// CHECK-NEXT:        %c0 = arith.constant 0.000000e+00 : f64
-// CHECK-NEXT:        "stencil.reduce"(%3, %c0) ({
-// CHECK-NEXT:        ^bb0(%acc: f64, %elem: f64):
-// CHECK-NEXT:          %sum = arith.addf %acc, %elem : f64
-// CHECK-NEXT:          "stencil.yield"(%sum) : (f64) -> ()
-// CHECK-NEXT:        }) : (f64, f64) -> ()
+// CHECK-NEXT:          stencil.yield %sum : f64
+// CHECK-NEXT:        } : f64
 // CHECK-NEXT:        %4 = stencil.store_result %3 : !stencil.result<f64>
 // CHECK-NEXT:        stencil.return %4 : !stencil.result<f64>
 // CHECK-NEXT:      } to <[0, 0, 0], [64, 64, 64]>

--- a/tests/filecheck/dialects/stencil/stencil_ops.mlir
+++ b/tests/filecheck/dialects/stencil/stencil_ops.mlir
@@ -247,6 +247,90 @@ builtin.module {
 // -----
 
 builtin.module {
+  func.func @stencil_copy_bufferized_with_reduction(%0: !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>, %1: !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>, %red: !llvm.ptr) {
+    stencil.apply(%6 = %0 : !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>)
+      outs (%1 : !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>)
+      reductions (%red : !llvm.ptr) {
+
+      %7 = stencil.access %6[0, 0, 0] : !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+
+      // reduction (side effect)
+      %c0 = arith.constant 0.000000e+00 : f64
+      "stencil.reduce"(%7, %c0) ({
+      ^bb0(%acc : f64, %elem : f64):
+        %sum = arith.addf %acc, %elem : f64
+        "stencil.yield"(%sum) : (f64) -> ()
+      }) : (f64, f64) -> ()
+
+      %8 = stencil.store_result %7 : !stencil.result<f64>
+      stencil.return %8 : !stencil.result<f64>
+    } to <[0, 0, 0], [64, 64, 64]>
+    func.return
+  }
+}
+
+// CHECK:       builtin.module {
+// CHECK-NEXT:    func.func @stencil_copy_bufferized_with_reduction(%0: !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>, %1: !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>, %red: !llvm.ptr) {
+// CHECK-NEXT:      stencil.apply(%2 = %0 : !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) outs (%1 : !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) reductions (%red : !llvm.ptr) {
+// CHECK-NEXT:        %3 = stencil.access %2[0, 0, 0] : !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+// CHECK-NEXT:        %c0 = arith.constant 0.000000e+00 : f64
+// CHECK-NEXT:        "stencil.reduce"(%3, %c0) ({
+// CHECK-NEXT:        ^bb0(%acc: f64, %elem: f64):
+// CHECK-NEXT:          %sum = arith.addf %acc, %elem : f64
+// CHECK-NEXT:          "stencil.yield"(%sum) : (f64) -> ()
+// CHECK-NEXT:        }) : (f64, f64) -> ()
+// CHECK-NEXT:        %4 = stencil.store_result %3 : !stencil.result<f64>
+// CHECK-NEXT:        stencil.return %4 : !stencil.result<f64>
+// CHECK-NEXT:      } to <[0, 0, 0], [64, 64, 64]>
+// CHECK-NEXT:      func.return
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }
+
+// -----
+
+builtin.module {
+  func.func @stencil_copy_bufferized_with_reduction(%0: !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>, %1: !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>, %red: !llvm.ptr) {
+    stencil.apply(%6 = %0 : !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>)
+      outs (%1 : !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>)
+      reductions (%red : !llvm.ptr) {
+
+      %7 = stencil.access %6[0, 0, 0] : !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+
+      // reduction (side effect)
+      %c0 = arith.constant 0.000000e+00 : f64
+      "stencil.reduce"(%7, %c0) ({
+      ^bb0(%acc : f64, %elem : f64):
+        %sum = arith.addf %acc, %elem : f64
+        "stencil.yield"(%sum) : (f64) -> ()
+      }) : (f64, f64) -> ()
+
+      %8 = stencil.store_result %7 : !stencil.result<f64>
+      stencil.return %8 : !stencil.result<f64>
+    } to <[0, 0, 0], [64, 64, 64]>
+    func.return
+  }
+}
+
+// CHECK:       builtin.module {
+// CHECK-NEXT:    func.func @stencil_copy_bufferized_with_reduction(%0: !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>, %1: !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>, %red: !llvm.ptr) {
+// CHECK-NEXT:      stencil.apply(%2 = %0 : !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) outs (%1 : !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) reductions (%red : !llvm.ptr) {
+// CHECK-NEXT:        %3 = stencil.access %2[0, 0, 0] : !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+// CHECK-NEXT:        %c0 = arith.constant 0.000000e+00 : f64
+// CHECK-NEXT:        "stencil.reduce"(%3, %c0) ({
+// CHECK-NEXT:        ^bb0(%acc: f64, %elem: f64):
+// CHECK-NEXT:          %sum = arith.addf %acc, %elem : f64
+// CHECK-NEXT:          "stencil.yield"(%sum) : (f64) -> ()
+// CHECK-NEXT:        }) : (f64, f64) -> ()
+// CHECK-NEXT:        %4 = stencil.store_result %3 : !stencil.result<f64>
+// CHECK-NEXT:        stencil.return %4 : !stencil.result<f64>
+// CHECK-NEXT:      } to <[0, 0, 0], [64, 64, 64]>
+// CHECK-NEXT:      func.return
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }
+
+// -----
+
+builtin.module {
   func.func @stencil_reduce(%a: f64, %b: f64) {
     stencil.reduce %a init %b {
       ^bb0(%x: f64, %y: f64):

--- a/tests/filecheck/transforms/stencil-tensorize-z-dimension.mlir
+++ b/tests/filecheck/transforms/stencil-tensorize-z-dimension.mlir
@@ -7,7 +7,7 @@ builtin.module {
     %0 = "stencil.external_load"(%a) : (memref<1024x512x512xf32>) -> !stencil.field<[-1,1023]x[-1,511]x[-1,511]xf32>
     %1 = "stencil.load"(%0) : (!stencil.field<[-1,1023]x[-1,511]x[-1,511]xf32>) -> !stencil.temp<[-1,1023]x[-1,511]x[-1,511]xf32>
     %2 = "stencil.external_load"(%b) : (memref<1024x512x512xf32>) -> !stencil.field<[-1,1023]x[-1,511]x[-1,511]xf32>
-    %3 = "stencil.apply"(%1)  <{operandSegmentSizes = array<i32: 1, 0>}> ({
+    %3 = "stencil.apply"(%1)  <{operandSegmentSizes = array<i32: 1, 0, 0>}> ({
     ^bb0(%4: !stencil.temp<[-1,1023]x[-1,511]x[-1,511]xf32>):
       %5 = arith.constant 1.666600e-01 : f32
       %6 = "stencil.access"(%4) {"offset" = #stencil.index<[1, 0, 0]>} : (!stencil.temp<[-1,1023]x[-1,511]x[-1,511]xf32>) -> f32
@@ -60,7 +60,7 @@ builtin.module {
 
   func.func @gauss_seidel_func(%a: !stencil.field<[-1,1023]x[-1,511]x[-1,511]xf32>, %b: !stencil.field<[-1,1023]x[-1,511]x[-1,511]xf32>) {
     %0 = "stencil.load"(%a) : (!stencil.field<[-1,1023]x[-1,511]x[-1,511]xf32>) -> !stencil.temp<[-1,1023]x[-1,511]x[-1,511]xf32>
-    %1 = "stencil.apply"(%0) <{operandSegmentSizes = array<i32: 1, 0>}>  ({
+    %1 = "stencil.apply"(%0) <{operandSegmentSizes = array<i32: 1, 0, 0>}>  ({
     ^bb0(%2: !stencil.temp<[-1,1023]x[-1,511]x[-1,511]xf32>):
       %3 = arith.constant 1.666600e-01 : f32
       %4 = "stencil.access"(%2) {"offset" = #stencil.index<[1, 0, 0]>} : (!stencil.temp<[-1,1023]x[-1,511]x[-1,511]xf32>) -> f32

--- a/xdsl/dialects/stencil.py
+++ b/xdsl/dialects/stencil.py
@@ -512,6 +512,7 @@ class ApplyOp(IRDLOperation):
 
     args = var_operand_def(Attribute)
     dest = var_operand_def(FieldType)
+    reductions = var_operand_def()
     region = region_def()
     res = var_result_def(TempType)
 
@@ -572,6 +573,12 @@ class ApplyOp(IRDLOperation):
             printer.print_string(" -> ")
             with printer.in_parens():
                 printer.print_list(self.res.types, printer.print_attribute)
+
+        if self.reductions:
+            printer.print_string(" reductions ")
+            with printer.in_parens():
+                printer.print_list(self.reductions, print_destination_operand)
+
         printer.print_string(" ")
         printer.print_op_attributes(self.attributes, print_keyword=True)
         printer.print_region(self.region, print_entry_block_args=False)
@@ -631,7 +638,8 @@ class ApplyOp(IRDLOperation):
         else:
             bounds = None
         return cls.build(
-            operands=[operands, destinations or []],
+            # TODO: support stencil reduction parsing
+            operands=[operands, destinations or [], []],
             result_types=[result_types or []],
             regions=[region],
             attributes=attrs,
@@ -645,8 +653,21 @@ class ApplyOp(IRDLOperation):
         body: Block | Region,
         result_types: Sequence[TempType[Attribute]] = (),
         bounds: StencilBoundsAttr | None = None,
+        reductions: Sequence[SSAValue] | Sequence[Operation] = (),
     ):
         return ApplyOp(args, body, result_types, bounds)
+        assert result_types or bounds
+        if isinstance(body, Block):
+            body = Region(body)
+
+        properties = {"bounds": bounds} if bounds else {}
+
+        return ApplyOp.build(
+            operands=[list(args), [], list(reductions)],
+            regions=[body],
+            result_types=[result_types],
+            properties=properties,
+        )
 
     def verify_(self) -> None:
         for operand, argument in zip(self.operands, self.region.block.args):

--- a/xdsl/dialects/stencil.py
+++ b/xdsl/dialects/stencil.py
@@ -532,7 +532,7 @@ class ApplyOp(IRDLOperation):
         properties = {"bounds": bounds} if bounds else {}
 
         super().__init__(
-            operands=[list(args), []],
+            operands=[list(args), [], []],
             regions=[body],
             result_types=[result_types],
             properties=properties,

--- a/xdsl/dialects/stencil.py
+++ b/xdsl/dialects/stencil.py
@@ -609,6 +609,7 @@ class ApplyOp(IRDLOperation):
         args: tuple[Parser.Argument, ...]
         operands: tuple[SSAValue, ...]
         args, operands = zip(*assign_args) if assign_args else ((), ())
+        reductions = []
 
         if parser.parse_optional_punctuation("->"):
             parser.parse_punctuation("(")
@@ -616,6 +617,7 @@ class ApplyOp(IRDLOperation):
                 parser.parse_optional_attribute, parser.parse_attribute
             )
             destinations = []
+            parser.parse_punctuation(")")
         else:
             parser.parse_keyword("outs")
             parser.parse_punctuation("(")
@@ -623,7 +625,15 @@ class ApplyOp(IRDLOperation):
                 parser.Delimiter.NONE, parse_operand
             )
             result_types = []
-        parser.parse_punctuation(")")
+            parser.parse_punctuation(")")
+
+            if parser.parse_optional_keyword("reductions"):
+                parser.parse_punctuation("(")
+                reductions = parser.parse_comma_separated_list(
+                    parser.Delimiter.NONE, parse_operand
+                )
+                parser.parse_punctuation(")")
+
         attrs = parser.parse_optional_attr_dict_with_keyword()
         if attrs is not None:
             attrs = dict(attrs.data)
@@ -639,7 +649,7 @@ class ApplyOp(IRDLOperation):
             bounds = None
         return cls.build(
             # TODO: support stencil reduction parsing
-            operands=[operands, destinations or [], []],
+            operands=[operands, destinations or [], reductions],
             result_types=[result_types or []],
             regions=[region],
             attributes=attrs,

--- a/xdsl/dialects/stencil.py
+++ b/xdsl/dialects/stencil.py
@@ -648,7 +648,6 @@ class ApplyOp(IRDLOperation):
         else:
             bounds = None
         return cls.build(
-            # TODO: support stencil reduction parsing
             operands=[operands, destinations or [], reductions],
             result_types=[result_types or []],
             regions=[region],

--- a/xdsl/dialects/stencil.py
+++ b/xdsl/dialects/stencil.py
@@ -665,18 +665,6 @@ class ApplyOp(IRDLOperation):
         reductions: Sequence[SSAValue] | Sequence[Operation] = (),
     ):
         return ApplyOp(args, body, result_types, bounds)
-        assert result_types or bounds
-        if isinstance(body, Block):
-            body = Region(body)
-
-        properties = {"bounds": bounds} if bounds else {}
-
-        return ApplyOp.build(
-            operands=[list(args), [], list(reductions)],
-            regions=[body],
-            result_types=[result_types],
-            properties=properties,
-        )
 
     def verify_(self) -> None:
         for operand, argument in zip(self.operands, self.region.block.args):

--- a/xdsl/transforms/canonicalization_patterns/stencil.py
+++ b/xdsl/transforms/canonicalization_patterns/stencil.py
@@ -96,7 +96,6 @@ class ApplyUnusedResults(RewritePattern):
             return_args.pop(i)
 
         new = stencil.ApplyOp.build(
-            # TODO: support stencil reductions
             operands=[op.args, op.dest, []],
             regions=[Region(block)],
             result_types=[[r.type for r in results]],

--- a/xdsl/transforms/canonicalization_patterns/stencil.py
+++ b/xdsl/transforms/canonicalization_patterns/stencil.py
@@ -96,7 +96,8 @@ class ApplyUnusedResults(RewritePattern):
             return_args.pop(i)
 
         new = stencil.ApplyOp.build(
-            operands=[op.args, op.dest],
+            # TODO: support stencil reductions
+            operands=[op.args, op.dest, []],
             regions=[Region(block)],
             result_types=[[r.type for r in results]],
             properties=op.properties.copy(),

--- a/xdsl/transforms/convert_stencil_to_csl_stencil.py
+++ b/xdsl/transforms/convert_stencil_to_csl_stencil.py
@@ -239,7 +239,8 @@ class ConvertSwapToPrefetchPattern(RewritePattern):
             r_types = apply_op.result_types
             assert isa(r_types, Sequence[stencil.TempType[Attribute]])
             new_apply_op = stencil.ApplyOp.build(
-                operands=[[*apply_op.args, prefetch_op.result], apply_op.dest],
+                # TODO: support stencil reductions
+                operands=[[*apply_op.args, prefetch_op.result], apply_op.dest, []],
                 regions=[apply_op.detach_region(apply_op.region)],
                 result_types=[r_types],
                 properties=apply_op.properties,

--- a/xdsl/transforms/convert_stencil_to_csl_stencil.py
+++ b/xdsl/transforms/convert_stencil_to_csl_stencil.py
@@ -239,7 +239,6 @@ class ConvertSwapToPrefetchPattern(RewritePattern):
             r_types = apply_op.result_types
             assert isa(r_types, Sequence[stencil.TempType[Attribute]])
             new_apply_op = stencil.ApplyOp.build(
-                # TODO: support stencil reductions
                 operands=[[*apply_op.args, prefetch_op.result], apply_op.dest, []],
                 regions=[apply_op.detach_region(apply_op.region)],
                 result_types=[r_types],

--- a/xdsl/transforms/experimental/convert_stencil_to_ll_mlir.py
+++ b/xdsl/transforms/experimental/convert_stencil_to_ll_mlir.py
@@ -279,7 +279,7 @@ class LoadOpToMemRef(RewritePattern):
         subview.result.name_hint = name
 
 
-def prepare_apply_body(op: ApplyOp):
+def prepare_apply_body(op: ApplyOp) -> tuple[Block, list[SSAValue]]:
     # First replace all current arguments by their definition
     # and erase them from the block. (We are changing the op
     # to a loop, which has access to them either way)
@@ -295,9 +295,9 @@ def prepare_apply_body(op: ApplyOp):
         if isinstance(block_op, ReduceOp):
             stencil_reduces.append(block_op)
 
-    reduce_values = []
-    reduce_regions = []
-    reduce_init_values = []
+    reduce_values: list[SSAValue] = []
+    reduce_regions: list[Block] = []
+    reduce_init_values: list[SSAValue] = []
 
     for stencil_reduce in stencil_reduces:
         reduce_values.append(stencil_reduce.operand)
@@ -481,10 +481,12 @@ class ApplyOpToParallel(RewritePattern):
             ),
         ]
 
-        cloned_init_ops = []
-        cloned_init_values = []
+        cloned_init_ops: list[Operation] = []
+        cloned_init_values: list[OpResult] = []
 
         for init_value in reduce_init_values:
+            assert isinstance(init_value, OpResult)
+
             # Clone the defining operation
             init_op = init_value.op
             cloned_op = init_op.clone()

--- a/xdsl/transforms/experimental/convert_stencil_to_ll_mlir.py
+++ b/xdsl/transforms/experimental/convert_stencil_to_ll_mlir.py
@@ -7,7 +7,7 @@ from warnings import warn
 from typing_extensions import TypeVar
 
 from xdsl.context import Context
-from xdsl.dialects import arith, builtin, memref, scf
+from xdsl.dialects import arith, builtin, llvm, memref, scf
 from xdsl.dialects.builtin import (
     MemRefType,
     UnrealizedConversionCastOp,
@@ -25,6 +25,8 @@ from xdsl.dialects.stencil import (
     IndexAttr,
     IndexOp,
     LoadOp,
+    ReduceOp,
+    ReduceReturnOp,
     ResultType,
     ReturnOp,
     StencilBoundsAttr,
@@ -286,11 +288,49 @@ def prepare_apply_body(op: ApplyOp):
     for operand, arg in zip(op.operands, entry.args):
         arg.replace_all_uses_with(operand)
         entry.erase_arg(arg)
-    entry.add_op(scf.ReduceOp())
+
+    stencil_reduces: list[ReduceOp] = []
+
+    for block_op in list(entry.ops):
+        if isinstance(block_op, ReduceOp):
+            stencil_reduces.append(block_op)
+
+    reduce_values = []
+    reduce_regions = []
+    reduce_init_values = []
+
+    for stencil_reduce in stencil_reduces:
+        reduce_values.append(stencil_reduce.operand)
+        reduce_init_values.append(stencil_reduce.init)
+
+        body_block = stencil_reduce.body.block
+
+        for body_op in list(body_block.ops):
+            if isinstance(body_op, ReduceReturnOp):
+                scf_return = scf.ReduceReturnOp(body_op.result)
+                body_block.insert_op_before(scf_return, body_op)
+                body_op.detach()
+                body_op.erase()
+
+        reduce_regions.append(stencil_reduce.body.detach_block(0))
+
+        stencil_reduce.detach()
+        stencil_reduce.erase()
+
+    if reduce_values:
+        # Create single scf.reduce with all reductions
+        scf_reduce = scf.ReduceOp(
+            reduce_values, [Region(block) for block in reduce_regions]
+        )
+        entry.add_op(scf_reduce)
+    else:
+        # No reductions, just add empty terminator
+        entry.add_op(scf.ReduceOp())
+
     for _ in range(op.get_rank()):
         entry.insert_arg(builtin.IndexType(), 0)
 
-    return op.region.detach_block(entry)
+    return op.region.detach_block(entry), reduce_init_values
 
 
 @dataclass
@@ -376,7 +416,9 @@ class ApplyOpFieldSubviews(RewritePattern):
             return
 
         new_apply = ApplyOp.create(
-            operands=[SSAValue.get(arg) for arg in args] + list(op.dest),
+            operands=[SSAValue.get(arg) for arg in args]
+            + list(op.dest)
+            + list(op.reductions),
             result_types=[r.type for r in op.res],
             regions=[op.detach_region(0)],
             attributes=op.attributes,
@@ -411,7 +453,7 @@ class ApplyOpToParallel(RewritePattern):
             unroll = list(u for u in unroll)
 
         rank = op.get_rank()
-        body = prepare_apply_body(op)
+        body, reduce_init_values = prepare_apply_body(op)
         if unroll is None:
             unroll = [1] * rank
         else:
@@ -439,6 +481,20 @@ class ApplyOpToParallel(RewritePattern):
             ),
         ]
 
+        cloned_init_ops = []
+        cloned_init_values = []
+
+        for init_value in reduce_init_values:
+            # Clone the defining operation
+            init_op = init_value.op
+            cloned_op = init_op.clone()
+            cloned_init_ops.append(cloned_op)
+            cloned_init_values.append(cloned_op.results[0])
+
+        # Insert cloned init ops
+        if cloned_init_ops:
+            rewriter.insert_op(cloned_init_ops)
+
         # Generate an outer parallel loop as well as two inner sequential
         # loops. The inner sequential loops ensure that the computational
         # kernel itself is not slowed down by the OpenMP runtime.
@@ -448,6 +504,7 @@ class ApplyOpToParallel(RewritePattern):
             upper_bounds=upperBounds,
             steps=tiled_steps,
             body=Region(body),
+            init_vals=cloned_init_values,
         )
         for index in body.walk():
             if isinstance(index, IndexOp):
@@ -469,6 +526,19 @@ class ApplyOpToParallel(RewritePattern):
         # Replace with the loop and necessary constants.
         assert isa(boilerplate_ops, list[Operation])
         rewriter.insert_op([*boilerplate_ops, p])
+
+        terminator = body.last_op
+        has_reductions = (
+            isinstance(terminator, scf.ReduceOp) and len(terminator.args) > 0
+        )
+
+        if has_reductions:
+            reduction_handles = list(op.reductions)
+
+            for result, handle_ptr in zip(p.results, reduction_handles):
+                store_op = llvm.StoreOp(result, handle_ptr)
+                rewriter.insert_op(store_op)
+
         rewriter.replace_op(op, [], new_results)
 
 

--- a/xdsl/transforms/experimental/convert_stencil_to_ll_mlir.py
+++ b/xdsl/transforms/experimental/convert_stencil_to_ll_mlir.py
@@ -26,7 +26,6 @@ from xdsl.dialects.stencil import (
     IndexOp,
     LoadOp,
     ReduceOp,
-    ReduceReturnOp,
     ResultType,
     ReturnOp,
     StencilBoundsAttr,
@@ -35,6 +34,7 @@ from xdsl.dialects.stencil import (
     StoreOp,
     StoreResultOp,
     TempType,
+    YieldOp,
 )
 from xdsl.ir import (
     Attribute,
@@ -306,7 +306,7 @@ def prepare_apply_body(op: ApplyOp) -> tuple[Block, list[SSAValue]]:
         body_block = stencil_reduce.body.block
 
         for body_op in list(body_block.ops):
-            if isinstance(body_op, ReduceReturnOp):
+            if isinstance(body_op, YieldOp):
                 scf_return = scf.ReduceReturnOp(body_op.result)
                 body_block.insert_op_before(scf_return, body_op)
                 body_op.detach()

--- a/xdsl/transforms/experimental/convert_stencil_to_ll_mlir.py
+++ b/xdsl/transforms/experimental/convert_stencil_to_ll_mlir.py
@@ -300,14 +300,14 @@ def prepare_apply_body(op: ApplyOp) -> tuple[Block, list[SSAValue]]:
     reduce_init_values: list[SSAValue] = []
 
     for stencil_reduce in stencil_reduces:
-        reduce_values.append(stencil_reduce.operand)
+        reduce_values.append(stencil_reduce.acc)
         reduce_init_values.append(stencil_reduce.init)
 
         body_block = stencil_reduce.body.block
 
         for body_op in list(body_block.ops):
             if isinstance(body_op, YieldOp):
-                scf_return = scf.ReduceReturnOp(body_op.result)
+                scf_return = scf.ReduceReturnOp(body_op.operand)
                 body_block.insert_op_before(scf_return, body_op)
                 body_op.detach()
                 body_op.erase()

--- a/xdsl/transforms/experimental/convert_stencil_to_ll_mlir.py
+++ b/xdsl/transforms/experimental/convert_stencil_to_ll_mlir.py
@@ -7,7 +7,7 @@ from warnings import warn
 from typing_extensions import TypeVar
 
 from xdsl.context import Context
-from xdsl.dialects import arith, builtin, llvm, memref, scf
+from xdsl.dialects import arith, builtin, memref, scf
 from xdsl.dialects.builtin import (
     MemRefType,
     UnrealizedConversionCastOp,
@@ -537,8 +537,12 @@ class ApplyOpToParallel(RewritePattern):
         if has_reductions:
             reduction_handles = list(op.reductions)
 
+            # for result, handle_ptr in zip(p.results, reduction_handles):
+            #     store_op = llvm.StoreOp(result, handle_ptr)
+            #     rewriter.insert_op(store_op)
+
             for result, handle_ptr in zip(p.results, reduction_handles):
-                store_op = llvm.StoreOp(result, handle_ptr)
+                store_op = memref.StoreOp.get(result, handle_ptr, [])
                 rewriter.insert_op(store_op)
 
         rewriter.replace_op(op, [], new_results)

--- a/xdsl/transforms/experimental/hls_convert_stencil_to_ll_mlir.py
+++ b/xdsl/transforms/experimental/hls_convert_stencil_to_ll_mlir.py
@@ -364,7 +364,7 @@ def transform_apply_into_loop(
 ):
     dim: int = ndim
     assert dim == 3
-    body = prepare_apply_body(op)
+    body, _ = prepare_apply_body(op)
 
     assert isinstance(op.attributes["shape_x"], builtin.IntegerAttr)
     assert isinstance(op.attributes["shape_y"], builtin.IntegerAttr)

--- a/xdsl/transforms/stencil_bufferize.py
+++ b/xdsl/transforms/stencil_bufferize.py
@@ -106,6 +106,9 @@ class ApplyBufferizePattern(RewritePattern):
 
         new = ApplyOp.build(
             operands=[args, op.dest],
+        new = ApplyOp(
+            # TODO: support stencil reductions
+            operands=[args, op.dest, []],
             regions=[op.detach_region(0)],
             result_types=[op.res.types],
             properties={"bounds": bounds},
@@ -280,6 +283,8 @@ class ApplyStoreFoldPattern(RewritePattern):
                 operands=[
                     apply.args,
                     (*apply.dest, *(store.field for store in stores)),
+                    # TODO: support stencil reductions
+                    [],
                 ],
                 # We only remove the considered result
                 result_types=[

--- a/xdsl/transforms/stencil_bufferize.py
+++ b/xdsl/transforms/stencil_bufferize.py
@@ -104,10 +104,8 @@ class ApplyBufferizePattern(RewritePattern):
             for o in op.args
         ]
 
+        # TODO: support stencil reductions
         new = ApplyOp.build(
-            operands=[args, op.dest],
-        new = ApplyOp(
-            # TODO: support stencil reductions
             operands=[args, op.dest, []],
             regions=[op.detach_region(0)],
             result_types=[op.res.types],

--- a/xdsl/transforms/stencil_bufferize.py
+++ b/xdsl/transforms/stencil_bufferize.py
@@ -104,7 +104,6 @@ class ApplyBufferizePattern(RewritePattern):
             for o in op.args
         ]
 
-        # TODO: support stencil reductions
         new = ApplyOp.build(
             operands=[args, op.dest, []],
             regions=[op.detach_region(0)],
@@ -281,7 +280,6 @@ class ApplyStoreFoldPattern(RewritePattern):
                 operands=[
                     apply.args,
                     (*apply.dest, *(store.field for store in stores)),
-                    # TODO: support stencil reductions
                     [],
                 ],
                 # We only remove the considered result


### PR DESCRIPTION
## Description

The stencil dialect does not support reduction operations, which are common in many stencil DSLs.

This PR adds support via two new stencil operations:
- `stencil.reduce`
- `stencil.yield`, a simple terminator for stencil operations (without an unroll factor)

When lowering from stencil dialect to the core MLIR dialects, these operations are converted to their analogous `scf` operations, `scf.reduce` and `scf.reduce.return`, respectively.

> Currently this change is limited to only the buffer semantic form of the stencil apply operation. For the value semantic form, more discussion with stencil dialect contributors is required

### Example IR

```llvm
  stencil.apply(%24 = %data_field : !stencil.field<[0,8]x[0,8]xf64>) outs (%data_field_1 : !stencil.field<[0,8]x[0,8]xf64>) reductions (%reduction_data_ptr : !llvm.ptr) {
    %25 = stencil.access %24[1, 0] : !stencil.temp<[0,8]x[0,8]xf64>
    %26 = stencil.access %24[-1, 0] : !stencil.temp<[0,8]x[0,8]xf64>
    %27 = stencil.access %24[0, -1] : !stencil.temp<[0,8]x[0,8]xf64>
    %28 = stencil.access %24[0, 1] : !stencil.temp<[0,8]x[0,8]xf64>
    %29 = stencil.access %24[0, 0] : !stencil.temp<[0,8]x[0,8]xf64>
    %30 = arith.constant 2.500000e-01 : f64
    %31 = arith.addf %25, %26 : f64
    %32 = arith.addf %31, %27 : f64
    %33 = arith.addf %32, %28 : f64
    %34 = arith.mulf %30, %33 : f64
    "stencil.reduce"(%29, %35) ({
    ^bb0(%36 : f64, %37 : f64):
      %38 = arith.addf %36, %37 : f64
      "stencil.reduce.return"(%38) : (f64) -> ()
    }) : (f64, f64) -> ()
    stencil.return %34 : f64
  } to <[1, 1], [7, 7]>
```

After running `ConvertStencilToLLMLIRPass()`:

```llvm
    %33 = "scf.parallel"(%27, %28, %31, %32, %29, %30, %26) <{operandSegmentSizes = array<i32: 2, 2, 2, 1>}> ({
    ^bb0(%34 : index, %35 : index):
      %36 = arith.constant 1 : index
      %37 = arith.addi %34, %36 : index
      %38 = memref.load %25[%37, %35] : memref<8x8xf64, strided<[8, 1]>>
      %39 = arith.constant -1 : index
      %40 = arith.addi %34, %39 : index
      %41 = memref.load %25[%40, %35] : memref<8x8xf64, strided<[8, 1]>>
      %42 = arith.constant -1 : index
      %43 = arith.addi %35, %42 : index
      %44 = memref.load %25[%34, %43] : memref<8x8xf64, strided<[8, 1]>>
      %45 = arith.constant 1 : index
      %46 = arith.addi %35, %45 : index
      %47 = memref.load %25[%34, %46] : memref<8x8xf64, strided<[8, 1]>>
      %48 = memref.load %25[%34, %35] : memref<8x8xf64, strided<[8, 1]>>
      %49 = arith.constant 2.500000e-01 : f64
      %50 = arith.addf %38, %41 : f64
      %51 = arith.addf %50, %44 : f64
      %52 = arith.addf %51, %47 : f64
      %53 = arith.mulf %49, %52 : f64
      memref.store %53, %24[%34, %35] : memref<8x8xf64, strided<[8, 1]>>
      scf.reduce(%48 : f64) {
      ^bb1(%54 : f64, %55 : f64):
        %56 = arith.addf %54, %55 : f64
        scf.reduce.return %56 : f64
      }
    }) : (index, index, index, index, index, index, f64) -> f64
    "llvm.store"(%33, %reduction_data_ptr) <{ordering = 0 : i64}> : (f64, !llvm.ptr) -> ()
```

Proof that it works has been externally verified in a DSL I'm working on.

### TODO

This draft PR is still in progress:
- [X]  Add new operations
- [X] Add support for reductions in `ConvertStencilToLLMLIRPass`
- [X] Fix any broken tests
- [X] Deprecate `get` constructors in stencil dialect (done in separate PR)
- [X] Add support for parsing new operations
- [X] Add example tests for reductions