### PR TITLE
dialects: (llvm) add VectorFMaxOp

### DIFF
--- a/tests/dialects/test_llvm.py
+++ b/tests/dialects/test_llvm.py
@@ -614,6 +614,15 @@ def test_select_op():
     assert op.res.type == builtin.i32
 
 
+def test_vector_fmax_op():
+    lhs = create_ssa_value(builtin.f32)
+    rhs = create_ssa_value(builtin.f32)
+    op = llvm.VectorFMaxOp(lhs, rhs)
+    assert op.lhs == lhs
+    assert op.rhs == rhs
+    assert op.res.type == builtin.f32
+
+
 def test_cond_br_op():
     cond = create_ssa_value(builtin.i1)
     then_block = Block()

--- a/tests/filecheck/backend/llvm/convert_op.mlir
+++ b/tests/filecheck/backend/llvm/convert_op.mlir
@@ -609,6 +609,18 @@ builtin.module {
   // CHECK-NEXT:   ret i32 %"[[V2]]"
   // CHECK-NEXT: }
 
+  llvm.func @maxnum_op(%arg0: f32, %arg1: f32) -> f32 {
+    %0 = llvm.intr.maxnum(%arg0, %arg1) : (f32, f32) -> f32
+    llvm.return %0 : f32
+  }
+
+  // CHECK: define float @"maxnum_op"(float %".1", float %".2")
+  // CHECK-NEXT: {
+  // CHECK-NEXT: [[ENTRY:.\d+]]:
+  // CHECK-NEXT:   %"[[RES:.\d+]]" = call float @"llvm.maxnum"(float %".1", float %".2")
+  // CHECK-NEXT:   ret float %"[[RES]]"
+  // CHECK-NEXT: }
+
   llvm.func @fabs_op(%arg0: f32) -> f32 {
     %0 = llvm.intr.fabs(%arg0) : (f32) -> f32
     llvm.return %0 : f32

--- a/tests/filecheck/dialects/llvm/llvm_intrinsics.mlir
+++ b/tests/filecheck/dialects/llvm/llvm_intrinsics.mlir
@@ -51,6 +51,15 @@
 %select_f32_res = llvm.select %select_cond, %select_f32_lhs, %select_f32_rhs : i1, f32
 // CHECK: %select_f32_res = llvm.select %select_cond, %select_f32_lhs, %select_f32_rhs : i1, f32
 
+%maxnum_f32 = llvm.intr.maxnum(%f32, %f32) : (f32, f32) -> f32
+// CHECK: %maxnum_f32 = llvm.intr.maxnum(%f32, %f32) : (f32, f32) -> f32
+
+%maxnum_f64 = llvm.intr.maxnum(%f64, %f64) : (f64, f64) -> f64
+// CHECK-NEXT: %maxnum_f64 = llvm.intr.maxnum(%f64, %f64) : (f64, f64) -> f64
+
+%maxnum_vec = llvm.intr.maxnum(%vec_f32, %vec_f32) : (vector<4xf32>, vector<4xf32>) -> vector<4xf32>
+// CHECK-NEXT: %maxnum_vec = llvm.intr.maxnum(%vec_f32, %vec_f32) : (vector<4xf32>, vector<4xf32>) -> vector<4xf32>
+
 "test.op"() ({
 ^bb0(%cond_br_cond: i1, %cond_br_arg: i32):
   llvm.cond_br %cond_br_cond, ^bb1(%cond_br_arg : i32), ^bb2(%cond_br_arg : i32)

--- a/xdsl/backend/llvm/convert_op.py
+++ b/xdsl/backend/llvm/convert_op.py
@@ -164,13 +164,34 @@ def _convert_fcmp(
     val_map[op.results[0]] = fn(cmpop, val_map[op.lhs], val_map[op.rhs])
 
 
-def _convert_fabs(
-    op: llvm.FAbsOp, builder: ir.IRBuilder, val_map: dict[SSAValue, ir.Value]
+_UNARY_INTRINSIC_MAP: dict[type[Operation], str] = {
+    llvm.FAbsOp: "llvm.fabs",
+}
+
+_BINARY_INTRINSIC_MAP: dict[type[Operation], str] = {
+    llvm.VectorFMaxOp: "llvm.maxnum",
+}
+
+
+def _convert_unary_intrinsic(
+    op: Operation, builder: ir.IRBuilder, val_map: dict[SSAValue, ir.Value]
 ):
-    operand = val_map[op.input]
+    operand = val_map[op.operands[0]]
     fn_type = ir.FunctionType(operand.type, [operand.type])
-    intrinsic = builder.module.declare_intrinsic("llvm.fabs", fnty=fn_type)
-    val_map[op.result] = builder.call(intrinsic, [operand])
+    intrinsic_name = _UNARY_INTRINSIC_MAP[type(op)]
+    intrinsic = builder.module.declare_intrinsic(intrinsic_name, fnty=fn_type)
+    val_map[op.results[0]] = builder.call(intrinsic, [operand])
+
+
+def _convert_binary_intrinsic(
+    op: Operation, builder: ir.IRBuilder, val_map: dict[SSAValue, ir.Value]
+):
+    lhs = val_map[op.operands[0]]
+    rhs = val_map[op.operands[1]]
+    fn_type = ir.FunctionType(lhs.type, [lhs.type, rhs.type])
+    intrinsic_name = _BINARY_INTRINSIC_MAP[type(op)]
+    intrinsic = builder.module.declare_intrinsic(intrinsic_name, fnty=fn_type)
+    val_map[op.results[0]] = builder.call(intrinsic, [lhs, rhs])
 
 
 def _convert_fneg(
@@ -347,8 +368,10 @@ def convert_op(
             _convert_fcmp(op, builder, val_map)
         case op if type(op) in _CAST_OP_NAMES:
             _convert_cast(op, builder, val_map)
-        case llvm.FAbsOp():
-            _convert_fabs(op, builder, val_map)
+        case op if type(op) in _UNARY_INTRINSIC_MAP:
+            _convert_unary_intrinsic(op, builder, val_map)
+        case op if type(op) in _BINARY_INTRINSIC_MAP:
+            _convert_binary_intrinsic(op, builder, val_map)
         case llvm.FNegOp():
             _convert_fneg(op, builder, val_map)
         case llvm.CallOp():

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -2421,6 +2421,41 @@ class CondBrOp(IRDLOperation):
 
 
 @irdl_op_definition
+class VectorFMaxOp(IRDLOperation):
+    T: ClassVar = VarConstraint("T", AnyFloatConstr | VectorType.constr(AnyFloatConstr))
+
+    name = "llvm.intr.maxnum"
+
+    lhs = operand_def(T)
+    rhs = operand_def(T)
+    res = result_def(T)
+
+    fastmathFlags = prop_def(FastMathAttr, default_value=FastMathAttr(None))
+
+    assembly_format = (
+        "`(` operands `)` attr-dict `:` functional-type(operands, results)"
+    )
+
+    irdl_options = (ParsePropInAttrDict(),)
+
+    traits = traits_def(Pure())
+
+    def __init__(
+        self,
+        lhs: Operation | SSAValue,
+        rhs: Operation | SSAValue,
+        fast_math: FastMathAttr | FastMathFlag | None = None,
+    ):
+        if isinstance(fast_math, FastMathFlag | str | None):
+            fast_math = FastMathAttr(fast_math)
+        super().__init__(
+            operands=[lhs, rhs],
+            result_types=[SSAValue.get(lhs).type],
+            properties={"fastmathFlags": fast_math},
+        )
+
+
+@irdl_op_definition
 class UnreachableOp(IRDLOperation):
     name = "llvm.unreachable"
 
@@ -2479,6 +2514,7 @@ LLVM = Dialect(
         URemOp,
         UndefOp,
         UnreachableOp,
+        VectorFMaxOp,
         XOrOp,
         ZExtOp,
         ZeroOp,


### PR DESCRIPTION
Adds `llvm.intr.maxnum` (element-wise float max). Includes backend lowering via  llvmlite. Also refactors `_convert_fabs` into shared `_UNARY_INTRINSIC_MAP` and `_BINARY_INTRINSIC_MAP` dispatch tables for intrinsics.

Based on: https://mlir.llvm.org/docs/Dialects/LLVM/#llvmintrmaxnum-llvmmaxnumop