### PR TITLE
dialects: (llvm) add FCosOp

### DIFF
--- a/tests/dialects/test_llvm.py
+++ b/tests/dialects/test_llvm.py
@@ -601,6 +601,13 @@ def test_flog_op():
     assert op.res.type == builtin.f32
 
 
+def test_fcos_op():
+    val = create_ssa_value(builtin.f32)
+    op = llvm.FCosOp(val)
+    assert op.arg == val
+    assert op.res.type == builtin.f32
+
+
 def test_fneg_op():
     val = create_ssa_value(builtin.f32)
     op = llvm.FNegOp(val)

--- a/tests/dialects/test_llvm.py
+++ b/tests/dialects/test_llvm.py
@@ -632,6 +632,10 @@ def test_fexp_op():
 def test_fsin_op():
     val = create_ssa_value(builtin.f32)
     op = llvm.FSinOp(val)
+    assert op.arg == val
+    assert op.res.type == builtin.f32
+
+
 def test_fcos_op():
     val = create_ssa_value(builtin.f32)
     op = llvm.FCosOp(val)

--- a/tests/dialects/test_llvm.py
+++ b/tests/dialects/test_llvm.py
@@ -632,6 +632,9 @@ def test_fexp_op():
 def test_fsin_op():
     val = create_ssa_value(builtin.f32)
     op = llvm.FSinOp(val)
+def test_fcos_op():
+    val = create_ssa_value(builtin.f32)
+    op = llvm.FCosOp(val)
     assert op.arg == val
     assert op.res.type == builtin.f32
 

