### PR TITLE
backend: preserve LLVM pointer address spaces in type conversion

### DIFF
--- a/tests/backend/llvm/test_convert_type.py
+++ b/tests/backend/llvm/test_convert_type.py
@@ -29,7 +29,7 @@ def test_convert_int():
         (builtin.NoneType(), ir.VoidType()),
         (LLVMVoidType(), ir.VoidType()),
         (LLVMPointerType(), ir.PointerType()),
-        (LLVMPointerType(builtin.IntAttr(1)), ir.PointerType(1)),
+        (LLVMPointerType(builtin.IntAttr(1)), ir.PointerType(addrspace=1)),
         (
             builtin.ComplexType(builtin.f32),
             ir.LiteralStructType([ir.FloatType(), ir.FloatType()]),

--- a/xdsl/backend/llvm/convert_type.py
+++ b/xdsl/backend/llvm/convert_type.py
@@ -33,7 +33,7 @@ def _convert_integer_type(type_attr: IntegerType) -> ir.Type:
 
 def _convert_pointer_type(type_attr: LLVMPointerType) -> ir.Type:
     if isinstance(type_attr.addr_space, IntAttr):
-        return ir.PointerType(type_attr.addr_space.data)
+        return ir.PointerType(addrspace=type_attr.addr_space.data)
     return ir.PointerType()
 
 


### PR DESCRIPTION
- preserve non-default LLVM pointer address spaces during llvmlite type conversion
- add a regression test for addrspace pointer conversion