### PR TITLE
backend: (llvm) add vector.BroadcastOp conversion

### DIFF
--- a/tests/backend/llvm/test_convert_op.py
+++ b/tests/backend/llvm/test_convert_op.py
@@ -4,8 +4,8 @@ from unittest.mock import MagicMock
 import pytest
 
 from xdsl.backend.llvm.convert_op import convert_op
-from xdsl.dialects import llvm, vector
-from xdsl.dialects.builtin import VectorType, f32, i32
+from xdsl.dialects import llvm
+from xdsl.dialects.builtin import i32
 from xdsl.ir import Block, SSAValue
 
 
@@ -31,26 +31,3 @@ def test_convert_null():
     convert_op(op, MagicMock(), val_map)
 
     assert str(val_map[op.nullptr]) == "ptr null"
-
-
-def test_convert_broadcast():
-    block = Block(arg_types=[f32])
-    arg = block.args[0]
-    vec_type = VectorType(f32, [4])
-    op = vector.BroadcastOp(arg, vec_type)
-
-    source_val = MagicMock()
-    inserted = MagicMock()
-    shuffled = MagicMock()
-
-    builder = MagicMock()
-    builder.insert_element.return_value = inserted
-    builder.shuffle_vector.return_value = shuffled
-
-    val_map: dict[SSAValue, Any] = {arg: source_val}
-
-    convert_op(op, builder, val_map)
-
-    builder.insert_element.assert_called_once()
-    builder.shuffle_vector.assert_called_once()
-    assert val_map[op.vector] is shuffled

--- a/tests/backend/llvm/test_convert_op.py
+++ b/tests/backend/llvm/test_convert_op.py
@@ -4,8 +4,8 @@ from unittest.mock import MagicMock
 import pytest
 
 from xdsl.backend.llvm.convert_op import convert_op
-from xdsl.dialects import llvm
-from xdsl.dialects.builtin import i32
+from xdsl.dialects import llvm, vector
+from xdsl.dialects.builtin import VectorType, f32, i32
 from xdsl.ir import Block, SSAValue
 
 
@@ -31,3 +31,26 @@ def test_convert_null():
     convert_op(op, MagicMock(), val_map)
 
     assert str(val_map[op.nullptr]) == "ptr null"
+
+
+def test_convert_broadcast():
+    block = Block(arg_types=[f32])
+    arg = block.args[0]
+    vec_type = VectorType(f32, [4])
+    op = vector.BroadcastOp(arg, vec_type)
+
+    source_val = MagicMock()
+    inserted = MagicMock()
+    shuffled = MagicMock()
+
+    builder = MagicMock()
+    builder.insert_element.return_value = inserted
+    builder.shuffle_vector.return_value = shuffled
+
+    val_map: dict[SSAValue, Any] = {arg: source_val}
+
+    convert_op(op, builder, val_map)
+
+    builder.insert_element.assert_called_once()
+    builder.shuffle_vector.assert_called_once()
+    assert val_map[op.vector] is shuffled

--- a/tests/filecheck/backend/llvm/convert_op.mlir
+++ b/tests/filecheck/backend/llvm/convert_op.mlir
@@ -817,4 +817,17 @@ builtin.module {
   // CHECK-NEXT:   call ccc void @"callee"(void ()* @"addressof_target")
   // CHECK-NEXT:   ret void
   // CHECK-NEXT: }
+
+  llvm.func @broadcast_f32(%arg0: f32) -> vector<4xf32> {
+    %0 = vector.broadcast %arg0 : f32 to vector<4xf32>
+    llvm.return %0 : vector<4xf32>
+  }
+
+  // CHECK: define <4 x float> @"broadcast_f32"(float %".1")
+  // CHECK-NEXT: {
+  // CHECK-NEXT: [[ENTRY:.\d+]]:
+  // CHECK-NEXT:   %"[[INS:.\d+]]" = insertelement <4 x float> <float undef, float undef, float undef, float undef>, float %".1", i32 0
+  // CHECK-NEXT:   %"[[RES:.\d+]]" = shufflevector <4 x float> %"[[INS]]", <4 x float> <float undef, float undef, float undef, float undef>, <4 x i32> <i32 0, i32 0, i32 0, i32 0>
+  // CHECK-NEXT:   ret <4 x float> %"[[RES]]"
+  // CHECK-NEXT: }
 }

