### PR TITLE
dialects: (llvm) add FCopySignOp

### DIFF
--- a/tests/dialects/test_llvm.py
+++ b/tests/dialects/test_llvm.py
@@ -601,6 +601,15 @@ def test_flog_op():
     assert op.res.type == builtin.f32
 
 
+def test_fcopysign_op():
+    lhs = create_ssa_value(builtin.f32)
+    rhs = create_ssa_value(builtin.f32)
+    op = llvm.FCopySignOp(lhs, rhs)
+    assert op.lhs == lhs
+    assert op.rhs == rhs
+    assert op.res.type == builtin.f32
+
+
 def test_fneg_op():
     val = create_ssa_value(builtin.f32)
     op = llvm.FNegOp(val)

--- a/tests/dialects/test_llvm.py
+++ b/tests/dialects/test_llvm.py
@@ -650,6 +650,15 @@ def test_fcos_op():
     assert op.res.type == builtin.f32
 
 
+def test_fcopysign_op():
+    lhs = create_ssa_value(builtin.f32)
+    rhs = create_ssa_value(builtin.f32)
+    op = llvm.FCopySignOp(lhs, rhs)
+    assert op.lhs == lhs
+    assert op.rhs == rhs
+    assert op.res.type == builtin.f32
+
+
 def test_fneg_op():
     val = create_ssa_value(builtin.f32)
     op = llvm.FNegOp(val)

