### PR TITLE
backend: (llvm) support vector operands in intrinsic lowerings

### DIFF
--- a/tests/filecheck/backend/llvm/convert_op.mlir
+++ b/tests/filecheck/backend/llvm/convert_op.mlir
@@ -621,6 +621,30 @@ builtin.module {
   // CHECK-NEXT:   ret float %"[[RES]]"
   // CHECK-NEXT: }
 
+  llvm.func @fabs_v4f32(%arg0: vector<4xf32>) -> vector<4xf32> {
+    %0 = llvm.intr.fabs(%arg0) : (vector<4xf32>) -> vector<4xf32>
+    llvm.return %0 : vector<4xf32>
+  }
+
+  // CHECK: define <4 x float> @"fabs_v4f32"(<4 x float> %".1")
+  // CHECK-NEXT: {
+  // CHECK-NEXT: [[ENTRY:.\d+]]:
+  // CHECK-NEXT:   %"[[RES:.\d+]]" = call <4 x float> @"llvm.fabs.v4f32"(<4 x float> %".1")
+  // CHECK-NEXT:   ret <4 x float> %"[[RES]]"
+  // CHECK-NEXT: }
+
+  llvm.func @fabs_v2f64(%arg0: vector<2xf64>) -> vector<2xf64> {
+    %0 = llvm.intr.fabs(%arg0) : (vector<2xf64>) -> vector<2xf64>
+    llvm.return %0 : vector<2xf64>
+  }
+
+  // CHECK: define <2 x double> @"fabs_v2f64"(<2 x double> %".1")
+  // CHECK-NEXT: {
+  // CHECK-NEXT: [[ENTRY:.\d+]]:
+  // CHECK-NEXT:   %"[[RES:.\d+]]" = call <2 x double> @"llvm.fabs.v2f64"(<2 x double> %".1")
+  // CHECK-NEXT:   ret <2 x double> %"[[RES]]"
+  // CHECK-NEXT: }
+
   llvm.func @fneg_op(%arg0: f32) -> f32 {
     %0 = llvm.fneg %arg0 : f32
     llvm.return %0 : f32

--- a/xdsl/backend/llvm/convert_op.py
+++ b/xdsl/backend/llvm/convert_op.py
@@ -1,4 +1,5 @@
 from collections.abc import Callable
+from typing import cast
 
 from llvmlite import ir
 from llvmlite.ir import instructions
@@ -164,12 +165,31 @@ def _convert_fcmp(
     val_map[op.results[0]] = fn(cmpop, val_map[op.lhs], val_map[op.rhs])
 
 
+def _declare_intrinsic(
+    module: ir.Module, base_name: str, fn_type: ir.FunctionType, operand_type: ir.Type
+) -> ir.Function:
+    # llvmlite's Module.declare_intrinsic raises on ir.VectorType, so build the
+    # mangled name manually for vector overloads (e.g. llvm.fabs.v4f32).
+    if isinstance(operand_type, ir.VectorType):
+        count = cast(int, operand_type.count)  # pyright: ignore[reportAttributeAccessIssue, reportUnknownMemberType]
+        element = cast(ir.Type, operand_type.element)  # pyright: ignore[reportAttributeAccessIssue, reportUnknownMemberType]
+        intrinsic_name = cast(str, element.intrinsic_name)  # pyright: ignore[reportAttributeAccessIssue, reportUnknownMemberType]
+        name = f"{base_name}.v{count}{intrinsic_name}"
+        try:
+            existing = module.get_global(name)
+        except KeyError:
+            return ir.Function(module, fn_type, name=name)
+        assert isinstance(existing, ir.Function)
+        return existing
+    return module.declare_intrinsic(base_name, fnty=fn_type)
+
+
 def _convert_fabs(
     op: llvm.FAbsOp, builder: ir.IRBuilder, val_map: dict[SSAValue, ir.Value]
 ):
     operand = val_map[op.input]
     fn_type = ir.FunctionType(operand.type, [operand.type])
-    intrinsic = builder.module.declare_intrinsic("llvm.fabs", fnty=fn_type)
+    intrinsic = _declare_intrinsic(builder.module, "llvm.fabs", fn_type, operand.type)
     val_map[op.result] = builder.call(intrinsic, [operand])
 
 


### PR DESCRIPTION
Draft: gated on dialect PRs landing first so this PR can route all new intrinsics through the same helper rather than shipping as a partial. Ready to mark non-draft once prerequisites merge.

## Changes

- Add `_declare_intrinsic` helper in `xdsl/backend/llvm/convert_op.py` that builds the mangled LLVM intrinsic name manually for vector operands (`llvm.fabs.v<N><elt>`) and falls back to `Module.declare_intrinsic` for scalars.
- llvmlite's `declare_intrinsic` can't accept `ir.VectorType` because `ir.Type` has no `intrinsic_name`, so the vector path uses `Module.get_global` to dedupe and materializes with `ir.Function(...)` when absent.
- Route `_convert_fabs` through the helper; scalar path is unchanged (still emits `@"llvm.fabs"`).
- Filecheck coverage: `fabs_v4f32` and `fabs_v2f64` alongside the existing scalar `fabs_op`.

## Dependencies (all currently CONFLICTING and need rebase)

- #5862 `dialects: (llvm) add FMAOp` — enables vector FMA lowering via the helper
- #5859 `dialects: (llvm) add FLog2Op`
- #5857 `dialects: (llvm) add FExpOp`
- #5858 `dialects: (llvm) add FCosOp`
- #5863 `dialects: (llvm) add FSinOp`
- #5860 `dialects: (llvm) add FFloorOp`
- #5861 `dialects: (llvm) add FCeilOp`
- #5864 `dialects: (llvm) add FCopySignOp`

Once those merge, this PR extends to route each new op through `_declare_intrinsic` with a unary/binary intrinsic map, covering both scalar and vector operands in a single cohesive change. `FSqrtOp`, `FLogOp`, and `VectorFMaxOp` are not yet represented by open dialect PRs — either they get added separately or are dropped from scope here.

Refs:
- MLIR: https://mlir.llvm.org/docs/Dialects/LLVM/#llvmintrfabs-llvmfabsop
- LLVM LangRef: https://llvm.org/docs/LangRef.html#llvm-fabs-intrinsic