--- a/typings/llvmlite/ir/builder.pyi
+++ b/typings/llvmlite/ir/builder.pyi
@@ -11,14 +11,17 @@ from llvmlite.ir.instructions import (
     Branch,
     CallInstr,
     ConditionalBranch,
+    ExtractElement,
     ExtractValue,
     GEPInstr,
     ICMPInstr,
+    InsertElement,
     InsertValue,
     Instruction,
     LoadInstr,
     PhiInstr,
     Ret,
+    ShuffleVector,
     StoreInstr,
     Unreachable,
 )
@@ -683,20 +686,26 @@ class IRBuilder:
         """
         ...
 
-    def extract_element(self, vector, idx, name=...):  # -> ExtractElement:
+    def extract_element(
+        self, vector: Value, idx: Value, name: str = ...
+    ) -> ExtractElement:
         """
         Returns the value at position idx.
         """
         ...
 
-    def insert_element(self, vector, value, idx, name=...):  # -> InsertElement:
+    def insert_element(
+        self, vector: Value, value: Value, idx: Value, name: str = ...
+    ) -> InsertElement:
         """
         Returns vector with vector[idx] replaced by value.
         The result is undefined if the idx is larger or equal the vector length.
         """
         ...
 
-    def shuffle_vector(self, vector1, vector2, mask, name=...):  # -> ShuffleVector:
+    def shuffle_vector(
+        self, vector1: Value, vector2: Value, mask: Value, name: str = ...
+    ) -> ShuffleVector:
         """
         Constructs a permutation of elements from *vector1* and *vector2*.
         Returns a new vector in the same length of *mask*.

--- a/xdsl/backend/llvm/convert_op.py
+++ b/xdsl/backend/llvm/convert_op.py
@@ -8,7 +8,7 @@ from llvmlite.ir.values import Block as LLVMBlock
 from llvmlite.ir.values import Value
 
 from xdsl.backend.llvm.convert_type import convert_type
-from xdsl.dialects import llvm
+from xdsl.dialects import llvm, vector
 from xdsl.dialects.vector import FMAOp
 from xdsl.ir import Block, Operation, SSAValue
 
@@ -391,6 +391,20 @@ def _convert_addressof(
     val_map[op.result] = builder.module.get_global(op.global_name.root_reference.data)
 
 
+def _convert_broadcast(
+    op: vector.BroadcastOp,
+    builder: ir.IRBuilder,
+    val_map: dict[SSAValue, ir.Value],
+):
+    source_val = val_map[op.source]
+    vec_type = convert_type(op.vector.type)
+    n_lanes = op.vector.type.get_shape()[0]
+    undef = ir.Constant(vec_type, ir.Undefined)
+    inserted = builder.insert_element(undef, source_val, ir.Constant(ir.IntType(32), 0))
+    mask = ir.Constant(ir.VectorType(ir.IntType(32), n_lanes), [0] * n_lanes)
+    val_map[op.vector] = builder.shuffle_vector(inserted, undef, mask)
+
+
 def convert_op(
     op: Operation,
     builder: ir.IRBuilder,
@@ -468,5 +482,7 @@ def convert_op(
             _convert_addressof(op, builder, val_map)
         case FMAOp():
             _convert_fma(op, builder, val_map)
+        case vector.BroadcastOp():
+            _convert_broadcast(op, builder, val_map)
         case _:
             raise NotImplementedError(f"Conversion not implemented for op: {op.name}")


### PR DESCRIPTION
- Add `vector.BroadcastOp` lowering to the llvmlite backend (`convert_op.py`)
- Implements the standard LLVM broadcast pattern: `insertelement` into lane 0 + `shufflevector` with zero mask
- First vector dialect op supported in the LLVM backend