### PR TITLE
documentation: Fix print for listlang booleans in marimo notebooks

### DIFF
--- a/docs/marimo/mlir_introduction.py
+++ b/docs/marimo/mlir_introduction.py
@@ -359,7 +359,7 @@ def _(bool_edit, lmo, mo, to_mlir, xmo):
     bool_3_ok = bool_3_output == bool_3_expected
     bool_3_check = "✅ " if bool_3_ok else "❌"
 
-    bool_3_cmp = mo.md(f"expected: {bool_3_expected}" + "&nbsp; &nbsp; ↔ &nbsp; " + f"current: {bool_1_output}")
+    bool_3_cmp = mo.md(f"expected: {bool_3_expected}" + "&nbsp; &nbsp; ↔ &nbsp; " + f"current: {bool_3_output}")
     bool_3_stack = mo.vstack([mo.md("### Case 3 &nbsp;&nbsp;" + bool_3_check), lmo.rust_md(bool_3_prefix), bool_3_cmp])
 
     bool_4_prefix = "let x = 3; let y = 5;"

--- a/docs/marimo/mlir_introduction.py
+++ b/docs/marimo/mlir_introduction.py
@@ -381,7 +381,53 @@ def _(bool_edit, lmo, mo, to_mlir, xmo):
 
     mo.vstack([bool_res, mo.hstack([bool_1_stack, bool_2_stack]), mo.md("<br>"),
     mo.hstack([bool_3_stack, bool_4_stack])])
-    return (bool_all_check,)
+    return (
+        bool_1_expected,
+        bool_1_prefix,
+        bool_2_expected,
+        bool_2_prefix,
+        bool_3_expected,
+        bool_3_prefix,
+        bool_4_expected,
+        bool_4_prefix,
+        bool_all_check,
+    )
+
+
+@app.cell(hide_code=True)
+def _(lmo, to_mlir):
+    def test_marimo_bool_print_true() -> None:
+        module = to_mlir("0 < 1")
+        assert lmo.interp(module) == "true"
+
+    def test_marimo_bool_print_false() -> None:
+        module = to_mlir("1 < 0")
+        assert lmo.interp(module) == "false"
+
+    return
+
+
+@app.cell(hide_code=True)
+def _(
+    bool_1_expected,
+    bool_1_prefix,
+    bool_2_expected,
+    bool_2_prefix,
+    bool_3_expected,
+    bool_3_prefix,
+    bool_4_expected,
+    bool_4_prefix,
+    lmo,
+    to_mlir,
+):
+    def test_boolean_expr_exercise_solution() -> None:
+        solution = "x != y"
+        assert lmo.interp(to_mlir(bool_1_prefix + solution)) == bool_1_expected
+        assert lmo.interp(to_mlir(bool_2_prefix + solution)) == bool_2_expected
+        assert lmo.interp(to_mlir(bool_3_prefix + solution)) == bool_3_expected
+        assert lmo.interp(to_mlir(bool_4_prefix + solution)) == bool_4_expected
+
+    return
 
 
 @app.cell(hide_code=True)

--- a/xdsl/frontend/listlang/marimo.py
+++ b/xdsl/frontend/listlang/marimo.py
@@ -23,10 +23,10 @@ class PrintfFunctions(InterpreterFunctions):
     def run_println(
         self, interpreter: Interpreter, op: PrintFormatOp, args: tuple[Any, ...]
     ):
