### PR TITLE
dialects: (llvm) add FFloorOp

### DIFF
--- a/tests/dialects/test_llvm.py
+++ b/tests/dialects/test_llvm.py
@@ -594,6 +594,13 @@ def test_fsqrt_op():
     assert op.res.type == builtin.f32
 
 
+def test_ffloor_op():
+    val = create_ssa_value(builtin.f32)
+    op = llvm.FFloorOp(val)
+    assert op.arg == val
+    assert op.res.type == builtin.f32
+
+
 def test_flog_op():
     val = create_ssa_value(builtin.f32)
     op = llvm.FLogOp(val)

--- a/tests/dialects/test_llvm.py
+++ b/tests/dialects/test_llvm.py
@@ -607,6 +607,13 @@ def test_fsqrt_op():
     assert op.res.type == builtin.f32
 
 
+def test_ffloor_op():
+    val = create_ssa_value(builtin.f32)
+    op = llvm.FFloorOp(val)
+    assert op.arg == val
+    assert op.res.type == builtin.f32
+
+
 def test_flog_op():
     val = create_ssa_value(builtin.f32)
     op = llvm.FLogOp(val)

--- a/tests/filecheck/backend/llvm/convert_op.mlir
+++ b/tests/filecheck/backend/llvm/convert_op.mlir
@@ -671,6 +671,21 @@ builtin.module {
   // CHECK-NEXT: {
   // CHECK-NEXT: [[ENTRY:.\d+]]:
   // CHECK-NEXT:   %"[[RES:.\d+]]" = call float @"llvm.sqrt"(float %".1")
+  // CHECK-NEXT:   ret float %"[[RES]]"
+  // CHECK-NEXT: }
+
+  llvm.func @ffloor_op(%arg0: f32) -> f32 {
+    %0 = llvm.intr.floor(%arg0) : (f32) -> f32
+    llvm.return %0 : f32
+  }
+
+  // CHECK: define float @"ffloor_op"(float %".1")
+  // CHECK-NEXT: {
+  // CHECK-NEXT: [[ENTRY:.\d+]]:
+  // CHECK-NEXT:   %"[[RES:.\d+]]" = call float @"llvm.floor"(float %".1")
+  // CHECK-NEXT:   ret float %"[[RES]]"
+  // CHECK-NEXT: }
+
   llvm.func @flog_op(%arg0: f32) -> f32 {
     %0 = llvm.intr.log(%arg0) : (f32) -> f32
     llvm.return %0 : f32

--- a/tests/filecheck/backend/llvm/convert_op.mlir
+++ b/tests/filecheck/backend/llvm/convert_op.mlir
@@ -760,6 +760,18 @@ builtin.module {
   // CHECK-NEXT:   ret float %"[[RES]]"
   // CHECK-NEXT: }
 
+  llvm.func @ffloor_op(%arg0: f32) -> f32 {
+    %0 = llvm.intr.floor(%arg0) : (f32) -> f32
+    llvm.return %0 : f32
+  }
+
+  // CHECK: define float @"ffloor_op"(float %".1")
+  // CHECK-NEXT: {
+  // CHECK-NEXT: [[ENTRY:.\d+]]:
+  // CHECK-NEXT:   %"[[RES:.\d+]]" = call float @"llvm.floor"(float %".1")
+  // CHECK-NEXT:   ret float %"[[RES]]"
+  // CHECK-NEXT: }
+
   llvm.func @flog_op(%arg0: f32) -> f32 {
     %0 = llvm.intr.log(%arg0) : (f32) -> f32
     llvm.return %0 : f32

--- a/tests/filecheck/dialects/irdl/pyrdl-to-irdl/cmath-conversion.py
+++ b/tests/filecheck/dialects/irdl/pyrdl-to-irdl/cmath-conversion.py
@@ -1,7 +1,6 @@
 # RUN: python %s | filecheck %s
 
 from xdsl.dialects.cmath import Cmath
-
 from xdsl.dialects.irdl.pyrdl_to_irdl import dialect_to_irdl
 
 print(dialect_to_irdl(Cmath, "cmath"))

--- a/tests/filecheck/dialects/irdl/pyrdl-to-irdl/cmath-conversion.py
+++ b/tests/filecheck/dialects/irdl/pyrdl-to-irdl/cmath-conversion.py
@@ -1,6 +1,7 @@
 # RUN: python %s | filecheck %s
 
 from xdsl.dialects.cmath import Cmath
+
 from xdsl.dialects.irdl.pyrdl_to_irdl import dialect_to_irdl
 
 print(dialect_to_irdl(Cmath, "cmath"))

--- a/tests/filecheck/dialects/llvm/llvm_intrinsics.mlir
+++ b/tests/filecheck/dialects/llvm/llvm_intrinsics.mlir
@@ -21,6 +21,16 @@
 
 %fsqrt_vec = llvm.intr.sqrt(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
 // CHECK-NEXT: %fsqrt_vec = llvm.intr.sqrt(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
+
+%ffloor_f32 = llvm.intr.floor(%f32) : (f32) -> f32
+// CHECK: %ffloor_f32 = llvm.intr.floor(%f32) : (f32) -> f32
+
+%ffloor_f64 = llvm.intr.floor(%f64) : (f64) -> f64
+// CHECK-NEXT: %ffloor_f64 = llvm.intr.floor(%f64) : (f64) -> f64
+
+%ffloor_vec = llvm.intr.floor(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
+// CHECK-NEXT: %ffloor_vec = llvm.intr.floor(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
+
 %flog_f32 = llvm.intr.log(%f32) : (f32) -> f32
 // CHECK: %flog_f32 = llvm.intr.log(%f32) : (f32) -> f32
 

--- a/tests/filecheck/dialects/llvm/llvm_intrinsics.mlir
+++ b/tests/filecheck/dialects/llvm/llvm_intrinsics.mlir
@@ -31,6 +31,18 @@
 %fsqrt_vec = llvm.intr.sqrt(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
 // CHECK-NEXT: %fsqrt_vec = llvm.intr.sqrt(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
 
+<<<<<<< HEAD
+=======
+%ffloor_f32 = llvm.intr.floor(%f32) : (f32) -> f32
+// CHECK: %ffloor_f32 = llvm.intr.floor(%f32) : (f32) -> f32
+
+%ffloor_f64 = llvm.intr.floor(%f64) : (f64) -> f64
+// CHECK-NEXT: %ffloor_f64 = llvm.intr.floor(%f64) : (f64) -> f64
+
+%ffloor_vec = llvm.intr.floor(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
+// CHECK-NEXT: %ffloor_vec = llvm.intr.floor(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
+
+>>>>>>> 08857e1cb (dialects: (llvm) add FFloorOp)
 %flog_f32 = llvm.intr.log(%f32) : (f32) -> f32
 // CHECK: %flog_f32 = llvm.intr.log(%f32) : (f32) -> f32
 

--- a/tests/filecheck/dialects/llvm/llvm_intrinsics.mlir
+++ b/tests/filecheck/dialects/llvm/llvm_intrinsics.mlir
@@ -31,8 +31,6 @@
 %fsqrt_vec = llvm.intr.sqrt(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
 // CHECK-NEXT: %fsqrt_vec = llvm.intr.sqrt(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
 
-<<<<<<< HEAD
-=======
 %ffloor_f32 = llvm.intr.floor(%f32) : (f32) -> f32
 // CHECK: %ffloor_f32 = llvm.intr.floor(%f32) : (f32) -> f32
 
@@ -42,7 +40,6 @@
 %ffloor_vec = llvm.intr.floor(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
 // CHECK-NEXT: %ffloor_vec = llvm.intr.floor(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
 
->>>>>>> 08857e1cb (dialects: (llvm) add FFloorOp)
 %flog_f32 = llvm.intr.log(%f32) : (f32) -> f32
 // CHECK: %flog_f32 = llvm.intr.log(%f32) : (f32) -> f32
 

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/llvm_intrinsics.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/llvm_intrinsics.mlir
@@ -30,6 +30,14 @@
 
 %fsin_2 = llvm.intr.sin(%arg2) : (vector<4xf32>) -> vector<4xf32>
 // CHECK: llvm.intr.sin([[arg2]]) : (vector<4xf32>) -> vector<4xf32>
+%ffloor_f32 = llvm.intr.floor(%arg0) : (f32) -> f32
+// CHECK: llvm.intr.floor([[arg0]]) : (f32) -> f32
+
+%ffloor_f64 = llvm.intr.floor(%arg1) : (f64) -> f64
+// CHECK: llvm.intr.floor([[arg1]]) : (f64) -> f64
+
+%ffloor_vec = llvm.intr.floor(%arg2) : (vector<4xf32>) -> vector<4xf32>
+// CHECK: llvm.intr.floor([[arg2]]) : (vector<4xf32>) -> vector<4xf32>
 
 %3 = llvm.fneg %arg0 : f32
 // CHECK: llvm.fneg [[arg0]] : f32

--- a/xdsl/backend/llvm/convert_op.py
+++ b/xdsl/backend/llvm/convert_op.py
@@ -198,6 +198,7 @@ def _convert_binary_intrinsic(
     intrinsic = builder.module.declare_intrinsic(intrinsic_name, fnty=fn_type)
     val_map[op.results[0]] = builder.call(intrinsic, [lhs, rhs])
 
+
 def _convert_fneg(
     op: llvm.FNegOp, builder: ir.IRBuilder, val_map: dict[SSAValue, ir.Value]
 ):

--- a/xdsl/backend/llvm/convert_op.py
+++ b/xdsl/backend/llvm/convert_op.py
@@ -167,6 +167,7 @@ def _convert_fcmp(
 
 _UNARY_INTRINSIC_MAP: dict[type[Operation], str] = {
     llvm.FAbsOp: "llvm.fabs",
+    llvm.FFloorOp: "llvm.floor",
     llvm.FSqrtOp: "llvm.sqrt",
     llvm.FLogOp: "llvm.log",
 }
@@ -196,7 +197,6 @@ def _convert_binary_intrinsic(
     intrinsic_name = _BINARY_INTRINSIC_MAP[type(op)]
     intrinsic = builder.module.declare_intrinsic(intrinsic_name, fnty=fn_type)
     val_map[op.results[0]] = builder.call(intrinsic, [lhs, rhs])
-
 
 def _convert_fneg(
     op: llvm.FNegOp, builder: ir.IRBuilder, val_map: dict[SSAValue, ir.Value]

--- a/xdsl/backend/llvm/convert_op.py
+++ b/xdsl/backend/llvm/convert_op.py
@@ -177,6 +177,7 @@ _UNARY_INTRINSIC_MAP: dict[type[Operation], str] = {
     llvm.FExpOp: "llvm.exp",
     llvm.FCeilOp: "llvm.ceil",
     llvm.FSinOp: "llvm.sin",
+    llvm.FFloorOp: "llvm.floor",
     llvm.FSqrtOp: "llvm.sqrt",
     llvm.FLogOp: "llvm.log",
 }
@@ -205,7 +206,6 @@ def _convert_binary_intrinsic(
     intrinsic_name = _BINARY_INTRINSIC_MAP[type(op)]
     intrinsic = builder.module.declare_intrinsic(intrinsic_name, fnty=fn_type)
     val_map[op.results[0]] = builder.call(intrinsic, [lhs, rhs])
-
 
 def _convert_fneg(
     op: llvm.FNegOp, builder: ir.IRBuilder, val_map: dict[SSAValue, ir.Value]

--- a/xdsl/backend/llvm/convert_op.py
+++ b/xdsl/backend/llvm/convert_op.py
@@ -207,6 +207,7 @@ def _convert_binary_intrinsic(
     intrinsic = builder.module.declare_intrinsic(intrinsic_name, fnty=fn_type)
     val_map[op.results[0]] = builder.call(intrinsic, [lhs, rhs])
 
+
 def _convert_fneg(
     op: llvm.FNegOp, builder: ir.IRBuilder, val_map: dict[SSAValue, ir.Value]
 ):

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -2326,6 +2326,39 @@ class FSqrtOp(IRDLOperation):
 
 
 @irdl_op_definition
+class FFloorOp(IRDLOperation):
+    T: ClassVar = VarConstraint("T", AnyFloatConstr | VectorType.constr(AnyFloatConstr))
+
+    name = "llvm.intr.floor"
+
+    arg = operand_def(T)
+    res = result_def(T)
+
+    fastmathFlags = prop_def(FastMathAttr, default_value=FastMathAttr(None))
+
+    assembly_format = (
+        "`(` operands `)` attr-dict `:` functional-type(operands, results)"
+    )
+
+    irdl_options = (ParsePropInAttrDict(),)
+
+    traits = traits_def(Pure())
+
+    def __init__(
+        self,
+        arg: Operation | SSAValue,
+        fast_math: FastMathAttr | FastMathFlag | None = None,
+    ):
+        if isinstance(fast_math, FastMathFlag | str | None):
+            fast_math = FastMathAttr(fast_math)
+        super().__init__(
+            operands=[arg],
+            result_types=[SSAValue.get(arg).type],
+            properties={"fastmathFlags": fast_math},
+        )
+
+
+@irdl_op_definition
 class FLogOp(IRDLOperation):
     T: ClassVar = VarConstraint("T", AnyFloatConstr | VectorType.constr(AnyFloatConstr))
 
@@ -2566,6 +2599,7 @@ LLVM = Dialect(
         FAddOp,
         FCmpOp,
         FDivOp,
+        FFloorOp,
         FLogOp,
         FMulOp,
         FNegOp,

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -3105,6 +3105,39 @@ class FSqrtOp(IRDLOperation):
 
 
 @irdl_op_definition
+class FFloorOp(IRDLOperation):
+    T: ClassVar = VarConstraint("T", AnyFloatConstr | VectorType.constr(AnyFloatConstr))
+
+    name = "llvm.intr.floor"
+
+    arg = operand_def(T)
+    res = result_def(T)
+
+    fastmathFlags = prop_def(FastMathAttr, default_value=FastMathAttr(None))
+
+    assembly_format = (
+        "`(` operands `)` attr-dict `:` functional-type(operands, results)"
+    )
+
+    irdl_options = (ParsePropInAttrDict(),)
+
+    traits = traits_def(Pure())
+
+    def __init__(
+        self,
+        arg: Operation | SSAValue,
+        fast_math: FastMathAttr | FastMathFlag | None = None,
+    ):
+        if isinstance(fast_math, FastMathFlag | str | None):
+            fast_math = FastMathAttr(fast_math)
+        super().__init__(
+            operands=[arg],
+            result_types=[SSAValue.get(arg).type],
+            properties={"fastmathFlags": fast_math},
+        )
+
+
+@irdl_op_definition
 class FLogOp(IRDLOperation):
     T: ClassVar = VarConstraint("T", AnyFloatConstr | VectorType.constr(AnyFloatConstr))
 
@@ -3450,6 +3483,8 @@ LLVM = Dialect(
         FCmpOp,
         FDivOp,
         FExpOp,
+
+        FFloorOp,
         FLogOp,
         FMAOp,
         FMulOp,

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -3483,7 +3483,6 @@ LLVM = Dialect(
         FCmpOp,
         FDivOp,
         FExpOp,
-
         FFloorOp,
         FLogOp,
         FMAOp,

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -3128,7 +3128,7 @@ class FFloorOp(IRDLOperation):
         arg: Operation | SSAValue,
         fast_math: FastMathAttr | FastMathFlag | None = None,
     ):
-        if isinstance(fast_math, FastMathFlag | str | None):
+        if not isinstance(fast_math, FastMathAttr):
             fast_math = FastMathAttr(fast_math)
         super().__init__(
             operands=[arg],


### PR DESCRIPTION
- Add `llvm.intr.floor` (`FFloorOp`) to the LLVM dialect; accepts scalar or vector-of-float
- Wire backend lowering via llvmlite (`declare_intrinsic("llvm.floor", ...)`)
- Dialect + MLIR + backend + pytest coverage mirroring `FAbsOp`

Refs:
- MLIR: https://mlir.llvm.org/docs/Dialects/LLVM/#llvmintrfloor-llvmfloorop
- LangRef: https://llvm.org/docs/LangRef.html#llvm-floor-intrinsic