### PR TITLE
[codex] Narrow llvm ConstantOp value prop

### DIFF
--- a/tests/dialects/test_llvm.py
+++ b/tests/dialects/test_llvm.py
@@ -309,6 +309,13 @@ def test_return_op_empty():
     assert len(op_empty.operands) == 0
 
 
+def test_constant_op_rejects_invalid_prop():
+    op = llvm.ConstantOp(builtin.StringAttr("invalid"), builtin.i32)
+
+    with pytest.raises(VerifyException):
+        op.verify()
+
+
 def test_calling_conv():
     cconv = llvm.CallingConventionAttr("cc 11")
     cconv.verify()

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -15,7 +15,9 @@ from xdsl.dialects.builtin import (
     AnyFloatConstr,
     ArrayAttr,
     DenseArrayBase,
+    DenseIntOrFPElementsAttr,
     DictionaryAttr,
+    FloatAttr,
     FunctionType,
     IntAttr,
     IntegerAttr,
@@ -1912,7 +1914,7 @@ class ReturnOp(IRDLOperation):
 class ConstantOp(IRDLOperation):
     name = "llvm.mlir.constant"
     result = result_def(Attribute)
-    value = prop_def()
+    value = prop_def(IntegerAttr | FloatAttr | DenseIntOrFPElementsAttr)
 
     traits = traits_def(NoMemoryEffect())
 


### PR DESCRIPTION
## Summary

- Narrow `llvm.ConstantOp.value` to the attribute kinds the LLVM backend conversion supports.
- Add a dialect test that verifies unsupported constant props are rejected.

## Why

The LLVM backend conversion only handles integer, float, and dense element constants. Tightening the dialect schema makes that contract explicit and keeps invalid props from slipping through verification.

## Validation

- `pytest -q tests/dialects/test_llvm.py`
