### PR TITLE
dialects: (llvm) add FLog2Op

### DIFF
--- a/tests/dialects/test_llvm.py
+++ b/tests/dialects/test_llvm.py
@@ -601,6 +601,13 @@ def test_flog_op():
     assert op.res.type == builtin.f32
 
 
+def test_flog2_op():
+    val = create_ssa_value(builtin.f32)
+    op = llvm.FLog2Op(val)
+    assert op.arg == val
+    assert op.res.type == builtin.f32
+
+
 def test_fneg_op():
     val = create_ssa_value(builtin.f32)
     op = llvm.FNegOp(val)

--- a/tests/dialects/test_llvm.py
+++ b/tests/dialects/test_llvm.py
@@ -650,6 +650,13 @@ def test_fcos_op():
     assert op.res.type == builtin.f32
 
 
+def test_flog2_op():
+    val = create_ssa_value(builtin.f32)
+    op = llvm.FLog2Op(val)
+    assert op.arg == val
+    assert op.res.type == builtin.f32
+
+
 def test_fneg_op():
     val = create_ssa_value(builtin.f32)
     op = llvm.FNegOp(val)

--- a/tests/filecheck/backend/llvm/convert_op.mlir
+++ b/tests/filecheck/backend/llvm/convert_op.mlir
@@ -671,6 +671,9 @@ builtin.module {
   // CHECK-NEXT: {
   // CHECK-NEXT: [[ENTRY:.\d+]]:
   // CHECK-NEXT:   %"[[RES:.\d+]]" = call float @"llvm.sqrt"(float %".1")
+  // CHECK-NEXT:   ret float %"[[RES]]"
+  // CHECK-NEXT: }
+
   llvm.func @flog_op(%arg0: f32) -> f32 {
     %0 = llvm.intr.log(%arg0) : (f32) -> f32
     llvm.return %0 : f32
@@ -680,6 +683,18 @@ builtin.module {
   // CHECK-NEXT: {
   // CHECK-NEXT: [[ENTRY:.\d+]]:
   // CHECK-NEXT:   %"[[RES:.\d+]]" = call float @"llvm.log"(float %".1")
+  // CHECK-NEXT:   ret float %"[[RES]]"
+  // CHECK-NEXT: }
+
+  llvm.func @flog2_op(%arg0: f32) -> f32 {
+    %0 = llvm.intr.log2(%arg0) : (f32) -> f32
+    llvm.return %0 : f32
+  }
+
+  // CHECK: define float @"flog2_op"(float %".1")
+  // CHECK-NEXT: {
+  // CHECK-NEXT: [[ENTRY:.\d+]]:
+  // CHECK-NEXT:   %"[[RES:.\d+]]" = call float @"llvm.log2"(float %".1")
   // CHECK-NEXT:   ret float %"[[RES]]"
   // CHECK-NEXT: }
 

--- a/tests/filecheck/backend/llvm/convert_op.mlir
+++ b/tests/filecheck/backend/llvm/convert_op.mlir
@@ -841,6 +841,18 @@ builtin.module {
   // CHECK-NEXT:   ret float %"[[RES]]"
   // CHECK-NEXT: }
 
+  llvm.func @flog2_op(%arg0: f32) -> f32 {
+    %0 = llvm.intr.log2(%arg0) : (f32) -> f32
+    llvm.return %0 : f32
+  }
+
+  // CHECK: define float @"flog2_op"(float %".1")
+  // CHECK-NEXT: {
+  // CHECK-NEXT: [[ENTRY:.\d+]]:
+  // CHECK-NEXT:   %"[[RES:.\d+]]" = call float @"llvm.log2"(float %".1")
+  // CHECK-NEXT:   ret float %"[[RES]]"
+  // CHECK-NEXT: }
+
   llvm.func @fneg_op(%arg0: f32) -> f32 {
     %0 = llvm.fneg %arg0 : f32
     llvm.return %0 : f32

--- a/tests/filecheck/dialects/irdl/pyrdl-to-irdl/cmath-conversion.py
+++ b/tests/filecheck/dialects/irdl/pyrdl-to-irdl/cmath-conversion.py
@@ -1,7 +1,6 @@
 # RUN: python %s | filecheck %s
 
 from xdsl.dialects.cmath import Cmath
-
 from xdsl.dialects.irdl.pyrdl_to_irdl import dialect_to_irdl
 
 print(dialect_to_irdl(Cmath, "cmath"))

--- a/tests/filecheck/dialects/irdl/pyrdl-to-irdl/cmath-conversion.py
+++ b/tests/filecheck/dialects/irdl/pyrdl-to-irdl/cmath-conversion.py
@@ -1,6 +1,7 @@
 # RUN: python %s | filecheck %s
 
 from xdsl.dialects.cmath import Cmath
+
 from xdsl.dialects.irdl.pyrdl_to_irdl import dialect_to_irdl
 
 print(dialect_to_irdl(Cmath, "cmath"))

--- a/tests/filecheck/dialects/llvm/llvm_intrinsics.mlir
+++ b/tests/filecheck/dialects/llvm/llvm_intrinsics.mlir
@@ -30,6 +30,15 @@
 %flog_vec = llvm.intr.log(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
 // CHECK-NEXT: %flog_vec = llvm.intr.log(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
 
+%flog2_f32 = llvm.intr.log2(%f32) : (f32) -> f32
+// CHECK: %flog2_f32 = llvm.intr.log2(%f32) : (f32) -> f32
+
+%flog2_f64 = llvm.intr.log2(%f64) : (f64) -> f64
+// CHECK-NEXT: %flog2_f64 = llvm.intr.log2(%f64) : (f64) -> f64
+
+%flog2_vec = llvm.intr.log2(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
+// CHECK-NEXT: %flog2_vec = llvm.intr.log2(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
+
 %fneg_f32 = llvm.fneg %f32 : f32
 // CHECK: %fneg_f32 = llvm.fneg %f32 : f32
 

--- a/tests/filecheck/dialects/llvm/llvm_intrinsics.mlir
+++ b/tests/filecheck/dialects/llvm/llvm_intrinsics.mlir
@@ -84,6 +84,15 @@
 %fcos_vec = llvm.intr.cos(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
 // CHECK-NEXT: %fcos_vec = llvm.intr.cos(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
 
+%flog2_f32 = llvm.intr.log2(%f32) : (f32) -> f32
+// CHECK: %flog2_f32 = llvm.intr.log2(%f32) : (f32) -> f32
+
+%flog2_f64 = llvm.intr.log2(%f64) : (f64) -> f64
+// CHECK-NEXT: %flog2_f64 = llvm.intr.log2(%f64) : (f64) -> f64
+
+%flog2_vec = llvm.intr.log2(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
+// CHECK-NEXT: %flog2_vec = llvm.intr.log2(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
+
 %fneg_f32 = llvm.fneg %f32 : f32
 // CHECK: %fneg_f32 = llvm.fneg %f32 : f32
 

--- a/xdsl/backend/llvm/convert_op.py
+++ b/xdsl/backend/llvm/convert_op.py
@@ -169,6 +169,7 @@ _UNARY_INTRINSIC_MAP: dict[type[Operation], str] = {
     llvm.FAbsOp: "llvm.fabs",
     llvm.FSqrtOp: "llvm.sqrt",
     llvm.FLogOp: "llvm.log",
+    llvm.FLog2Op: "llvm.log2",
 }
 
 

--- a/xdsl/backend/llvm/convert_op.py
+++ b/xdsl/backend/llvm/convert_op.py
@@ -182,6 +182,7 @@ _UNARY_INTRINSIC_MAP: dict[type[Operation], str] = {
     llvm.FSqrtOp: "llvm.sqrt",
     llvm.FLogOp: "llvm.log",
     llvm.FCosOp: "llvm.cos",
+    llvm.FLog2Op: "llvm.log2",
 }
 
 _BINARY_INTRINSIC_MAP: dict[type[Operation], str] = {

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -2359,6 +2359,39 @@ class FLogOp(IRDLOperation):
 
 
 @irdl_op_definition
+class FLog2Op(IRDLOperation):
+    T: ClassVar = VarConstraint("T", AnyFloatConstr | VectorType.constr(AnyFloatConstr))
+
+    name = "llvm.intr.log2"
+
+    arg = operand_def(T)
+    res = result_def(T)
+
+    fastmathFlags = prop_def(FastMathAttr, default_value=FastMathAttr(None))
+
+    assembly_format = (
+        "`(` operands `)` attr-dict `:` functional-type(operands, results)"
+    )
+
+    irdl_options = (ParsePropInAttrDict(),)
+
+    traits = traits_def(Pure())
+
+    def __init__(
+        self,
+        arg: Operation | SSAValue,
+        fast_math: FastMathAttr | FastMathFlag | None = None,
+    ):
+        if isinstance(fast_math, FastMathFlag | str | None):
+            fast_math = FastMathAttr(fast_math)
+        super().__init__(
+            operands=[arg],
+            result_types=[SSAValue.get(arg).type],
+            properties={"fastmathFlags": fast_math},
+        )
+
+
+@irdl_op_definition
 class FNegOp(IRDLOperation):
     T: ClassVar = VarConstraint("T", AnyFloatConstr | VectorType.constr(AnyFloatConstr))
 
@@ -2567,6 +2600,7 @@ LLVM = Dialect(
         FCmpOp,
         FDivOp,
         FLogOp,
+        FLog2Op,
         FMulOp,
         FNegOp,
         FPExtOp,

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -3303,6 +3303,39 @@ class FCosOp(IRDLOperation):
 
 
 @irdl_op_definition
+class FLog2Op(IRDLOperation):
+    T: ClassVar = VarConstraint("T", AnyFloatConstr | VectorType.constr(AnyFloatConstr))
+
+    name = "llvm.intr.log2"
+
+    arg = operand_def(T)
+    res = result_def(T)
+
+    fastmathFlags = prop_def(FastMathAttr, default_value=FastMathAttr(None))
+
+    assembly_format = (
+        "`(` operands `)` attr-dict `:` functional-type(operands, results)"
+    )
+
+    irdl_options = (ParsePropInAttrDict(),)
+
+    traits = traits_def(Pure())
+
+    def __init__(
+        self,
+        arg: Operation | SSAValue,
+        fast_math: FastMathAttr | FastMathFlag | None = None,
+    ):
+        if isinstance(fast_math, FastMathFlag | str | None):
+            fast_math = FastMathAttr(fast_math)
+        super().__init__(
+            operands=[arg],
+            result_types=[SSAValue.get(arg).type],
+            properties={"fastmathFlags": fast_math},
+        )
+
+
+@irdl_op_definition
 class FNegOp(IRDLOperation):
     T: ClassVar = VarConstraint("T", AnyFloatConstr | VectorType.constr(AnyFloatConstr))
 
@@ -3588,6 +3621,7 @@ LLVM = Dialect(
         FFloorOp,
         FExp2Op,
         FLogOp,
+        FLog2Op,
         FMAOp,
         FMulOp,
         FNegOp,


### PR DESCRIPTION
- Add `llvm.intr.log2` (`FLog2Op`) to the LLVM dialect; accepts scalar or vector-of-float
- Refactor `_convert_fabs` into a shared `_UNARY_INTRINSIC_MAP` dispatch and wire `FLog2Op` through it
- Dialect + MLIR + backend + pytest coverage mirroring `FAbsOp`

Refs:
- MLIR: https://mlir.llvm.org/docs/Dialects/LLVM/#llvmintrlog2-llvmlog2op
- LangRef: https://llvm.org/docs/LangRef.html#llvm-log2-intrinsic