### PR TITLE
dialects: (x86) move non-jump ops to custom format

### DIFF
--- a/tests/dialects/test_x86.py
+++ b/tests/dialects/test_x86.py
@@ -272,7 +272,7 @@ def test_mr_vops(
 ):
     output = x86.ops.GetRegisterOp(dest)
     input = x86.ops.GetAVXRegisterOp(src)
-    op = OpClass(memory=output, source=input, memory_offset=IntegerAttr(0, 64))
+    op = OpClass(memory=output, source=input, memory_offset=0)
     assert op.memory.type == dest
     assert op.source.type == src
 

--- a/tests/filecheck/backend/x86/convert_ptr_to_x86.mlir
+++ b/tests/filecheck/backend/x86/convert_ptr_to_x86.mlir
@@ -5,7 +5,7 @@
 // CHECK:       builtin.module {
 // CHECK-NEXT:    %ptr0 = "test.op"() : () -> !ptr_xdsl.ptr
 // CHECK-NEXT:    %ptr0_1 = builtin.unrealized_conversion_cast %ptr0 : !ptr_xdsl.ptr to !x86.reg
-// CHECK-NEXT:    %v0 = x86.dm.vmovups %ptr0_1, 0 : (!x86.reg) -> !x86.avx2reg
+// CHECK-NEXT:    %v0 = x86.dm.vmovups %ptr0_1 : (!x86.reg) -> !x86.avx2reg
 // CHECK-NEXT:    %v0_1 = builtin.unrealized_conversion_cast %v0 : !x86.avx2reg to vector<8xf32>
 // CHECK-NEXT:  }
 
@@ -16,7 +16,7 @@
 // CHECK:       builtin.module {
 // CHECK-NEXT:    %ptr0b = "test.op"() : () -> !ptr_xdsl.ptr
 // CHECK-NEXT:    %ptr0b_1 = builtin.unrealized_conversion_cast %ptr0b : !ptr_xdsl.ptr to !x86.reg
-// CHECK-NEXT:    %v0b = x86.dm.vmovups %ptr0b_1, 0 : (!x86.reg) -> !x86.avx512reg
+// CHECK-NEXT:    %v0b = x86.dm.vmovups %ptr0b_1 : (!x86.reg) -> !x86.avx512reg
 // CHECK-NEXT:    %v0b_1 = builtin.unrealized_conversion_cast %v0b : !x86.avx512reg to vector<16xf32>
 // CHECK-NEXT:  }
 
@@ -27,7 +27,7 @@
 // CHECK:      builtin.module {
 // CHECK-NEXT:   %ptr1 = "test.op"() : () -> !ptr_xdsl.ptr
 // CHECK-NEXT:   %ptr1_1 = builtin.unrealized_conversion_cast %ptr1 : !ptr_xdsl.ptr to !x86.reg
-// CHECK-NEXT:   %v1 = x86.dm.mov %ptr1_1, 0 : (!x86.reg) -> !x86.reg
+// CHECK-NEXT:   %v1 = x86.dm.mov %ptr1_1 : (!x86.reg) -> !x86.reg
 // CHECK-NEXT:   %v1_1 = builtin.unrealized_conversion_cast %v1 : !x86.reg to f32
 // CHECK-NEXT: }
 
@@ -45,7 +45,7 @@
 // CHECK:      builtin.module {
 // CHECK-NEXT:   %ptr3 = "test.op"() : () -> !ptr_xdsl.ptr
 // CHECK-NEXT:   %ptr3_1 = builtin.unrealized_conversion_cast %ptr3 : !ptr_xdsl.ptr to !x86.reg
-// CHECK-NEXT:   %v3 = x86.dm.vmovupd %ptr3_1, 0 : (!x86.reg) -> !x86.avx2reg
+// CHECK-NEXT:   %v3 = x86.dm.vmovupd %ptr3_1 : (!x86.reg) -> !x86.avx2reg
 // CHECK-NEXT:   %v3_1 = builtin.unrealized_conversion_cast %v3 : !x86.avx2reg to vector<4xf64>
 // CHECK-NEXT: }
 
@@ -72,7 +72,7 @@ ptr_xdsl.store %v6, %ptr6 : vector<8xf32>, !ptr_xdsl.ptr
 // CHECK-NEXT:   %v6 = "test.op"() : () -> vector<8xf32>
 // CHECK-NEXT:   %ptr6_1 = builtin.unrealized_conversion_cast %ptr6 : !ptr_xdsl.ptr to !x86.reg
 // CHECK-NEXT:   %v6_1 = builtin.unrealized_conversion_cast %v6 : vector<8xf32> to !x86.avx2reg
-// CHECK-NEXT:   x86.ms.vmovups %ptr6_1, %v6_1, 0 : (!x86.reg, !x86.avx2reg) -> ()
+// CHECK-NEXT:   x86.ms.vmovups %ptr6_1, %v6_1 : (!x86.reg, !x86.avx2reg) -> ()
 // CHECK-NEXT: }
 
 // -----
@@ -86,7 +86,7 @@ ptr_xdsl.store %v6b, %ptr6b : vector<16xf32>, !ptr_xdsl.ptr
 // CHECK-NEXT:   %v6b = "test.op"() : () -> vector<16xf32>
 // CHECK-NEXT:   %ptr6b_1 = builtin.unrealized_conversion_cast %ptr6b : !ptr_xdsl.ptr to !x86.reg
 // CHECK-NEXT:   %v6b_1 = builtin.unrealized_conversion_cast %v6b : vector<16xf32> to !x86.avx512reg
-// CHECK-NEXT:   x86.ms.vmovups %ptr6b_1, %v6b_1, 0 : (!x86.reg, !x86.avx512reg) -> ()
+// CHECK-NEXT:   x86.ms.vmovups %ptr6b_1, %v6b_1 : (!x86.reg, !x86.avx512reg) -> ()
 // CHECK-NEXT: }
 
 // -----
@@ -100,7 +100,7 @@ ptr_xdsl.store %v6, %ptr6 : vector<4xf64>, !ptr_xdsl.ptr
 // CHECK-NEXT:   %v6 = "test.op"() : () -> vector<4xf64>
 // CHECK-NEXT:   %ptr6_1 = builtin.unrealized_conversion_cast %ptr6 : !ptr_xdsl.ptr to !x86.reg
 // CHECK-NEXT:   %v6_1 = builtin.unrealized_conversion_cast %v6 : vector<4xf64> to !x86.avx2reg
-// CHECK-NEXT:   x86.ms.vmovapd %ptr6_1, %v6_1, 0 : (!x86.reg, !x86.avx2reg) -> ()
+// CHECK-NEXT:   x86.ms.vmovapd %ptr6_1, %v6_1 : (!x86.reg, !x86.avx2reg) -> ()
 // CHECK-NEXT: }
 
 // -----
@@ -128,7 +128,7 @@ ptr_xdsl.store %v6, %ptr6 : f32, !ptr_xdsl.ptr
 // CHECK-NEXT:   %v6 = "test.op"() : () -> f32
 // CHECK-NEXT:   %ptr6_1 = builtin.unrealized_conversion_cast %ptr6 : !ptr_xdsl.ptr to !x86.reg
 // CHECK-NEXT:   %v6_1 = builtin.unrealized_conversion_cast %v6 : f32 to !x86.reg
-// CHECK-NEXT:   x86.ms.mov %ptr6_1, %v6_1, 0 : (!x86.reg, !x86.reg) -> ()
+// CHECK-NEXT:   x86.ms.mov %ptr6_1, %v6_1 : (!x86.reg, !x86.reg) -> ()
 // CHECK-NEXT: }
 
 // -----