-        pretty_args: list[str] = [
+        pretty_args = tuple(
             self._format_arg(fmt_val, arg)
             for fmt_val, arg in zip(op.format_vals, args, strict=True)
-        ]
+        )
 
         print(
             op.format_str.data.format(*pretty_args),

--- a/xdsl/frontend/listlang/marimo.py
+++ b/xdsl/frontend/listlang/marimo.py
@@ -1,13 +1,38 @@
 from io import StringIO
+from typing import Any
 
 import marimo as mo
 
 from xdsl.dialects import builtin
-from xdsl.interpreter import Interpreter
+from xdsl.dialects.printf import PrintFormatOp
+from xdsl.interpreter import Interpreter, InterpreterFunctions, impl, register_impls
 from xdsl.interpreters.arith import ArithFunctions
-from xdsl.interpreters.printf import PrintfFunctions
 from xdsl.interpreters.scf import ScfFunctions
 from xdsl.interpreters.tensor import TensorFunctions
+from xdsl.utils.hints import isa
+
+
+@register_impls
+class PrintfFunctions(InterpreterFunctions):
+    def _format_arg(self, fmt_val, arg):
+        if isa(fmt_val.type, builtin.I1):
+            return "true" if arg else "false"
+        return arg
+
+    @impl(PrintFormatOp)
+    def run_println(
+        self, interpreter: Interpreter, op: PrintFormatOp, args: tuple[Any, ...]
+    ):
+        pretty_args = [
+            self._format_arg(fmt_val, arg) for fmt_val, arg in zip(op.format_vals, args)
+        ]
+
+        print(
+            op.format_str.data.format(*pretty_args),
+            file=interpreter.file,
+            end="",
+        )
+        return ()
 
 
 def interp(module: builtin.ModuleOp) -> str:
@@ -20,9 +45,7 @@ def interp(module: builtin.ModuleOp) -> str:
     _i.register_implementations(TensorFunctions())
     _i.run_ssacfg_region(module.body, ())
 
-    # Lowercase to avoid capitals in `True` and `False` printing of bools.
-    # Safe since we never print strings other than `True` and `False`.
-    return _io.getvalue().lower()
+    return _io.getvalue()
 
 
 def rust_md(code: str) -> mo.Html:

--- a/xdsl/frontend/listlang/marimo.py
+++ b/xdsl/frontend/listlang/marimo.py
@@ -14,16 +14,17 @@ from xdsl.utils.hints import isa
 
 @register_impls
 class PrintfFunctions(InterpreterFunctions):
-    def _format_arg(self, fmt_val, arg):
+    def _format_arg(self, fmt_val: Any, arg: Any) -> str:
         if isa(fmt_val.type, builtin.I1):
             return "true" if arg else "false"
-        return arg
+        return str(arg)
 
     @impl(PrintFormatOp)
     def run_println(
         self, interpreter: Interpreter, op: PrintFormatOp, args: tuple[Any, ...]
     ):
-        pretty_args = [
+
+        pretty_args: list[str] = [
             self._format_arg(fmt_val, arg) for fmt_val, arg in zip(op.format_vals, args)
         ]
 

--- a/xdsl/frontend/listlang/marimo.py
+++ b/xdsl/frontend/listlang/marimo.py
@@ -23,7 +23,6 @@ class PrintfFunctions(InterpreterFunctions):
     def run_println(
         self, interpreter: Interpreter, op: PrintFormatOp, args: tuple[Any, ...]
     ):
-
         pretty_args: list[str] = [
             self._format_arg(fmt_val, arg) for fmt_val, arg in zip(op.format_vals, args)
         ]

--- a/xdsl/frontend/listlang/marimo.py
+++ b/xdsl/frontend/listlang/marimo.py
@@ -24,9 +24,9 @@ class PrintfFunctions(InterpreterFunctions):
         self, interpreter: Interpreter, op: PrintFormatOp, args: tuple[Any, ...]
     ):
         pretty_args: list[str] = [
-        pretty_args = tuple(
-            self._format_arg(fmt_val, arg) for fmt_val, arg in zip(op.format_vals, args, strict=True)
-        )
+            self._format_arg(fmt_val, arg)
+            for fmt_val, arg in zip(op.format_vals, args, strict=True)
+        ]
 
         print(
             op.format_str.data.format(*pretty_args),

--- a/xdsl/frontend/listlang/marimo.py
+++ b/xdsl/frontend/listlang/marimo.py
@@ -24,7 +24,8 @@ class PrintfFunctions(InterpreterFunctions):
         self, interpreter: Interpreter, op: PrintFormatOp, args: tuple[Any, ...]
     ):
         pretty_args: list[str] = [
-            self._format_arg(fmt_val, arg) for fmt_val, arg in zip(op.format_vals, args)
+            self._format_arg(fmt_val, arg)
+            for fmt_val, arg in zip(op.format_vals, args, strict=True)
         ]
 
         print(

--- a/xdsl/frontend/listlang/marimo.py
+++ b/xdsl/frontend/listlang/marimo.py
@@ -24,9 +24,9 @@ class PrintfFunctions(InterpreterFunctions):
         self, interpreter: Interpreter, op: PrintFormatOp, args: tuple[Any, ...]
     ):
         pretty_args: list[str] = [
-            self._format_arg(fmt_val, arg)
-            for fmt_val, arg in zip(op.format_vals, args, strict=True)
-        ]
+        pretty_args = tuple(
+            self._format_arg(fmt_val, arg) for fmt_val, arg in zip(op.format_vals, args, strict=True)
+        )
 
         print(
             op.format_str.data.format(*pretty_args),


### PR DESCRIPTION
730dc639c4d64a8c44906284e9ebd1b31c5cd68e changes the print for booleans in listlang to print the actual `i1` representation, which broke an exercise in the tutorial notebooks.

This change reverts the formatting for booleans in marimo notebooks only.

Also fixes a variable-mixup in the same broken exercise.