--- a/tests/filecheck/backend/llvm/convert_op.mlir
+++ b/tests/filecheck/backend/llvm/convert_op.mlir
@@ -671,6 +671,9 @@ builtin.module {
   // CHECK-NEXT: {
   // CHECK-NEXT: [[ENTRY:.\d+]]:
   // CHECK-NEXT:   %"[[RES:.\d+]]" = call float @"llvm.sqrt"(float %".1")
+  // CHECK-NEXT:   ret float %"[[RES]]"
+  // CHECK-NEXT: }
+
   llvm.func @flog_op(%arg0: f32) -> f32 {
     %0 = llvm.intr.log(%arg0) : (f32) -> f32
     llvm.return %0 : f32
@@ -680,6 +683,18 @@ builtin.module {
   // CHECK-NEXT: {
   // CHECK-NEXT: [[ENTRY:.\d+]]:
   // CHECK-NEXT:   %"[[RES:.\d+]]" = call float @"llvm.log"(float %".1")
+  // CHECK-NEXT:   ret float %"[[RES]]"
+  // CHECK-NEXT: }
+
+  llvm.func @copysign_op(%arg0: f32, %arg1: f32) -> f32 {
+    %0 = llvm.intr.copysign(%arg0, %arg1) : (f32, f32) -> f32
+    llvm.return %0 : f32
+  }
+
+  // CHECK: define float @"copysign_op"(float %".1", float %".2")
+  // CHECK-NEXT: {
+  // CHECK-NEXT: [[ENTRY:.\d+]]:
+  // CHECK-NEXT:   %"[[RES:.\d+]]" = call float @"llvm.copysign"(float %".1", float %".2")
   // CHECK-NEXT:   ret float %"[[RES]]"
   // CHECK-NEXT: }
 

--- a/tests/filecheck/backend/llvm/convert_op.mlir
+++ b/tests/filecheck/backend/llvm/convert_op.mlir
@@ -841,6 +841,18 @@ builtin.module {
   // CHECK-NEXT:   ret float %"[[RES]]"
   // CHECK-NEXT: }
 
+  llvm.func @copysign_op(%arg0: f32, %arg1: f32) -> f32 {
+    %0 = llvm.intr.copysign(%arg0, %arg1) : (f32, f32) -> f32
+    llvm.return %0 : f32
+  }
+
+  // CHECK: define float @"copysign_op"(float %".1", float %".2")
+  // CHECK-NEXT: {
+  // CHECK-NEXT: [[ENTRY:.\d+]]:
+  // CHECK-NEXT:   %"[[RES:.\d+]]" = call float @"llvm.copysign"(float %".1", float %".2")
+  // CHECK-NEXT:   ret float %"[[RES]]"
+  // CHECK-NEXT: }
+
   llvm.func @fneg_op(%arg0: f32) -> f32 {
     %0 = llvm.fneg %arg0 : f32
     llvm.return %0 : f32

--- a/tests/filecheck/dialects/irdl/pyrdl-to-irdl/cmath-conversion.py
+++ b/tests/filecheck/dialects/irdl/pyrdl-to-irdl/cmath-conversion.py
@@ -1,7 +1,6 @@
 # RUN: python %s | filecheck %s
 
 from xdsl.dialects.cmath import Cmath
-
 from xdsl.dialects.irdl.pyrdl_to_irdl import dialect_to_irdl
 
 print(dialect_to_irdl(Cmath, "cmath"))

--- a/tests/filecheck/dialects/irdl/pyrdl-to-irdl/cmath-conversion.py
+++ b/tests/filecheck/dialects/irdl/pyrdl-to-irdl/cmath-conversion.py
@@ -1,6 +1,7 @@
 # RUN: python %s | filecheck %s
 
 from xdsl.dialects.cmath import Cmath
+
 from xdsl.dialects.irdl.pyrdl_to_irdl import dialect_to_irdl
 
 print(dialect_to_irdl(Cmath, "cmath"))

--- a/tests/filecheck/dialects/llvm/llvm_intrinsics.mlir
+++ b/tests/filecheck/dialects/llvm/llvm_intrinsics.mlir
@@ -77,6 +77,15 @@
 %maxnum_vec = llvm.intr.maxnum(%vec_f32, %vec_f32) : (vector<4xf32>, vector<4xf32>) -> vector<4xf32>
 // CHECK-NEXT: %maxnum_vec = llvm.intr.maxnum(%vec_f32, %vec_f32) : (vector<4xf32>, vector<4xf32>) -> vector<4xf32>
 
+%copysign_f32 = llvm.intr.copysign(%f32, %f32) : (f32, f32) -> f32
+// CHECK: %copysign_f32 = llvm.intr.copysign(%f32, %f32) : (f32, f32) -> f32
+
+%copysign_f64 = llvm.intr.copysign(%f64, %f64) : (f64, f64) -> f64
+// CHECK-NEXT: %copysign_f64 = llvm.intr.copysign(%f64, %f64) : (f64, f64) -> f64
+
+%copysign_vec = llvm.intr.copysign(%vec_f32, %vec_f32) : (vector<4xf32>, vector<4xf32>) -> vector<4xf32>
+// CHECK-NEXT: %copysign_vec = llvm.intr.copysign(%vec_f32, %vec_f32) : (vector<4xf32>, vector<4xf32>) -> vector<4xf32>
+
 "test.op"() ({
 ^bb0(%br_arg: i32):
   llvm.br ^bb1(%br_arg : i32)

--- a/tests/filecheck/dialects/llvm/llvm_intrinsics.mlir
+++ b/tests/filecheck/dialects/llvm/llvm_intrinsics.mlir
@@ -131,6 +131,15 @@
 %maxnum_vec = llvm.intr.maxnum(%vec_f32, %vec_f32) : (vector<4xf32>, vector<4xf32>) -> vector<4xf32>
 // CHECK-NEXT: %maxnum_vec = llvm.intr.maxnum(%vec_f32, %vec_f32) : (vector<4xf32>, vector<4xf32>) -> vector<4xf32>
 
+%copysign_f32 = llvm.intr.copysign(%f32, %f32) : (f32, f32) -> f32
+// CHECK: %copysign_f32 = llvm.intr.copysign(%f32, %f32) : (f32, f32) -> f32
+
+%copysign_f64 = llvm.intr.copysign(%f64, %f64) : (f64, f64) -> f64
+// CHECK-NEXT: %copysign_f64 = llvm.intr.copysign(%f64, %f64) : (f64, f64) -> f64
+
+%copysign_vec = llvm.intr.copysign(%vec_f32, %vec_f32) : (vector<4xf32>, vector<4xf32>) -> vector<4xf32>
+// CHECK-NEXT: %copysign_vec = llvm.intr.copysign(%vec_f32, %vec_f32) : (vector<4xf32>, vector<4xf32>) -> vector<4xf32>
+
 %fma_f32 = llvm.intr.fma(%f32, %f32, %f32) : (f32, f32, f32) -> f32
 // CHECK: %fma_f32 = llvm.intr.fma(%f32, %f32, %f32) : (f32, f32, f32) -> f32
 

--- a/xdsl/backend/llvm/convert_op.py
+++ b/xdsl/backend/llvm/convert_op.py
@@ -174,6 +174,7 @@ _UNARY_INTRINSIC_MAP: dict[type[Operation], str] = {
 
 _BINARY_INTRINSIC_MAP: dict[type[Operation], str] = {
     llvm.VectorFMaxOp: "llvm.maxnum",
+    llvm.FCopySignOp: "llvm.copysign",
 }
 
 

--- a/xdsl/backend/llvm/convert_op.py
+++ b/xdsl/backend/llvm/convert_op.py
@@ -187,6 +187,7 @@ _UNARY_INTRINSIC_MAP: dict[type[Operation], str] = {
 _BINARY_INTRINSIC_MAP: dict[type[Operation], str] = {
     llvm.VectorFMaxOp: "llvm.maxnum",
     llvm.VectorFMinOp: "llvm.minnum",
+    llvm.FCopySignOp: "llvm.copysign",
 }
 
 

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -2540,6 +2540,41 @@ class VectorFMaxOp(IRDLOperation):
 
 
 @irdl_op_definition
+class FCopySignOp(IRDLOperation):
+    T: ClassVar = VarConstraint("T", AnyFloatConstr | VectorType.constr(AnyFloatConstr))
+
+    name = "llvm.intr.copysign"
+
+    lhs = operand_def(T)
+    rhs = operand_def(T)
+    res = result_def(T)
+
+    fastmathFlags = prop_def(FastMathAttr, default_value=FastMathAttr(None))
+
+    assembly_format = (
+        "`(` operands `)` attr-dict `:` functional-type(operands, results)"
+    )
+
+    irdl_options = (ParsePropInAttrDict(),)
+
+    traits = traits_def(Pure())
+
+    def __init__(
+        self,
+        lhs: Operation | SSAValue,
+        rhs: Operation | SSAValue,
+        fast_math: FastMathAttr | FastMathFlag | None = None,
+    ):
+        if isinstance(fast_math, FastMathFlag | str | None):
+            fast_math = FastMathAttr(fast_math)
+        super().__init__(
+            operands=[lhs, rhs],
+            result_types=[SSAValue.get(lhs).type],
+            properties={"fastmathFlags": fast_math},
+        )
+
+
+@irdl_op_definition
 class UnreachableOp(IRDLOperation):
     name = "llvm.unreachable"
 
@@ -2565,6 +2600,7 @@ LLVM = Dialect(
         FAbsOp,
         FAddOp,
         FCmpOp,
+        FCopySignOp,
         FDivOp,
         FLogOp,
         FMulOp,

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -3484,6 +3484,41 @@ class VectorFMaxOp(IRDLOperation):
 
 
 @irdl_op_definition
+class FCopySignOp(IRDLOperation):
+    T: ClassVar = VarConstraint("T", AnyFloatConstr | VectorType.constr(AnyFloatConstr))
+
+    name = "llvm.intr.copysign"
+
+    lhs = operand_def(T)
+    rhs = operand_def(T)
+    res = result_def(T)
+
+    fastmathFlags = prop_def(FastMathAttr, default_value=FastMathAttr(None))
+
+    assembly_format = (
+        "`(` operands `)` attr-dict `:` functional-type(operands, results)"
+    )
+
+    irdl_options = (ParsePropInAttrDict(),)
+
+    traits = traits_def(Pure())
+
+    def __init__(
+        self,
+        lhs: Operation | SSAValue,
+        rhs: Operation | SSAValue,
+        fast_math: FastMathAttr | FastMathFlag | None = None,
+    ):
+        if isinstance(fast_math, FastMathFlag | str | None):
+            fast_math = FastMathAttr(fast_math)
+        super().__init__(
+            operands=[lhs, rhs],
+            result_types=[SSAValue.get(lhs).type],
+            properties={"fastmathFlags": fast_math},
+        )
+
+
+@irdl_op_definition
 class FMAOp(IRDLOperation):
     T: ClassVar = VarConstraint("T", AnyFloatConstr | VectorType.constr(AnyFloatConstr))
 
@@ -3582,6 +3617,7 @@ LLVM = Dialect(
         FAddOp,
         FCeilOp,
         FCmpOp,
+        FCopySignOp,
         FCosOp,
         FDivOp,
         FExpOp,


### PR DESCRIPTION
- Add `llvm.intr.copysign` (`FCopySignOp`) to the LLVM dialect; accepts
  scalar or vector-of-float for both operands
- Wire into `_BINARY_INTRINSIC_MAP` in `convert_op.py`
- Dialect + MLIR + backend + pytest coverage mirroring `VectorFMaxOp`

Refs:
- MLIR: https://mlir.llvm.org/docs/Dialects/LLVM/#llvmintrcopysign-llvmcopysignop
- LangRef: https://llvm.org/docs/LangRef.html#llvm-copysign-intrinsic
- Template: #5825