### PR TITLE
dialects: (llvm) add FExpOp

### DIFF
--- a/tests/dialects/test_llvm.py
+++ b/tests/dialects/test_llvm.py
@@ -601,6 +601,13 @@ def test_flog_op():
     assert op.res.type == builtin.f32
 
 
+def test_fexp_op():
+    val = create_ssa_value(builtin.f32)
+    op = llvm.FExpOp(val)
+    assert op.arg == val
+    assert op.res.type == builtin.f32
+
+
 def test_fneg_op():
     val = create_ssa_value(builtin.f32)
     op = llvm.FNegOp(val)

--- a/tests/dialects/test_llvm.py
+++ b/tests/dialects/test_llvm.py
@@ -614,6 +614,14 @@ def test_flog_op():
     assert op.res.type == builtin.f32
 
 
+def test_fexp_op():
+    val = create_ssa_value(builtin.f32)
+    op = llvm.FExpOp(val)
+    assert op.arg == val
+    assert op.res.type == builtin.f32
+    assert op.name == "llvm.intr.exp"
+
+
 def test_fneg_op():
     val = create_ssa_value(builtin.f32)
     op = llvm.FNegOp(val)

--- a/tests/filecheck/backend/llvm/convert_op.mlir
+++ b/tests/filecheck/backend/llvm/convert_op.mlir
@@ -671,6 +671,9 @@ builtin.module {
   // CHECK-NEXT: {
   // CHECK-NEXT: [[ENTRY:.\d+]]:
   // CHECK-NEXT:   %"[[RES:.\d+]]" = call float @"llvm.sqrt"(float %".1")
+  // CHECK-NEXT:   ret float %"[[RES]]"
+  // CHECK-NEXT: }
+
   llvm.func @flog_op(%arg0: f32) -> f32 {
     %0 = llvm.intr.log(%arg0) : (f32) -> f32
     llvm.return %0 : f32
@@ -680,6 +683,18 @@ builtin.module {
   // CHECK-NEXT: {
   // CHECK-NEXT: [[ENTRY:.\d+]]:
   // CHECK-NEXT:   %"[[RES:.\d+]]" = call float @"llvm.log"(float %".1")
+  // CHECK-NEXT:   ret float %"[[RES]]"
+  // CHECK-NEXT: }
+
+  llvm.func @fexp_op(%arg0: f32) -> f32 {
+    %0 = llvm.intr.exp(%arg0) : (f32) -> f32
+    llvm.return %0 : f32
+  }
+
+  // CHECK: define float @"fexp_op"(float %".1")
+  // CHECK-NEXT: {
+  // CHECK-NEXT: [[ENTRY:.\d+]]:
+  // CHECK-NEXT:   %"[[RES:.\d+]]" = call float @"llvm.exp"(float %".1")
   // CHECK-NEXT:   ret float %"[[RES]]"
   // CHECK-NEXT: }
 

--- a/tests/filecheck/backend/llvm/convert_op.mlir
+++ b/tests/filecheck/backend/llvm/convert_op.mlir
@@ -772,6 +772,18 @@ builtin.module {
   // CHECK-NEXT:   ret float %"[[RES]]"
   // CHECK-NEXT: }
 
+  llvm.func @exp_op(%arg0: f32) -> f32 {
+    %0 = llvm.intr.exp(%arg0) : (f32) -> f32
+    llvm.return %0 : f32
+  }
+
+  // CHECK: define float @"exp_op"(float %".1")
+  // CHECK-NEXT: {
+  // CHECK-NEXT: [[ENTRY:.\d+]]:
+  // CHECK-NEXT:   %"[[RES:.\d+]]" = call float @"llvm.exp"(float %".1")
+  // CHECK-NEXT:   ret float %"[[RES]]"
+  // CHECK-NEXT: }
+
   llvm.func @fneg_op(%arg0: f32) -> f32 {
     %0 = llvm.fneg %arg0 : f32
     llvm.return %0 : f32

--- a/tests/filecheck/dialects/irdl/pyrdl-to-irdl/cmath-conversion.py
+++ b/tests/filecheck/dialects/irdl/pyrdl-to-irdl/cmath-conversion.py
@@ -1,6 +1,7 @@
 # RUN: python %s | filecheck %s
 
 from xdsl.dialects.cmath import Cmath
+
 from xdsl.dialects.irdl.pyrdl_to_irdl import dialect_to_irdl
 
 print(dialect_to_irdl(Cmath, "cmath"))

--- a/tests/filecheck/dialects/llvm/llvm_intrinsics.mlir
+++ b/tests/filecheck/dialects/llvm/llvm_intrinsics.mlir
@@ -21,6 +21,7 @@
 
 %fsqrt_vec = llvm.intr.sqrt(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
 // CHECK-NEXT: %fsqrt_vec = llvm.intr.sqrt(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
+
 %flog_f32 = llvm.intr.log(%f32) : (f32) -> f32
 // CHECK: %flog_f32 = llvm.intr.log(%f32) : (f32) -> f32
 
@@ -29,6 +30,15 @@
 
 %flog_vec = llvm.intr.log(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
 // CHECK-NEXT: %flog_vec = llvm.intr.log(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
+
+%fexp_f32 = llvm.intr.exp(%f32) : (f32) -> f32
+// CHECK: %fexp_f32 = llvm.intr.exp(%f32) : (f32) -> f32
+
+%fexp_f64 = llvm.intr.exp(%f64) : (f64) -> f64
+// CHECK-NEXT: %fexp_f64 = llvm.intr.exp(%f64) : (f64) -> f64
+
+%fexp_vec = llvm.intr.exp(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
+// CHECK-NEXT: %fexp_vec = llvm.intr.exp(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
 
 %fneg_f32 = llvm.fneg %f32 : f32
 // CHECK: %fneg_f32 = llvm.fneg %f32 : f32

--- a/tests/filecheck/dialects/llvm/llvm_intrinsics.mlir
+++ b/tests/filecheck/dialects/llvm/llvm_intrinsics.mlir
@@ -39,6 +39,15 @@
 %flog_vec = llvm.intr.log(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
 // CHECK-NEXT: %flog_vec = llvm.intr.log(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
 
+%fexp_f32 = llvm.intr.exp(%f32) : (f32) -> f32
+// CHECK: %fexp_f32 = llvm.intr.exp(%f32) : (f32) -> f32
+
+%fexp_f64 = llvm.intr.exp(%f64) : (f64) -> f64
+// CHECK-NEXT: %fexp_f64 = llvm.intr.exp(%f64) : (f64) -> f64
+
+%fexp_vec = llvm.intr.exp(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
+// CHECK-NEXT: %fexp_vec = llvm.intr.exp(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
+
 %fneg_f32 = llvm.fneg %f32 : f32
 // CHECK: %fneg_f32 = llvm.fneg %f32 : f32
 

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/llvm_intrinsics.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/llvm_intrinsics.mlir
@@ -13,6 +13,15 @@
 %2 = llvm.intr.fabs(%arg2) : (vector<4xf32>) -> vector<4xf32>
 // CHECK: llvm.intr.fabs([[arg2]]) : (vector<4xf32>) -> vector<4xf32>
 
+%fexp_f32 = llvm.intr.exp(%arg0) : (f32) -> f32
+// CHECK: llvm.intr.exp([[arg0]]) : (f32) -> f32
+
+%fexp_f64 = llvm.intr.exp(%arg1) : (f64) -> f64
+// CHECK: llvm.intr.exp([[arg1]]) : (f64) -> f64
+
+%fexp_vec = llvm.intr.exp(%arg2) : (vector<4xf32>) -> vector<4xf32>
+// CHECK: llvm.intr.exp([[arg2]]) : (vector<4xf32>) -> vector<4xf32>
+
 %3 = llvm.fneg %arg0 : f32
 // CHECK: llvm.fneg [[arg0]] : f32
 

--- a/xdsl/backend/llvm/convert_op.py
+++ b/xdsl/backend/llvm/convert_op.py
@@ -169,6 +169,7 @@ _UNARY_INTRINSIC_MAP: dict[type[Operation], str] = {
     llvm.FAbsOp: "llvm.fabs",
     llvm.FSqrtOp: "llvm.sqrt",
     llvm.FLogOp: "llvm.log",
+    llvm.FExpOp: "llvm.exp",
 }
 
 

--- a/xdsl/backend/llvm/convert_op.py
+++ b/xdsl/backend/llvm/convert_op.py
@@ -174,6 +174,7 @@ def _convert_fcmp(
 
 _UNARY_INTRINSIC_MAP: dict[type[Operation], str] = {
     llvm.FAbsOp: "llvm.fabs",
+    llvm.FExpOp: "llvm.exp",
     llvm.FCeilOp: "llvm.ceil",
     llvm.FSqrtOp: "llvm.sqrt",
     llvm.FLogOp: "llvm.log",

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -2359,6 +2359,39 @@ class FLogOp(IRDLOperation):
 
 
 @irdl_op_definition
+class FExpOp(IRDLOperation):
+    T: ClassVar = VarConstraint("T", AnyFloatConstr | VectorType.constr(AnyFloatConstr))
+
+    name = "llvm.intr.exp"
+
+    arg = operand_def(T)
+    res = result_def(T)
+
+    fastmathFlags = prop_def(FastMathAttr, default_value=FastMathAttr(None))
+
+    assembly_format = (
+        "`(` operands `)` attr-dict `:` functional-type(operands, results)"
+    )
+
+    irdl_options = (ParsePropInAttrDict(),)
+
+    traits = traits_def(Pure())
+
+    def __init__(
+        self,
+        arg: Operation | SSAValue,
+        fast_math: FastMathAttr | FastMathFlag | None = None,
+    ):
+        if isinstance(fast_math, FastMathFlag | str | None):
+            fast_math = FastMathAttr(fast_math)
+        super().__init__(
+            operands=[arg],
+            result_types=[SSAValue.get(arg).type],
+            properties={"fastmathFlags": fast_math},
+        )
+
+
+@irdl_op_definition
 class FNegOp(IRDLOperation):
     T: ClassVar = VarConstraint("T", AnyFloatConstr | VectorType.constr(AnyFloatConstr))
 
@@ -2566,6 +2599,7 @@ LLVM = Dialect(
         FAddOp,
         FCmpOp,
         FDivOp,
+        FExpOp,
         FLogOp,
         FMulOp,
         FNegOp,

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -3161,7 +3161,7 @@ class FExpOp(IRDLOperation):
         arg: Operation | SSAValue,
         fast_math: FastMathAttr | FastMathFlag | None = None,
     ):
-        if isinstance(fast_math, FastMathFlag | str | None):
+        if not isinstance(fast_math, FastMathAttr):
             fast_math = FastMathAttr(fast_math)
         super().__init__(
             operands=[arg],

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -3138,6 +3138,39 @@ class FLogOp(IRDLOperation):
 
 
 @irdl_op_definition
+class FExpOp(IRDLOperation):
+    T: ClassVar = VarConstraint("T", AnyFloatConstr | VectorType.constr(AnyFloatConstr))
+
+    name = "llvm.intr.exp"
+
+    arg = operand_def(T)
+    res = result_def(T)
+
+    fastmathFlags = prop_def(FastMathAttr, default_value=FastMathAttr(None))
+
+    assembly_format = (
+        "`(` operands `)` attr-dict `:` functional-type(operands, results)"
+    )
+
+    irdl_options = (ParsePropInAttrDict(),)
+
+    traits = traits_def(Pure())
+
+    def __init__(
+        self,
+        arg: Operation | SSAValue,
+        fast_math: FastMathAttr | FastMathFlag | None = None,
+    ):
+        if isinstance(fast_math, FastMathFlag | str | None):
+            fast_math = FastMathAttr(fast_math)
+        super().__init__(
+            operands=[arg],
+            result_types=[SSAValue.get(arg).type],
+            properties={"fastmathFlags": fast_math},
+        )
+
+
+@irdl_op_definition
 class FNegOp(IRDLOperation):
     T: ClassVar = VarConstraint("T", AnyFloatConstr | VectorType.constr(AnyFloatConstr))
 
@@ -3383,6 +3416,7 @@ LLVM = Dialect(
         FCeilOp,
         FCmpOp,
         FDivOp,
+        FExpOp,
         FLogOp,
         FMAOp,
         FMulOp,


### PR DESCRIPTION
- Add `llvm.intr.exp` (`FExpOp`) to the LLVM dialect; accepts scalar or vector-of-float
- Wire into `_UNARY_INTRINSIC_MAP` in `convert_op.py` (refactors `_convert_fabs` into a shared dispatch)
- Dialect + filecheck roundtrip + backend lowering + pytest coverage mirroring `FAbsOp`

Refs:
- MLIR: https://mlir.llvm.org/docs/Dialects/LLVM/#llvmintrexp-llvmexpop
- LangRef: https://llvm.org/docs/LangRef.html#llvm-exp-intrinsic