--- a/tests/filecheck/backend/x86/verify_register_allocation.mlir
+++ b/tests/filecheck/backend/x86/verify_register_allocation.mlir
@@ -2,7 +2,7 @@
 
 // CHECK-LABEL:    @inc
 x86_func.func @inc(%ptr: !x86.reg<rax>) {
-// CHECK-NEXT: %val = x86.dm.mov %ptr, 0 : (!x86.reg<rax>) -> !x86.reg<rcx>
+// CHECK-NEXT: %val = x86.dm.mov %ptr : (!x86.reg<rax>) -> !x86.reg<rcx>
 // CHECK-NEXT: %ptr2 = x86.r.inc %ptr : (!x86.reg<rax>) -> !x86.reg<rax>
   %val = x86.dm.mov %ptr : (!x86.reg<rax>) -> !x86.reg<rcx>
   %ptr2 = x86.r.inc %ptr : (!x86.reg<rax>) -> !x86.reg<rax>

--- a/tests/filecheck/dialects/x86/x86_assembly_emission.mlir
+++ b/tests/filecheck/dialects/x86/x86_assembly_emission.mlir
@@ -117,7 +117,7 @@ x86.mi.xor %rax, 2, 8 : (!x86.reg<rax>) -> ()
 // CHECK-NEXT: xor [rax+8], 2
 x86.mi.mov %rax, 2, 8 : (!x86.reg<rax>) -> ()
 // CHECK-NEXT: mov [rax+8], 2
-%mi_cmp = x86.mi.cmp %rax, 2, 8 : (!x86.reg<rax>) -> !x86.rflags<rflags>
+%mi_cmp = x86.mi.cmp %rax, 2, 8 : !x86.reg<rax> -> !x86.rflags<rflags>
 // CHECK-NEXT: cmp [rax+8], 2
 
 %rri_imul = x86.dsi.imul %1, 2 : (!x86.reg<rdx>) -> !x86.reg<rax>

--- a/tests/filecheck/dialects/x86/x86_memory_effects.mlir
+++ b/tests/filecheck/dialects/x86/x86_memory_effects.mlir
@@ -5,7 +5,7 @@
 
 // CHECK-NEXT: %unallocated = x86.ds.mov %c42 : (!x86.reg) -> !x86.reg
 %unallocated = x86.ds.mov %c42 : (!x86.reg) -> !x86.reg
-// CHECK-NEXT: %allocated = x86.ds.mov %c42 : (!x86.reg) -> !x86.reg<rax> 
+// CHECK-NEXT: %allocated = x86.ds.mov %c42 : (!x86.reg) -> !x86.reg<rax>
 %allocated = x86.ds.mov %c42 : (!x86.reg) -> !x86.reg<rax>
 // CHECK-NEXT: %rsp = "test.op"() : () -> !x86.reg<rsp>
 %rsp = "test.op"() : () -> !x86.reg<rsp>
@@ -14,7 +14,7 @@
 
 // Write effects don't get eliminated even if the result is unused
 
-// CHECK-NEXT: x86.ms.add %unallocated, %unallocated, 0 : (!x86.reg, !x86.reg) -> ()
+// CHECK-NEXT: x86.ms.add %unallocated, %unallocated : (!x86.reg, !x86.reg) -> ()
 x86.ms.add %unallocated, %unallocated : (!x86.reg, !x86.reg) -> ()
 // CHECK-NEXT: x86.ms.sub %unallocated, %unallocated, -8 : (!x86.reg, !x86.reg) -> ()
 x86.ms.sub %unallocated, %unallocated, -8 : (!x86.reg, !x86.reg) -> ()
@@ -40,13 +40,13 @@ x86.mi.xor %unallocated, 2, 8 : (!x86.reg) -> ()
 // CHECK-NEXT: x86.mi.mov %unallocated, 2, 8 : (!x86.reg) -> ()
 x86.mi.mov %unallocated, 2, 8 : (!x86.reg) -> ()
 
-// CHECK-NEXT: %m_push_rsp = x86.m.push %rsp, %unallocated, 0 : (!x86.reg<rsp>, !x86.reg) -> !x86.reg<rsp>
+// CHECK-NEXT: %m_push_rsp = x86.m.push %rsp, %unallocated : (!x86.reg<rsp>, !x86.reg) -> !x86.reg<rsp>
 %m_push_rsp = x86.m.push %rsp, %unallocated : (!x86.reg<rsp>, !x86.reg) -> !x86.reg<rsp>
 
 // CHECK-NEXT: %m_pop_rsp = x86.m.pop %rsp, %unallocated, 8 : (!x86.reg<rsp>, !x86.reg) -> !x86.reg<rsp>
 %m_pop_rsp = x86.m.pop %rsp, %unallocated, 8 : (!x86.reg<rsp>, !x86.reg) -> !x86.reg<rsp>
 
-// CHECK-NEXT: x86.m.neg %unallocated, 0 : (!x86.reg) -> ()
+// CHECK-NEXT: x86.m.neg %unallocated : (!x86.reg) -> ()
 x86.m.neg %unallocated : (!x86.reg) -> ()
 // CHECK-NEXT: x86.m.not %unallocated, 8 : (!x86.reg) -> ()
 x86.m.not %unallocated, 8 : (!x86.reg) -> ()

--- a/tests/filecheck/dialects/x86/x86_ops.mlir
+++ b/tests/filecheck/dialects/x86/x86_ops.mlir
@@ -113,8 +113,8 @@ x86.mi.xor %1, 2, 8 : (!x86.reg) -> ()
 // CHECK-NEXT: x86.mi.xor %{{.*}}, 2, 8 : (!x86.reg) -> ()
 x86.mi.mov %1, 2, 8 : (!x86.reg) -> ()
 // CHECK-NEXT: x86.mi.mov %{{.*}}, 2, 8 : (!x86.reg) -> ()
-%mi_cmp = x86.mi.cmp %1, 2, 8 : (!x86.reg) -> !x86.rflags<rflags>
-// CHECK-NEXT: %{{.*}} = x86.mi.cmp %{{.*}}, 2, 8 : (!x86.reg) -> !x86.rflags
+%mi_cmp = x86.mi.cmp %1, 2, 8 : !x86.reg -> !x86.rflags<rflags>
+// CHECK-NEXT: %{{.*}} = x86.mi.cmp %{{.*}}, 2, 8 : !x86.reg -> !x86.rflags
 
 %rri_imul = x86.dsi.imul %1, 2 : (!x86.reg) -> !x86.reg
 // CHECK-NEXT: %{{.*}} = x86.dsi.imul %{{.*}}, 2 : (!x86.reg) -> !x86.reg
@@ -425,12 +425,12 @@ func.func @funcyasm() {
 // CHECK-NEXT: %{{.*}} = x86.dm.vbroadcastss %{{.*}}, 8 : (!x86.reg) -> !x86.ssereg
 
 // ---- vmovapd ----
-%dm_vmovapd_sse = x86.dm.vmovapd %1 : (!x86.reg) -> !x86.ssereg
-// CHECK-NEXT: %dm_vmovapd_sse = x86.dm.vmovapd %1, 0 : (!x86.reg) -> !x86.ssereg
-%dm_vmovapd_avx2 = x86.dm.vmovapd %1 : (!x86.reg) -> !x86.avx2reg
-// CHECK-NEXT: %dm_vmovapd_avx2 = x86.dm.vmovapd %1, 0 : (!x86.reg) -> !x86.avx2reg
-%dm_vmovapd_avx512 = x86.dm.vmovapd %1 : (!x86.reg) -> !x86.avx512reg
-// CHECK-NEXT: %dm_vmovapd_avx512 = x86.dm.vmovapd %1, 0 : (!x86.reg) -> !x86.avx512reg
+%dm_vmovapd_sse = x86.dm.vmovapd %1, 128 : (!x86.reg) -> !x86.ssereg
+// CHECK-NEXT: %dm_vmovapd_sse = x86.dm.vmovapd %1, 128 : (!x86.reg) -> !x86.ssereg
+%dm_vmovapd_avx2 = x86.dm.vmovapd %1, 256 : (!x86.reg) -> !x86.avx2reg
+// CHECK-NEXT: %dm_vmovapd_avx2 = x86.dm.vmovapd %1, 256 : (!x86.reg) -> !x86.avx2reg
+%dm_vmovapd_avx512 = x86.dm.vmovapd %1, 512 : (!x86.reg) -> !x86.avx512reg
+// CHECK-NEXT: %dm_vmovapd_avx512 = x86.dm.vmovapd %1, 512 : (!x86.reg) -> !x86.avx512reg
 
 %ds_vmovapd_sse = x86.ds.vmovapd %xmm1 : (!x86.ssereg) -> !x86.ssereg
 // CHECK-NEXT: %ds_vmovapd_sse = x86.ds.vmovapd %xmm1 : (!x86.ssereg) -> !x86.ssereg
@@ -452,12 +452,12 @@ x86.ms.vmovapd %1, %zmm1, 8 : (!x86.reg, !x86.avx512reg) -> ()
 
 
 // ---- vmovaps ----
-%dm_vmovaps_sse = x86.dm.vmovaps %1 : (!x86.reg) -> !x86.ssereg
-// CHECK-NEXT: %dm_vmovaps_sse = x86.dm.vmovaps %1, 0 : (!x86.reg) -> !x86.ssereg
-%dm_vmovaps_avx2 = x86.dm.vmovaps %1 : (!x86.reg) -> !x86.avx2reg
-// CHECK-NEXT: %dm_vmovaps_avx2 = x86.dm.vmovaps %1, 0 : (!x86.reg) -> !x86.avx2reg
-%dm_vmovaps_avx512 = x86.dm.vmovaps %1 : (!x86.reg) -> !x86.avx512reg
-// CHECK-NEXT: %dm_vmovaps_avx512 = x86.dm.vmovaps %1, 0 : (!x86.reg) -> !x86.avx512reg
+%dm_vmovaps_sse = x86.dm.vmovaps %1, 128 : (!x86.reg) -> !x86.ssereg
+// CHECK-NEXT: %dm_vmovaps_sse = x86.dm.vmovaps %1, 128 : (!x86.reg) -> !x86.ssereg
+%dm_vmovaps_avx2 = x86.dm.vmovaps %1, 256 : (!x86.reg) -> !x86.avx2reg
+// CHECK-NEXT: %dm_vmovaps_avx2 = x86.dm.vmovaps %1, 256 : (!x86.reg) -> !x86.avx2reg
+%dm_vmovaps_avx512 = x86.dm.vmovaps %1, 512 : (!x86.reg) -> !x86.avx512reg
+// CHECK-NEXT: %dm_vmovaps_avx512 = x86.dm.vmovaps %1, 512 : (!x86.reg) -> !x86.avx512reg
 
 %ds_vmovaps_sse = x86.ds.vmovaps %xmm1 : (!x86.ssereg) -> !x86.ssereg
 // CHECK-NEXT: %ds_vmovaps_sse = x86.ds.vmovaps %xmm1 : (!x86.ssereg) -> !x86.ssereg
@@ -475,12 +475,12 @@ x86.ms.vmovaps %1, %zmm1, 8 : (!x86.reg, !x86.avx512reg) -> ()
 
 
 // ---- vmovupd ----
-%dm_vmovupd_sse = x86.dm.vmovupd %1 : (!x86.reg) -> !x86.ssereg
-// CHECK-NEXT: %dm_vmovupd_sse = x86.dm.vmovupd %1, 0 : (!x86.reg) -> !x86.ssereg
-%dm_vmovupd_avx2 = x86.dm.vmovupd %1 : (!x86.reg) -> !x86.avx2reg
-// CHECK-NEXT: %dm_vmovupd_avx2 = x86.dm.vmovupd %1, 0 : (!x86.reg) -> !x86.avx2reg
-%dm_vmovupd_avx512 = x86.dm.vmovupd %1 : (!x86.reg) -> !x86.avx512reg
-// CHECK-NEXT: %dm_vmovupd_avx512 = x86.dm.vmovupd %1, 0 : (!x86.reg) -> !x86.avx512reg
+%dm_vmovupd_sse = x86.dm.vmovupd %1, 128 : (!x86.reg) -> !x86.ssereg
+// CHECK-NEXT: %dm_vmovupd_sse = x86.dm.vmovupd %1, 128 : (!x86.reg) -> !x86.ssereg
+%dm_vmovupd_avx2 = x86.dm.vmovupd %1, 256 : (!x86.reg) -> !x86.avx2reg
+// CHECK-NEXT: %dm_vmovupd_avx2 = x86.dm.vmovupd %1, 256 : (!x86.reg) -> !x86.avx2reg
+%dm_vmovupd_avx512 = x86.dm.vmovupd %1, 512 : (!x86.reg) -> !x86.avx512reg
+// CHECK-NEXT: %dm_vmovupd_avx512 = x86.dm.vmovupd %1, 512 : (!x86.reg) -> !x86.avx512reg
 
 x86.ms.vmovupd %1, %xmm1, 8 : (!x86.reg, !x86.ssereg) -> ()
 // CHECK-NEXT: x86.ms.vmovupd %1, %xmm1, 8 : (!x86.reg, !x86.ssereg) -> ()
@@ -491,12 +491,12 @@ x86.ms.vmovupd %1, %zmm1, 8 : (!x86.reg, !x86.avx512reg) -> ()
 
 
 // ---- vmovups ----
-%dm_vmovups_sse = x86.dm.vmovups %1 : (!x86.reg) -> !x86.ssereg
-// CHECK-NEXT: %dm_vmovups_sse = x86.dm.vmovups %1, 0 : (!x86.reg) -> !x86.ssereg
-%dm_vmovups_avx2 = x86.dm.vmovups %1 : (!x86.reg) -> !x86.avx2reg
-// CHECK-NEXT: %dm_vmovups_avx2 = x86.dm.vmovups %1, 0 : (!x86.reg) -> !x86.avx2reg
-%dm_vmovups_avx512 = x86.dm.vmovups %1 : (!x86.reg) -> !x86.avx512reg
-// CHECK-NEXT: %dm_vmovups_avx512 = x86.dm.vmovups %1, 0 : (!x86.reg) -> !x86.avx512reg
+%dm_vmovups_sse = x86.dm.vmovups %1, 128 : (!x86.reg) -> !x86.ssereg
+// CHECK-NEXT: %dm_vmovups_sse = x86.dm.vmovups %1, 128 : (!x86.reg) -> !x86.ssereg
+%dm_vmovups_avx2 = x86.dm.vmovups %1, 256 : (!x86.reg) -> !x86.avx2reg
+// CHECK-NEXT: %dm_vmovups_avx2 = x86.dm.vmovups %1, 256 : (!x86.reg) -> !x86.avx2reg
+%dm_vmovups_avx512 = x86.dm.vmovups %1, 512 : (!x86.reg) -> !x86.avx512reg
+// CHECK-NEXT: %dm_vmovups_avx512 = x86.dm.vmovups %1, 512 : (!x86.reg) -> !x86.avx512reg
 
 x86.ms.vmovups %1, %xmm1, 8 : (!x86.reg, !x86.ssereg) -> ()
 // CHECK-NEXT: x86.ms.vmovups %1, %xmm1, 8 : (!x86.reg, !x86.ssereg) -> ()

--- a/tests/filecheck/transforms/convert-x86-scf-to-x86.mlir
+++ b/tests/filecheck/transforms/convert-x86-scf-to-x86.mlir
@@ -20,9 +20,9 @@
 //  CHECK-NEXT:      x86_func.ret
 //  CHECK-NEXT:    }
 x86_func.func @copy10(%src: !x86.reg<rax>, %dst: !x86.reg<rbx>) {
-    %zero = x86.di.mov 0 : () -> (!x86.reg<rcx>)
-    %step = x86.di.mov 4 : () -> (!x86.reg<rdx>)
-    %forty = x86.di.mov 40 : () -> (!x86.reg<r8>)
+    %zero = x86.di.mov 0 : () -> !x86.reg<rcx>
+    %step = x86.di.mov 4 : () -> !x86.reg<rdx>
+    %forty = x86.di.mov 40 : () -> !x86.reg<r8>
     x86_scf.for %offset : !x86.reg<r9> = %zero to %forty step %step {
         "test.op"(%offset, %src, %dst) :  (!x86.reg<r9>, !x86.reg<rax>, !x86.reg<rbx>) -> ()
         yield
@@ -69,13 +69,13 @@ x86_func.func @copy10(%src: !x86.reg<rax>, %dst: !x86.reg<rbx>) {
 
 
 x86_func.func @nested(%src: !x86.reg<rax>, %dst: !x86.reg<rbx>) {
-    %zero_outer = x86.di.mov 0 : () -> (!x86.reg<rcx>)
-    %step_outer = x86.di.mov 4 : () -> (!x86.reg<rdx>)
-    %forty_outer = x86.di.mov 40 : () -> (!x86.reg<r8>)
+    %zero_outer = x86.di.mov 0 : () -> !x86.reg<rcx>
+    %step_outer = x86.di.mov 4 : () -> !x86.reg<rdx>
+    %forty_outer = x86.di.mov 40 : () -> !x86.reg<r8>
     x86_scf.for %offset_outer : !x86.reg<r9> = %zero_outer to %forty_outer step %step_outer {
-        %zero_inner = x86.di.mov 0 : () -> (!x86.reg<r10>)
-        %step_inner = x86.di.mov 2 : () -> (!x86.reg<r11>)
-        %forty_inner = x86.di.mov 40 : () -> (!x86.reg<r12>)
+        %zero_inner = x86.di.mov 0 : () -> !x86.reg<r10>
+        %step_inner = x86.di.mov 2 : () -> !x86.reg<r11>
+        %forty_inner = x86.di.mov 40 : () -> !x86.reg<r12>
         x86_scf.for %offset_inner : !x86.reg<r13> = %zero_inner to %forty_inner step %step_inner {
             "test.op"(%src, %dst, %offset_outer, %offset_inner) : (!x86.reg<rax>, !x86.reg<rbx>, !x86.reg<r9>, !x86.reg<r13>) -> ()
             x86_scf.yield

--- a/tests/filecheck/transforms/x86-infer-broadcast.mlir
+++ b/tests/filecheck/transforms/x86-infer-broadcast.mlir
@@ -2,6 +2,6 @@
 
 %ptr = "test.op"() : () -> !x86.reg
 %s = x86.dm.mov %ptr, 0 : (!x86.reg) -> !x86.reg
-// CHECK:   %r = x86.dm.vbroadcastsd %ptr, 0 : (!x86.reg) -> !x86.avx2reg
+// CHECK:   %r = x86.dm.vbroadcastsd %ptr : (!x86.reg) -> !x86.avx2reg
 %r = x86.ds.vpbroadcastq %s : (!x86.reg) -> !x86.avx2reg
 "test.op"(%r) : (!x86.avx2reg) -> ()

--- a/xdsl/dialects/x86/assembly.py
+++ b/xdsl/dialects/x86/assembly.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TypeAlias
 
 from xdsl.backend.assembly_printer import reg
-from xdsl.dialects.builtin import IndexType, IntegerAttr, IntegerType, UnitAttr
+from xdsl.dialects.builtin import IntegerAttr, UnitAttr
 from xdsl.ir import SSAValue
 from xdsl.parser import Parser
 from xdsl.printer import Printer
@@ -20,35 +20,6 @@ def assembly_arg_str(arg: AssemblyInstructionArg) -> str:
         return arg.data
 
     return arg
-
-
-def parse_immediate_value(
-    parser: Parser, integer_type: IntegerType | IndexType
-) -> IntegerAttr[IntegerType | IndexType] | LabelAttr:
-    return parser.expect(
-        lambda: parse_optional_immediate_value(parser, integer_type),
-        "Expected immediate",
-    )
-
-
-def parse_optional_immediate_value(
-    parser: Parser, integer_type: IntegerType | IndexType
-) -> IntegerAttr[IntegerType | IndexType] | LabelAttr | None:
-    """
-    Parse an optional immediate value. If an integer is parsed, an integer attr with the specified type is created.
-    """
-    if (immediate := parser.parse_optional_integer()) is not None:
-        return IntegerAttr(immediate, integer_type)
-    if (immediate := parser.parse_optional_str_literal()) is not None:
-        return LabelAttr(immediate)
-
-
-def print_immediate_value(printer: Printer, immediate: IntegerAttr | LabelAttr):
-    match immediate:
-        case IntegerAttr():
-            immediate.print_without_type(printer)
-        case LabelAttr():
-            printer.print_string_literal(immediate.data)
 
 
 def memory_access_str(register: SSAValue, offset: IntegerAttr) -> str:

--- a/xdsl/dialects/x86/ops.py
+++ b/xdsl/dialects/x86/ops.py
@@ -43,6 +43,7 @@ from xdsl.backend.register_allocatable import (
 )
 from xdsl.backend.register_type import RegisterAllocatedMemoryEffect
 from xdsl.dialects.builtin import (
+    I64,
     ArrayAttr,
     IntegerAttr,
     IntegerType,
@@ -50,6 +51,7 @@ from xdsl.dialects.builtin import (
     Signedness,
     StringAttr,
     UnitAttr,
+    i64,
 )
 from xdsl.ir import (
     Attribute,
@@ -93,10 +95,7 @@ from .assembly import (
     assembly_arg_str,
     masked_source_str,
     memory_access_str,
-    parse_immediate_value,
-    parse_optional_immediate_value,
     parse_type_pair,
-    print_immediate_value,
     print_type_pair,
 )
 from .attributes import LabelAttr
@@ -164,15 +163,6 @@ class X86CustomFormatOperation(IRDLOperation, ABC):
             result_types=result_types,
             attributes=attributes,
             regions=regions,
-        )
-
-    @classmethod
-    def parse_optional_memory_access_offset(
-        cls, parser: Parser, integer_type: IntegerType = si64
-    ) -> Attribute | None:
-        return parse_optional_immediate_value(
-            parser,
-            integer_type,
         )
 
     @classmethod
@@ -434,9 +424,7 @@ class R_Operation(X86Instruction, ABC, Generic[R1InvT]):
         return RegisterConstraints((), (), ((self.register_in, self.register_out),))
 
 
-class RM_Operation(
-    X86Instruction, X86CustomFormatOperation, ABC, Generic[R1InvT, R2InvT]
-):
+class RM_Operation(X86Instruction, ABC, Generic[R1InvT, R2InvT]):
     """
     A base class for x86 operations that have one register read and written to and one
     memory access with an optional offset.
@@ -446,21 +434,26 @@ class RM_Operation(
     register_out = result_def(R1InvT)
 
     memory = operand_def(R2InvT)
-    memory_offset = attr_def(IntegerAttr, default_value=IntegerAttr(0, 64))
+    memory_offset = attr_def(IntegerAttr[I64], default_value=IntegerAttr(0, i64))
 
     traits = traits_def(MemoryReadEffect())
+
+    assembly_format = (
+        "$register_in `,` $memory (`,` $memory_offset^)? attr-dict `:` "
+        "`(` type($register_in) `,` type($memory) `)` `->` type($register_out)"
+    )
 
     def __init__(
         self,
         register_in: Operation | SSAValue,
         memory: Operation | SSAValue,
-        memory_offset: int | IntegerAttr,
+        memory_offset: int | IntegerAttr[I64],
         *,
         comment: str | StringAttr | None = None,
         register_out: R1InvT | None = None,
     ):
         if isinstance(memory_offset, int):
-            memory_offset = IntegerAttr(memory_offset, 64)
+            memory_offset = IntegerAttr(memory_offset, i64)
         if isinstance(comment, str):
             comment = StringAttr(comment)
         register_in = SSAValue.get(register_in)
@@ -481,18 +474,6 @@ class RM_Operation(
         destination = assembly_arg_str(reg(self.register_in))
         return (destination, memory_access)
 
-    @classmethod
-    def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
-        attributes = dict[str, Attribute]()
-        if offset := cls.parse_optional_memory_access_offset(parser):
-            attributes["memory_offset"] = offset
-        return attributes
-
-    def custom_print_attributes(self, printer: Printer) -> AbstractSet[str]:
-        printer.print_string(", ")
-        print_immediate_value(printer, self.memory_offset)
-        return {"memory_offset"}
-
     def get_register_constraints(self) -> RegisterConstraints:
         return RegisterConstraints(
             (self.memory,), (), ((self.register_in, self.register_out),)
@@ -509,20 +490,23 @@ class DM_OperationHasCanonicalizationPatterns(HasCanonicalizationPatternsTrait):
         return (DM_Operation_ConstantOffset(),)
 
 
-class DM_Operation(
-    X86Instruction, X86CustomFormatOperation, ABC, Generic[R1InvT, R2InvT]
-):
+class DM_Operation(X86Instruction, ABC, Generic[R1InvT, R2InvT]):
     """
     A base class for x86 operations that load from memory into a destination register.
     """
 
     destination = result_def(R1InvT)
     memory = operand_def(R2InvT)
-    memory_offset = attr_def(IntegerAttr, default_value=IntegerAttr(0, 64))
+    memory_offset = attr_def(IntegerAttr[I64], default_value=IntegerAttr(0, i64))
 
     traits = traits_def(
         DM_OperationHasCanonicalizationPatterns(),
         MemoryReadEffect(),
+    )
+
+    assembly_format = (
+        "$memory (`,` $memory_offset^)? attr-dict `:` "
+        "functional-type($memory, $destination)"
     )
 
     def __init__(
@@ -534,7 +518,7 @@ class DM_Operation(
         destination: R1InvT,
     ):
         if isinstance(memory_offset, int):
-            memory_offset = IntegerAttr(memory_offset, 64)
+            memory_offset = IntegerAttr(memory_offset, i64)
         if isinstance(comment, str):
             comment = StringAttr(comment)
         super().__init__(
@@ -551,20 +535,8 @@ class DM_Operation(
         destination = assembly_arg_str(reg(self.destination))
         return (destination, memory_access)
 
-    @classmethod
-    def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
-        attributes = dict[str, Attribute]()
-        if offset := cls.parse_optional_memory_access_offset(parser):
-            attributes["memory_offset"] = offset
-        return attributes
 
-    def custom_print_attributes(self, printer: Printer) -> AbstractSet[str]:
-        printer.print_string(", ")
-        print_immediate_value(printer, self.memory_offset)
-        return {"memory_offset"}
-
-
-class DI_Operation(X86Instruction, X86CustomFormatOperation, ABC, Generic[R1InvT]):
+class DI_Operation(X86Instruction, ABC, Generic[R1InvT]):
     """
     A base class for x86 operations that have one destination register and an immediate
     value.
@@ -574,6 +546,8 @@ class DI_Operation(X86Instruction, X86CustomFormatOperation, ABC, Generic[R1InvT
     # representation.
     immediate = attr_def(IntegerAttr[SI32])
     destination = result_def(R1InvT)
+
+    assembly_format = "$immediate attr-dict `:` `(` `)` `->` type($destination)"
 
     def __init__(
         self,
@@ -598,17 +572,8 @@ class DI_Operation(X86Instruction, X86CustomFormatOperation, ABC, Generic[R1InvT
     def assembly_line_args(self) -> tuple[AssemblyInstructionArg | None, ...]:
         return reg(self.destination), self.immediate
 
-    @classmethod
-    def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
-        return {"immediate": parse_immediate_value(parser, si32)}
 
-    def custom_print_attributes(self, printer: Printer) -> AbstractSet[str]:
-        printer.print_string(" ", indent=0)
-        print_immediate_value(printer, self.immediate)
-        return {"immediate"}
-
-
-class RI_Operation(X86Instruction, X86CustomFormatOperation, ABC, Generic[R1InvT]):
+class RI_Operation(X86Instruction, ABC, Generic[R1InvT]):
     """
     A base class for x86 operations that have one register that is read and written to
     and an immediate value.
@@ -620,6 +585,11 @@ class RI_Operation(X86Instruction, X86CustomFormatOperation, ABC, Generic[R1InvT
     # In the future, we should look into the legal bitwidths in the binary
     # representation.
     immediate = attr_def(IntegerAttr[SI32])
+
+    assembly_format = (
+        "$register_in `,` $immediate attr-dict `:` "
+        "`(` type($register_in) `)` `->` type($register_out)"
+    )
 
     def __init__(
         self,
@@ -649,19 +619,6 @@ class RI_Operation(X86Instruction, X86CustomFormatOperation, ABC, Generic[R1InvT
     def assembly_line_args(self) -> tuple[AssemblyInstructionArg | None, ...]:
         return reg(self.register_in), self.immediate
 
-    @classmethod
-    def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
-        attributes = dict[str, Attribute]()
-        temp = parse_optional_immediate_value(parser, si32)
-        if temp is not None:
-            attributes["immediate"] = temp
-        return attributes
-
-    def custom_print_attributes(self, printer: Printer) -> AbstractSet[str]:
-        printer.print_string(", ")
-        print_immediate_value(printer, self.immediate)
-        return {"immediate"}
-
     def get_register_constraints(self) -> RegisterConstraints:
         return RegisterConstraints((), (), ((self.register_in, self.register_out),))
 
@@ -676,16 +633,14 @@ class MS_OperationHasCanonicalizationPatterns(HasCanonicalizationPatternsTrait):
         return (MS_Operation_ConstantOffset(),)
 
 
-class MS_Operation(
-    X86Instruction, X86CustomFormatOperation, ABC, Generic[R1InvT, R2InvT]
-):
+class MS_Operation(X86Instruction, ABC, Generic[R1InvT, R2InvT]):
     """
     A base class for x86 operations that have one memory reference and one source
     register.
     """
 
     memory = operand_def(R1InvT)
-    memory_offset = attr_def(IntegerAttr, default_value=IntegerAttr(0, 64))
+    memory_offset = attr_def(IntegerAttr[I64], default_value=IntegerAttr(0, i64))
     source = operand_def(R2InvT)
 
     traits = traits_def(
@@ -694,16 +649,21 @@ class MS_Operation(
         MemoryWriteEffect(),
     )
 
+    assembly_format = (
+        "$memory `,` $source (`,` $memory_offset^)? attr-dict `:` "
+        "`(` type($memory) `,` type($source) `)` `->` `(` `)`"
+    )
+
     def __init__(
         self,
         memory: Operation | SSAValue,
         source: Operation | SSAValue,
-        memory_offset: int | IntegerAttr,
+        memory_offset: int | IntegerAttr[I64],
         *,
         comment: str | StringAttr | None = None,
     ):
         if isinstance(memory_offset, int):
-            memory_offset = IntegerAttr(memory_offset, 64)
+            memory_offset = IntegerAttr(memory_offset, i64)
         if isinstance(comment, str):
             comment = StringAttr(comment)
 
@@ -720,20 +680,8 @@ class MS_Operation(
         memory_access = memory_access_str(self.memory, self.memory_offset)
         return memory_access, reg(self.source)
 
-    @classmethod
-    def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
-        attributes = dict[str, Attribute]()
-        if offset := cls.parse_optional_memory_access_offset(parser):
-            attributes["memory_offset"] = offset
-        return attributes
 
-    def custom_print_attributes(self, printer: Printer) -> AbstractSet[str]:
-        printer.print_string(", ")
-        print_immediate_value(printer, self.memory_offset)
-        return {"memory_offset"}
-
-
-class MI_Operation(X86Instruction, X86CustomFormatOperation, ABC, Generic[R1InvT]):
+class MI_Operation(X86Instruction, ABC, Generic[R1InvT]):
     """
     A base class for x86 operations that have one memory reference and an immediate
     value.
@@ -746,6 +694,11 @@ class MI_Operation(X86Instruction, X86CustomFormatOperation, ABC, Generic[R1InvT
     immediate = attr_def(IntegerAttr[SI32])
 
     traits = traits_def(MemoryReadEffect(), MemoryWriteEffect())
+
+    assembly_format = (
+        "$memory `,` $immediate (`,` $memory_offset^)? attr-dict `:` "
+        "`(` type($memory) `)` `->` `(` `)`"
+    )
 
     def __init__(
         self,
@@ -777,28 +730,8 @@ class MI_Operation(X86Instruction, X86CustomFormatOperation, ABC, Generic[R1InvT
         memory_access = memory_access_str(self.memory, self.memory_offset)
         return memory_access, immediate
 
-    @classmethod
-    def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
-        attributes = dict[str, Attribute]()
-        temp = parse_immediate_value(parser, si32)
-        attributes["immediate"] = temp
-        if parser.parse_optional_punctuation(",") is not None:
-            if offset := cls.parse_optional_memory_access_offset(parser):
-                attributes["memory_offset"] = offset
-        return attributes
 
-    def custom_print_attributes(self, printer: Printer) -> AbstractSet[str]:
-        printer.print_string(", ")
-        print_immediate_value(printer, self.immediate)
-        if self.memory_offset.value.data != 0:
-            printer.print_string(", ")
-            print_immediate_value(printer, self.memory_offset)
-        return {"immediate", "memory_offset"}
-
-
-class DSI_Operation(
-    X86Instruction, X86CustomFormatOperation, ABC, Generic[R1InvT, R2InvT]
-):
+class DSI_Operation(X86Instruction, ABC, Generic[R1InvT, R2InvT]):
     """
     A base class for x86 operations that have one destination register, one source
     register and an immediate value.
@@ -809,6 +742,11 @@ class DSI_Operation(
     # In the future, we should look into the legal bitwidths in the binary
     # representation.
     immediate = attr_def(IntegerAttr[SI32])
+
+    assembly_format = (
+        "$source `,` $immediate attr-dict `:` "
+        "`(` type($source) `)` `->` type($destination)"
+    )
 
     def __init__(
         self,
@@ -835,22 +773,8 @@ class DSI_Operation(
     def assembly_line_args(self) -> tuple[AssemblyInstructionArg | None, ...]:
         return reg(self.destination), reg(self.source), self.immediate
 
-    @classmethod
-    def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
-        attributes = dict[str, Attribute]()
-        temp = parse_immediate_value(parser, si32)
-        attributes["immediate"] = temp
-        return attributes
 
-    def custom_print_attributes(self, printer: Printer) -> AbstractSet[str]:
-        printer.print_string(", ")
-        print_immediate_value(printer, self.immediate)
-        return {"immediate"}
-
-
-class DMI_Operation(
-    X86Instruction, X86CustomFormatOperation, ABC, Generic[R1InvT, R2InvT]
-):
+class DMI_Operation(X86Instruction, ABC, Generic[R1InvT, R2InvT]):
     """
     A base class for x86 operations that have one destination register, one memory
     reference and an immediate value.
@@ -863,6 +787,11 @@ class DMI_Operation(
     memory_offset = attr_def(IntegerAttr[SI64], default_value=IntegerAttr(0, si64))
     immediate = attr_def(IntegerAttr[SI32])
     traits = traits_def(MemoryReadEffect())
+
+    assembly_format = (
+        "$memory `,` $immediate (`,` $memory_offset^)? attr-dict `:` "
+        "`(` type($memory) `)` `->` type($destination)"
+    )
 
     def __init__(
         self,
@@ -896,26 +825,8 @@ class DMI_Operation(
         memory_access = memory_access_str(self.memory, self.memory_offset)
         return destination, memory_access, immediate
 
-    @classmethod
-    def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
-        attributes = dict[str, Attribute]()
-        temp = parse_immediate_value(parser, si32)
-        attributes["immediate"] = temp
-        if parser.parse_optional_punctuation(",") is not None:
-            if offset := cls.parse_optional_memory_access_offset(parser):
-                attributes["memory_offset"] = offset
-        return attributes
 
-    def custom_print_attributes(self, printer: Printer) -> AbstractSet[str]:
-        printer.print_string(", ")
-        print_immediate_value(printer, self.immediate)
-        if self.memory_offset.value.data != 0:
-            printer.print_string(", ")
-            print_immediate_value(printer, self.memory_offset)
-        return {"immediate", "memory_offset"}
-
-
-class M_Operation(X86Instruction, X86CustomFormatOperation, ABC, Generic[R1InvT]):
+class M_Operation(X86Instruction, ABC, Generic[R1InvT]):
     """
     A base class for x86 operations with a memory reference.
     """
@@ -923,6 +834,11 @@ class M_Operation(X86Instruction, X86CustomFormatOperation, ABC, Generic[R1InvT]
     memory = operand_def(R1InvT)
     memory_offset = attr_def(IntegerAttr[SI64], default_value=IntegerAttr(0, si64))
     traits = traits_def(MemoryWriteEffect(), MemoryReadEffect())
+
+    assembly_format = (
+        "$memory (`,` $memory_offset^)? attr-dict `:` "
+        "`(` type($memory) `)` `->` `(` `)`"
+    )
 
     def __init__(
         self,
@@ -948,18 +864,6 @@ class M_Operation(X86Instruction, X86CustomFormatOperation, ABC, Generic[R1InvT]
     def assembly_line_args(self) -> tuple[AssemblyInstructionArg | None, ...]:
         memory_access = memory_access_str(self.memory, self.memory_offset)
         return (memory_access,)
-
-    @classmethod
-    def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
-        attributes = dict[str, Attribute]()
-        if offset := cls.parse_optional_memory_access_offset(parser):
-            attributes["memory_offset"] = offset
-        return attributes
-
-    def custom_print_attributes(self, printer: Printer) -> AbstractSet[str]:
-        printer.print_string(", ")
-        print_immediate_value(printer, self.memory_offset)
-        return {"memory_offset"}
 
 
 class ConditionalJumpOperation(X86Instruction, X86CustomFormatOperation, ABC):
@@ -1245,9 +1149,7 @@ class DSS_Operation(X86Instruction, ABC, Generic[R1InvT, R2InvT, R3InvT]):
         )
 
 
-class RSM_Operation(
-    X86Instruction, X86CustomFormatOperation, ABC, Generic[R1InvT, R2InvT, R4InvT]
-):
+class RSM_Operation(X86Instruction, ABC, Generic[R1InvT, R2InvT, R4InvT]):
     """
     A base class for x86 operations that have one register that is read and written to,
     one source register and one memory source operand.
@@ -1260,6 +1162,12 @@ class RSM_Operation(
     memory_offset = attr_def(IntegerAttr[SI64], default_value=IntegerAttr(0, si64))
 
     traits = traits_def(MemoryReadEffect())
+
+    assembly_format = (
+        "$register_in `,` $source1 `,` $memory (`,` $memory_offset^)? attr-dict `:` "
+        "`(` type($register_in) `,` type($source1) `,` type($memory) `)` "
+        "`->` type($register_out)"
+    )
 
     def __init__(
         self,
@@ -1294,27 +1202,13 @@ class RSM_Operation(
         destination = reg(self.register_in)
         return destination, src1, memory_access
 
-    @classmethod
-    def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
-        attributes = dict[str, Attribute]()
-        if offset := cls.parse_optional_memory_access_offset(parser):
-            attributes["memory_offset"] = offset
-        return attributes
-
-    def custom_print_attributes(self, printer: Printer) -> AbstractSet[str]:
-        printer.print_string(", ")
-        print_immediate_value(printer, self.memory_offset)
-        return {"memory_offset"}
-
     def get_register_constraints(self) -> RegisterConstraints:
         return RegisterConstraints(
             (self.source1, self.memory), (), ((self.register_in, self.register_out),)
         )
 
 
-class DSSI_Operation(
-    X86Instruction, X86CustomFormatOperation, ABC, Generic[R1InvT, R2InvT, R3InvT]
-):
+class DSSI_Operation(X86Instruction, ABC, Generic[R1InvT, R2InvT, R3InvT]):
     """
     A base class for x86 operations that have one destination register, one source
     register and an immediate value.
@@ -1324,6 +1218,11 @@ class DSSI_Operation(
     source0 = operand_def(R2InvT)
     source1 = operand_def(R3InvT)
     immediate = attr_def(IntegerAttr[UI8])
+
+    assembly_format = (
+        "$source0 `,` $source1 `,` $immediate attr-dict "
+        "`:` `(` type($source0) `,` type($source1) `)` `->`  type($destination)"
+    )
 
     def __init__(
         self,
@@ -1355,18 +1254,6 @@ class DSSI_Operation(
             reg(self.source1),
             self.immediate,
         )
-
-    @classmethod
-    def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
-        attributes = dict[str, Attribute]()
-        temp = parse_immediate_value(parser, ui8)
-        attributes["immediate"] = temp
-        return attributes
-
-    def custom_print_attributes(self, printer: Printer) -> AbstractSet[str]:
-        printer.print_string(", ")
-        print_immediate_value(printer, self.immediate)
-        return {"immediate"}
 
 
 # endregion
@@ -1548,7 +1435,7 @@ class DS_VpbroadcastqOp(DS_Operation[X86VectorRegisterType, GeneralRegisterType]
 
 
 @irdl_op_definition
-class S_PushOp(X86Instruction, X86CustomFormatOperation):
+class S_PushOp(X86Instruction):
     """
     Decreases %rsp and places s at the new memory location pointed to by %rsp.
 
@@ -1560,6 +1447,11 @@ class S_PushOp(X86Instruction, X86CustomFormatOperation):
     rsp_in = operand_def(RSP)
     rsp_out = result_def(RSP)
     source = operand_def(X86RegisterType)
+
+    assembly_format = (
+        "$rsp_in `,` $source attr-dict `:` "
+        "`(` type($rsp_in) `,` type($source) `)` `->` type($rsp_out)"
+    )
 
     def __init__(
         self,
@@ -1584,7 +1476,7 @@ class S_PushOp(X86Instruction, X86CustomFormatOperation):
 
 
 @irdl_op_definition
-class D_PopOp(X86Instruction, X86CustomFormatOperation):
+class D_PopOp(X86Instruction):
     """
     Copies the value at the top of the stack into d and increases %rsp.
 
@@ -1596,6 +1488,11 @@ class D_PopOp(X86Instruction, X86CustomFormatOperation):
     rsp_in = operand_def(RSP)
     rsp_out = result_def(RSP)
     destination = result_def(X86RegisterType)
+
+    assembly_format = (
+        "$rsp_in attr-dict `:` "
+        "`(` type($rsp_in) `)` `->` `(` type($rsp_out) `,` type($destination) `)`"
+    )
 
     def __init__(
         self,
@@ -1676,7 +1573,7 @@ class R_DecOp(R_Operation[GeneralRegisterType]):
 
 
 @irdl_op_definition
-class S_IDivOp(X86Instruction, X86CustomFormatOperation):
+class S_IDivOp(X86Instruction):
     """
     Divides the value in RDX:RAX by s and stores the quotient in RAX and the remainder
     in RDX.
@@ -1692,6 +1589,12 @@ class S_IDivOp(X86Instruction, X86CustomFormatOperation):
 
     rdx_output = result_def(RDX)
     rax_output = result_def(RAX)
+
+    assembly_format = (
+        "$source `,` $rdx_input `,` $rax_input attr-dict `:` "
+        "`(` type($source) `,` type($rdx_input) `,` type($rax_input) `)` "
+        "`->` `(` type($rdx_output) `,` type($rax_output) `)`"
+    )
 
     def __init__(
         self,
@@ -1719,7 +1622,7 @@ class S_IDivOp(X86Instruction, X86CustomFormatOperation):
 
 
 @irdl_op_definition
-class S_ImulOp(X86Instruction, X86CustomFormatOperation):
+class S_ImulOp(X86Instruction):
     """
     The source operand is multiplied by the value in the RAX register and the product is
     stored in the RDX:RAX registers.
@@ -1737,6 +1640,12 @@ class S_ImulOp(X86Instruction, X86CustomFormatOperation):
 
     rdx_output = result_def(RDX)
     rax_output = result_def(RAX)
+
+    assembly_format = (
+        "$source `,` $rax_input attr-dict `:` "
+        "`(` type($source) `,` type($rax_input) `)` "
+        "`->` `(` type($rdx_output) `,` type($rax_output) `)`"
+    )
 
     def __init__(
         self,
@@ -2140,7 +2049,7 @@ class DMI_ImulOp(DMI_Operation[GeneralRegisterType, GeneralRegisterType]):
 
 
 @irdl_op_definition
-class M_PushOp(X86Instruction, X86CustomFormatOperation):
+class M_PushOp(X86Instruction):
     """
     Decreases %rsp and places [m] at the new memory location pointed to by %rsp.
 
@@ -2153,9 +2062,14 @@ class M_PushOp(X86Instruction, X86CustomFormatOperation):
     rsp_out = result_def(RSP)
 
     memory = operand_def(X86RegisterType)
-    memory_offset = attr_def(IntegerAttr, default_value=IntegerAttr(0, 64))
+    memory_offset = attr_def(IntegerAttr[I64], default_value=IntegerAttr(0, i64))
 
     traits = traits_def(MemoryWriteEffect())
+
+    assembly_format = (
+        "$rsp_in `,` $memory (`,` $memory_offset^)? attr-dict `:` "
+        "`(` type($rsp_in) `,` type($memory) `)` `->` type($rsp_out)"
+    )
 
     def __init__(
         self,
@@ -2169,7 +2083,7 @@ class M_PushOp(X86Instruction, X86CustomFormatOperation):
         if isinstance(comment, str):
             comment = StringAttr(comment)
         if isinstance(memory_offset, int):
-            memory_offset = IntegerAttr(memory_offset, 64)
+            memory_offset = IntegerAttr(memory_offset, i64)
 
         super().__init__(
             operands=[rsp_in, memory],
@@ -2184,21 +2098,9 @@ class M_PushOp(X86Instruction, X86CustomFormatOperation):
         memory_access = memory_access_str(self.memory, self.memory_offset)
         return (memory_access,)
 
-    @classmethod
-    def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
-        attributes = dict[str, Attribute]()
-        if offset := cls.parse_optional_memory_access_offset(parser):
-            attributes["memory_offset"] = offset
-        return attributes
-
-    def custom_print_attributes(self, printer: Printer) -> AbstractSet[str]:
-        printer.print_string(", ")
-        print_immediate_value(printer, self.memory_offset)
-        return {"memory_offset"}
-
 
 @irdl_op_definition
-class M_PopOp(X86Instruction, X86CustomFormatOperation):
+class M_PopOp(X86Instruction):
     """
     Copies the value at the top of the stack into [m] and increases %rsp.
     The value held by m is a pointer to the memory location where the value is stored.
@@ -2211,10 +2113,15 @@ class M_PopOp(X86Instruction, X86CustomFormatOperation):
 
     rsp_in = operand_def(RSP)
     memory = operand_def(GeneralRegisterType)
-    memory_offset = attr_def(IntegerAttr, default_value=IntegerAttr(0, 64))
+    memory_offset = attr_def(IntegerAttr[I64], default_value=IntegerAttr(0, i64))
     rsp_out = result_def(RSP)
 
     traits = traits_def(MemoryWriteEffect())
+
+    assembly_format = (
+        "$rsp_in `,` $memory (`,` $memory_offset^)? attr-dict `:` "
+        "`(` type($rsp_in) `,` type($memory) `)` `->` type($rsp_out)"
+    )
 
     def __init__(
         self,
@@ -2226,13 +2133,14 @@ class M_PopOp(X86Instruction, X86CustomFormatOperation):
         rsp_out: GeneralRegisterType,
     ):
         if isinstance(memory_offset, int):
-            memory_offset = IntegerAttr(memory_offset, 64)
+            memory_offset = IntegerAttr(memory_offset, i64)
         if isinstance(comment, str):
             comment = StringAttr(comment)
 
         super().__init__(
             operands=[rsp_in, memory],
             attributes={
+                "memory_offset": memory_offset,
                 "comment": comment,
             },
             result_types=[rsp_out],
@@ -2241,19 +2149,6 @@ class M_PopOp(X86Instruction, X86CustomFormatOperation):
     def assembly_line_args(self) -> tuple[AssemblyInstructionArg | None, ...]:
         memory_access = memory_access_str(self.memory, self.memory_offset)
         return (memory_access,)
-
-    @classmethod
-    def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
-        attributes = dict[str, Attribute]()
-        temp = parse_optional_immediate_value(parser, si64)
-        if temp is not None:
-            attributes["memory_offset"] = temp
-        return attributes
-
-    def custom_print_attributes(self, printer: Printer) -> AbstractSet[str]:
-        printer.print_string(", ")
-        print_immediate_value(printer, self.memory_offset)
-        return {"memory_offset"}
 
 
 @irdl_op_definition
@@ -2309,7 +2204,7 @@ class M_DecOp(M_Operation[GeneralRegisterType]):
 
 
 @irdl_op_definition
-class M_IDivOp(X86Instruction, X86CustomFormatOperation):
+class M_IDivOp(X86Instruction):
     """
     Divides the value in RDX:RAX by [m] and stores the quotient in RAX and the remainder in RDX.
 
@@ -2319,13 +2214,19 @@ class M_IDivOp(X86Instruction, X86CustomFormatOperation):
     name = "x86.m.idiv"
 
     memory = operand_def(X86RegisterType)
-    memory_offset = attr_def(IntegerAttr, default_value=IntegerAttr(0, 64))
+    memory_offset = attr_def(IntegerAttr[I64], default_value=IntegerAttr(0, i64))
     rdx_in = operand_def(RDX)
     rdx_out = result_def(RDX)
     rax_in = operand_def(RAX)
     rax_out = result_def(RAX)
 
     traits = traits_def(MemoryReadEffect())
+
+    assembly_format = (
+        "$memory `,` $rdx_in `,` $rax_in (`,` $memory_offset^)? attr-dict `:` "
+        "`(` type($memory) `,` type($rdx_in) `,` type($rax_in) `)` "
+        "`->` `(` type($rdx_out) `,` type($rax_out) `)`"
+    )
 
     def __init__(
         self,
@@ -2339,7 +2240,7 @@ class M_IDivOp(X86Instruction, X86CustomFormatOperation):
         rax_out: GeneralRegisterType,
     ):
         if isinstance(memory_offset, int):
-            memory_offset = IntegerAttr(memory_offset, 64)
+            memory_offset = IntegerAttr(memory_offset, i64)
         if isinstance(comment, str):
             comment = StringAttr(comment)
 
@@ -2356,21 +2257,9 @@ class M_IDivOp(X86Instruction, X86CustomFormatOperation):
         memory_access = memory_access_str(self.memory, self.memory_offset)
         return (memory_access,)
 
-    @classmethod
-    def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
-        attributes = dict[str, Attribute]()
-        if offset := cls.parse_optional_memory_access_offset(parser):
-            attributes["memory_offset"] = offset
-        return attributes
-
-    def custom_print_attributes(self, printer: Printer) -> AbstractSet[str]:
-        printer.print_string(", ")
-        print_immediate_value(printer, self.memory_offset)
-        return {"memory_offset"}
-
 
 @irdl_op_definition
-class M_ImulOp(X86Instruction, X86CustomFormatOperation):
+class M_ImulOp(X86Instruction):
     """
     The source operand is multiplied by the value in the RAX register and the product is stored in the RDX:RAX registers.
     x[RDX:RAX] = x[RAX] * [x[m]]
@@ -2381,14 +2270,19 @@ class M_ImulOp(X86Instruction, X86CustomFormatOperation):
     name = "x86.m.imul"
 
     memory = operand_def(GeneralRegisterType)
-    memory_offset = attr_def(IntegerAttr, default_value=IntegerAttr(0, 64))
+    memory_offset = attr_def(IntegerAttr[I64], default_value=IntegerAttr(0, i64))
 
     rdx_out = result_def(RDX)
-
     rax_in = operand_def(RAX)
     rax_out = result_def(RAX)
 
     traits = traits_def(MemoryReadEffect())
+
+    assembly_format = (
+        "$memory `,` $rax_in (`,` $memory_offset^)? attr-dict `:` "
+        "`(` type($memory) `,` type($rax_in) `)` "
+        "`->` `(` type($rdx_out) `,` type($rax_out) `)`"
+    )
 
     def __init__(
         self,
@@ -2401,7 +2295,7 @@ class M_ImulOp(X86Instruction, X86CustomFormatOperation):
         rax_out: GeneralRegisterType,
     ):
         if isinstance(memory_offset, int):
-            memory_offset = IntegerAttr(memory_offset, 64)
+            memory_offset = IntegerAttr(memory_offset, i64)
         if isinstance(comment, str):
             comment = StringAttr(comment)
 
@@ -2417,19 +2311,6 @@ class M_ImulOp(X86Instruction, X86CustomFormatOperation):
     def assembly_line_args(self) -> tuple[AssemblyInstructionArg | None, ...]:
         memory_access = memory_access_str(self.memory, self.memory_offset)
         return (memory_access,)
-
-    @classmethod
-    def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
-        attributes = dict[str, Attribute]()
-        temp = parse_optional_immediate_value(parser, si64)
-        if temp is not None:
-            attributes["memory_offset"] = temp
-        return attributes
-
-    def custom_print_attributes(self, printer: Printer) -> AbstractSet[str]:
-        printer.print_string(", ")
-        print_immediate_value(printer, self.memory_offset)
-        return {"memory_offset"}
 
 
 @irdl_op_definition
@@ -2711,7 +2592,7 @@ class FallthroughOp(X86AsmOperation, X86RegallocOperation, X86CustomFormatOperat
 
 
 @irdl_op_definition
-class SS_CmpOp(X86Instruction, X86CustomFormatOperation):
+class SS_CmpOp(X86Instruction):
     """
     Compares the first source operand with the second source operand and sets the status
     flags in the EFLAGS register according to the results.
@@ -2725,6 +2606,11 @@ class SS_CmpOp(X86Instruction, X86CustomFormatOperation):
     source2 = operand_def(X86RegisterType)
 
     result = result_def(RFLAGSRegisterType)
+
+    assembly_format = (
+        "$source1 `,` $source2 attr-dict `:` "
+        "`(` type($source1) `,` type($source2) `)` `->` type($result)"
+    )
 
     def __init__(
         self,
@@ -2750,7 +2636,7 @@ class SS_CmpOp(X86Instruction, X86CustomFormatOperation):
 
 
 @irdl_op_definition
-class SM_CmpOp(X86Instruction, X86CustomFormatOperation):
+class SM_CmpOp(X86Instruction):
     """
     Compares the first source operand with the second source operand and sets the status
     flags in the EFLAGS register according to the results.
@@ -2762,11 +2648,16 @@ class SM_CmpOp(X86Instruction, X86CustomFormatOperation):
 
     source = operand_def(GeneralRegisterType)
     memory = operand_def(GeneralRegisterType)
-    memory_offset = attr_def(IntegerAttr, default_value=IntegerAttr(0, 64))
+    memory_offset = attr_def(IntegerAttr[I64], default_value=IntegerAttr(0, i64))
 
     result = result_def(RFLAGSRegisterType)
 
     traits = traits_def(MemoryReadEffect())
+
+    assembly_format = (
+        "$source `,` $memory (`,` $memory_offset^)? attr-dict `:` "
+        "`(` type($source) `,` type($memory) `)` `->` type($result)"
+    )
 
     def __init__(
         self,
@@ -2778,7 +2669,7 @@ class SM_CmpOp(X86Instruction, X86CustomFormatOperation):
         result: RFLAGSRegisterType,
     ):
         if isinstance(memory_offset, int):
-            memory_offset = IntegerAttr(memory_offset, 64)
+            memory_offset = IntegerAttr(memory_offset, i64)
         if isinstance(comment, str):
             comment = StringAttr(comment)
 
@@ -2795,22 +2686,9 @@ class SM_CmpOp(X86Instruction, X86CustomFormatOperation):
         memory_access = memory_access_str(self.memory, self.memory_offset)
         return reg(self.source), memory_access
 
-    @classmethod
-    def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
-        attributes = dict[str, Attribute]()
-        temp = parse_optional_immediate_value(parser, si64)
-        if temp is not None:
-            attributes["memory_offset"] = temp
-        return attributes
-
-    def custom_print_attributes(self, printer: Printer) -> AbstractSet[str]:
-        printer.print_string(", ")
-        print_immediate_value(printer, self.memory_offset)
-        return {"memory_offset"}
-
 
 @irdl_op_definition
-class SI_CmpOp(X86Instruction, X86CustomFormatOperation):
+class SI_CmpOp(X86Instruction):
     """
     Compares the first source operand with the second source operand and sets the status
     flags in the EFLAGS register according to the results.
@@ -2824,6 +2702,10 @@ class SI_CmpOp(X86Instruction, X86CustomFormatOperation):
     immediate = attr_def(IntegerAttr[SI32])
 
     result = result_def(RFLAGS)
+
+    assembly_format = (
+        "$source `,` $immediate attr-dict `:` `(` type($source) `)` `->` type($result)"
+    )
 
     def __init__(
         self,
@@ -2849,21 +2731,9 @@ class SI_CmpOp(X86Instruction, X86CustomFormatOperation):
     def assembly_line_args(self) -> tuple[AssemblyInstructionArg, ...]:
         return reg(self.source), self.immediate
 
-    @classmethod
-    def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
-        attributes = dict[str, Attribute]()
-        temp = parse_immediate_value(parser, si32)
-        attributes["immediate"] = temp
-        return attributes
-
-    def custom_print_attributes(self, printer: Printer) -> AbstractSet[str]:
-        printer.print_string(", ")
-        print_immediate_value(printer, self.immediate)
-        return {"immediate"}
-
 
 @irdl_op_definition
-class MS_CmpOp(X86Instruction, X86CustomFormatOperation):
+class MS_CmpOp(X86Instruction):
     """
     Compares the first source operand with the second source operand and sets the status
     flags in the EFLAGS register according to the results.
@@ -2874,12 +2744,17 @@ class MS_CmpOp(X86Instruction, X86CustomFormatOperation):
     name = "x86.ms.cmp"
 
     memory = operand_def(GeneralRegisterType)
-    memory_offset = attr_def(IntegerAttr, default_value=IntegerAttr(0, 64))
+    memory_offset = attr_def(IntegerAttr[I64], default_value=IntegerAttr(0, i64))
     source = operand_def(GeneralRegisterType)
 
     result = result_def(RFLAGSRegisterType)
 
     traits = traits_def(MemoryReadEffect())
+
+    assembly_format = (
+        "$memory `,` $source (`,` $memory_offset^)? attr-dict `:` "
+        "`(` type($memory) `,` type($source) `)` `->` type($result)"
+    )
 
     def __init__(
         self,
@@ -2891,7 +2766,7 @@ class MS_CmpOp(X86Instruction, X86CustomFormatOperation):
         result: RFLAGSRegisterType,
     ):
         if isinstance(memory_offset, int):
-            memory_offset = IntegerAttr(memory_offset, 64)
+            memory_offset = IntegerAttr(memory_offset, i64)
         if isinstance(comment, str):
             comment = StringAttr(comment)
 
@@ -2908,22 +2783,9 @@ class MS_CmpOp(X86Instruction, X86CustomFormatOperation):
         memory_access = memory_access_str(self.memory, self.memory_offset)
         return memory_access, reg(self.source)
 
-    @classmethod
-    def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
-        attributes = dict[str, Attribute]()
-        temp = parse_optional_immediate_value(parser, si64)
-        if temp is not None:
-            attributes["memory_offset"] = temp
-        return attributes
-
-    def custom_print_attributes(self, printer: Printer) -> AbstractSet[str]:
-        printer.print_string(", ")
-        print_immediate_value(printer, self.memory_offset)
-        return {"memory_offset"}
-
 
 @irdl_op_definition
-class MI_CmpOp(X86Instruction, X86CustomFormatOperation):
+class MI_CmpOp(X86Instruction):
     """
     Compares the first source operand with the second source operand and sets the status
     flags in the EFLAGS register according to the results.
@@ -2940,6 +2802,8 @@ class MI_CmpOp(X86Instruction, X86CustomFormatOperation):
     result = result_def(RFLAGSRegisterType)
 
     traits = traits_def(MemoryReadEffect())
+
+    assembly_format = "$memory `,` $immediate (`,` $memory_offset^)? attr-dict `:` type($memory) `->` type($result)"
 
     def __init__(
         self,
@@ -2971,24 +2835,6 @@ class MI_CmpOp(X86Instruction, X86CustomFormatOperation):
         immediate = assembly_arg_str(self.immediate)
         memory_access = memory_access_str(self.memory, self.memory_offset)
         return memory_access, immediate
-
-    @classmethod
-    def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
-        attributes = dict[str, Attribute]()
-        temp = parse_immediate_value(parser, si32)
-        attributes["immediate"] = temp
-        if parser.parse_optional_punctuation(",") is not None:
-            temp2 = parse_optional_immediate_value(parser, si64)
-            if temp2 is not None:
-                attributes["memory_offset"] = temp2
-        return attributes
-
-    def custom_print_attributes(self, printer: Printer) -> AbstractSet[str]:
-        printer.print_string(", ")
-        print_immediate_value(printer, self.immediate)
-        printer.print_string(", ")
-        print_immediate_value(printer, self.memory_offset)
-        return {"immediate", "memory_offset"}
 
 
 @irdl_op_definition


### PR DESCRIPTION
We can't handle successors yet, but I'd like to migrate the jump ops too.