### PR TITLE
dialects: (llvm) add FSinOp

### DIFF
--- a/tests/dialects/test_llvm.py
+++ b/tests/dialects/test_llvm.py
@@ -587,6 +587,13 @@ def test_fabs_op():
     assert op.result.type == builtin.f32
 
 
+def test_fsin_op():
+    val = create_ssa_value(builtin.f32)
+    op = llvm.FSinOp(val)
+    assert op.arg == val
+    assert op.res.type == builtin.f32
+
+
 def test_fneg_op():
     val = create_ssa_value(builtin.f32)
     op = llvm.FNegOp(val)

--- a/tests/dialects/test_llvm.py
+++ b/tests/dialects/test_llvm.py
@@ -621,6 +621,12 @@ def test_fexp_op():
     assert op.res.type == builtin.f32
     assert op.name == "llvm.intr.exp"
 
+def test_fsin_op():
+    val = create_ssa_value(builtin.f32)
+    op = llvm.FSinOp(val)
+    assert op.arg == val
+    assert op.res.type == builtin.f32
+
 
 def test_fneg_op():
     val = create_ssa_value(builtin.f32)

--- a/tests/dialects/test_llvm.py
+++ b/tests/dialects/test_llvm.py
@@ -621,6 +621,7 @@ def test_fexp_op():
     assert op.res.type == builtin.f32
     assert op.name == "llvm.intr.exp"
 
+
 def test_fsin_op():
     val = create_ssa_value(builtin.f32)
     op = llvm.FSinOp(val)

