### PR TITLE
Implement initial spilling algorithm for RISC-V

### DIFF
--- a/tests/filecheck/backend/riscv/convert_riscv_stack_to_riscv.mlir
+++ b/tests/filecheck/backend/riscv/convert_riscv_stack_to_riscv.mlir
@@ -14,15 +14,12 @@ builtin.module {
 // CHECK:       builtin.module {
 // CHECK-NEXT:    riscv_func.func @main() {
 // CHECK-NEXT:      %0 = rv32.get_register : !riscv.reg<sp>
-// CHECK-NEXT:      %1 = riscv.addi %0, -16 : (!riscv.reg<sp>) -> !riscv.reg<sp>
+// CHECK-NEXT:      %1 = riscv.addi %0, -8 : (!riscv.reg<sp>) -> !riscv.reg<sp>
 // CHECK-NEXT:      %2 = "test.op"() : () -> !riscv.reg
-// CHECK-NEXT:      %3 = rv32.get_register : !riscv.reg<sp>
-// CHECK-NEXT:      riscv.sw %3, %2, 0 : (!riscv.reg<sp>, !riscv.reg) -> ()
-// CHECK-NEXT:      %4 = rv32.get_register : !riscv.reg<sp>
-// CHECK-NEXT:      %5 = riscv.lw %4, 0 : (!riscv.reg<sp>) -> !riscv.reg
-// CHECK-NEXT:      %6 = rv32.get_register : !riscv.reg<sp>
-// CHECK-NEXT:      riscv.sw %6, %5, 4 : (!riscv.reg<sp>, !riscv.reg) -> ()
-// CHECK-NEXT:      %7 = riscv.addi %0, 16 : (!riscv.reg<sp>) -> !riscv.reg<sp>
+// CHECK-NEXT:      riscv.sw %0, %2, 0 : (!riscv.reg<sp>, !riscv.reg) -> ()
+// CHECK-NEXT:      %3 = riscv.lw %0, 0 : (!riscv.reg<sp>) -> !riscv.reg
+// CHECK-NEXT:      riscv.sw %0, %3, 4 : (!riscv.reg<sp>, !riscv.reg) -> ()
+// CHECK-NEXT:      %4 = riscv.addi %0, 8 : (!riscv.reg<sp>) -> !riscv.reg<sp>
 // CHECK-NEXT:      riscv_func.return
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
@@ -47,17 +44,13 @@ builtin.module {
 // CHECK:       builtin.module {
 // CHECK-NEXT:    riscv_func.func @main() {
 // CHECK-NEXT:      %0 = rv32.get_register : !riscv.reg<sp>
-// CHECK-NEXT:      %1 = riscv.addi %0, -16 : (!riscv.reg<sp>) -> !riscv.reg<sp>
+// CHECK-NEXT:      %1 = riscv.addi %0, -12 : (!riscv.reg<sp>) -> !riscv.reg<sp>
 // CHECK-NEXT:      %2, %3 = "test.op"() : () -> (!riscv.reg, !riscv.freg)
-// CHECK-NEXT:      %4 = rv32.get_register : !riscv.reg<sp>
-// CHECK-NEXT:      riscv.sw %4, %2, 8 : (!riscv.reg<sp>, !riscv.reg) -> ()
-// CHECK-NEXT:      %5 = rv32.get_register : !riscv.reg<sp>
-// CHECK-NEXT:      riscv.fsd %5, %3, 0 : (!riscv.reg<sp>, !riscv.freg) -> ()
-// CHECK-NEXT:      %6 = rv32.get_register : !riscv.reg<sp>
-// CHECK-NEXT:      %7 = riscv.lw %6, 8 : (!riscv.reg<sp>) -> !riscv.reg
-// CHECK-NEXT:      %8 = rv32.get_register : !riscv.reg<sp>
-// CHECK-NEXT:      %9 = riscv.fld %8, 0 : (!riscv.reg<sp>) -> !riscv.freg
-// CHECK-NEXT:      %10 = riscv.addi %0, 16 : (!riscv.reg<sp>) -> !riscv.reg<sp>
+// CHECK-NEXT:      riscv.sw %0, %2, 8 : (!riscv.reg<sp>, !riscv.reg) -> ()
+// CHECK-NEXT:      riscv.fsd %0, %3, 0 : (!riscv.reg<sp>, !riscv.freg) -> ()
+// CHECK-NEXT:      %4 = riscv.lw %0, 8 : (!riscv.reg<sp>) -> !riscv.reg
+// CHECK-NEXT:      %5 = riscv.fld %0, 0 : (!riscv.reg<sp>) -> !riscv.freg
+// CHECK-NEXT:      %6 = riscv.addi %0, 12 : (!riscv.reg<sp>) -> !riscv.reg<sp>
 // CHECK-NEXT:      riscv_func.return
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }

--- a/tests/filecheck/backend/riscv/convert_riscv_stack_to_riscv.mlir
+++ b/tests/filecheck/backend/riscv/convert_riscv_stack_to_riscv.mlir
@@ -1,0 +1,28 @@
+// RUN: xdsl-opt -p convert-riscv-stack-to-riscv %s | filecheck %s
+
+builtin.module {
+  riscv_func.func @main() {
+    %0 = "test.op"() : () -> !riscv.reg
+    %1 = riscv_stack.alloca : () -> !riscv_stack.ptr<i32>
+    riscv_stack.store %1, %0 : (!riscv_stack.ptr<i32>, !riscv.reg) -> ()
+    %2 = riscv_stack.load %1 : (!riscv_stack.ptr<i32>) -> !riscv.reg
+    %3 = riscv_stack.alloca : () -> !riscv_stack.ptr<i32>
+    riscv_stack.store %3, %2 : (!riscv_stack.ptr<i32>, !riscv.reg) -> ()
+    riscv_func.return
+  }
+}
+// CHECK:       builtin.module {
+// CHECK-NEXT:    riscv_func.func @main() {
+// CHECK-NEXT:      %0 = rv32.get_register : !riscv.reg<sp>
+// CHECK-NEXT:      %1 = riscv.addi %0, -16 : (!riscv.reg<sp>) -> !riscv.reg<sp>
+// CHECK-NEXT:      %2 = "test.op"() : () -> !riscv.reg
+// CHECK-NEXT:      %3 = rv32.get_register : !riscv.reg<sp>
+// CHECK-NEXT:      riscv.sw %3, %2, 0 : (!riscv.reg<sp>, !riscv.reg) -> ()
+// CHECK-NEXT:      %4 = rv32.get_register : !riscv.reg<sp>
+// CHECK-NEXT:      %5 = riscv.lw %4, 0 : (!riscv.reg<sp>) -> !riscv.reg
+// CHECK-NEXT:      %6 = rv32.get_register : !riscv.reg<sp>
+// CHECK-NEXT:      riscv.sw %6, %5, 4 : (!riscv.reg<sp>, !riscv.reg) -> ()
+// CHECK-NEXT:      %7 = riscv.addi %0, 16 : (!riscv.reg<sp>) -> !riscv.reg<sp>
+// CHECK-NEXT:      riscv_func.return
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/tests/filecheck/backend/riscv/convert_riscv_stack_to_riscv.mlir
+++ b/tests/filecheck/backend/riscv/convert_riscv_stack_to_riscv.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -p convert-riscv-stack-to-riscv %s | filecheck %s
+// RUN: xdsl-opt --split-input-file -p convert-riscv-stack-to-riscv %s | filecheck %s
 
 builtin.module {
   riscv_func.func @main() {
@@ -23,6 +23,41 @@ builtin.module {
 // CHECK-NEXT:      %6 = rv32.get_register : !riscv.reg<sp>
 // CHECK-NEXT:      riscv.sw %6, %5, 4 : (!riscv.reg<sp>, !riscv.reg) -> ()
 // CHECK-NEXT:      %7 = riscv.addi %0, 16 : (!riscv.reg<sp>) -> !riscv.reg<sp>
+// CHECK-NEXT:      riscv_func.return
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }
+
+// -----
+// Test floats
+builtin.module {
+  riscv_func.func @main() {
+    %0, %1 = "test.op"() : () -> (!riscv.reg, !riscv.freg)
+    %3 = riscv_stack.alloca : () -> !riscv_stack.ptr<f64>
+    %2 = riscv_stack.alloca : () -> !riscv_stack.ptr<i32>
+
+    riscv_stack.store %2, %0 : (!riscv_stack.ptr<i32>, !riscv.reg) -> ()
+    riscv_stack.store %3, %1 : (!riscv_stack.ptr<f64>, !riscv.freg) -> ()
+
+    %4 = riscv_stack.load %2 : (!riscv_stack.ptr<i32>) -> (!riscv.reg)
+    %5 = riscv_stack.load %3 : (!riscv_stack.ptr<f64>) -> (!riscv.freg)
+
+    riscv_func.return
+  }
+}
+// CHECK:       builtin.module {
+// CHECK-NEXT:    riscv_func.func @main() {
+// CHECK-NEXT:      %0 = rv32.get_register : !riscv.reg<sp>
+// CHECK-NEXT:      %1 = riscv.addi %0, -16 : (!riscv.reg<sp>) -> !riscv.reg<sp>
+// CHECK-NEXT:      %2, %3 = "test.op"() : () -> (!riscv.reg, !riscv.freg)
+// CHECK-NEXT:      %4 = rv32.get_register : !riscv.reg<sp>
+// CHECK-NEXT:      riscv.sw %4, %2, 8 : (!riscv.reg<sp>, !riscv.reg) -> ()
+// CHECK-NEXT:      %5 = rv32.get_register : !riscv.reg<sp>
+// CHECK-NEXT:      riscv.fsd %5, %3, 0 : (!riscv.reg<sp>, !riscv.freg) -> ()
+// CHECK-NEXT:      %6 = rv32.get_register : !riscv.reg<sp>
+// CHECK-NEXT:      %7 = riscv.lw %6, 8 : (!riscv.reg<sp>) -> !riscv.reg
+// CHECK-NEXT:      %8 = rv32.get_register : !riscv.reg<sp>
+// CHECK-NEXT:      %9 = riscv.fld %8, 0 : (!riscv.reg<sp>) -> !riscv.freg
+// CHECK-NEXT:      %10 = riscv.addi %0, 16 : (!riscv.reg<sp>) -> !riscv.reg<sp>
 // CHECK-NEXT:      riscv_func.return
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }

--- a/tests/filecheck/backend/riscv/prologue_epilogue_insertion.mlir
+++ b/tests/filecheck/backend/riscv/prologue_epilogue_insertion.mlir
@@ -1,5 +1,5 @@
-// RUN: xdsl-opt --split-input-file -p "riscv-prologue-epilogue-insertion" %s | filecheck %s
-// RUN: xdsl-opt --split-input-file -p "riscv-prologue-epilogue-insertion{flen=4}" %s | filecheck %s --check-prefix=CHECK-SMALL-FLEN
+// RUN: xdsl-opt --split-input-file -p "riscv-prologue-epilogue-insertion,convert-riscv-stack-to-riscv" %s | filecheck %s
+// RUN: xdsl-opt --split-input-file -p "riscv-prologue-epilogue-insertion{flen=4},convert-riscv-stack-to-riscv" %s | filecheck %s --check-prefix=CHECK-SMALL-FLEN
 
 // CHECK: func @main
 riscv_func.func @main() {

--- a/tests/filecheck/dialects/riscv/riscv_stack.mlir
+++ b/tests/filecheck/dialects/riscv/riscv_stack.mlir
@@ -1,0 +1,12 @@
+// RUN: xdsl-opt --split-input-file --verify-diagnostics %s | filecheck %s
+
+%0 = "test.op"(): () -> !riscv.reg
+
+%1 = riscv_stack.alloca : () -> !riscv_stack.ptr<i32>
+// CHECK: %{{.*}} = riscv_stack.alloca : () -> !riscv_stack.ptr<i32>
+
+riscv_stack.store %1, %0: (!riscv_stack.ptr<i32>, !riscv.reg) -> ()
+// CHECK-NEXT: riscv_stack.store %{{.*}}, %{{.*}} : (!riscv_stack.ptr<i32>, !riscv.reg) -> ()
+
+riscv_stack.load %1: (!riscv_stack.ptr<i32>) -> !riscv.reg
+// CHECK-NEXT: %{{.*}} = riscv_stack.load %{{.*}} : (!riscv_stack.ptr<i32>) -> !riscv.reg

--- a/tests/filecheck/transforms/test-riscv-spilling.mlir
+++ b/tests/filecheck/transforms/test-riscv-spilling.mlir
@@ -1,0 +1,27 @@
+// RUN: xdsl-opt --split-input-file -p test-riscv-spilling %s | filecheck %s
+builtin.module {
+  riscv_func.func @main() {
+    %0, %1, %2 = "test.op"() : () -> (!riscv.reg, !riscv.reg, !riscv.reg)
+    %3 = riscv.add %0, %1 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+    %4 = riscv.add %2, %3 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+    %5 = riscv.add %0, %1 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+    riscv_func.return
+  }
+}
+// CHECK:       builtin.module {
+// CHECK-NEXT:    riscv_func.func @main() {
+// CHECK-NEXT:      %0 = rv32.get_register : !riscv.reg<sp>
+// CHECK-NEXT:      %1 = riscv.addi %0, -16 : (!riscv.reg<sp>) -> !riscv.reg<sp>
+// CHECK-NEXT:      %2, %3, %4 = "test.op"() : () -> (!riscv.reg, !riscv.reg, !riscv.reg)
+// CHECK-NEXT:      riscv.sw %0, %4, 0 : (!riscv.reg<sp>, !riscv.reg) -> ()
+// CHECK-NEXT:      %5 = riscv.add %2, %3 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:      riscv.sw %0, %2, 4 : (!riscv.reg<sp>, !riscv.reg) -> ()
+// CHECK-NEXT:      %6 = riscv.lw %0, 0 : (!riscv.reg<sp>) -> !riscv.reg
+// CHECK-NEXT:      %7 = riscv.add %6, %5 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:      riscv.sw %0, %6, 8 : (!riscv.reg<sp>, !riscv.reg) -> ()
+// CHECK-NEXT:      %8 = riscv.lw %0, 4 : (!riscv.reg<sp>) -> !riscv.reg
+// CHECK-NEXT:      %9 = riscv.add %8, %3 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:      %10 = riscv.addi %0, 16 : (!riscv.reg<sp>) -> !riscv.reg<sp>
+// CHECK-NEXT:      riscv_func.return
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/tests/filecheck/transforms/test-riscv-spilling.mlir
+++ b/tests/filecheck/transforms/test-riscv-spilling.mlir
@@ -21,7 +21,7 @@ builtin.module {
 // CHECK-NEXT:      riscv.sw %0, %6, 8 : (!riscv.reg<sp>, !riscv.reg) -> ()
 // CHECK-NEXT:      %8 = riscv.lw %0, 4 : (!riscv.reg<sp>) -> !riscv.reg
 // CHECK-NEXT:      %9 = riscv.add %8, %3 : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:      %10 = riscv.addi %0, 12: (!riscv.reg<sp>) -> !riscv.reg<sp>
+// CHECK-NEXT:      %10 = riscv.addi %0, 12 : (!riscv.reg<sp>) -> !riscv.reg<sp>
 // CHECK-NEXT:      riscv_func.return
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }

--- a/tests/filecheck/transforms/test-riscv-spilling.mlir
+++ b/tests/filecheck/transforms/test-riscv-spilling.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt --split-input-file -p test-riscv-spilling %s | filecheck %s
+// RUN: xdsl-opt --split-input-file -p test-riscv-spilling,convert-riscv-stack-to-riscv %s | filecheck %s
 builtin.module {
   riscv_func.func @main() {
     %0, %1, %2 = "test.op"() : () -> (!riscv.reg, !riscv.reg, !riscv.reg)
@@ -11,7 +11,7 @@ builtin.module {
 // CHECK:       builtin.module {
 // CHECK-NEXT:    riscv_func.func @main() {
 // CHECK-NEXT:      %0 = rv32.get_register : !riscv.reg<sp>
-// CHECK-NEXT:      %1 = riscv.addi %0, -16 : (!riscv.reg<sp>) -> !riscv.reg<sp>
+// CHECK-NEXT:      %1 = riscv.addi %0, -12 : (!riscv.reg<sp>) -> !riscv.reg<sp>
 // CHECK-NEXT:      %2, %3, %4 = "test.op"() : () -> (!riscv.reg, !riscv.reg, !riscv.reg)
 // CHECK-NEXT:      riscv.sw %0, %4, 0 : (!riscv.reg<sp>, !riscv.reg) -> ()
 // CHECK-NEXT:      %5 = riscv.add %2, %3 : (!riscv.reg, !riscv.reg) -> !riscv.reg
@@ -21,7 +21,7 @@ builtin.module {
 // CHECK-NEXT:      riscv.sw %0, %6, 8 : (!riscv.reg<sp>, !riscv.reg) -> ()
 // CHECK-NEXT:      %8 = riscv.lw %0, 4 : (!riscv.reg<sp>) -> !riscv.reg
 // CHECK-NEXT:      %9 = riscv.add %8, %3 : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:      %10 = riscv.addi %0, 16 : (!riscv.reg<sp>) -> !riscv.reg<sp>
+// CHECK-NEXT:      %10 = riscv.addi %0, 12: (!riscv.reg<sp>) -> !riscv.reg<sp>
 // CHECK-NEXT:      riscv_func.return
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }

--- a/xdsl/backend/riscv/lowering/convert_riscv_stack_to_riscv.py
+++ b/xdsl/backend/riscv/lowering/convert_riscv_stack_to_riscv.py
@@ -1,7 +1,7 @@
 from xdsl.builder import Builder
 from xdsl.context import Context
 from xdsl.dialects import riscv_func, rv32
-from xdsl.dialects.builtin import ModuleOp
+from xdsl.dialects.builtin import IntegerType, ModuleOp
 from xdsl.dialects.riscv.ops import AddiOp, LwOp, SwOp
 from xdsl.dialects.riscv.registers import IntRegisterType, Registers
 from xdsl.dialects.riscv.stack import AllocaOp, LoadOp, StoreOp
@@ -29,7 +29,7 @@ class ConvertRiscvStackToRiscvPass(ModulePass):
             # For each function, give each alloca its stack offset
             for alloca_op in alloca_ops:
                 stack_slot = alloca_op.ref.type
-                assert isinstance(stack_slot.value_type, IntRegisterType)
+                assert isinstance(stack_slot.value_type, IntegerType)
                 value_size = get_type_size(stack_slot.value_type)
 
                 for use in alloca_op.ref.uses:

--- a/xdsl/backend/riscv/lowering/convert_riscv_stack_to_riscv.py
+++ b/xdsl/backend/riscv/lowering/convert_riscv_stack_to_riscv.py
@@ -93,7 +93,8 @@ class ConvertRiscvStackToRiscvPass(ModulePass):
         stack_ptr: rv32.GetRegisterOp,
     ):
         # Align SP to 16 bytes (from RISC-V calling convention)
-        total_offset = (total_offset + 15) & ~15
+        # commented to match previous prologue-epilogue-insertion behaviour
+        # total_offset = (total_offset + 15) & ~15
 
         if total_offset > 0:
             # prologue

--- a/xdsl/backend/riscv/lowering/convert_riscv_stack_to_riscv.py
+++ b/xdsl/backend/riscv/lowering/convert_riscv_stack_to_riscv.py
@@ -1,3 +1,5 @@
+from dataclasses import dataclass, field
+
 from xdsl.builder import Builder
 from xdsl.context import Context
 from xdsl.dialects import riscv_func, rv32
@@ -16,8 +18,11 @@ def get_type_size(value_type: FixedBitwidthType):
     return (value_type.bitwidth + 7) // 8
 
 
+@dataclass(frozen=True)
 class ConvertRiscvStackToRiscvPass(ModulePass):
     name = "convert-riscv-stack-to-riscv"
+
+    align_sp: bool = field(default=False)
 
     def apply(self, ctx: Context, op: ModuleOp) -> None:
         for func_op in op.walk():
@@ -93,8 +98,8 @@ class ConvertRiscvStackToRiscvPass(ModulePass):
         stack_ptr: rv32.GetRegisterOp,
     ):
         # Align SP to 16 bytes (from RISC-V calling convention)
-        # commented to match previous prologue-epilogue-insertion behaviour
-        # total_offset = (total_offset + 15) & ~15
+        if self.align_sp:
+            total_offset = (total_offset + 15) & ~15
 
         if total_offset > 0:
             # prologue

--- a/xdsl/backend/riscv/lowering/convert_riscv_stack_to_riscv.py
+++ b/xdsl/backend/riscv/lowering/convert_riscv_stack_to_riscv.py
@@ -1,0 +1,82 @@
+from xdsl.builder import Builder
+from xdsl.context import Context
+from xdsl.dialects import riscv_func, rv32
+from xdsl.dialects.builtin import ModuleOp
+from xdsl.dialects.riscv.ops import AddiOp, LwOp, SwOp
+from xdsl.dialects.riscv.registers import IntRegisterType, Registers
+from xdsl.dialects.riscv.stack import AllocaOp, LoadOp, StoreOp
+from xdsl.ir import Attribute, Use
+from xdsl.passes import ModulePass
+from xdsl.rewriter import InsertPoint, Rewriter
+from xdsl.utils.exceptions import PassFailedException
+
+
+def get_type_size(value_type: Attribute):
+    return 4
+
+
+class ConvertRiscvStackToRiscvPass(ModulePass):
+    name = "convert-riscv-stack-to-riscv"
+
+    def apply(self, ctx: Context, op: ModuleOp) -> None:
+        for func_op in op.walk():
+            if not isinstance(func_op, riscv_func.FuncOp):
+                continue
+
+            cur_offset = 0
+            # Need to instantiate generator so erasing op doesn't stop iteration
+            alloca_ops = tuple(op for op in func_op.walk() if isinstance(op, AllocaOp))
+            # For each function, give each alloca its stack offset
+            for alloca_op in alloca_ops:
+                stack_slot = alloca_op.ref.type
+                assert isinstance(stack_slot.value_type, IntRegisterType)
+                value_size = get_type_size(stack_slot.value_type)
+
+                for use in alloca_op.ref.uses:
+                    self.rewrite_stack_slot_use(use, cur_offset)
+
+                Rewriter.erase_op(alloca_op)
+                cur_offset += value_size
+
+            # Adjust stack pointer
+            self.insert_prologue_epilogue(cur_offset, func_op)
+
+    def rewrite_stack_slot_use(self, use: Use, stack_offset: int):
+        if isinstance(use.operation, StoreOp):
+            Rewriter.replace_op(
+                use.operation,
+                (
+                    stack_ptr := rv32.GetRegisterOp(Registers.SP),
+                    SwOp(stack_ptr, use.operation.rs, stack_offset),
+                ),
+            )
+        elif isinstance(use.operation, LoadOp):
+            assert isinstance(use.operation.rd.type, IntRegisterType)
+            Rewriter.replace_op(
+                use.operation,
+                (
+                    stack_ptr := rv32.GetRegisterOp(Registers.SP),
+                    LwOp(stack_ptr, stack_offset, rd=use.operation.rd.type),
+                ),
+            )
+        else:
+            raise PassFailedException("Invalid use of StackSlotType: ", use.operation)
+
+    def insert_prologue_epilogue(self, total_offset: int, func_op: riscv_func.FuncOp):
+        # Align SP to 16 bytes (from RISC-V calling convention)
+        total_offset = (total_offset + 15) & ~15
+
+        if total_offset > 0:
+            # prologue
+            builder = Builder(InsertPoint.at_start(func_op.body.blocks[0]))
+            builder.insert(stack_ptr := rv32.GetRegisterOp(Registers.SP))
+            builder.insert(AddiOp(stack_ptr, -total_offset, rd=Registers.SP))
+            # epilogue
+            # using logic from prologue_epilogue_insertion.py
+            for block in func_op.body.blocks:
+                ret_op = block.last_op
+                if not isinstance(ret_op, riscv_func.ReturnOp):
+                    continue
+
+                builder = Builder(InsertPoint.before(ret_op))
+                builder.insert(AddiOp(stack_ptr, total_offset, rd=Registers.SP))

--- a/xdsl/backend/riscv/lowering/convert_riscv_stack_to_riscv.py
+++ b/xdsl/backend/riscv/lowering/convert_riscv_stack_to_riscv.py
@@ -1,18 +1,22 @@
 from xdsl.builder import Builder
 from xdsl.context import Context
 from xdsl.dialects import riscv_func, rv32
-from xdsl.dialects.builtin import IntegerType, ModuleOp
-from xdsl.dialects.riscv.ops import AddiOp, LwOp, SwOp
-from xdsl.dialects.riscv.registers import IntRegisterType, Registers
+from xdsl.dialects.builtin import FixedBitwidthType, IntegerType, ModuleOp
+from xdsl.dialects.riscv.ops import AddiOp, FLdOp, FSdOp, LwOp, SwOp
+from xdsl.dialects.riscv.registers import FloatRegisterType, IntRegisterType, Registers
 from xdsl.dialects.riscv.stack import AllocaOp, LoadOp, StoreOp
-from xdsl.ir import Attribute, Use
+from xdsl.ir import Use
 from xdsl.passes import ModulePass
 from xdsl.rewriter import InsertPoint, Rewriter
 from xdsl.utils.exceptions import PassFailedException
 
 
-def get_type_size(value_type: Attribute):
-    return 4
+def get_type_size(value_type: FixedBitwidthType):
+    # For now, assume 32 bit ints and 64 bit floats
+    if isinstance(value_type, IntegerType):
+        return 4
+    else:
+        return 8
 
 
 class ConvertRiscvStackToRiscvPass(ModulePass):
@@ -29,11 +33,10 @@ class ConvertRiscvStackToRiscvPass(ModulePass):
             # For each function, give each alloca its stack offset
             for alloca_op in alloca_ops:
                 stack_slot = alloca_op.ref.type
-                assert isinstance(stack_slot.value_type, IntegerType)
                 value_size = get_type_size(stack_slot.value_type)
 
                 for use in alloca_op.ref.uses:
-                    self.rewrite_stack_slot_use(use, cur_offset)
+                    self.rewrite_stack_slot_use(use, cur_offset, stack_slot.value_type)
 
                 Rewriter.erase_op(alloca_op)
                 cur_offset += value_size
@@ -41,24 +44,47 @@ class ConvertRiscvStackToRiscvPass(ModulePass):
             # Adjust stack pointer
             self.insert_prologue_epilogue(cur_offset, func_op)
 
-    def rewrite_stack_slot_use(self, use: Use, stack_offset: int):
+    def rewrite_stack_slot_use(
+        self, use: Use, stack_offset: int, val_type: FixedBitwidthType
+    ):
         if isinstance(use.operation, StoreOp):
-            Rewriter.replace_op(
-                use.operation,
-                (
-                    stack_ptr := rv32.GetRegisterOp(Registers.SP),
-                    SwOp(stack_ptr, use.operation.rs, stack_offset),
-                ),
-            )
+            if isinstance(val_type, IntegerType):
+                Rewriter.replace_op(
+                    use.operation,
+                    (
+                        stack_ptr := rv32.GetRegisterOp(Registers.SP),
+                        SwOp(stack_ptr, use.operation.rs, stack_offset),
+                    ),
+                )
+            else:
+                Rewriter.replace_op(
+                    use.operation,
+                    (
+                        stack_ptr := rv32.GetRegisterOp(Registers.SP),
+                        FSdOp(stack_ptr, use.operation.rs, stack_offset),
+                    ),
+                )
+
         elif isinstance(use.operation, LoadOp):
-            assert isinstance(use.operation.rd.type, IntRegisterType)
-            Rewriter.replace_op(
-                use.operation,
-                (
-                    stack_ptr := rv32.GetRegisterOp(Registers.SP),
-                    LwOp(stack_ptr, stack_offset, rd=use.operation.rd.type),
-                ),
-            )
+            if isinstance(val_type, IntegerType):
+                assert isinstance(use.operation.rd.type, IntRegisterType)
+                Rewriter.replace_op(
+                    use.operation,
+                    (
+                        stack_ptr := rv32.GetRegisterOp(Registers.SP),
+                        LwOp(stack_ptr, stack_offset, rd=use.operation.rd.type),
+                    ),
+                )
+            else:
+                assert isinstance(use.operation.rd.type, FloatRegisterType)
+                Rewriter.replace_op(
+                    use.operation,
+                    (
+                        stack_ptr := rv32.GetRegisterOp(Registers.SP),
+                        FLdOp(stack_ptr, stack_offset, rd=use.operation.rd.type),
+                    ),
+                )
+
         else:
             raise PassFailedException("Invalid use of StackSlotType: ", use.operation)
 

--- a/xdsl/backend/riscv/lowering/convert_riscv_stack_to_riscv.py
+++ b/xdsl/backend/riscv/lowering/convert_riscv_stack_to_riscv.py
@@ -14,7 +14,6 @@ from xdsl.utils.exceptions import PassFailedException
 
 
 def get_type_size(value_type: FixedBitwidthType):
-    # Use match case for now, should be a better way
     return (value_type.bitwidth + 7) // 8
 
 

--- a/xdsl/backend/riscv/lowering/convert_riscv_stack_to_riscv.py
+++ b/xdsl/backend/riscv/lowering/convert_riscv_stack_to_riscv.py
@@ -12,11 +12,8 @@ from xdsl.utils.exceptions import PassFailedException
 
 
 def get_type_size(value_type: FixedBitwidthType):
-    # For now, assume 32 bit ints and 64 bit floats
-    if isinstance(value_type, IntegerType):
-        return 4
-    else:
-        return 8
+    # Use match case for now, should be a better way
+    return (value_type.bitwidth + 7) // 8
 
 
 class ConvertRiscvStackToRiscvPass(ModulePass):

--- a/xdsl/backend/riscv/lowering/convert_riscv_stack_to_riscv.py
+++ b/xdsl/backend/riscv/lowering/convert_riscv_stack_to_riscv.py
@@ -30,39 +30,46 @@ class ConvertRiscvStackToRiscvPass(ModulePass):
             cur_offset = 0
             # Need to instantiate generator so erasing op doesn't stop iteration
             alloca_ops = tuple(op for op in func_op.walk() if isinstance(op, AllocaOp))
+
+            if not alloca_ops:
+                return
+
+            stack_ptr = rv32.GetRegisterOp(
+                Registers.SP
+            )  # inserted in insert_prologue_epilogue
             # For each function, give each alloca its stack offset
             for alloca_op in alloca_ops:
                 stack_slot = alloca_op.ref.type
                 value_size = get_type_size(stack_slot.value_type)
 
                 for use in alloca_op.ref.uses:
-                    self.rewrite_stack_slot_use(use, cur_offset, stack_slot.value_type)
+                    self.rewrite_stack_slot_use(
+                        use, cur_offset, stack_slot.value_type, stack_ptr
+                    )
 
                 Rewriter.erase_op(alloca_op)
                 cur_offset += value_size
 
             # Adjust stack pointer
-            self.insert_prologue_epilogue(cur_offset, func_op)
+            self.insert_prologue_epilogue(cur_offset, func_op, stack_ptr)
 
     def rewrite_stack_slot_use(
-        self, use: Use, stack_offset: int, val_type: FixedBitwidthType
+        self,
+        use: Use,
+        stack_offset: int,
+        val_type: FixedBitwidthType,
+        stack_ptr: rv32.GetRegisterOp,
     ):
         if isinstance(use.operation, StoreOp):
             if isinstance(val_type, IntegerType):
                 Rewriter.replace_op(
                     use.operation,
-                    (
-                        stack_ptr := rv32.GetRegisterOp(Registers.SP),
-                        SwOp(stack_ptr, use.operation.rs, stack_offset),
-                    ),
+                    (SwOp(stack_ptr, use.operation.rs, stack_offset),),
                 )
             else:
                 Rewriter.replace_op(
                     use.operation,
-                    (
-                        stack_ptr := rv32.GetRegisterOp(Registers.SP),
-                        FSdOp(stack_ptr, use.operation.rs, stack_offset),
-                    ),
+                    (FSdOp(stack_ptr, use.operation.rs, stack_offset),),
                 )
 
         elif isinstance(use.operation, LoadOp):
@@ -70,32 +77,31 @@ class ConvertRiscvStackToRiscvPass(ModulePass):
                 assert isinstance(use.operation.rd.type, IntRegisterType)
                 Rewriter.replace_op(
                     use.operation,
-                    (
-                        stack_ptr := rv32.GetRegisterOp(Registers.SP),
-                        LwOp(stack_ptr, stack_offset, rd=use.operation.rd.type),
-                    ),
+                    (LwOp(stack_ptr, stack_offset, rd=use.operation.rd.type),),
                 )
             else:
                 assert isinstance(use.operation.rd.type, FloatRegisterType)
                 Rewriter.replace_op(
                     use.operation,
-                    (
-                        stack_ptr := rv32.GetRegisterOp(Registers.SP),
-                        FLdOp(stack_ptr, stack_offset, rd=use.operation.rd.type),
-                    ),
+                    (FLdOp(stack_ptr, stack_offset, rd=use.operation.rd.type),),
                 )
 
         else:
             raise PassFailedException("Invalid use of StackSlotType: ", use.operation)
 
-    def insert_prologue_epilogue(self, total_offset: int, func_op: riscv_func.FuncOp):
+    def insert_prologue_epilogue(
+        self,
+        total_offset: int,
+        func_op: riscv_func.FuncOp,
+        stack_ptr: rv32.GetRegisterOp,
+    ):
         # Align SP to 16 bytes (from RISC-V calling convention)
         total_offset = (total_offset + 15) & ~15
 
         if total_offset > 0:
             # prologue
             builder = Builder(InsertPoint.at_start(func_op.body.blocks[0]))
-            builder.insert(stack_ptr := rv32.GetRegisterOp(Registers.SP))
+            builder.insert(stack_ptr)
             builder.insert(AddiOp(stack_ptr, -total_offset, rd=Registers.SP))
             # epilogue
             # using logic from prologue_epilogue_insertion.py

--- a/xdsl/backend/riscv/prologue_epilogue_insertion.py
+++ b/xdsl/backend/riscv/prologue_epilogue_insertion.py
@@ -49,7 +49,7 @@ class PrologueEpilogueInsertion(ModulePass):
 
         # Build the prologue at the beginning of the function.
         builder = Builder(InsertPoint.at_start(func.body.blocks[0]))
-        memrefs = []
+        memrefs: list[AllocaOp] = []
         for reg in used_callee_preserved_registers:
             if isinstance(reg, IntRegisterType):
                 alloca_op = builder.insert(AllocaOp(builtin.i32))

--- a/xdsl/backend/riscv/prologue_epilogue_insertion.py
+++ b/xdsl/backend/riscv/prologue_epilogue_insertion.py
@@ -9,8 +9,8 @@ from xdsl.dialects.riscv import (
     FloatRegisterType,
     IntRegisterType,
     Registers,
-    RISCVRegisterType,
 )
+from xdsl.dialects.riscv.stack import AllocaOp, LoadOp, StoreOp
 from xdsl.passes import ModulePass
 
 
@@ -47,27 +47,26 @@ class PrologueEpilogueInsertion(ModulePass):
         if not used_callee_preserved_registers:
             return
 
-        def get_register_size(r: RISCVRegisterType):
-            if isinstance(r, IntRegisterType):
-                return self.xlen
-            return self.flen
-
         # Build the prologue at the beginning of the function.
         builder = Builder(InsertPoint.at_start(func.body.blocks[0]))
-        sp_register = builder.insert(rv32.GetRegisterOp(Registers.SP))
-        stack_size = sum(get_register_size(r) for r in used_callee_preserved_registers)
-        builder.insert(riscv.AddiOp(sp_register, -stack_size, rd=Registers.SP))
-        offset = 0
+        memrefs = []
         for reg in used_callee_preserved_registers:
             if isinstance(reg, IntRegisterType):
+                alloca_op = builder.insert(AllocaOp(builtin.i32))
                 reg_op = builder.insert(rv32.GetRegisterOp(reg))
-                op = riscv.SwOp(rs1=sp_register, rs2=reg_op, immediate=offset)
             else:
-                reg_op = builder.insert(riscv.GetFloatRegisterOp(reg))
-                op = riscv.FSdOp(rs1=sp_register, rs2=reg_op, immediate=offset)
+                match self.flen:
+                    case 8:
+                        float_size = builtin.f64
+                    case 4:
+                        float_size = builtin.f32
+                    case _:
+                        raise NotImplementedError("flen must be 4 or 8")
 
-            builder.insert(op)
-            offset += get_register_size(reg)
+                alloca_op = builder.insert(AllocaOp(float_size))
+                reg_op = builder.insert(riscv.GetFloatRegisterOp(reg))
+            builder.insert(StoreOp(alloca_op, reg_op))
+            memrefs.append(alloca_op)
 
         # Now build the epilogue right before every return operation.
         for block in func.body.blocks:
@@ -76,16 +75,8 @@ class PrologueEpilogueInsertion(ModulePass):
                 continue
 
             builder = Builder(InsertPoint.before(ret_op))
-            offset = 0
-            for reg in used_callee_preserved_registers:
-                if isinstance(reg, IntRegisterType):
-                    op = riscv.LwOp(rs1=sp_register, rd=reg, immediate=offset)
-                else:
-                    op = riscv.FLdOp(rs1=sp_register, rd=reg, immediate=offset)
-                builder.insert(op)
-                offset += get_register_size(reg)
-
-            builder.insert(riscv.AddiOp(sp_register, stack_size, rd=Registers.SP))
+            for memref, reg in zip(memrefs, used_callee_preserved_registers):
+                builder.insert(LoadOp(memref, rd=reg))
 
     def apply(self, ctx: Context, op: builtin.ModuleOp) -> None:
         for func in op.walk():

--- a/xdsl/dialects/__init__.py
+++ b/xdsl/dialects/__init__.py
@@ -283,6 +283,11 @@ def get_all_dialects() -> dict[str, Callable[[], Dialect]]:
 
         return RISCV_Snitch
 
+    def get_riscv_stack():
+        from xdsl.dialects.riscv.stack import RISCVStack
+
+        return RISCVStack
+
     def get_scf():
         from xdsl.dialects.scf import Scf
 
@@ -439,6 +444,7 @@ def get_all_dialects() -> dict[str, Callable[[], Dialect]]:
         "riscv_scf": get_riscv_scf,
         "riscv_cf": get_riscv_cf,
         "riscv_snitch": get_riscv_snitch,
+        "riscv_stack": get_riscv_stack,
         "scf": get_scf,
         "seq": get_seq,
         "shard": get_shard,

--- a/xdsl/dialects/riscv/__init__.py
+++ b/xdsl/dialects/riscv/__init__.py
@@ -9,6 +9,7 @@ from xdsl.ir import Dialect
 
 # The imports with re-export are to preserve the API of the dialect, as it was when it
 # was a single file. They will be deprecated and removed in the future.
+from . import stack as stack
 from .abstract_ops import (
     AssemblyInstructionArg as AssemblyInstructionArg,
 )

--- a/xdsl/dialects/riscv/stack.py
+++ b/xdsl/dialects/riscv/stack.py
@@ -5,14 +5,13 @@ from typing import ClassVar, Generic
 from typing_extensions import TypeVar
 
 from xdsl.dialects.builtin import Attribute, ContainerType
-from xdsl.ir import Dialect, ParametrizedAttribute, SSAValue, TypeAttribute
+from xdsl.ir import Dialect, Operation, ParametrizedAttribute, SSAValue, TypeAttribute
 from xdsl.irdl import (
     AnyAttr,
     AttrConstraint,
     IRDLAttrConstraint,
     IRDLOperation,
     ParamAttrConstraint,
-    TypeVarConstraint,
     VarConstraint,
     irdl_attr_definition,
     irdl_op_definition,
@@ -33,8 +32,6 @@ class StackSlotType(
     Generic[_StackValueType],
 ):
     name = "riscv_stack.ptr"
-
-    _StackTypeConstr = TypeVarConstraint(_StackValueType, AnyAttr())
     value_type: _StackValueType
 
     def __init__(self, value_type: _StackValueType):
@@ -74,15 +71,16 @@ class StoreOp(IRDLOperation):
 
     _T: ClassVar = VarConstraint("_T", AnyAttr())
     ptr = operand_def(StackSlotType.constr(_T))
-    value = operand_def(_T)
+    rs = operand_def(_T)
 
     def __init__(
         self,
-        ptr: SSAValue[StackSlotType[_StackValueType]],
-        value: SSAValue[_StackValueType],
+        ptr: SSAValue[StackSlotType[_StackValueType]] | AllocaOp,
+        value: SSAValue[_StackValueType] | Operation,
     ):
+        ptr_val = ptr.ref if isinstance(ptr, AllocaOp) else ptr
         super().__init__(
-            operands=(ptr, value),
+            operands=(ptr_val, value),
         )
 
 
@@ -94,10 +92,11 @@ class LoadOp(IRDLOperation):
 
     _T: ClassVar = VarConstraint("_T", AnyAttr())
     ptr = operand_def(StackSlotType.constr(_T))
-    res = result_def(_T)
+    rd = result_def(_T)
 
-    def __init__(self, ptr: SSAValue[StackSlotType]):
-        super().__init__(operands=(ptr,), result_types=[ptr.type.value_type])
+    def __init__(self, ptr: SSAValue[StackSlotType] | AllocaOp):
+        ptr_val = ptr.ref if isinstance(ptr, AllocaOp) else ptr
+        super().__init__(operands=(ptr,), result_types=[ptr_val.type.value_type])
 
 
 # Define the Dialect

--- a/xdsl/dialects/riscv/stack.py
+++ b/xdsl/dialects/riscv/stack.py
@@ -4,10 +4,10 @@ from xdsl.dialects.builtin import (
     FixedBitwidthType,
     IntegerType,
 )
+from xdsl.dialects.riscv.abstract_ops import RISCVCustomFormatOperation
 from xdsl.dialects.riscv.registers import Registers, RISCVRegisterType
 from xdsl.ir import Dialect, Operation, ParametrizedAttribute, SSAValue, TypeAttribute
 from xdsl.irdl import (
-    IRDLOperation,
     irdl_attr_definition,
     irdl_op_definition,
     operand_def,
@@ -32,7 +32,7 @@ class StackSlotType(
 
 
 @irdl_op_definition
-class AllocaOp(IRDLOperation):
+class AllocaOp(RISCVCustomFormatOperation):
     """Allocates space on the stack."""
 
     name = "riscv_stack.alloca"
@@ -46,7 +46,7 @@ class AllocaOp(IRDLOperation):
 
 
 @irdl_op_definition
-class StoreOp(IRDLOperation):
+class StoreOp(RISCVCustomFormatOperation):
     """Stores a value into a stack pointer."""
 
     name = "riscv_stack.store"
@@ -66,7 +66,7 @@ class StoreOp(IRDLOperation):
 
 
 @irdl_op_definition
-class LoadOp(IRDLOperation):
+class LoadOp(RISCVCustomFormatOperation):
     """Loads a value from a stack-allocated slot."""
 
     name = "riscv_stack.load"

--- a/xdsl/dialects/riscv/stack.py
+++ b/xdsl/dialects/riscv/stack.py
@@ -1,26 +1,17 @@
-from __future__ import annotations
-
-from typing import ClassVar, Generic
-
-from typing_extensions import TypeVar
-
-from xdsl.dialects.builtin import Attribute, ContainerType
+from xdsl.dialects.builtin import (
+    AnyFloat,
+    ContainerType,
+    FixedBitwidthType,
+    IntegerType,
+)
+from xdsl.dialects.riscv.registers import Registers, RISCVRegisterType
 from xdsl.ir import Dialect, Operation, ParametrizedAttribute, SSAValue, TypeAttribute
 from xdsl.irdl import (
-    AnyAttr,
-    AttrConstraint,
-    IRDLAttrConstraint,
     IRDLOperation,
-    ParamAttrConstraint,
-    VarConstraint,
     irdl_attr_definition,
     irdl_op_definition,
     operand_def,
     result_def,
-)
-
-_StackValueType = TypeVar(
-    "_StackValueType", bound=Attribute, covariant=True, default=Attribute
 )
 
 
@@ -28,25 +19,16 @@ _StackValueType = TypeVar(
 class StackSlotType(
     ParametrizedAttribute,
     TypeAttribute,
-    ContainerType[_StackValueType],
-    Generic[_StackValueType],
+    ContainerType[FixedBitwidthType],
 ):
     name = "riscv_stack.ptr"
-    value_type: _StackValueType
+    value_type: FixedBitwidthType
 
-    def __init__(self, value_type: _StackValueType):
+    def __init__(self, value_type: FixedBitwidthType):
         super().__init__(value_type)
 
-    def get_element_type(self) -> _StackValueType:
+    def get_element_type(self) -> FixedBitwidthType:
         return self.value_type
-
-    @staticmethod
-    def constr(
-        element_type: IRDLAttrConstraint[_StackValueType] = AnyAttr(),
-    ) -> AttrConstraint[StackSlotType[_StackValueType]]:
-        return ParamAttrConstraint[StackSlotType[_StackValueType]](
-            StackSlotType, (element_type,)
-        )
 
 
 @irdl_op_definition
@@ -57,7 +39,7 @@ class AllocaOp(IRDLOperation):
 
     ref = result_def(StackSlotType)
 
-    def __init__(self, value_type: Attribute):
+    def __init__(self, value_type: FixedBitwidthType):
         super().__init__(
             result_types=(StackSlotType(value_type),),
         )
@@ -69,14 +51,13 @@ class StoreOp(IRDLOperation):
 
     name = "riscv_stack.store"
 
-    _T: ClassVar = VarConstraint("_T", AnyAttr())
-    ptr = operand_def(StackSlotType.constr(_T))
-    rs = operand_def(_T)
+    ptr = operand_def(StackSlotType)
+    rs = operand_def(RISCVRegisterType)
 
     def __init__(
         self,
-        ptr: SSAValue[StackSlotType[_StackValueType]] | AllocaOp,
-        value: SSAValue[_StackValueType] | Operation,
+        ptr: SSAValue[StackSlotType] | AllocaOp,
+        value: SSAValue | Operation,
     ):
         ptr_val = ptr.ref if isinstance(ptr, AllocaOp) else ptr
         super().__init__(
@@ -90,13 +71,21 @@ class LoadOp(IRDLOperation):
 
     name = "riscv_stack.load"
 
-    _T: ClassVar = VarConstraint("_T", AnyAttr())
-    ptr = operand_def(StackSlotType.constr(_T))
-    rd = result_def(_T)
+    ptr = operand_def(StackSlotType)
+    rd = result_def(RISCVRegisterType)
 
-    def __init__(self, ptr: SSAValue[StackSlotType] | AllocaOp):
+    def __init__(
+        self,
+        ptr: SSAValue[StackSlotType] | AllocaOp,
+        rd: RISCVRegisterType | None = None,
+    ):
         ptr_val = ptr.ref if isinstance(ptr, AllocaOp) else ptr
-        super().__init__(operands=(ptr,), result_types=[ptr_val.type.value_type])
+        if rd is None:
+            if isinstance(ptr_val.type.value_type, AnyFloat):
+                rd = Registers.UNALLOCATED_FLOAT
+            elif isinstance(ptr_val.type.value_type, IntegerType):
+                rd = Registers.UNALLOCATED_INT
+        super().__init__(operands=(ptr,), result_types=[rd])
 
 
 # Define the Dialect

--- a/xdsl/dialects/riscv/stack.py
+++ b/xdsl/dialects/riscv/stack.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from typing import ClassVar, Generic
+
+from typing_extensions import TypeVar
+
+from xdsl.dialects.builtin import Attribute, ContainerType
+from xdsl.ir import Dialect, ParametrizedAttribute, SSAValue, TypeAttribute
+from xdsl.irdl import (
+    AnyAttr,
+    AttrConstraint,
+    IRDLAttrConstraint,
+    IRDLOperation,
+    ParamAttrConstraint,
+    TypeVarConstraint,
+    VarConstraint,
+    irdl_attr_definition,
+    irdl_op_definition,
+    operand_def,
+    result_def,
+)
+
+_StackValueType = TypeVar(
+    "_StackValueType", bound=Attribute, covariant=True, default=Attribute
+)
+
+
+@irdl_attr_definition
+class StackSlotType(
+    ParametrizedAttribute,
+    TypeAttribute,
+    ContainerType[_StackValueType],
+    Generic[_StackValueType],
+):
+    name = "riscv_stack.ptr"
+
+    _StackTypeConstr = TypeVarConstraint(_StackValueType, AnyAttr())
+    value_type: _StackValueType
+
+    def __init__(self, value_type: _StackValueType):
+        super().__init__(value_type)
+
+    def get_element_type(self) -> _StackValueType:
+        return self.value_type
+
+    @staticmethod
+    def constr(
+        element_type: IRDLAttrConstraint[_StackValueType] = AnyAttr(),
+    ) -> AttrConstraint[StackSlotType[_StackValueType]]:
+        return ParamAttrConstraint[StackSlotType[_StackValueType]](
+            StackSlotType, (element_type,)
+        )
+
+
+@irdl_op_definition
+class AllocaOp(IRDLOperation):
+    """Allocates space on the stack."""
+
+    name = "riscv_stack.alloca"
+
+    ref = result_def(StackSlotType)
+
+    def __init__(self, value_type: Attribute):
+        super().__init__(
+            result_types=(StackSlotType(value_type),),
+        )
+
+
+@irdl_op_definition
+class StoreOp(IRDLOperation):
+    """Stores a value into a stack pointer."""
+
+    name = "riscv_stack.store"
+
+    _T: ClassVar = VarConstraint("_T", AnyAttr())
+    ptr = operand_def(StackSlotType.constr(_T))
+    value = operand_def(_T)
+
+    def __init__(
+        self,
+        ptr: SSAValue[StackSlotType[_StackValueType]],
+        value: SSAValue[_StackValueType],
+    ):
+        super().__init__(
+            operands=(ptr, value),
+        )
+
+
+@irdl_op_definition
+class LoadOp(IRDLOperation):
+    """Loads a value from a stack-allocated slot."""
+
+    name = "riscv_stack.load"
+
+    _T: ClassVar = VarConstraint("_T", AnyAttr())
+    ptr = operand_def(StackSlotType.constr(_T))
+    res = result_def(_T)
+
+    def __init__(self, ptr: SSAValue[StackSlotType]):
+        super().__init__(operands=(ptr,), result_types=[ptr.type.value_type])
+
+
+# Define the Dialect
+RISCVStack = Dialect(
+    "riscv_stack",
+    [
+        AllocaOp,
+        StoreOp,
+        LoadOp,
+    ],
+    [
+        StackSlotType,
+    ],
+)

--- a/xdsl/transforms/__init__.py
+++ b/xdsl/transforms/__init__.py
@@ -175,6 +175,11 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
 
         return convert_riscv_scf_to_riscv_cf.ConvertRiscvScfToRiscvCfPass
 
+    def get_convert_riscv_stack_to_riscv():
+        from xdsl.backend.riscv.lowering import convert_riscv_stack_to_riscv
+
+        return convert_riscv_stack_to_riscv.ConvertRiscvStackToRiscvPass()
+
     def get_convert_riscv_to_llvm():
         from xdsl.transforms import convert_riscv_to_llvm
 
@@ -698,6 +703,7 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
         "convert-ptr-to-x86": get_convert_ptr_to_x86,
         "convert-riscv-scf-for-to-frep": get_convert_riscv_scf_for_to_frep,
         "convert-riscv-scf-to-riscv-cf": get_convert_riscv_scf_to_riscv_cf,
+        "convert-riscv-stack-to-riscv": get_convert_riscv_stack_to_riscv,
         "convert-riscv-to-llvm": get_convert_riscv_to_llvm,
         "convert-scf-to-cf": get_convert_scf_to_cf,
         "convert-scf-to-openmp": get_convert_scf_to_openmp,

--- a/xdsl/transforms/__init__.py
+++ b/xdsl/transforms/__init__.py
@@ -610,6 +610,11 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
 
         return test_lower_linalg_to_snitch.TestLowerLinalgToSnitchPass
 
+    def get_test_riscv_spilling():
+        from xdsl.transforms import test_riscv_spilling
+
+        return test_riscv_spilling.TestRiscvSpillingPass
+
     def get_test_specialised_constant_folding():
         from xdsl.transforms import test_constant_folding
 
@@ -790,6 +795,7 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
         "test-add-timers-to-top-level-funcs": get_test_add_timers_to_top_level_funcs,
         "test-constant-folding": get_test_constant_folding,
         "test-lower-linalg-to-snitch": get_test_lower_linalg_to_snitch,
+        "test-riscv-spilling": get_test_riscv_spilling,
         "test-specialised-constant-folding": get_test_specialised_constant_folding,
         "test-transform-dialect-erase-schedule": get_test_transform_dialect_erase_schedule,
         "test-vectorize-matmul": get_test_vectorize_matmul,

--- a/xdsl/transforms/__init__.py
+++ b/xdsl/transforms/__init__.py
@@ -178,7 +178,7 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
     def get_convert_riscv_stack_to_riscv():
         from xdsl.backend.riscv.lowering import convert_riscv_stack_to_riscv
 
-        return convert_riscv_stack_to_riscv.ConvertRiscvStackToRiscvPass()
+        return convert_riscv_stack_to_riscv.ConvertRiscvStackToRiscvPass
 
     def get_convert_riscv_to_llvm():
         from xdsl.transforms import convert_riscv_to_llvm

--- a/xdsl/transforms/riscv_allocate_registers_spilling.py
+++ b/xdsl/transforms/riscv_allocate_registers_spilling.py
@@ -1,4 +1,3 @@
-import typing as t
 from dataclasses import dataclass
 from itertools import islice
 
@@ -7,15 +6,46 @@ from ordered_set import OrderedSet
 from xdsl.backend.riscv.register_stack import RiscvRegisterStack
 from xdsl.context import Context
 from xdsl.dialects import builtin, riscv_func
-from xdsl.dialects.riscv.registers import IntRegisterType
-from xdsl.ir import Operation, SSAValue
+from xdsl.dialects.riscv.registers import IntRegisterType, Registers
+from xdsl.ir import Operation, ParametrizedAttribute, SSAValue
+from xdsl.irdl import (
+    IRDLOperation,
+    irdl_attr_definition,
+    irdl_op_definition,
+    operand_def,
+    result_def,
+)
 from xdsl.passes import ModulePass
+from xdsl.rewriter import InsertPoint, Rewriter
+
+
+@irdl_attr_definition
+class SpillType(ParametrizedAttribute):
+    name = "spilling.type"
+
+
+@irdl_op_definition
+class SpillOp(IRDLOperation):
+    name = "spilling.spill_op"
+    value = operand_def()
+    result = result_def(SpillType())
+
+    def __init__(self, val):
+        super().__init__(operands=[val], result_types=[SpillType()])
+
+
+@irdl_op_definition
+class LoadOp(IRDLOperation):
+    name = "spilling.load_op"
+    value = operand_def(SpillType())
+    result = result_def()
+
+    def __init__(self, val):
+        super().__init__(operands=[val], result_types=[Registers.UNALLOCATED_INT])
 
 
 @dataclass(frozen=True)
-class RISCVSpillingPass(ModulePass):
-    name = "riscv-allocate-infinite-registers-spilling"
-
+class SpillPass(ModulePass):
     def apply(self, ctx: Context, op: builtin.ModuleOp) -> None:
         for func_op in op.walk():
             if isinstance(func_op, riscv_func.FuncOp):
@@ -45,7 +75,8 @@ class RISCVSpillingPass(ModulePass):
 
                         self.insert_spill(inner_op, regs_to_spill)
                         loaded_values -= regs_to_spill
-                    loaded_values |= uses
+                    loaded_uses = self.insert_load(inner_op, uses - loaded_values)
+                    loaded_values |= loaded_uses
 
                     # Remove dead values from live set
                     loaded_values -= die[inner_op]
@@ -65,8 +96,38 @@ class RISCVSpillingPass(ModulePass):
                         loaded_values -= regs_to_spill
                     loaded_values |= defns
 
-    def insert_spill(self, inner_op: Operation, regs_to_spill: t.Iterable[SSAValue]):
-        pass
+    def insert_spill(self, inner_op: Operation, spills: OrderedSet[SSAValue]):
+        """Insert spills before inner_op."""
+        if not spills:
+            return
+
+        spill_ops = tuple(SpillOp(spill_val) for spill_val in spills)
+        for spill_op in spill_ops:
+            Rewriter.insert_op(spill_op, InsertPoint.before(inner_op))
+        # change all uses after pmov_op to results of pmov
+        for src, spill_op in zip(spills, spill_ops):
+            dst = spill_op.result
+            src.replace_uses_with_if(
+                dst, lambda use: spill_op.is_before_in_block(use.operation)
+            )
+
+    def insert_load(
+        self, inner_op: Operation, loads: OrderedSet[SSAValue]
+    ) -> OrderedSet[SSAValue]:
+        """Insert loads before inner_op."""
+        if not loads:
+            return OrderedSet([])
+
+        load_ops = tuple(LoadOp(load_val) for load_val in loads)
+        for load_op in load_ops:
+            Rewriter.insert_op(load_op, InsertPoint.before(inner_op))
+        # change all uses after pmov_op to results of pmov
+        for src, load_op in zip(loads, load_ops):
+            dst = load_op.result
+            src.replace_uses_with_if(
+                dst, lambda use: load_op.is_before_in_block(use.operation)
+            )
+        return OrderedSet(i.result for i in load_ops)
 
     def get_die_set(self, func_op: riscv_func.FuncOp):
         """Create set of values that die at each operation."""

--- a/xdsl/transforms/riscv_allocate_registers_spilling.py
+++ b/xdsl/transforms/riscv_allocate_registers_spilling.py
@@ -48,53 +48,50 @@ class LoadOp(IRDLOperation):
 class SpillPass(ModulePass):
     def apply(self, ctx: Context, op: builtin.ModuleOp) -> None:
         for func_op in op.walk():
-            if isinstance(func_op, riscv_func.FuncOp):
-                # Assume for now we only have integer regs
-                total_regs = len(
-                    RiscvRegisterStack.get().available_registers[IntRegisterType.name]
-                )
-                loaded_values = OrderedSet[SSAValue]([])
+            if not isinstance(func_op, riscv_func.FuncOp):
+                continue
+            # Assume for now we only have integer regs
+            total_regs = len(
+                RiscvRegisterStack.get().available_registers[IntRegisterType.name]
+            )
+            loaded_values = OrderedSet[SSAValue]([])
 
-                die = self.get_die_set(func_op)
+            die = self.get_die_set(func_op)
 
-                for inner_op in func_op.walk():
-                    uses = OrderedSet(inner_op.operands)
-                    free_values = iter(
-                        loaded_values - uses
-                    )  # values that we can use to spill
+            for inner_op in func_op.walk():
+                uses = OrderedSet(inner_op.operands)
+                free_values = iter(
+                    loaded_values - uses
+                )  # values that we can use to spill
 
-                    # Process uses
-                    if len(loaded_values | uses) > total_regs:
-                        # spill excess regs
-                        num_regs_to_spill = len(uses | loaded_values) - total_regs
-                        # get registers not used by current op
-                        # TODO: use heuristic to select
-                        regs_to_spill = OrderedSet(
-                            islice(free_values, num_regs_to_spill)
-                        )
+                # Process uses
+                if len(loaded_values | uses) > total_regs:
+                    # spill excess regs
+                    num_regs_to_spill = len(uses | loaded_values) - total_regs
+                    # get registers not used by current op
+                    # TODO: use heuristic to select
+                    regs_to_spill = OrderedSet(islice(free_values, num_regs_to_spill))
 
-                        self.insert_spill(inner_op, regs_to_spill)
-                        loaded_values -= regs_to_spill
-                    loaded_uses = self.insert_load(inner_op, uses - loaded_values)
-                    loaded_values |= loaded_uses
+                    self.insert_spill(inner_op, regs_to_spill)
+                    loaded_values -= regs_to_spill
+                loaded_uses = self.insert_load(inner_op, uses - loaded_values)
+                loaded_values |= loaded_uses
 
-                    # Remove dead values from live set
-                    loaded_values -= die[inner_op]
+                # Remove dead values from live set
+                loaded_values -= die[inner_op]
 
-                    # Process definitions
-                    defns = OrderedSet(inner_op.results)
-                    if len(loaded_values | defns) > total_regs:
-                        # spill excess regs
-                        num_regs_to_spill = len(loaded_values | defns) - total_regs
-                        # get registers not used by current op
-                        # TODO: use heuristic to select
-                        regs_to_spill = OrderedSet(
-                            islice(free_values, num_regs_to_spill)
-                        )
+                # Process definitions
+                defns = OrderedSet(inner_op.results)
+                if len(loaded_values | defns) > total_regs:
+                    # spill excess regs
+                    num_regs_to_spill = len(loaded_values | defns) - total_regs
+                    # get registers not used by current op
+                    # TODO: use heuristic to select
+                    regs_to_spill = OrderedSet(islice(free_values, num_regs_to_spill))
 
-                        self.insert_spill(inner_op, regs_to_spill)
-                        loaded_values -= regs_to_spill
-                    loaded_values |= defns
+                    self.insert_spill(inner_op, regs_to_spill)
+                    loaded_values -= regs_to_spill
+                loaded_values |= defns
 
     def insert_spill(self, inner_op: Operation, spills: OrderedSet[SSAValue]):
         """Insert spills before inner_op."""

--- a/xdsl/transforms/riscv_allocate_registers_spilling.py
+++ b/xdsl/transforms/riscv_allocate_registers_spilling.py
@@ -1,0 +1,74 @@
+import typing as t
+from dataclasses import dataclass
+from itertools import islice
+
+from xdsl.backend.riscv.register_stack import RiscvRegisterStack
+from xdsl.context import Context
+from xdsl.dialects import builtin, riscv_func
+from xdsl.dialects.riscv.registers import IntRegisterType
+from xdsl.ir import Operation, SSAValue
+from xdsl.passes import ModulePass
+
+
+@dataclass(frozen=True)
+class RISCVSpillingPass(ModulePass):
+    name = "riscv-allocate-infinite-registers-spilling"
+
+    def apply(self, ctx: Context, op: builtin.ModuleOp) -> None:
+        for func_op in op.walk():
+            if isinstance(func_op, riscv_func.FuncOp):
+                # Assume for now we only have integer regs
+                total_regs = len(
+                    RiscvRegisterStack.get().available_registers[IntRegisterType.name]
+                )
+                loaded_values = set[SSAValue]()
+
+                die = self.get_die_set(func_op)
+
+                for inner_op in func_op.walk():
+                    uses = set(inner_op.operands)
+                    free_values = iter(
+                        loaded_values - uses
+                    )  # values that we can use to spill
+
+                    # Process uses
+                    if len(loaded_values | uses) > total_regs:
+                        # spill excess regs
+                        num_regs_to_spill = len(uses | loaded_values) - total_regs
+                        # get registers not used by current op
+                        # TODO: use heuristic to select
+                        regs_to_spill = set(islice(free_values, num_regs_to_spill))
+
+                        self.insert_spill(inner_op, regs_to_spill)
+                        loaded_values -= regs_to_spill
+                    loaded_values |= uses
+
+                    # Remove dead values from live set
+                    loaded_values -= die[inner_op]
+
+                    # Process definitions
+                    defns = set(inner_op.results)
+                    if len(loaded_values | defns) > total_regs:
+                        # spill excess regs
+                        num_regs_to_spill = len(loaded_values | defns) - total_regs
+                        # get registers not used by current op
+                        # TODO: use heuristic to select
+                        regs_to_spill = set(islice(free_values, num_regs_to_spill))
+
+                        self.insert_spill(inner_op, regs_to_spill)
+                        loaded_values -= regs_to_spill
+                    loaded_values |= defns
+
+    def insert_spill(self, inner_op: Operation, regs_to_spill: t.Iterable[SSAValue]):
+        pass
+
+    def get_die_set(self, func_op: riscv_func.FuncOp):
+        """Create set of values that die at each operation."""
+        die: dict[Operation, set[SSAValue]] = {}
+        seen_vals = set[SSAValue]()
+        for inner_op in func_op.walk(reverse=True):
+            # by SSA, we can just check if this is the first seen use
+            uses = set(inner_op.operands)
+            die[inner_op] = uses - seen_vals
+            seen_vals |= uses
+        return die

--- a/xdsl/transforms/riscv_allocate_registers_spilling.py
+++ b/xdsl/transforms/riscv_allocate_registers_spilling.py
@@ -2,6 +2,8 @@ import typing as t
 from dataclasses import dataclass
 from itertools import islice
 
+from ordered_set import OrderedSet
+
 from xdsl.backend.riscv.register_stack import RiscvRegisterStack
 from xdsl.context import Context
 from xdsl.dialects import builtin, riscv_func
@@ -21,12 +23,12 @@ class RISCVSpillingPass(ModulePass):
                 total_regs = len(
                     RiscvRegisterStack.get().available_registers[IntRegisterType.name]
                 )
-                loaded_values = set[SSAValue]()
+                loaded_values = OrderedSet[SSAValue]([])
 
                 die = self.get_die_set(func_op)
 
                 for inner_op in func_op.walk():
-                    uses = set(inner_op.operands)
+                    uses = OrderedSet(inner_op.operands)
                     free_values = iter(
                         loaded_values - uses
                     )  # values that we can use to spill
@@ -37,7 +39,9 @@ class RISCVSpillingPass(ModulePass):
                         num_regs_to_spill = len(uses | loaded_values) - total_regs
                         # get registers not used by current op
                         # TODO: use heuristic to select
-                        regs_to_spill = set(islice(free_values, num_regs_to_spill))
+                        regs_to_spill = OrderedSet(
+                            islice(free_values, num_regs_to_spill)
+                        )
 
                         self.insert_spill(inner_op, regs_to_spill)
                         loaded_values -= regs_to_spill
@@ -47,13 +51,15 @@ class RISCVSpillingPass(ModulePass):
                     loaded_values -= die[inner_op]
 
                     # Process definitions
-                    defns = set(inner_op.results)
+                    defns = OrderedSet(inner_op.results)
                     if len(loaded_values | defns) > total_regs:
                         # spill excess regs
                         num_regs_to_spill = len(loaded_values | defns) - total_regs
                         # get registers not used by current op
                         # TODO: use heuristic to select
-                        regs_to_spill = set(islice(free_values, num_regs_to_spill))
+                        regs_to_spill = OrderedSet(
+                            islice(free_values, num_regs_to_spill)
+                        )
 
                         self.insert_spill(inner_op, regs_to_spill)
                         loaded_values -= regs_to_spill

--- a/xdsl/transforms/riscv_allocate_registers_spilling.py
+++ b/xdsl/transforms/riscv_allocate_registers_spilling.py
@@ -6,7 +6,7 @@ from ordered_set import OrderedSet
 from xdsl.backend.riscv.register_stack import RiscvRegisterStack
 from xdsl.context import Context
 from xdsl.dialects import builtin, riscv_func
-from xdsl.dialects.riscv.ops import LwOp, SwOp
+from xdsl.dialects.riscv.ops import AddiOp, LwOp, SwOp
 from xdsl.dialects.riscv.registers import IntRegisterType, Registers
 from xdsl.dialects.rv32 import GetRegisterOp
 from xdsl.ir import Operation, ParametrizedAttribute, SSAValue
@@ -174,3 +174,22 @@ class ResolveSpillingOps(ModulePass):
                 # Use insert/erase since we are dropping the spill_op's result
                 Rewriter.insert_op(store_op, InsertPoint.before(spill_op))
                 Rewriter.erase_op(spill_op)
+
+            # Manage stack pointer
+            # Align stack to 16 bytes
+            stack_size = (offset + 15) & ~15
+            if stack_size > 0:
+                Rewriter.insert_op(
+                    AddiOp(stack_pointer, -stack_size, rd=Registers.SP),
+                    InsertPoint.after(stack_pointer),
+                )
+
+                for block in func_op.body.blocks:
+                    ret_op = block.last_op
+                    if not isinstance(ret_op, riscv_func.ReturnOp):
+                        continue
+
+                    Rewriter.insert_op(
+                        AddiOp(stack_pointer, stack_size, rd=Registers.SP),
+                        InsertPoint.before(ret_op),
+                    )

--- a/xdsl/transforms/riscv_allocate_registers_spilling.py
+++ b/xdsl/transforms/riscv_allocate_registers_spilling.py
@@ -6,7 +6,9 @@ from ordered_set import OrderedSet
 from xdsl.backend.riscv.register_stack import RiscvRegisterStack
 from xdsl.context import Context
 from xdsl.dialects import builtin, riscv_func
+from xdsl.dialects.riscv.ops import LwOp, SwOp
 from xdsl.dialects.riscv.registers import IntRegisterType, Registers
+from xdsl.dialects.rv32 import GetRegisterOp
 from xdsl.ir import Operation, ParametrizedAttribute, SSAValue
 from xdsl.irdl import (
     IRDLOperation,
@@ -136,3 +138,39 @@ class SpillPass(ModulePass):
             die[inner_op] = uses - seen_vals
             seen_vals |= uses
         return die
+
+
+class ResolveSpillingOps(ModulePass):
+    def apply(self, ctx: Context, op: builtin.ModuleOp) -> None:
+        for func_op in op.walk():
+            if not isinstance(func_op, riscv_func.FuncOp):
+                continue
+            spill_ops = tuple(op for op in func_op.walk() if isinstance(op, SpillOp))
+            load_ops = tuple(op for op in func_op.walk() if isinstance(op, LoadOp))
+
+            # Map each spill value with its own stack offset
+            offset_by_value = {}
+            offset = 0
+            for spill_op in spill_ops:
+                offset_by_value[spill_op.result] = offset
+                offset += 4  # assume 32 bit values for now
+
+            # Get stack pointer for Lw/Sw to reference
+            stack_pointer = GetRegisterOp(Registers.SP)
+            Rewriter.insert_op(stack_pointer, InsertPoint.at_start(func_op.body.block))
+
+            # Resolve loads
+            for load_op in load_ops:
+                Rewriter.replace_op(
+                    load_op,
+                    LwOp(stack_pointer, offset_by_value[load_op.value]),
+                )
+
+            # Resolve spills
+            for spill_op in spill_ops:
+                store_op = SwOp(
+                    stack_pointer, spill_op.value, offset_by_value[spill_op.result]
+                )
+                # Use insert/erase since we are dropping the spill_op's result
+                Rewriter.insert_op(store_op, InsertPoint.before(spill_op))
+                Rewriter.erase_op(spill_op)

--- a/xdsl/transforms/test_riscv_spilling.py
+++ b/xdsl/transforms/test_riscv_spilling.py
@@ -193,3 +193,21 @@ class ResolveSpillingOps(ModulePass):
                         AddiOp(stack_pointer, stack_size, rd=Registers.SP),
                         InsertPoint.before(ret_op),
                     )
+
+
+@dataclass(frozen=True)
+class TestRiscvSpillingPass(ModulePass):
+    name = "test-riscv-spilling"
+
+    def apply(self, ctx: Context, op: builtin.ModuleOp) -> None:
+        defaults = RiscvRegisterStack.DEFAULT_ALLOCATABLE_REGISTERS
+        # Use reduced register set for testing
+        RiscvRegisterStack.DEFAULT_ALLOCATABLE_REGISTERS = (
+            Registers.T0,
+            Registers.T1,
+            Registers.T2,
+        )
+        SpillPass().apply(ctx, op)
+        ResolveSpillingOps().apply(ctx, op)
+
+        RiscvRegisterStack.DEFAULT_ALLOCATABLE_REGISTERS = defaults

--- a/xdsl/transforms/test_riscv_spilling.py
+++ b/xdsl/transforms/test_riscv_spilling.py
@@ -32,7 +32,7 @@ class SpillOp(IRDLOperation):
     value = operand_def()
     result = result_def(SpillType())
 
-    def __init__(self, val):
+    def __init__(self, val: SSAValue):
         super().__init__(operands=[val], result_types=[SpillType()])
 
 
@@ -42,7 +42,7 @@ class LoadOp(IRDLOperation):
     value = operand_def(SpillType())
     result = result_def()
 
-    def __init__(self, val):
+    def __init__(self, val: SSAValue):
         super().__init__(operands=[val], result_types=[Registers.UNALLOCATED_INT])
 
 
@@ -149,7 +149,7 @@ class ResolveSpillingOps(ModulePass):
             load_ops = tuple(op for op in func_op.walk() if isinstance(op, LoadOp))
 
             # Map each spill value with its own stack offset
-            offset_by_value = {}
+            offset_by_value: dict[SSAValue, int] = {}
             offset = 0
             for spill_op in spill_ops:
                 offset_by_value[spill_op.result] = offset

--- a/xdsl/transforms/test_riscv_spilling.py
+++ b/xdsl/transforms/test_riscv_spilling.py
@@ -4,46 +4,14 @@ from itertools import islice
 from ordered_set import OrderedSet
 
 from xdsl.backend.riscv.register_stack import RiscvRegisterStack
+from xdsl.builder import Builder
 from xdsl.context import Context
-from xdsl.dialects import builtin, riscv_func
-from xdsl.dialects.riscv.ops import AddiOp, LwOp, SwOp
+from xdsl.dialects import builtin, riscv, riscv_func
 from xdsl.dialects.riscv.registers import IntRegisterType, Registers
-from xdsl.dialects.rv32 import GetRegisterOp
-from xdsl.ir import Operation, ParametrizedAttribute, SSAValue
-from xdsl.irdl import (
-    IRDLOperation,
-    irdl_attr_definition,
-    irdl_op_definition,
-    operand_def,
-    result_def,
-)
+from xdsl.ir import Operation, SSAValue
 from xdsl.passes import ModulePass
-from xdsl.rewriter import InsertPoint, Rewriter
-
-
-@irdl_attr_definition
-class SpillType(ParametrizedAttribute):
-    name = "spilling.type"
-
-
-@irdl_op_definition
-class SpillOp(IRDLOperation):
-    name = "spilling.spill_op"
-    value = operand_def()
-    result = result_def(SpillType())
-
-    def __init__(self, val: SSAValue):
-        super().__init__(operands=[val], result_types=[SpillType()])
-
-
-@irdl_op_definition
-class LoadOp(IRDLOperation):
-    name = "spilling.load_op"
-    value = operand_def(SpillType())
-    result = result_def()
-
-    def __init__(self, val: SSAValue):
-        super().__init__(operands=[val], result_types=[Registers.UNALLOCATED_INT])
+from xdsl.rewriter import InsertPoint
+from xdsl.utils.hints import isa
 
 
 @dataclass(frozen=True)
@@ -100,14 +68,16 @@ class SpillPass(ModulePass):
         if not spills:
             return
 
-        spill_ops = tuple(SpillOp(spill_val) for spill_val in spills)
-        for spill_op in spill_ops:
-            Rewriter.insert_op(spill_op, InsertPoint.before(inner_op))
-        # change all uses after pmov_op to results of pmov
-        for src, spill_op in zip(spills, spill_ops):
-            dst = spill_op.result
-            src.replace_uses_with_if(
-                dst, lambda use: spill_op.is_before_in_block(use.operation)
+        builder = Builder(InsertPoint.before(inner_op))
+        for spill_val in spills:
+            alloca_op = riscv.stack.AllocaOp(builtin.i32)
+            spill_op = riscv.stack.StoreOp(alloca_op, spill_val)
+            builder.insert_op(alloca_op)
+            builder.insert_op(spill_op)
+
+            # replace all uses after spill to the ref
+            spill_val.replace_uses_with_if(
+                alloca_op.ref, lambda use: spill_op.is_before_in_block(use.operation)
             )
 
     def insert_load(
@@ -117,16 +87,22 @@ class SpillPass(ModulePass):
         if not loads:
             return OrderedSet([])
 
-        load_ops = tuple(LoadOp(load_val) for load_val in loads)
-        for load_op in load_ops:
-            Rewriter.insert_op(load_op, InsertPoint.before(inner_op))
-        # change all uses after pmov_op to results of pmov
-        for src, load_op in zip(loads, load_ops):
-            dst = load_op.result
-            src.replace_uses_with_if(
-                dst, lambda use: load_op.is_before_in_block(use.operation)
+        assert isa(loads, OrderedSet[SSAValue[riscv.stack.StackSlotType]])
+
+        load_results = OrderedSet[SSAValue]([])
+        builder = Builder(InsertPoint.before(inner_op))
+
+        for load_val in loads:
+            load_op = riscv.stack.LoadOp(load_val)
+            builder.insert_op(load_op)
+            # replace all uses of the ref after load to the loaded result
+            load_val.replace_uses_with_if(
+                load_op.rd,
+                lambda use: load_op.is_before_in_block(use.operation),
             )
-        return OrderedSet(i.result for i in load_ops)
+            load_results.add(load_op.rd)
+
+        return load_results
 
     def get_die_set(self, func_op: riscv_func.FuncOp):
         """Create set of values that die at each operation."""
@@ -138,61 +114,6 @@ class SpillPass(ModulePass):
             die[inner_op] = uses - seen_vals
             seen_vals |= uses
         return die
-
-
-class ResolveSpillingOps(ModulePass):
-    def apply(self, ctx: Context, op: builtin.ModuleOp) -> None:
-        for func_op in op.walk():
-            if not isinstance(func_op, riscv_func.FuncOp):
-                continue
-            spill_ops = tuple(op for op in func_op.walk() if isinstance(op, SpillOp))
-            load_ops = tuple(op for op in func_op.walk() if isinstance(op, LoadOp))
-
-            # Map each spill value with its own stack offset
-            offset_by_value: dict[SSAValue, int] = {}
-            offset = 0
-            for spill_op in spill_ops:
-                offset_by_value[spill_op.result] = offset
-                offset += 4  # assume 32 bit values for now
-
-            # Get stack pointer for Lw/Sw to reference
-            stack_pointer = GetRegisterOp(Registers.SP)
-            Rewriter.insert_op(stack_pointer, InsertPoint.at_start(func_op.body.block))
-
-            # Resolve loads
-            for load_op in load_ops:
-                Rewriter.replace_op(
-                    load_op,
-                    LwOp(stack_pointer, offset_by_value[load_op.value]),
-                )
-
-            # Resolve spills
-            for spill_op in spill_ops:
-                store_op = SwOp(
-                    stack_pointer, spill_op.value, offset_by_value[spill_op.result]
-                )
-                # Use insert/erase since we are dropping the spill_op's result
-                Rewriter.insert_op(store_op, InsertPoint.before(spill_op))
-                Rewriter.erase_op(spill_op)
-
-            # Manage stack pointer
-            # Align stack to 16 bytes
-            stack_size = (offset + 15) & ~15
-            if stack_size > 0:
-                Rewriter.insert_op(
-                    AddiOp(stack_pointer, -stack_size, rd=Registers.SP),
-                    InsertPoint.after(stack_pointer),
-                )
-
-                for block in func_op.body.blocks:
-                    ret_op = block.last_op
-                    if not isinstance(ret_op, riscv_func.ReturnOp):
-                        continue
-
-                    Rewriter.insert_op(
-                        AddiOp(stack_pointer, stack_size, rd=Registers.SP),
-                        InsertPoint.before(ret_op),
-                    )
 
 
 @dataclass(frozen=True)
@@ -208,6 +129,5 @@ class TestRiscvSpillingPass(ModulePass):
             Registers.T2,
         )
         SpillPass().apply(ctx, op)
-        ResolveSpillingOps().apply(ctx, op)
 
         RiscvRegisterStack.DEFAULT_ALLOCATABLE_REGISTERS = defaults

--- a/xdsl/transforms/test_riscv_spilling.py
+++ b/xdsl/transforms/test_riscv_spilling.py
@@ -1,3 +1,4 @@
+from collections.abc import Set as AbstractSet
 from dataclasses import dataclass
 from itertools import islice
 
@@ -81,7 +82,7 @@ class SpillPass(ModulePass):
             )
 
     def insert_load(
-        self, inner_op: Operation, loads: OrderedSet[SSAValue]
+        self, inner_op: Operation, loads: AbstractSet[SSAValue]
     ) -> OrderedSet[SSAValue]:
         """Insert loads before inner_op."""
         if not loads:


### PR DESCRIPTION
In this PR, we add a pass that performs register spilling within a basic block for the RISC-V dialect.

We first perform a liveness analysis on the block, maintaining a live set at each operation, and inserting custom spill and load ops where necessary. Then we convert the custom spills and loads into the corresponding RISC-V memory ops in a second pass.

This PR assumes all values are 32 bit integers and does not implement any spilling heuristics.