### PR TITLE
dialects: (llvm) add FMAOp

### DIFF
--- a/tests/dialects/test_llvm.py
+++ b/tests/dialects/test_llvm.py
@@ -601,6 +601,17 @@ def test_flog_op():
     assert op.res.type == builtin.f32
 
 
+def test_fma_op():
+    a = create_ssa_value(builtin.f32)
+    b = create_ssa_value(builtin.f32)
+    c = create_ssa_value(builtin.f32)
+    op = llvm.FMAOp(a, b, c)
+    assert op.a == a
+    assert op.b == b
+    assert op.c == c
+    assert op.res.type == builtin.f32
+
+
 def test_fneg_op():
     val = create_ssa_value(builtin.f32)
     op = llvm.FNegOp(val)

--- a/tests/dialects/test_llvm.py
+++ b/tests/dialects/test_llvm.py
@@ -608,6 +608,17 @@ def test_flog_op():
     assert op.res.type == builtin.f32
 
 
+def test_fma_op():
+    a = create_ssa_value(builtin.f32)
+    b = create_ssa_value(builtin.f32)
+    c = create_ssa_value(builtin.f32)
+    op = llvm.FMAOp(a, b, c)
+    assert op.a == a
+    assert op.b == b
+    assert op.c == c
+    assert op.res.type == builtin.f32
+
+
 def test_fneg_op():
     val = create_ssa_value(builtin.f32)
     op = llvm.FNegOp(val)

