### PR TITLE
backend: (llvm) add ConstantOp conversion

### DIFF
--- a/tests/backend/llvm/test_convert.py
+++ b/tests/backend/llvm/test_convert.py
@@ -1,6 +1,6 @@
 import pytest
 
-from xdsl.dialects import llvm as llvm_dialect
+from xdsl.dialects import llvm
 from xdsl.dialects.builtin import ModuleOp, i32
 from xdsl.dialects.test import TestOp
 from xdsl.ir import Block, Region
@@ -59,8 +59,8 @@ def test_convert_module_target_config_combined():
 
 def test_convert_module_declaration():
     # a func op with no body becomes a declaration
-    ft = llvm_dialect.LLVMFunctionType([i32], i32)
-    func = llvm_dialect.FuncOp("my_decl", ft)
+    ft = llvm.LLVMFunctionType([i32], i32)
+    func = llvm.FuncOp("my_decl", ft)
     module = ModuleOp([func])
 
     llvm_module = convert_module(module)
@@ -71,25 +71,25 @@ def test_convert_module_declaration():
 
 def test_convert_module_forward_reference():
     # a function can call another function defined later in the module
-    ft_callee = llvm_dialect.LLVMFunctionType([i32], i32)
-    ft_caller = llvm_dialect.LLVMFunctionType([i32], i32)
+    ft_callee = llvm.LLVMFunctionType([i32], i32)
+    ft_caller = llvm.LLVMFunctionType([i32], i32)
 
     caller_block = Block(arg_types=[i32])
     arg = caller_block.args[0]
-    call_op = llvm_dialect.CallOp("callee", arg, return_type=i32)
+    call_op = llvm.CallOp("callee", arg, return_type=i32)
     caller_block.add_op(call_op)
-    ret_op = llvm_dialect.ReturnOp(call_op.returned)
+    ret_op = llvm.ReturnOp(call_op.returned)
     caller_block.add_op(ret_op)
     caller_body = Region(caller_block)
 
-    caller = llvm_dialect.FuncOp("caller", ft_caller, body=caller_body)
+    caller = llvm.FuncOp("caller", ft_caller, body=caller_body)
 
     callee_block = Block(arg_types=[i32])
-    callee_ret = llvm_dialect.ReturnOp(callee_block.args[0])
+    callee_ret = llvm.ReturnOp(callee_block.args[0])
     callee_block.add_op(callee_ret)
     callee_body = Region(callee_block)
 
-    callee = llvm_dialect.FuncOp("callee", ft_callee, body=callee_body)
+    callee = llvm.FuncOp("callee", ft_callee, body=callee_body)
 
     # caller defined before callee
     module = ModuleOp([caller, callee])

--- a/tests/filecheck/backend/llvm/convert_op.mlir
+++ b/tests/filecheck/backend/llvm/convert_op.mlir
@@ -830,4 +830,37 @@ builtin.module {
   // CHECK-NEXT:   %"[[RES:.\d+]]" = shufflevector <4 x float> %"[[INS]]", <4 x float> <float undef, float undef, float undef, float undef>, <4 x i32> <i32 0, i32 0, i32 0, i32 0>
   // CHECK-NEXT:   ret <4 x float> %"[[RES]]"
   // CHECK-NEXT: }
+
+  llvm.func @constant_int() -> i32 {
+    %0 = llvm.mlir.constant(42 : i32) : i32
+    llvm.return %0 : i32
+  }
+
+  // CHECK: define i32 @"constant_int"()
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {{.[0-9]+}}:
+  // CHECK-NEXT:   ret i32 42
+  // CHECK-NEXT: }
+
+  llvm.func @constant_float() -> f32 {
+    %0 = llvm.mlir.constant(3.14 : f32) : f32
+    llvm.return %0 : f32
+  }
+
+  // CHECK: define float @"constant_float"()
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {{.[0-9]+}}:
+  // CHECK-NEXT:   ret float 0x40091eb860000000
+  // CHECK-NEXT: }
+
+  llvm.func @constant_dense_vector() -> vector<4xi32> {
+    %0 = llvm.mlir.constant(dense<[1, 2, 3, 4]> : vector<4xi32>) : vector<4xi32>
+    llvm.return %0 : vector<4xi32>
+  }
+
+  // CHECK: define <4 x i32> @"constant_dense_vector"()
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {{.[0-9]+}}:
+  // CHECK-NEXT:   ret <4 x i32> <i32 1, i32 2, i32 3, i32 4>
+  // CHECK-NEXT: }
 }

--- a/xdsl/backend/llvm/convert_op.py
+++ b/xdsl/backend/llvm/convert_op.py
@@ -1,4 +1,5 @@
 from collections.abc import Callable
+from typing import cast
 
 from llvmlite import ir
 from llvmlite.ir import instructions
@@ -9,8 +10,13 @@ from llvmlite.ir.values import Value
 
 from xdsl.backend.llvm.convert_type import convert_type
 from xdsl.dialects import llvm, vector
+from xdsl.dialects.builtin import (
+    DenseIntOrFPElementsAttr,
+    FloatAttr,
+    IntegerAttr,
+)
 from xdsl.dialects.vector import FMAOp
-from xdsl.ir import Block, Operation, SSAValue
+from xdsl.ir import Attribute, Block, Operation, SSAValue
 
 _BINARY_OP_MAP: dict[
     type[Operation], Callable[[ir.IRBuilder], Callable[[ir.Value, ir.Value], ir.Value]]
@@ -405,6 +411,28 @@ def _convert_broadcast(
     val_map[op.vector] = builder.shuffle_vector(inserted, undef, mask)
 
 
+_CONSTANT_VALUE_MAP: dict[type[Attribute], Callable[[Attribute], object]] = {
+    DenseIntOrFPElementsAttr: lambda v: list(
+        cast(DenseIntOrFPElementsAttr, v).iter_values()
+    ),
+    IntegerAttr: lambda v: cast(IntegerAttr, v).value.data,
+    FloatAttr: lambda v: cast(FloatAttr, v).value.data,
+}
+
+
+def _convert_constant(
+    op: llvm.ConstantOp, builder: ir.IRBuilder, val_map: dict[SSAValue, ir.Value]
+):
+    value = op.value
+    try:
+        handler = _CONSTANT_VALUE_MAP[type(value)]
+    except KeyError:
+        raise NotImplementedError(
+            f"Unsupported constant attribute type: {type(value)}"
+        ) from None
+    val_map[op.result] = ir.Constant(convert_type(op.result.type), handler(value))
+
+
 def convert_op(
     op: Operation,
     builder: ir.IRBuilder,
@@ -484,5 +512,7 @@ def convert_op(
             _convert_fma(op, builder, val_map)
         case vector.BroadcastOp():
             _convert_broadcast(op, builder, val_map)
+        case llvm.ConstantOp():
+            _convert_constant(op, builder, val_map)
         case _:
             raise NotImplementedError(f"Conversion not implemented for op: {op.name}")


### PR DESCRIPTION
- Add `_convert_constant` to `convert_op.py` handling `IntegerAttr`, `FloatAttr`, and `DenseIntOrFPElementsAttr`
- Wire `llvm.ConstantOp()` case into `convert_op()` match block
- Add filecheck tests for scalar int, scalar float, and dense vector constants
- Add pytest integration tests via `convert_module`