### PR TITLE
backend: (llvm) add AddressOfOp conversion

### DIFF
--- a/tests/filecheck/backend/llvm/convert_op.mlir
+++ b/tests/filecheck/backend/llvm/convert_op.mlir
@@ -769,4 +769,23 @@ builtin.module {
   // CHECK-NEXT:   %"[[RES:.\d+]]" = call <2 x double> @"llvm.fma.v2f64"(<2 x double> %".1", <2 x double> %".2", <2 x double> %".3")
   // CHECK-NEXT:   ret <2 x double> %"[[RES]]"
   // CHECK-NEXT: }
+
+  llvm.func @callee(!llvm.ptr)
+
+  llvm.func @addressof_target() {
+    llvm.return
+  }
+
+  llvm.func @addressof_op() {
+    %0 = "llvm.mlir.addressof"() <{global_name = @addressof_target}> : () -> !llvm.ptr
+    "llvm.call"(%0) <{callee = @callee, fastmathFlags = #llvm.fastmath<>, CConv = #llvm.cconv<ccc>, TailCallKind = #llvm.tailcallkind<none>, operandSegmentSizes = array<i32: 1, 0>}> : (!llvm.ptr) -> ()
+    llvm.return
+  }
+
+  // CHECK: define void @"addressof_op"()
+  // CHECK-NEXT: {
+  // CHECK-NEXT: [[ENTRY:.\d+]]:
+  // CHECK-NEXT:   call ccc void @"callee"(void ()* @"addressof_target")
+  // CHECK-NEXT:   ret void
+  // CHECK-NEXT: }
 }

--- a/tests/filecheck/dialects/irdl/pyrdl-to-irdl/cmath-conversion.py
+++ b/tests/filecheck/dialects/irdl/pyrdl-to-irdl/cmath-conversion.py
@@ -1,7 +1,6 @@
 # RUN: python %s | filecheck %s
 
 from xdsl.dialects.cmath import Cmath
-
 from xdsl.dialects.irdl.pyrdl_to_irdl import dialect_to_irdl
 
 print(dialect_to_irdl(Cmath, "cmath"))

--- a/tests/filecheck/dialects/irdl/pyrdl-to-irdl/cmath-conversion.py
+++ b/tests/filecheck/dialects/irdl/pyrdl-to-irdl/cmath-conversion.py
@@ -1,6 +1,7 @@
 # RUN: python %s | filecheck %s
 
 from xdsl.dialects.cmath import Cmath
+
 from xdsl.dialects.irdl.pyrdl_to_irdl import dialect_to_irdl
 
 print(dialect_to_irdl(Cmath, "cmath"))

--- a/xdsl/backend/llvm/convert_op.py
+++ b/xdsl/backend/llvm/convert_op.py
@@ -385,6 +385,12 @@ def _convert_null(
     val_map[op.nullptr] = ir.Constant(convert_type(op.nullptr.type), None)
 
 
+def _convert_addressof(
+    op: llvm.AddressOfOp, builder: ir.IRBuilder, val_map: dict[SSAValue, ir.Value]
+):
+    val_map[op.result] = builder.module.get_global(op.global_name.root_reference.data)
+
+
 def convert_op(
     op: Operation,
     builder: ir.IRBuilder,
@@ -458,6 +464,8 @@ def convert_op(
             _convert_return(op, builder, val_map)
         case llvm.NullOp():
             _convert_null(op, builder, val_map)
+        case llvm.AddressOfOp():
+            _convert_addressof(op, builder, val_map)
         case FMAOp():
             _convert_fma(op, builder, val_map)
         case _:


### PR DESCRIPTION
- Add `llvm.AddressOfOp` to the llvmlite backend's `convert_op` dispatch
- Resolves a global symbol name to a pointer via `builder.module.get_global()`
- Add filecheck test exercising addressof through a call argument