### PR TITLE
core: Propagate block arg locations in func like ops

### DIFF
--- a/tests/filecheck/dialects/func/func_ops.mlir
+++ b/tests/filecheck/dialects/func/func_ops.mlir
@@ -61,7 +61,7 @@ builtin.module {
   // CHECK: func.func private @f_named_loc_only(%{{.*}} : i32) {
   // CHECK-NEXT:   func.return
   // CHECK-NEXT: }
-  // CHECK-DEBUG-INFO: func.func private @f_named_loc_only(%{{.*}} : i32 loc(unknown))
+  // CHECK-DEBUG-INFO: func.func private @f_named_loc_only(%{{.*}} : i32 loc("file.mlir":3:5))
 
   func.func private @f_named_attr_then_loc(%arg0: i32 {test.arg_name = "x"} loc("file.mlir":5:7)) {
     func.return
@@ -69,7 +69,7 @@ builtin.module {
   // CHECK: func.func private @f_named_attr_then_loc(%{{.*}} : i32 {test.arg_name = "x"}) {
   // CHECK-NEXT:   func.return
   // CHECK-NEXT: }
-  // CHECK-DEBUG-INFO: func.func private @f_named_attr_then_loc(%{{.*}} : i32 {test.arg_name = "x"} loc(unknown))
+  // CHECK-DEBUG-INFO: func.func private @f_named_attr_then_loc(%{{.*}} : i32 {test.arg_name = "x"} loc("file.mlir":5:7))
 
   func.func private @f_decl_loc_only(i32 loc("model.mlir":7:9))
   // CHECK: func.func private @f_decl_loc_only(i32) -> ()

--- a/tests/filecheck/dialects/llvm/func.mlir
+++ b/tests/filecheck/dialects/llvm/func.mlir
@@ -26,7 +26,7 @@ llvm.func @named_arg_attrs_loc(%arg0: i64 {llvm.noundef} loc("model.mlir":8:11))
 // CHECK: llvm.func @named_arg_attrs_loc(%{{.*}} : i64 {llvm.noundef}) {
 // CHECK-NEXT:   llvm.return
 // CHECK-NEXT: }
-// CHECK-DEBUG-INFO: llvm.func @named_arg_attrs_loc(%{{.*}} : i64 {llvm.noundef} loc(unknown)) {
+// CHECK-DEBUG-INFO: llvm.func @named_arg_attrs_loc(%{{.*}} : i64 {llvm.noundef} loc("model.mlir":8:11)) {
 // CHECK-DEBUG-INFO-NEXT:   llvm.return
 // CHECK-DEBUG-INFO-NEXT: }
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -26,6 +26,7 @@ from xdsl.dialects.builtin import (
     UnknownLoc,
     i32,
 )
+from xdsl.dialects.func import Func, FuncOp
 from xdsl.dialects.test import Test
 from xdsl.ir import Attribute, Block, ParametrizedAttribute
 from xdsl.irdl import (
@@ -1024,6 +1025,24 @@ def test_parse_location():
 
     with pytest.raises(ParseError, match="Unexpected location syntax."):
         Parser(ctx, "loc(1)").parse_optional_location()
+
+
+def test_parse_func_argument_location_is_preserved() -> None:
+    ctx = Context()
+    ctx.load_dialect(Func)
+
+    op = Parser(
+        ctx,
+        'func.func private @f(%arg0: i32 {test.arg_name = "x"} loc("one":2:3), %arg1: i32) { func.return }',
+    ).parse_op()
+    assert isinstance(op, FuncOp)
+
+    block = op.body.blocks.first
+    assert block is not None
+    assert block.args[0].location == FileLineColLoc(
+        StringAttr("one"), IntAttr(2), IntAttr(3)
+    )
+    assert block.args[1].location == UnknownLoc()
 
 
 @pytest.mark.parametrize(

--- a/xdsl/dialects/utils/format.py
+++ b/xdsl/dialects/utils/format.py
@@ -5,6 +5,7 @@ from xdsl.dialects.builtin import (
     ArrayAttr,
     DictionaryAttr,
     FunctionType,
+    LocationAttr,
     StringAttr,
 )
 from xdsl.ir import (
@@ -372,19 +373,21 @@ def parse_func_op_like(
     def parse_fun_input() -> (
         Attribute | tuple[Parser.Argument, dict[str, Attribute]] | None
     ):
-        def parse_optional_attrs_and_loc() -> dict[str, Attribute]:
+        def parse_optional_attrs_and_loc() -> tuple[
+            dict[str, Attribute], LocationAttr | None
+        ]:
             arg_attr_dict = parser.parse_optional_dictionary_attr_dict()
-            has_loc = parser.parse_optional_location() is not None
+            arg_loc = parser.parse_optional_location()
 
             # Reject attrs after location, including empty dictionaries.
-            if has_loc:
+            if arg_loc is not None:
                 arg_attr_pos = parser.pos
                 parser.parse_optional_dictionary_attr_dict()
                 if parser.pos != arg_attr_pos:
                     parser.raise_error(
                         "Expected function argument attributes before location."
                     )
-            return arg_attr_dict
+            return arg_attr_dict, arg_loc
 
         nonlocal is_variadic
         if allow_variadic and parser.parse_optional_characters("...") is not None:
@@ -398,7 +401,8 @@ def parse_func_op_like(
             # Declarative args keep only the type and consume attributes and location.
             parse_optional_attrs_and_loc()
         else:
-            arg_attr_dict = parse_optional_attrs_and_loc()
+            arg_attr_dict, arg_loc = parse_optional_attrs_and_loc()
+            arg.location = arg_loc
             ret = (arg, arg_attr_dict)
         return ret
 

--- a/xdsl/parser/core.py
+++ b/xdsl/parser/core.py
@@ -9,7 +9,7 @@ from typing import Literal, overload
 
 from xdsl.context import Context
 from xdsl.dialect_interfaces.op_asm import OpAsmDialectInterface
-from xdsl.dialects.builtin import DictionaryAttr, ModuleOp
+from xdsl.dialects.builtin import DictionaryAttr, LocationAttr, ModuleOp
 from xdsl.ir import (
     Attribute,
     Block,
@@ -444,6 +444,9 @@ class Parser(AttrParser):
         type: Attribute
         """The type of the argument, if any."""
 
+        location: LocationAttr | None = None
+        """The optional source location attached to the argument."""
+
     @overload
     def parse_optional_argument(
         self, expect_type: Literal[True] = True
@@ -548,6 +551,8 @@ class Parser(AttrParser):
             entry_block = Block(arg_types=arg_types)
             for block_arg, arg in zip(entry_block.args, arguments):
                 self._register_ssa_definition(arg.name.text[1:], (block_arg,), arg.name)
+                if arg.location is not None:
+                    block_arg.location = arg.location
 
             # Parse the entry block body
             self._parse_block_body(entry_block)


### PR DESCRIPTION
Locations attached with **func block args** are only parsed but not propagated, so applying `xdsl-opt` driver on such IR results in unknown locations.

```mlir
builtin.module {
  func.func private @decl_only(%arg0: i32 loc("decl.mlir":1:1))
  func.func @with_body(%arg0: i32 loc("body.mlir":2:3)) {
    func.return
  }
}
```
On running with xdsl-opt --print-debuginfo

```mlir
builtin.module {
  func.func private @decl_only(i32) -> ()
  func.func @with_body(%arg0 : i32 loc(unknown)) {
    func.return
  }
}
``` 
**Function declarations** behavior is similar to how it behaves in MLIR, but **function with body** should preserve its arg locations.