--- a/tests/filecheck/backend/llvm/convert_op.mlir
+++ b/tests/filecheck/backend/llvm/convert_op.mlir
@@ -671,6 +671,9 @@ builtin.module {
   // CHECK-NEXT: {
   // CHECK-NEXT: [[ENTRY:.\d+]]:
   // CHECK-NEXT:   %"[[RES:.\d+]]" = call float @"llvm.sqrt"(float %".1")
+  // CHECK-NEXT:   ret float %"[[RES]]"
+  // CHECK-NEXT: }
+
   llvm.func @flog_op(%arg0: f32) -> f32 {
     %0 = llvm.intr.log(%arg0) : (f32) -> f32
     llvm.return %0 : f32
@@ -683,6 +686,41 @@ builtin.module {
   // CHECK-NEXT:   ret float %"[[RES]]"
   // CHECK-NEXT: }
 
+  llvm.func @llvm_intr_fma_op_f32(%arg0: f32, %arg1: f32, %arg2: f32) -> f32 {
+    %0 = llvm.intr.fma(%arg0, %arg1, %arg2) : (f32, f32, f32) -> f32
+    llvm.return %0 : f32
+  }
+
+  // CHECK: define float @"llvm_intr_fma_op_f32"(float %".1", float %".2", float %".3")
+  // CHECK-NEXT: {
+  // CHECK-NEXT: [[ENTRY:.\d+]]:
+  // CHECK-NEXT:   %"[[RES:.\d+]]" = call float @"llvm.fma.f32"(float %".1", float %".2", float %".3")
+  // CHECK-NEXT:   ret float %"[[RES]]"
+  // CHECK-NEXT: }
+
+  llvm.func @llvm_intr_fma_op_f64(%arg0: f64, %arg1: f64, %arg2: f64) -> f64 {
+    %0 = llvm.intr.fma(%arg0, %arg1, %arg2) : (f64, f64, f64) -> f64
+    llvm.return %0 : f64
+  }
+
+  // CHECK: define double @"llvm_intr_fma_op_f64"(double %".1", double %".2", double %".3")
+  // CHECK-NEXT: {
+  // CHECK-NEXT: [[ENTRY:.\d+]]:
+  // CHECK-NEXT:   %"[[RES:.\d+]]" = call double @"llvm.fma.f64"(double %".1", double %".2", double %".3")
+  // CHECK-NEXT:   ret double %"[[RES]]"
+  // CHECK-NEXT: }
+
+  llvm.func @llvm_intr_fma_op_vec_f32(%arg0: vector<4xf32>, %arg1: vector<4xf32>, %arg2: vector<4xf32>) -> vector<4xf32> {
+    %0 = llvm.intr.fma(%arg0, %arg1, %arg2) : (vector<4xf32>, vector<4xf32>, vector<4xf32>) -> vector<4xf32>
+    llvm.return %0 : vector<4xf32>
+  }
+
+  // CHECK: define <4 x float> @"llvm_intr_fma_op_vec_f32"(<4 x float> %".1", <4 x float> %".2", <4 x float> %".3")
+  // CHECK-NEXT: {
+  // CHECK-NEXT: [[ENTRY:.\d+]]:
+  // CHECK-NEXT:   %"[[RES:.\d+]]" = call <4 x float> @"llvm.fma.v4f32"(<4 x float> %".1", <4 x float> %".2", <4 x float> %".3")
+  // CHECK-NEXT:   ret <4 x float> %"[[RES]]"
+  // CHECK-NEXT: }
   llvm.func @fneg_op(%arg0: f32) -> f32 {
     %0 = llvm.fneg %arg0 : f32
     llvm.return %0 : f32

--- a/tests/filecheck/backend/llvm/convert_op.mlir
+++ b/tests/filecheck/backend/llvm/convert_op.mlir
@@ -759,6 +759,41 @@ builtin.module {
   // CHECK-NEXT:   ret float %"[[RES]]"
   // CHECK-NEXT: }
 
+  llvm.func @llvm_intr_fma_op_f32(%arg0: f32, %arg1: f32, %arg2: f32) -> f32 {
+    %0 = llvm.intr.fma(%arg0, %arg1, %arg2) : (f32, f32, f32) -> f32
+    llvm.return %0 : f32
+  }
+
+  // CHECK: define float @"llvm_intr_fma_op_f32"(float %".1", float %".2", float %".3")
+  // CHECK-NEXT: {
+  // CHECK-NEXT: [[ENTRY:.\d+]]:
+  // CHECK-NEXT:   %"[[RES:.\d+]]" = call float @"llvm.fma.f32"(float %".1", float %".2", float %".3")
+  // CHECK-NEXT:   ret float %"[[RES]]"
+  // CHECK-NEXT: }
+
+  llvm.func @llvm_intr_fma_op_f64(%arg0: f64, %arg1: f64, %arg2: f64) -> f64 {
+    %0 = llvm.intr.fma(%arg0, %arg1, %arg2) : (f64, f64, f64) -> f64
+    llvm.return %0 : f64
+  }
+
+  // CHECK: define double @"llvm_intr_fma_op_f64"(double %".1", double %".2", double %".3")
+  // CHECK-NEXT: {
+  // CHECK-NEXT: [[ENTRY:.\d+]]:
+  // CHECK-NEXT:   %"[[RES:.\d+]]" = call double @"llvm.fma.f64"(double %".1", double %".2", double %".3")
+  // CHECK-NEXT:   ret double %"[[RES]]"
+  // CHECK-NEXT: }
+
+  llvm.func @llvm_intr_fma_op_vec_f32(%arg0: vector<4xf32>, %arg1: vector<4xf32>, %arg2: vector<4xf32>) -> vector<4xf32> {
+    %0 = llvm.intr.fma(%arg0, %arg1, %arg2) : (vector<4xf32>, vector<4xf32>, vector<4xf32>) -> vector<4xf32>
+    llvm.return %0 : vector<4xf32>
+  }
+
+  // CHECK: define <4 x float> @"llvm_intr_fma_op_vec_f32"(<4 x float> %".1", <4 x float> %".2", <4 x float> %".3")
+  // CHECK-NEXT: {
+  // CHECK-NEXT: [[ENTRY:.\d+]]:
+  // CHECK-NEXT:   %"[[RES:.\d+]]" = call <4 x float> @"llvm.fma.v4f32"(<4 x float> %".1", <4 x float> %".2", <4 x float> %".3")
+  // CHECK-NEXT:   ret <4 x float> %"[[RES]]"
+  // CHECK-NEXT: }
   llvm.func @fneg_op(%arg0: f32) -> f32 {
     %0 = llvm.fneg %arg0 : f32
     llvm.return %0 : f32

--- a/tests/filecheck/dialects/irdl/pyrdl-to-irdl/cmath-conversion.py
+++ b/tests/filecheck/dialects/irdl/pyrdl-to-irdl/cmath-conversion.py
@@ -1,7 +1,6 @@
 # RUN: python %s | filecheck %s
 
 from xdsl.dialects.cmath import Cmath
-
 from xdsl.dialects.irdl.pyrdl_to_irdl import dialect_to_irdl
 
 print(dialect_to_irdl(Cmath, "cmath"))

--- a/tests/filecheck/dialects/irdl/pyrdl-to-irdl/cmath-conversion.py
+++ b/tests/filecheck/dialects/irdl/pyrdl-to-irdl/cmath-conversion.py
@@ -1,6 +1,7 @@
 # RUN: python %s | filecheck %s
 
 from xdsl.dialects.cmath import Cmath
+
 from xdsl.dialects.irdl.pyrdl_to_irdl import dialect_to_irdl
 
 print(dialect_to_irdl(Cmath, "cmath"))

--- a/tests/filecheck/dialects/llvm/llvm_intrinsics.mlir
+++ b/tests/filecheck/dialects/llvm/llvm_intrinsics.mlir
@@ -21,6 +21,7 @@
 
 %fsqrt_vec = llvm.intr.sqrt(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
 // CHECK-NEXT: %fsqrt_vec = llvm.intr.sqrt(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
+
 %flog_f32 = llvm.intr.log(%f32) : (f32) -> f32
 // CHECK: %flog_f32 = llvm.intr.log(%f32) : (f32) -> f32
 
@@ -29,6 +30,15 @@
 
 %flog_vec = llvm.intr.log(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
 // CHECK-NEXT: %flog_vec = llvm.intr.log(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
+
+%fma_f32 = llvm.intr.fma(%f32, %f32, %f32) : (f32, f32, f32) -> f32
+// CHECK: %fma_f32 = llvm.intr.fma(%f32, %f32, %f32) : (f32, f32, f32) -> f32
+
+%fma_f64 = llvm.intr.fma(%f64, %f64, %f64) : (f64, f64, f64) -> f64
+// CHECK-NEXT: %fma_f64 = llvm.intr.fma(%f64, %f64, %f64) : (f64, f64, f64) -> f64
+
+%fma_vec = llvm.intr.fma(%vec_f32, %vec_f32, %vec_f32) : (vector<4xf32>, vector<4xf32>, vector<4xf32>) -> vector<4xf32>
+// CHECK-NEXT: %fma_vec = llvm.intr.fma(%vec_f32, %vec_f32, %vec_f32) : (vector<4xf32>, vector<4xf32>, vector<4xf32>) -> vector<4xf32>
 
 %fneg_f32 = llvm.fneg %f32 : f32
 // CHECK: %fneg_f32 = llvm.fneg %f32 : f32

--- a/tests/filecheck/dialects/llvm/llvm_intrinsics.mlir
+++ b/tests/filecheck/dialects/llvm/llvm_intrinsics.mlir
@@ -30,6 +30,7 @@
 
 %fsqrt_vec = llvm.intr.sqrt(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
 // CHECK-NEXT: %fsqrt_vec = llvm.intr.sqrt(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
+
 %flog_f32 = llvm.intr.log(%f32) : (f32) -> f32
 // CHECK: %flog_f32 = llvm.intr.log(%f32) : (f32) -> f32
 
@@ -38,6 +39,15 @@
 
 %flog_vec = llvm.intr.log(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
 // CHECK-NEXT: %flog_vec = llvm.intr.log(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
+
+%fma_f32 = llvm.intr.fma(%f32, %f32, %f32) : (f32, f32, f32) -> f32
+// CHECK: %fma_f32 = llvm.intr.fma(%f32, %f32, %f32) : (f32, f32, f32) -> f32
+
+%fma_f64 = llvm.intr.fma(%f64, %f64, %f64) : (f64, f64, f64) -> f64
+// CHECK-NEXT: %fma_f64 = llvm.intr.fma(%f64, %f64, %f64) : (f64, f64, f64) -> f64
+
+%fma_vec = llvm.intr.fma(%vec_f32, %vec_f32, %vec_f32) : (vector<4xf32>, vector<4xf32>, vector<4xf32>) -> vector<4xf32>
+// CHECK-NEXT: %fma_vec = llvm.intr.fma(%vec_f32, %vec_f32, %vec_f32) : (vector<4xf32>, vector<4xf32>, vector<4xf32>) -> vector<4xf32>
 
 %fneg_f32 = llvm.fneg %f32 : f32
 // CHECK: %fneg_f32 = llvm.fneg %f32 : f32

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/llvm_intrinsics.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/llvm_intrinsics.mlir
@@ -13,6 +13,15 @@
 %2 = llvm.intr.fabs(%arg2) : (vector<4xf32>) -> vector<4xf32>
 // CHECK: llvm.intr.fabs([[arg2]]) : (vector<4xf32>) -> vector<4xf32>
 
+%fma_f32 = llvm.intr.fma(%arg0, %arg0, %arg0) : (f32, f32, f32) -> f32
+// CHECK: llvm.intr.fma([[arg0]], [[arg0]], [[arg0]]) : (f32, f32, f32) -> f32
+
+%fma_f64 = llvm.intr.fma(%arg1, %arg1, %arg1) : (f64, f64, f64) -> f64
+// CHECK: llvm.intr.fma([[arg1]], [[arg1]], [[arg1]]) : (f64, f64, f64) -> f64
+
+%fma_vec = llvm.intr.fma(%arg2, %arg2, %arg2) : (vector<4xf32>, vector<4xf32>, vector<4xf32>) -> vector<4xf32>
+// CHECK: llvm.intr.fma([[arg2]], [[arg2]], [[arg2]]) : (vector<4xf32>, vector<4xf32>, vector<4xf32>) -> vector<4xf32>
+
 %3 = llvm.fneg %arg0 : f32
 // CHECK: llvm.fneg [[arg0]] : f32
 

--- a/xdsl/backend/llvm/convert_op.py
+++ b/xdsl/backend/llvm/convert_op.py
@@ -205,6 +205,29 @@ def _convert_fneg(
     val_map[op.res] = builder.fneg(operand)
 
 
+def _convert_fma_intr(
+    op: llvm.FMAOp, builder: ir.IRBuilder, val_map: dict[SSAValue, ir.Value]
+):
+    a = val_map[op.a]
+    b = val_map[op.b]
+    c = val_map[op.c]
+    res_type = convert_type(op.res.type)
+    fn_type = ir.FunctionType(res_type, [res_type, res_type, res_type])
+    if isinstance(res_type, ir.VectorType):
+        assert isinstance(res_type.element, (ir.HalfType, ir.FloatType, ir.DoubleType))
+        # declare_intrinsic doesn't support VectorType, build name manually
+        name = f"llvm.fma.v{res_type.count}{res_type.element.intrinsic_name}"
+        try:
+            intrinsic = builder.module.get_global(name)
+        except KeyError:
+            intrinsic = ir.Function(builder.module, fn_type, name=name)
+    else:
+        intrinsic = builder.module.declare_intrinsic(
+            "llvm.fma", tys=[res_type], fnty=fn_type
+        )
+    val_map[op.res] = builder.call(intrinsic, [a, b, c])
+
+
 def _convert_call(
     op: llvm.CallOp, builder: ir.IRBuilder, val_map: dict[SSAValue, ir.Value]
 ):
@@ -428,6 +451,8 @@ def convert_op(
             _convert_binary_intrinsic(op, builder, val_map)
         case llvm.FNegOp():
             _convert_fneg(op, builder, val_map)
+        case llvm.FMAOp():
+            _convert_fma_intr(op, builder, val_map)
         case llvm.CallOp():
             _convert_call(op, builder, val_map)
         case llvm.AllocaOp():

--- a/xdsl/backend/llvm/convert_op.py
+++ b/xdsl/backend/llvm/convert_op.py
@@ -213,6 +213,29 @@ def _convert_fneg(
     val_map[op.res] = builder.fneg(operand)
 
 
+def _convert_fma_intr(
+    op: llvm.FMAOp, builder: ir.IRBuilder, val_map: dict[SSAValue, ir.Value]
+):
+    a = val_map[op.a]
+    b = val_map[op.b]
+    c = val_map[op.c]
+    res_type = convert_type(op.res.type)
+    fn_type = ir.FunctionType(res_type, [res_type, res_type, res_type])
+    if isinstance(res_type, ir.VectorType):
+        assert isinstance(res_type.element, (ir.HalfType, ir.FloatType, ir.DoubleType))
+        # declare_intrinsic doesn't support VectorType, build name manually
+        name = f"llvm.fma.v{res_type.count}{res_type.element.intrinsic_name}"
+        try:
+            intrinsic = builder.module.get_global(name)
+        except KeyError:
+            intrinsic = ir.Function(builder.module, fn_type, name=name)
+    else:
+        intrinsic = builder.module.declare_intrinsic(
+            "llvm.fma", tys=[res_type], fnty=fn_type
+        )
+    val_map[op.res] = builder.call(intrinsic, [a, b, c])
+
+
 def _convert_call(
     op: llvm.CallOp, builder: ir.IRBuilder, val_map: dict[SSAValue, ir.Value]
 ):
@@ -472,6 +495,8 @@ def convert_op(
             _convert_binary_intrinsic(op, builder, val_map)
         case llvm.FNegOp():
             _convert_fneg(op, builder, val_map)
+        case llvm.FMAOp():
+            _convert_fma_intr(op, builder, val_map)
         case llvm.CallOp():
             _convert_call(op, builder, val_map)
         case llvm.AllocaOp():

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -2359,6 +2359,43 @@ class FLogOp(IRDLOperation):
 
 
 @irdl_op_definition
+class FMAOp(IRDLOperation):
+    T: ClassVar = VarConstraint("T", AnyFloatConstr | VectorType.constr(AnyFloatConstr))
+
+    name = "llvm.intr.fma"
+
+    a = operand_def(T)
+    b = operand_def(T)
+    c = operand_def(T)
+    res = result_def(T)
+
+    fastmathFlags = prop_def(FastMathAttr, default_value=FastMathAttr(None))
+
+    assembly_format = (
+        "`(` operands `)` attr-dict `:` functional-type(operands, results)"
+    )
+
+    irdl_options = (ParsePropInAttrDict(),)
+
+    traits = traits_def(Pure())
+
+    def __init__(
+        self,
+        a: Operation | SSAValue,
+        b: Operation | SSAValue,
+        c: Operation | SSAValue,
+        fast_math: FastMathAttr | FastMathFlag | None = None,
+    ):
+        if isinstance(fast_math, FastMathFlag | str | None):
+            fast_math = FastMathAttr(fast_math)
+        super().__init__(
+            operands=[a, b, c],
+            result_types=[SSAValue.get(a).type],
+            properties={"fastmathFlags": fast_math},
+        )
+
+
+@irdl_op_definition
 class FNegOp(IRDLOperation):
     T: ClassVar = VarConstraint("T", AnyFloatConstr | VectorType.constr(AnyFloatConstr))
 
@@ -2567,6 +2604,7 @@ LLVM = Dialect(
         FCmpOp,
         FDivOp,
         FLogOp,
+        FMAOp,
         FMulOp,
         FNegOp,
         FPExtOp,

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -2773,6 +2773,43 @@ class FLogOp(IRDLOperation):
 
 
 @irdl_op_definition
+class FMAOp(IRDLOperation):
+    T: ClassVar = VarConstraint("T", AnyFloatConstr | VectorType.constr(AnyFloatConstr))
+
+    name = "llvm.intr.fma"
+
+    a = operand_def(T)
+    b = operand_def(T)
+    c = operand_def(T)
+    res = result_def(T)
+
+    fastmathFlags = prop_def(FastMathAttr, default_value=FastMathAttr(None))
+
+    assembly_format = (
+        "`(` operands `)` attr-dict `:` functional-type(operands, results)"
+    )
+
+    irdl_options = (ParsePropInAttrDict(),)
+
+    traits = traits_def(Pure())
+
+    def __init__(
+        self,
+        a: Operation | SSAValue,
+        b: Operation | SSAValue,
+        c: Operation | SSAValue,
+        fast_math: FastMathAttr | FastMathFlag | None = None,
+    ):
+        if isinstance(fast_math, FastMathFlag | str | None):
+            fast_math = FastMathAttr(fast_math)
+        super().__init__(
+            operands=[a, b, c],
+            result_types=[SSAValue.get(a).type],
+            properties={"fastmathFlags": fast_math},
+        )
+
+
+@irdl_op_definition
 class FNegOp(IRDLOperation):
     T: ClassVar = VarConstraint("T", AnyFloatConstr | VectorType.constr(AnyFloatConstr))
 
@@ -2982,6 +3019,7 @@ LLVM = Dialect(
         FCmpOp,
         FDivOp,
         FLogOp,
+        FMAOp,
         FMulOp,
         FNegOp,
         FPExtOp,


### PR DESCRIPTION
- Add `llvm.intr.fma` (`llvm.FMAOp`) to the LLVM dialect; accepts scalar or vector-of-float (3-operand ternary fused multiply-add)
- Backend lowering emits `llvm.fma.*` intrinsic: scalar via `declare_intrinsic`, vector via manual name construction (llvmlite's `declare_intrinsic` doesn't accept `VectorType`)
- Dialect + MLIR roundtrip + backend + pytest coverage

Refs

- MLIR: https://mlir.llvm.org/docs/Dialects/LLVM/#llvmintrfma-llvmfmaop
- LangRef: https://llvm.org/docs/LangRef.html#llvm-fma-intrinsic
