### PR TITLE
backend: add RegisterNameSpec and add as optional arg to reg

### DIFF
--- a/tests/backend/test_assembly_printer.py
+++ b/tests/backend/test_assembly_printer.py
@@ -1,4 +1,4 @@
-from xdsl.backend.assembly_printer import reg
+from xdsl.backend.assembly_printer import RegisterNameSpec, reg
 from xdsl.backend.register_type import RegisterType
 from xdsl.irdl import irdl_attr_definition
 from xdsl.utils.test_value import create_ssa_value
@@ -22,3 +22,14 @@ def test_reg():
     x1_val = create_ssa_value(TestRegister.from_name("x1"))
     assert reg(x0_val) == "x0"
     assert reg(x1_val) == "x1"
+
+
+def test_register_name_spec():
+    class TestSpec(RegisterNameSpec):
+        def get_register_name(self, index: int) -> str:
+            return f"hello{index}"
+
+    x0_val = create_ssa_value(TestRegister.from_name("x0"))
+    x1_val = create_ssa_value(TestRegister.from_name("x1"))
+    assert reg(x0_val, TestSpec()) == "hello0"
+    assert reg(x1_val, TestSpec()) == "hello1"

--- a/xdsl/backend/assembly_printer.py
+++ b/xdsl/backend/assembly_printer.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 
 from xdsl.backend.register_type import RegisterType
-from xdsl.dialects.builtin import ModuleOp, StringAttr
+from xdsl.dialects.builtin import IntAttr, ModuleOp, StringAttr
 from xdsl.ir import Operation, SSAValue
 from xdsl.utils.base_printer import BasePrinter
 
@@ -81,14 +81,34 @@ class OneLineAssemblyPrintable(AssemblyPrintable, ABC):
 # region: Assembly arg printing utilities
 
 
-def reg(value: SSAValue) -> str:
+class RegisterNameSpec(ABC):
+    """
+    Abstract base class for classes that provide the name for registers.
+    On some targets, a single register may be accessed via multiple names, subclass this
+    to specify how the access should be printed in assembly.
+    """
+
+    @abstractmethod
+    def get_register_name(self, index: int) -> str:
+        """
+        Returns the register name for a given index.
+        """
+
+
+def reg(value: SSAValue, spec: RegisterNameSpec | None = None) -> str:
     """
     A wrapper around SSAValue to be printed in assembly.
     Only valid if the type of the value is a RegisterType.
     """
 
     assert isinstance(value.type, RegisterType)
-    return value.type.register_name.data
+    if spec is None:
+        name = value.type.register_name.data
+    else:
+        index = value.type.index
+        assert isinstance(index, IntAttr)
+        name = spec.get_register_name(index.data)
+    return name
 
 
 # endregion


### PR DESCRIPTION
Allows clients to override the register printing in assembly.