--- a/tests/filecheck/backend/llvm/convert_op.mlir
+++ b/tests/filecheck/backend/llvm/convert_op.mlir
@@ -671,6 +671,9 @@ builtin.module {
   // CHECK-NEXT: {
   // CHECK-NEXT: [[ENTRY:.\d+]]:
   // CHECK-NEXT:   %"[[RES:.\d+]]" = call float @"llvm.sqrt"(float %".1")
+  // CHECK-NEXT:   ret float %"[[RES]]"
+  // CHECK-NEXT: }
+
   llvm.func @flog_op(%arg0: f32) -> f32 {
     %0 = llvm.intr.log(%arg0) : (f32) -> f32
     llvm.return %0 : f32
@@ -680,6 +683,18 @@ builtin.module {
   // CHECK-NEXT: {
   // CHECK-NEXT: [[ENTRY:.\d+]]:
   // CHECK-NEXT:   %"[[RES:.\d+]]" = call float @"llvm.log"(float %".1")
+  // CHECK-NEXT:   ret float %"[[RES]]"
+  // CHECK-NEXT: }
+
+  llvm.func @fcos_op(%arg0: f32) -> f32 {
+    %0 = llvm.intr.cos(%arg0) : (f32) -> f32
+    llvm.return %0 : f32
+  }
+
+  // CHECK: define float @"fcos_op"(float %".1")
+  // CHECK-NEXT: {
+  // CHECK-NEXT: [[ENTRY:.\d+]]:
+  // CHECK-NEXT:   %"[[RES:.\d+]]" = call float @"llvm.cos"(float %".1")
   // CHECK-NEXT:   ret float %"[[RES]]"
   // CHECK-NEXT: }
 

--- a/tests/filecheck/backend/llvm/convert_op.mlir
+++ b/tests/filecheck/backend/llvm/convert_op.mlir
@@ -805,6 +805,15 @@ builtin.module {
   // CHECK-NEXT: {
   // CHECK-NEXT: [[ENTRY:.\d+]]:
   // CHECK-NEXT:   %"[[RES:.\d+]]" = call float @"llvm.sin"(float %".1")
+  llvm.func @fcos_op(%arg0: f32) -> f32 {
+    %0 = llvm.intr.cos(%arg0) : (f32) -> f32
+    llvm.return %0 : f32
+  }
+
+  // CHECK: define float @"fcos_op"(float %".1")
+  // CHECK-NEXT: {
+  // CHECK-NEXT: [[ENTRY:.\d+]]:
+  // CHECK-NEXT:   %"[[RES:.\d+]]" = call float @"llvm.cos"(float %".1")
   // CHECK-NEXT:   ret float %"[[RES]]"
   // CHECK-NEXT: }
 

--- a/tests/filecheck/backend/llvm/convert_op.mlir
+++ b/tests/filecheck/backend/llvm/convert_op.mlir
@@ -805,6 +805,9 @@ builtin.module {
   // CHECK-NEXT: {
   // CHECK-NEXT: [[ENTRY:.\d+]]:
   // CHECK-NEXT:   %"[[RES:.\d+]]" = call float @"llvm.sin"(float %".1")
+  // CHECK-NEXT:   ret float %"[[RES]]"
+  // CHECK-NEXT: }
+
   llvm.func @fcos_op(%arg0: f32) -> f32 {
     %0 = llvm.intr.cos(%arg0) : (f32) -> f32
     llvm.return %0 : f32

--- a/tests/filecheck/dialects/irdl/pyrdl-to-irdl/cmath-conversion.py
+++ b/tests/filecheck/dialects/irdl/pyrdl-to-irdl/cmath-conversion.py
@@ -1,7 +1,6 @@
 # RUN: python %s | filecheck %s
 
 from xdsl.dialects.cmath import Cmath
-
 from xdsl.dialects.irdl.pyrdl_to_irdl import dialect_to_irdl
 
 print(dialect_to_irdl(Cmath, "cmath"))

--- a/tests/filecheck/dialects/irdl/pyrdl-to-irdl/cmath-conversion.py
+++ b/tests/filecheck/dialects/irdl/pyrdl-to-irdl/cmath-conversion.py
@@ -1,6 +1,7 @@
 # RUN: python %s | filecheck %s
 
 from xdsl.dialects.cmath import Cmath
+
 from xdsl.dialects.irdl.pyrdl_to_irdl import dialect_to_irdl
 
 print(dialect_to_irdl(Cmath, "cmath"))

--- a/tests/filecheck/dialects/llvm/llvm_intrinsics.mlir
+++ b/tests/filecheck/dialects/llvm/llvm_intrinsics.mlir
@@ -21,6 +21,7 @@
 
 %fsqrt_vec = llvm.intr.sqrt(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
 // CHECK-NEXT: %fsqrt_vec = llvm.intr.sqrt(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
+
 %flog_f32 = llvm.intr.log(%f32) : (f32) -> f32
 // CHECK: %flog_f32 = llvm.intr.log(%f32) : (f32) -> f32
 
@@ -29,6 +30,15 @@
 
 %flog_vec = llvm.intr.log(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
 // CHECK-NEXT: %flog_vec = llvm.intr.log(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
+
+%fcos_f32 = llvm.intr.cos(%f32) : (f32) -> f32
+// CHECK: %fcos_f32 = llvm.intr.cos(%f32) : (f32) -> f32
+
+%fcos_f64 = llvm.intr.cos(%f64) : (f64) -> f64
+// CHECK-NEXT: %fcos_f64 = llvm.intr.cos(%f64) : (f64) -> f64
+
+%fcos_vec = llvm.intr.cos(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
+// CHECK-NEXT: %fcos_vec = llvm.intr.cos(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
 
 %fneg_f32 = llvm.fneg %f32 : f32
 // CHECK: %fneg_f32 = llvm.fneg %f32 : f32

--- a/tests/filecheck/dialects/llvm/llvm_intrinsics.mlir
+++ b/tests/filecheck/dialects/llvm/llvm_intrinsics.mlir
@@ -66,6 +66,7 @@
 
 %fsin_vec = llvm.intr.sin(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
 // CHECK-NEXT: %fsin_vec = llvm.intr.sin(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
+
 %fcos_f32 = llvm.intr.cos(%f32) : (f32) -> f32
 // CHECK: %fcos_f32 = llvm.intr.cos(%f32) : (f32) -> f32
 

--- a/tests/filecheck/dialects/llvm/llvm_intrinsics.mlir
+++ b/tests/filecheck/dialects/llvm/llvm_intrinsics.mlir
@@ -66,6 +66,14 @@
 
 %fsin_vec = llvm.intr.sin(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
 // CHECK-NEXT: %fsin_vec = llvm.intr.sin(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
+%fcos_f32 = llvm.intr.cos(%f32) : (f32) -> f32
+// CHECK: %fcos_f32 = llvm.intr.cos(%f32) : (f32) -> f32
+
+%fcos_f64 = llvm.intr.cos(%f64) : (f64) -> f64
+// CHECK-NEXT: %fcos_f64 = llvm.intr.cos(%f64) : (f64) -> f64
+
+%fcos_vec = llvm.intr.cos(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
+// CHECK-NEXT: %fcos_vec = llvm.intr.cos(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
 
 %fneg_f32 = llvm.fneg %f32 : f32
 // CHECK: %fneg_f32 = llvm.fneg %f32 : f32

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/llvm_intrinsics.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/llvm_intrinsics.mlir
@@ -13,6 +13,15 @@
 %2 = llvm.intr.fabs(%arg2) : (vector<4xf32>) -> vector<4xf32>
 // CHECK: llvm.intr.fabs([[arg2]]) : (vector<4xf32>) -> vector<4xf32>
 
+%fcos_f32 = llvm.intr.cos(%arg0) : (f32) -> f32
+// CHECK: llvm.intr.cos([[arg0]]) : (f32) -> f32
+
+%fcos_f64 = llvm.intr.cos(%arg1) : (f64) -> f64
+// CHECK: llvm.intr.cos([[arg1]]) : (f64) -> f64
+
+%fcos_vec = llvm.intr.cos(%arg2) : (vector<4xf32>) -> vector<4xf32>
+// CHECK: llvm.intr.cos([[arg2]]) : (vector<4xf32>) -> vector<4xf32>
+
 %3 = llvm.fneg %arg0 : f32
 // CHECK: llvm.fneg [[arg0]] : f32
 

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/llvm_intrinsics.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/llvm_intrinsics.mlir
@@ -38,6 +38,14 @@
 
 %ffloor_vec = llvm.intr.floor(%arg2) : (vector<4xf32>) -> vector<4xf32>
 // CHECK: llvm.intr.floor([[arg2]]) : (vector<4xf32>) -> vector<4xf32>
+%fcos_f32 = llvm.intr.cos(%arg0) : (f32) -> f32
+// CHECK: llvm.intr.cos([[arg0]]) : (f32) -> f32
+
+%fcos_f64 = llvm.intr.cos(%arg1) : (f64) -> f64
+// CHECK: llvm.intr.cos([[arg1]]) : (f64) -> f64
+
+%fcos_vec = llvm.intr.cos(%arg2) : (vector<4xf32>) -> vector<4xf32>
+// CHECK: llvm.intr.cos([[arg2]]) : (vector<4xf32>) -> vector<4xf32>
 
 %3 = llvm.fneg %arg0 : f32
 // CHECK: llvm.fneg [[arg0]] : f32

--- a/xdsl/backend/llvm/convert_op.py
+++ b/xdsl/backend/llvm/convert_op.py
@@ -169,6 +169,7 @@ _UNARY_INTRINSIC_MAP: dict[type[Operation], str] = {
     llvm.FAbsOp: "llvm.fabs",
     llvm.FSqrtOp: "llvm.sqrt",
     llvm.FLogOp: "llvm.log",
+    llvm.FCosOp: "llvm.cos",
 }
 
 
@@ -182,8 +183,9 @@ def _convert_unary_intrinsic(
 ):
     operand = val_map[op.operands[0]]
     fn_type = ir.FunctionType(operand.type, [operand.type])
-    intrinsic_name = _UNARY_INTRINSIC_MAP[type(op)]
-    intrinsic = builder.module.declare_intrinsic(intrinsic_name, fnty=fn_type)
+    intrinsic = builder.module.declare_intrinsic(
+        _UNARY_INTRINSIC_MAP[type(op)], fnty=fn_type
+    )
     val_map[op.results[0]] = builder.call(intrinsic, [operand])
 
 
@@ -193,8 +195,9 @@ def _convert_binary_intrinsic(
     lhs = val_map[op.operands[0]]
     rhs = val_map[op.operands[1]]
     fn_type = ir.FunctionType(lhs.type, [lhs.type, rhs.type])
-    intrinsic_name = _BINARY_INTRINSIC_MAP[type(op)]
-    intrinsic = builder.module.declare_intrinsic(intrinsic_name, fnty=fn_type)
+    intrinsic = builder.module.declare_intrinsic(
+        _BINARY_INTRINSIC_MAP[type(op)], fnty=fn_type
+    )
     val_map[op.results[0]] = builder.call(intrinsic, [lhs, rhs])
 
 

--- a/xdsl/backend/llvm/convert_op.py
+++ b/xdsl/backend/llvm/convert_op.py
@@ -180,6 +180,7 @@ _UNARY_INTRINSIC_MAP: dict[type[Operation], str] = {
     llvm.FFloorOp: "llvm.floor",
     llvm.FSqrtOp: "llvm.sqrt",
     llvm.FLogOp: "llvm.log",
+    llvm.FCosOp: "llvm.cos",
 }
 
 _BINARY_INTRINSIC_MAP: dict[type[Operation], str] = {
@@ -192,8 +193,9 @@ def _convert_unary_intrinsic(
 ):
     operand = val_map[op.operands[0]]
     fn_type = ir.FunctionType(operand.type, [operand.type])
-    intrinsic_name = _UNARY_INTRINSIC_MAP[type(op)]
-    intrinsic = builder.module.declare_intrinsic(intrinsic_name, fnty=fn_type)
+    intrinsic = builder.module.declare_intrinsic(
+        _UNARY_INTRINSIC_MAP[type(op)], fnty=fn_type
+    )
     val_map[op.results[0]] = builder.call(intrinsic, [operand])
 
 
@@ -203,8 +205,9 @@ def _convert_binary_intrinsic(
     lhs = val_map[op.operands[0]]
     rhs = val_map[op.operands[1]]
     fn_type = ir.FunctionType(lhs.type, [lhs.type, rhs.type])
-    intrinsic_name = _BINARY_INTRINSIC_MAP[type(op)]
-    intrinsic = builder.module.declare_intrinsic(intrinsic_name, fnty=fn_type)
+    intrinsic = builder.module.declare_intrinsic(
+        _BINARY_INTRINSIC_MAP[type(op)], fnty=fn_type
+    )
     val_map[op.results[0]] = builder.call(intrinsic, [lhs, rhs])
 
 

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -2359,6 +2359,39 @@ class FLogOp(IRDLOperation):
 
 
 @irdl_op_definition
+class FCosOp(IRDLOperation):
+    T: ClassVar = VarConstraint("T", AnyFloatConstr | VectorType.constr(AnyFloatConstr))
+
+    name = "llvm.intr.cos"
+
+    arg = operand_def(T)
+    res = result_def(T)
+
+    fastmathFlags = prop_def(FastMathAttr, default_value=FastMathAttr(None))
+
+    assembly_format = (
+        "`(` operands `)` attr-dict `:` functional-type(operands, results)"
+    )
+
+    irdl_options = (ParsePropInAttrDict(),)
+
+    traits = traits_def(Pure())
+
+    def __init__(
+        self,
+        arg: Operation | SSAValue,
+        fast_math: FastMathAttr | FastMathFlag | None = None,
+    ):
+        if isinstance(fast_math, FastMathFlag | str | None):
+            fast_math = FastMathAttr(fast_math)
+        super().__init__(
+            operands=[arg],
+            result_types=[SSAValue.get(arg).type],
+            properties={"fastmathFlags": fast_math},
+        )
+
+
+@irdl_op_definition
 class FNegOp(IRDLOperation):
     T: ClassVar = VarConstraint("T", AnyFloatConstr | VectorType.constr(AnyFloatConstr))
 
@@ -2565,6 +2598,7 @@ LLVM = Dialect(
         FAbsOp,
         FAddOp,
         FCmpOp,
+        FCosOp,
         FDivOp,
         FLogOp,
         FMulOp,

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -3208,6 +3208,10 @@ class FSinOp(IRDLOperation):
     T: ClassVar = VarConstraint("T", AnyFloatConstr | VectorType.constr(AnyFloatConstr))
 
     name = "llvm.intr.sin"
+class FCosOp(IRDLOperation):
+    T: ClassVar = VarConstraint("T", AnyFloatConstr | VectorType.constr(AnyFloatConstr))
+
+    name = "llvm.intr.cos"
 
     arg = operand_def(T)
     res = result_def(T)
@@ -3481,6 +3485,7 @@ LLVM = Dialect(
         FAddOp,
         FCeilOp,
         FCmpOp,
+        FCosOp,
         FDivOp,
         FExpOp,
         FFloorOp,

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -3208,6 +3208,35 @@ class FSinOp(IRDLOperation):
     T: ClassVar = VarConstraint("T", AnyFloatConstr | VectorType.constr(AnyFloatConstr))
 
     name = "llvm.intr.sin"
+
+    arg = operand_def(T)
+    res = result_def(T)
+
+    fastmathFlags = prop_def(FastMathAttr, default_value=FastMathAttr(None))
+
+    assembly_format = (
+        "`(` operands `)` attr-dict `:` functional-type(operands, results)"
+    )
+
+    irdl_options = (ParsePropInAttrDict(),)
+
+    traits = traits_def(Pure())
+
+    def __init__(
+        self,
+        arg: Operation | SSAValue,
+        fast_math: FastMathAttr | FastMathFlag | None = None,
+    ):
+        if not isinstance(fast_math, FastMathAttr):
+            fast_math = FastMathAttr(fast_math)
+        super().__init__(
+            operands=[arg],
+            result_types=[SSAValue.get(arg).type],
+            properties={"fastmathFlags": fast_math},
+        )
+
+
+@irdl_op_definition
 class FCosOp(IRDLOperation):
     T: ClassVar = VarConstraint("T", AnyFloatConstr | VectorType.constr(AnyFloatConstr))
 


### PR DESCRIPTION
- Add `llvm.intr.cos` (`FCosOp`) to the LLVM dialect; accepts scalar or vector-of-float
- Wire into `_UNARY_INTRINSIC_MAP` in `convert_op.py` (refactors `_convert_fabs` into a shared unary-intrinsic dispatch)
- Dialect + MLIR + backend + pytest coverage mirroring `FAbsOp`

Refs:
- MLIR: https://mlir.llvm.org/docs/Dialects/LLVM/#llvmintrcos-llvmcosop
- LangRef: https://llvm.org/docs/LangRef.html#llvm-cos-intrinsic