### PR TITLE
documentation: (Toy) use ToyInlinerInterface in inline-toy pass

### DIFF
--- a/docs/Toy/toy/dialects/toy.py
+++ b/docs/Toy/toy/dialects/toy.py
@@ -5,8 +5,9 @@ Toy language dialect from MLIR tutorial.
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import TypeAlias
+from typing import TypeAlias, cast
 
+from xdsl.dialect_interfaces import DialectInterface
 from xdsl.dialects.builtin import (
     DenseIntOrFPElementsAttr,
     Float64Type,
@@ -23,6 +24,7 @@ from xdsl.ir import (
     Attribute,
     Block,
     Dialect,
+    IRNode,
     Operation,
     Region,
     SSAValue,
@@ -506,7 +508,7 @@ class CastOp(IRDLOperation):
 
     traits = traits_def(Pure(), CastOpHasShapeInferencePatternsTrait())
 
-    def __init__(self, arg: SSAValue, res: AnyTensorTypeF64 | None = None):
+    def __init__(self, arg: SSAValue, res: Attribute | None = None):
         if res is None:
             res = UnrankedTensorType(f64)
 
@@ -514,6 +516,64 @@ class CastOp(IRDLOperation):
             operands=[arg],
             result_types=[res],
         )
+
+
+# region: ToyInlinerInterface
+
+
+class ToyInlinerInterface(DialectInterface):
+    """
+    This class defines the interface for handling inlining with Toy operations.
+    """
+
+    # Analysis hooks
+
+    def is_legal_to_inline(
+        self, call: Operation, callable: Operation, would_be_cloned: bool
+    ) -> bool:
+        # All call operations within toy can be inlined.
+        return True
+
+    def is_legal_to_inline_operation(
+        self, operation: Operation, region: Region, ir_mapping: dict[IRNode, IRNode]
+    ) -> bool:
+        # All operations within toy can be inlined.
+        return True
+
+    def is_legal_to_inline_region(
+        self, src_region: Region, dest_region: Region, ir_mapping: dict[IRNode, IRNode]
+    ) -> bool:
+        # All functions within toy can be inlined.
+        return True
+
+    # Transformation Hooks
+
+    def handle_terminator(
+        self, op: Operation, values_to_replace: Sequence[SSAValue]
+    ) -> None:
+        # Handle the given inlined terminator(toy.return) by replacing it with a new
+        # operation as necessary.
+
+        # Only "toy.return" needs to be handled here.
+        return_op = cast(ReturnOp, op)
+
+        # Replace the values directly with the return operands.
+        assert len(return_op.operands) == len(values_to_replace)
+        for value, operand in zip(values_to_replace, return_op.operands):
+            value.replace_all_uses_with(operand)
+
+    def materialize_call_conversion(
+        self, input: SSAValue, result_type: Attribute
+    ) -> Operation:
+        # Attempts to materialize a conversion for a type mismatch between a call
+        # from this dialect and a callable region. This method should generate an
+        # operation that takes 'input' as the only operand, and produces a single
+        # result of 'result_type'. If a conversion cannot be generated, None
+        # should be returned.
+        return CastOp(input, result_type)
+
+
+# endregion
 
 
 Toy = Dialect(
@@ -531,4 +591,7 @@ Toy = Dialect(
         CastOp,
     ],
     [],
+    [
+        ToyInlinerInterface(),
+    ],
 )

--- a/docs/Toy/toy/rewrites/inline_toy.py
+++ b/docs/Toy/toy/rewrites/inline_toy.py
@@ -20,6 +20,7 @@ class InlineFunctions(RewritePattern):
         """
         For each generic call, find the function that it calls, and inline it.
         """
+        inliner_interface = toy.ToyInlinerInterface()
 
         callee = SymbolTable.lookup_symbol(op, op.callee)
         assert callee is not None
@@ -31,20 +32,11 @@ class InlineFunctions(RewritePattern):
         # Clone called function body
         impl_block = impl_body.clone().block
 
-        # Cast operands to unranked
-        inputs = [toy.CastOp(operand) for operand in op.operands]
-
-        # Insert casts before matched op
-        rewriter.insert_op(inputs)
-
         # Replace block args with operand casts
-        for i, arg in zip(inputs, impl_block.args):
-            arg.replace_all_uses_with(i.res)
-
-        # remove block args
-        while len(impl_block.args):
-            assert not impl_block.args[-1].uses
-            rewriter.erase_block_argument(impl_block.args[-1])
+        for operand, arg in zip(op.operands, impl_block.args):
+            cast_op = inliner_interface.materialize_call_conversion(operand, arg.type)
+            rewriter.insert(cast_op)
+            arg.replace_all_uses_with(cast_op.results[0])
 
         # Inline function definition before matched op
         rewriter.inline_block(impl_block, InsertPoint.before(op))
@@ -53,8 +45,10 @@ class InlineFunctions(RewritePattern):
         return_op = op.prev_op
         assert return_op is not None
 
-        rewriter.replace_op(op, [], return_op.operands)
+        inliner_interface.handle_terminator(return_op, op.results)
+
         rewriter.erase_op(return_op)
+        rewriter.erase_op(op)
 
 
 class RemoveUnusedPrivateFunctions(RewritePattern):


### PR DESCRIPTION
The idea is to eventually get to a state where we can just hook into an inline pass (to be added in a future PR), similar to the one in MLIR, from within Toy, which actually uses this as an example of a generic mechanism to be opted into with a DialectInterface. Func version still to be ported.