### PR TITLE
testing: add tests for marimo notebooks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,8 +74,8 @@ filecheck: uv-installed ## run filecheck tests
 	uv run lit $(LIT_OPTIONS) tests/filecheck
 
 .PHONY: pytest
-pytest: uv-installed ## run pytest tests
-	uv run pytest tests -W error $(PYTEST_OPTIONS)
+pytest: uv-installed ## run pytest tests on tests and marimo (paths specified in pyproject.toml)
+	uv run pytest -W error $(PYTEST_OPTIONS)
 
 .PHONY: filecheck-toy
 filecheck-toy: uv-installed ## run tests for Toy tutorial

--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,7 @@ tests-marimo: uv-installed
 			rm -f "$$error_log"; \
 			echo -e "\n\nAll marimo tests passed successfully."; \
 		fi'
+	uv run pytest docs/marimo
 
 .PHONY: tests-functional
 tests-functional: pytest tests-toy filecheck tests-marimo ## run functional tests
@@ -162,7 +163,8 @@ coverage: coverage-tests coverage-filecheck-tests ## run coverage over all tests
 
 .PHONY: coverage-tests
 coverage-tests: uv-installed ## use different coverage data file per coverage run, otherwise combine complains
-	COVERAGE_FILE="${COVERAGE_FILE}.$@" uv run pytest -W error --cov
+	# Run pytest both on the tests folder and the marimo notebooks that have test cells
+	COVERAGE_FILE="${COVERAGE_FILE}.$@" uv run pytest -W error --cov tests docs/marimo
 
 .PHONY: coverage-filecheck-tests
 coverage-filecheck-tests: uv-installed ## run coverage over filecheck tests

--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,6 @@ tests-marimo: uv-installed
 			rm -f "$$error_log"; \
 			echo -e "\n\nAll marimo tests passed successfully."; \
 		fi'
-	uv run pytest docs/marimo
 
 .PHONY: tests-functional
 tests-functional: pytest tests-toy filecheck tests-marimo ## run functional tests
@@ -163,8 +162,7 @@ coverage: coverage-tests coverage-filecheck-tests ## run coverage over all tests
 
 .PHONY: coverage-tests
 coverage-tests: uv-installed ## use different coverage data file per coverage run, otherwise combine complains
-	# Run pytest both on the tests folder and the marimo notebooks that have test cells
-	COVERAGE_FILE="${COVERAGE_FILE}.$@" uv run pytest -W error --cov tests docs/marimo
+	COVERAGE_FILE="${COVERAGE_FILE}.$@" uv run pytest -W error --cov
 
 .PHONY: coverage-filecheck-tests
 coverage-filecheck-tests: uv-installed ## run coverage over filecheck tests


### PR DESCRIPTION
We currently specify the `tests` folder in `make pytest`, but if we remove this specification then the options from the pyproject.toml are used, which actually includes more tests.