### PR TITLE
dialects: (llvm) verify CallOp callee is a declared FuncOp

### DIFF
--- a/tests/dialects/test_llvm.py
+++ b/tests/dialects/test_llvm.py
@@ -557,6 +557,38 @@ def test_call_op_variadic():
     assert op.var_callee_type.is_variadic
 
 
+def test_call_op_symbol_verification_missing_callee():
+    ft = llvm.LLVMFunctionType([i32], i32)
+    caller_block = Block(arg_types=[i32])
+    call_op = llvm.CallOp("unknown_fn", caller_block.args[0], return_type=i32)
+    caller_block.add_op(call_op)
+    caller_block.add_op(llvm.ReturnOp(call_op.returned))
+    caller = llvm.FuncOp("caller", ft, body=Region(caller_block))
+    module = builtin.ModuleOp([caller])
+
+    with pytest.raises(
+        VerifyException, match="'@unknown_fn' could not be found in symbol table"
+    ):
+        module.verify()
+
+
+def test_call_op_symbol_verification_resolved_callee():
+    ft = llvm.LLVMFunctionType([i32], i32)
+
+    caller_block = Block(arg_types=[i32])
+    call_op = llvm.CallOp("callee", caller_block.args[0], return_type=i32)
+    caller_block.add_op(call_op)
+    caller_block.add_op(llvm.ReturnOp(call_op.returned))
+    caller = llvm.FuncOp("caller", ft, body=Region(caller_block))
+
+    callee_block = Block(arg_types=[i32])
+    callee_block.add_op(llvm.ReturnOp(callee_block.args[0]))
+    callee = llvm.FuncOp("callee", ft, body=Region(callee_block))
+
+    module = builtin.ModuleOp([caller, callee])
+    module.verify()
+
+
 def test_call_intrinsic_op_converts_str_to_stringattr():
     # verify string intrinsic name is auto-converted to StringAttr
     op = llvm.CallIntrinsicOp(

--- a/tests/dialects/test_llvm.py
+++ b/tests/dialects/test_llvm.py
@@ -557,38 +557,6 @@ def test_call_op_variadic():
     assert op.var_callee_type.is_variadic
 
 
-def test_call_op_symbol_verification_missing_callee():
-    ft = llvm.LLVMFunctionType([i32], i32)
-    caller_block = Block(arg_types=[i32])
-    call_op = llvm.CallOp("unknown_fn", caller_block.args[0], return_type=i32)
-    caller_block.add_op(call_op)
-    caller_block.add_op(llvm.ReturnOp(call_op.returned))
-    caller = llvm.FuncOp("caller", ft, body=Region(caller_block))
-    module = builtin.ModuleOp([caller])
-
-    with pytest.raises(
-        VerifyException, match="'@unknown_fn' could not be found in symbol table"
-    ):
-        module.verify()
-
-
-def test_call_op_symbol_verification_resolved_callee():
-    ft = llvm.LLVMFunctionType([i32], i32)
-
-    caller_block = Block(arg_types=[i32])
-    call_op = llvm.CallOp("callee", caller_block.args[0], return_type=i32)
-    caller_block.add_op(call_op)
-    caller_block.add_op(llvm.ReturnOp(call_op.returned))
-    caller = llvm.FuncOp("caller", ft, body=Region(caller_block))
-
-    callee_block = Block(arg_types=[i32])
-    callee_block.add_op(llvm.ReturnOp(callee_block.args[0]))
-    callee = llvm.FuncOp("callee", ft, body=Region(callee_block))
-
-    module = builtin.ModuleOp([caller, callee])
-    module.verify()
-
-
 def test_call_intrinsic_op_converts_str_to_stringattr():
     # verify string intrinsic name is auto-converted to StringAttr
     op = llvm.CallIntrinsicOp(

--- a/tests/filecheck/dialects/llvm/invalid.mlir
+++ b/tests/filecheck/dialects/llvm/invalid.mlir
@@ -90,3 +90,16 @@ llvm.func @caller(%arg0: i32) -> i32 {
 }
 
 // CHECK: '@unknown_fn' could not be found in symbol table
+
+// -----
+
+func.func @not_llvm_func(%arg0: i32) -> i32 {
+  func.return %arg0 : i32
+}
+
+llvm.func @caller(%arg0: i32) -> i32 {
+  %0 = "llvm.call"(%arg0) <{callee = @not_llvm_func, op_bundle_sizes = array<i32>, operandSegmentSizes = array<i32: 1, 0>}> : (i32) -> i32
+  llvm.return %0 : i32
+}
+
+// CHECK: '@not_llvm_func' does not reference a valid function

--- a/tests/filecheck/dialects/llvm/invalid.mlir
+++ b/tests/filecheck/dialects/llvm/invalid.mlir
@@ -81,3 +81,12 @@ func.func @constant_op_rejects_invalid_prop() {
 }
 
 // CHECK: Unexpected attribute "invalid"
+
+// -----
+
+llvm.func @caller(%arg0: i32) -> i32 {
+  %0 = "llvm.call"(%arg0) <{callee = @unknown_fn, op_bundle_sizes = array<i32>, operandSegmentSizes = array<i32: 1, 0>}> : (i32) -> i32
+  llvm.return %0 : i32
+}
+
+// CHECK: '@unknown_fn' could not be found in symbol table

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -1998,6 +1998,14 @@ class CallIntrinsicOp(IRDLOperation):
 
 
 class CallOpSymbolUserOpInterface(SymbolUserOpInterface):
+    """
+    Verifies that a direct `llvm.call` resolves to an `llvm.func` in the enclosing
+    symbol table. Indirect calls (no `callee` symbol) are skipped.
+
+    Mirrors MLIR's `LLVM::CallOp::verifySymbolUses`:
+    https://github.com/llvm/llvm-project/blob/main/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
+    """
+
     def verify(self, op: Operation) -> None:
         assert isinstance(op, CallOp)
 

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -80,6 +80,8 @@ from xdsl.traits import (
     Pure,
     SameOperandsAndResultType,
     SymbolOpInterface,
+    SymbolTable,
+    SymbolUserOpInterface,
 )
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.hints import isa
@@ -1703,6 +1705,8 @@ class FuncOp(IRDLOperation):
     tune_cpu = opt_prop_def(StringAttr)
     unnamed_addr = opt_prop_def(IntegerAttr)
 
+    traits = traits_def(SymbolOpInterface())
+
     def __init__(
         self,
         sym_name: str | StringAttr,
@@ -1993,6 +1997,21 @@ class CallIntrinsicOp(IRDLOperation):
         )
 
 
+class CallOpSymbolUserOpInterface(SymbolUserOpInterface):
+    def verify(self, op: Operation) -> None:
+        assert isinstance(op, CallOp)
+
+        if op.callee is None:
+            return
+
+        found_callee = SymbolTable.lookup_symbol(op, op.callee)
+        if not found_callee:
+            raise VerifyException(f"'{op.callee}' could not be found in symbol table")
+
+        if not isinstance(found_callee, FuncOp):
+            raise VerifyException(f"'{op.callee}' does not reference a valid function")
+
+
 @irdl_op_definition
 class CallOp(IRDLOperation):
     name = "llvm.call"
@@ -2012,6 +2031,8 @@ class CallOp(IRDLOperation):
         TailCallKindAttr, default_value=TailCallKindAttr(TailCallKind.NONE)
     )
     returned = opt_result_def()
+
+    traits = traits_def(CallOpSymbolUserOpInterface())
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 


### PR DESCRIPTION
Split out of #5831.

Add `SymbolOpInterface` to `llvm.FuncOp` and a `SymbolUserOpInterface` on `llvm.CallOp` that requires the callee symbol to resolve to a `FuncOp` in an enclosing symbol table, matching MLIR's [LLVM::CallOp verifier](https://github.com/llvm/llvm-project/blob/main/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp#L1246-L1251).

This surfaces undeclared-call errors at verification time rather than letting them propagate into later lowering/backend stages, and removes the need for workarounds like auto-declaring externals in the LLVM backend.