--- a/tests/filecheck/backend/llvm/convert_op.mlir
+++ b/tests/filecheck/backend/llvm/convert_op.mlir
@@ -621,6 +621,18 @@ builtin.module {
   // CHECK-NEXT:   ret float %"[[RES]]"
   // CHECK-NEXT: }
 
+  llvm.func @fsin_op(%arg0: f32) -> f32 {
+    %0 = llvm.intr.sin(%arg0) : (f32) -> f32
+    llvm.return %0 : f32
+  }
+
+  // CHECK: define float @"fsin_op"(float %".1")
+  // CHECK-NEXT: {
+  // CHECK-NEXT: [[ENTRY:.\d+]]:
+  // CHECK-NEXT:   %"[[RES:.\d+]]" = call float @"llvm.sin"(float %".1")
+  // CHECK-NEXT:   ret float %"[[RES]]"
+  // CHECK-NEXT: }
+
   llvm.func @fneg_op(%arg0: f32) -> f32 {
     %0 = llvm.fneg %arg0 : f32
     llvm.return %0 : f32

--- a/tests/filecheck/backend/llvm/convert_op.mlir
+++ b/tests/filecheck/backend/llvm/convert_op.mlir
@@ -781,6 +781,8 @@ builtin.module {
   // CHECK-NEXT: {
   // CHECK-NEXT: [[ENTRY:.\d+]]:
   // CHECK-NEXT:   %"[[RES:.\d+]]" = call float @"llvm.exp"(float %".1")
+  // CHECK-NEXT:   ret float %"[[RES]]"
+  // CHECK-NEXT: }
 
   llvm.func @fsin_op(%arg0: f32) -> f32 {
     %0 = llvm.intr.sin(%arg0) : (f32) -> f32

--- a/tests/filecheck/backend/llvm/convert_op.mlir
+++ b/tests/filecheck/backend/llvm/convert_op.mlir
@@ -781,6 +781,16 @@ builtin.module {
   // CHECK-NEXT: {
   // CHECK-NEXT: [[ENTRY:.\d+]]:
   // CHECK-NEXT:   %"[[RES:.\d+]]" = call float @"llvm.exp"(float %".1")
+
+  llvm.func @fsin_op(%arg0: f32) -> f32 {
+    %0 = llvm.intr.sin(%arg0) : (f32) -> f32
+    llvm.return %0 : f32
+  }
+
+  // CHECK: define float @"fsin_op"(float %".1")
+  // CHECK-NEXT: {
+  // CHECK-NEXT: [[ENTRY:.\d+]]:
+  // CHECK-NEXT:   %"[[RES:.\d+]]" = call float @"llvm.sin"(float %".1")
   // CHECK-NEXT:   ret float %"[[RES]]"
   // CHECK-NEXT: }
 

--- a/tests/filecheck/dialects/irdl/pyrdl-to-irdl/cmath-conversion.py
+++ b/tests/filecheck/dialects/irdl/pyrdl-to-irdl/cmath-conversion.py
@@ -1,7 +1,6 @@
 # RUN: python %s | filecheck %s
 
 from xdsl.dialects.cmath import Cmath
-
 from xdsl.dialects.irdl.pyrdl_to_irdl import dialect_to_irdl
 
 print(dialect_to_irdl(Cmath, "cmath"))

--- a/tests/filecheck/dialects/irdl/pyrdl-to-irdl/cmath-conversion.py
+++ b/tests/filecheck/dialects/irdl/pyrdl-to-irdl/cmath-conversion.py
@@ -1,6 +1,7 @@
 # RUN: python %s | filecheck %s
 
 from xdsl.dialects.cmath import Cmath
+
 from xdsl.dialects.irdl.pyrdl_to_irdl import dialect_to_irdl
 
 print(dialect_to_irdl(Cmath, "cmath"))

--- a/tests/filecheck/dialects/llvm/llvm_intrinsics.mlir
+++ b/tests/filecheck/dialects/llvm/llvm_intrinsics.mlir
@@ -13,6 +13,15 @@
 %fabs_vec = llvm.intr.fabs(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
 // CHECK-NEXT: %fabs_vec = llvm.intr.fabs(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
 
+%fsin_f32 = llvm.intr.sin(%f32) : (f32) -> f32
+// CHECK: %fsin_f32 = llvm.intr.sin(%f32) : (f32) -> f32
+
+%fsin_f64 = llvm.intr.sin(%f64) : (f64) -> f64
+// CHECK-NEXT: %fsin_f64 = llvm.intr.sin(%f64) : (f64) -> f64
+
+%fsin_vec = llvm.intr.sin(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
+// CHECK-NEXT: %fsin_vec = llvm.intr.sin(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
+
 %fneg_f32 = llvm.fneg %f32 : f32
 // CHECK: %fneg_f32 = llvm.fneg %f32 : f32
 

--- a/tests/filecheck/dialects/llvm/llvm_intrinsics.mlir
+++ b/tests/filecheck/dialects/llvm/llvm_intrinsics.mlir
@@ -30,6 +30,7 @@
 
 %fsqrt_vec = llvm.intr.sqrt(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
 // CHECK-NEXT: %fsqrt_vec = llvm.intr.sqrt(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
+
 %flog_f32 = llvm.intr.log(%f32) : (f32) -> f32
 // CHECK: %flog_f32 = llvm.intr.log(%f32) : (f32) -> f32
 
@@ -47,6 +48,15 @@
 
 %fexp_vec = llvm.intr.exp(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
 // CHECK-NEXT: %fexp_vec = llvm.intr.exp(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
+
+%fsin_f32 = llvm.intr.sin(%f32) : (f32) -> f32
+// CHECK: %fsin_f32 = llvm.intr.sin(%f32) : (f32) -> f32
+
+%fsin_f64 = llvm.intr.sin(%f64) : (f64) -> f64
+// CHECK-NEXT: %fsin_f64 = llvm.intr.sin(%f64) : (f64) -> f64
+
+%fsin_vec = llvm.intr.sin(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
+// CHECK-NEXT: %fsin_vec = llvm.intr.sin(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
 
 %fneg_f32 = llvm.fneg %f32 : f32
 // CHECK: %fneg_f32 = llvm.fneg %f32 : f32

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/llvm_intrinsics.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/llvm_intrinsics.mlir
@@ -13,6 +13,15 @@
 %2 = llvm.intr.fabs(%arg2) : (vector<4xf32>) -> vector<4xf32>
 // CHECK: llvm.intr.fabs([[arg2]]) : (vector<4xf32>) -> vector<4xf32>
 
+%fsin_0 = llvm.intr.sin(%arg0) : (f32) -> f32
+// CHECK: llvm.intr.sin([[arg0]]) : (f32) -> f32
+
+%fsin_1 = llvm.intr.sin(%arg1) : (f64) -> f64
+// CHECK: llvm.intr.sin([[arg1]]) : (f64) -> f64
+
+%fsin_2 = llvm.intr.sin(%arg2) : (vector<4xf32>) -> vector<4xf32>
+// CHECK: llvm.intr.sin([[arg2]]) : (vector<4xf32>) -> vector<4xf32>
+
 %3 = llvm.fneg %arg0 : f32
 // CHECK: llvm.fneg [[arg0]] : f32
 

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/llvm_intrinsics.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/llvm_intrinsics.mlir
@@ -22,6 +22,15 @@
 %fexp_vec = llvm.intr.exp(%arg2) : (vector<4xf32>) -> vector<4xf32>
 // CHECK: llvm.intr.exp([[arg2]]) : (vector<4xf32>) -> vector<4xf32>
 
+%fsin_0 = llvm.intr.sin(%arg0) : (f32) -> f32
+// CHECK: llvm.intr.sin([[arg0]]) : (f32) -> f32
+
+%fsin_1 = llvm.intr.sin(%arg1) : (f64) -> f64
+// CHECK: llvm.intr.sin([[arg1]]) : (f64) -> f64
+
+%fsin_2 = llvm.intr.sin(%arg2) : (vector<4xf32>) -> vector<4xf32>
+// CHECK: llvm.intr.sin([[arg2]]) : (vector<4xf32>) -> vector<4xf32>
+
 %3 = llvm.fneg %arg0 : f32
 // CHECK: llvm.fneg [[arg0]] : f32
 

--- a/xdsl/backend/llvm/convert_op.py
+++ b/xdsl/backend/llvm/convert_op.py
@@ -164,6 +164,22 @@ def _convert_fcmp(
     val_map[op.results[0]] = fn(cmpop, val_map[op.lhs], val_map[op.rhs])
 
 
+_UNARY_INTRINSIC_MAP: dict[type[Operation], str] = {
+    llvm.FSinOp: "llvm.sin",
+}
+
+
+def _convert_unary_intrinsic(
+    op: Operation, builder: ir.IRBuilder, val_map: dict[SSAValue, ir.Value]
+):
+    operand = val_map[op.operands[0]]
+    fn_type = ir.FunctionType(operand.type, [operand.type])
+    intrinsic = builder.module.declare_intrinsic(
+        _UNARY_INTRINSIC_MAP[type(op)], fnty=fn_type
+    )
+    val_map[op.results[0]] = builder.call(intrinsic, [operand])
+
+
 def _convert_fabs(
     op: llvm.FAbsOp, builder: ir.IRBuilder, val_map: dict[SSAValue, ir.Value]
 ):
@@ -349,6 +365,8 @@ def convert_op(
             _convert_cast(op, builder, val_map)
         case llvm.FAbsOp():
             _convert_fabs(op, builder, val_map)
+        case op if type(op) in _UNARY_INTRINSIC_MAP:
+            _convert_unary_intrinsic(op, builder, val_map)
         case llvm.FNegOp():
             _convert_fneg(op, builder, val_map)
         case llvm.CallOp():

--- a/xdsl/backend/llvm/convert_op.py
+++ b/xdsl/backend/llvm/convert_op.py
@@ -176,6 +176,7 @@ _UNARY_INTRINSIC_MAP: dict[type[Operation], str] = {
     llvm.FAbsOp: "llvm.fabs",
     llvm.FExpOp: "llvm.exp",
     llvm.FCeilOp: "llvm.ceil",
+    llvm.FSinOp: "llvm.sin",
     llvm.FSqrtOp: "llvm.sqrt",
     llvm.FLogOp: "llvm.log",
 }

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -2291,6 +2291,39 @@ class FAbsOp(IRDLOperation):
 
 
 @irdl_op_definition
+class FSinOp(IRDLOperation):
+    T: ClassVar = VarConstraint("T", AnyFloatConstr | VectorType.constr(AnyFloatConstr))
+
+    name = "llvm.intr.sin"
+
+    arg = operand_def(T)
+    res = result_def(T)
+
+    fastmathFlags = prop_def(FastMathAttr, default_value=FastMathAttr(None))
+
+    assembly_format = (
+        "`(` operands `)` attr-dict `:` functional-type(operands, results)"
+    )
+
+    irdl_options = (ParsePropInAttrDict(),)
+
+    traits = traits_def(Pure())
+
+    def __init__(
+        self,
+        arg: Operation | SSAValue,
+        fast_math: FastMathAttr | FastMathFlag | None = None,
+    ):
+        if isinstance(fast_math, FastMathFlag | str | None):
+            fast_math = FastMathAttr(fast_math)
+        super().__init__(
+            operands=[arg],
+            result_types=[SSAValue.get(arg).type],
+            properties={"fastmathFlags": fast_math},
+        )
+
+
+@irdl_op_definition
 class FNegOp(IRDLOperation):
     T: ClassVar = VarConstraint("T", AnyFloatConstr | VectorType.constr(AnyFloatConstr))
 
@@ -2450,6 +2483,7 @@ LLVM = Dialect(
         FNegOp,
         FPExtOp,
         FRemOp,
+        FSinOp,
         FSubOp,
         FuncOp,
         GEPOp,

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -3143,6 +3143,34 @@ class FExpOp(IRDLOperation):
 
     name = "llvm.intr.exp"
 
+    arg = operand_def(T)
+    res = result_def(T)
+
+    fastmathFlags = prop_def(FastMathAttr, default_value=FastMathAttr(None))
+
+    assembly_format = (
+        "`(` operands `)` attr-dict `:` functional-type(operands, results)"
+    )
+
+    irdl_options = (ParsePropInAttrDict(),)
+
+    traits = traits_def(Pure())
+
+    def __init__(
+        self,
+        arg: Operation | SSAValue,
+        fast_math: FastMathAttr | FastMathFlag | None = None,
+    ):
+        if not isinstance(fast_math, FastMathAttr):
+            fast_math = FastMathAttr(fast_math)
+        super().__init__(
+            operands=[arg],
+            result_types=[SSAValue.get(arg).type],
+            properties={"fastmathFlags": fast_math},
+        )
+
+
+@irdl_op_definition
 class FSinOp(IRDLOperation):
     T: ClassVar = VarConstraint("T", AnyFloatConstr | VectorType.constr(AnyFloatConstr))
 

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -3143,6 +3143,11 @@ class FExpOp(IRDLOperation):
 
     name = "llvm.intr.exp"
 
+class FSinOp(IRDLOperation):
+    T: ClassVar = VarConstraint("T", AnyFloatConstr | VectorType.constr(AnyFloatConstr))
+
+    name = "llvm.intr.sin"
+
     arg = operand_def(T)
     res = result_def(T)
 
@@ -3423,6 +3428,7 @@ LLVM = Dialect(
         FNegOp,
         FPExtOp,
         FRemOp,
+        FSinOp,
         FSqrtOp,
         FSubOp,
         FuncOp,


### PR DESCRIPTION
- Add `llvm.intr.sin` (`FSinOp`) to the LLVM dialect; accepts scalar or vector-of-float
- Wire into `_UNARY_INTRINSIC_MAP` in `convert_op.py` (new shared dispatch for unary float intrinsics)
- Dialect + MLIR roundtrip + backend + pytest coverage mirroring `FAbsOp`

Refs:
- MLIR: https://mlir.llvm.org/docs/Dialects/LLVM/#llvmintrsin-llvmsinop
- LangRef: https://llvm.org/docs/LangRef.html#llvm-sin-intrinsic