### PR TITLE
dialects: (llvm) add FExp2Op

### DIFF
--- a/tests/dialects/test_llvm.py
+++ b/tests/dialects/test_llvm.py
@@ -594,6 +594,13 @@ def test_fsqrt_op():
     assert op.res.type == builtin.f32
 
 
+def test_fexp2_op():
+    val = create_ssa_value(builtin.f32)
+    op = llvm.FExp2Op(val)
+    assert op.arg == val
+    assert op.res.type == builtin.f32
+
+
 def test_flog_op():
     val = create_ssa_value(builtin.f32)
     op = llvm.FLogOp(val)

--- a/tests/dialects/test_llvm.py
+++ b/tests/dialects/test_llvm.py
@@ -610,6 +610,10 @@ def test_fsqrt_op():
 def test_ffloor_op():
     val = create_ssa_value(builtin.f32)
     op = llvm.FFloorOp(val)
+    assert op.arg == val
+    assert op.res.type == builtin.f32
+
+
 def test_fexp2_op():
     val = create_ssa_value(builtin.f32)
     op = llvm.FExp2Op(val)

--- a/tests/dialects/test_llvm.py
+++ b/tests/dialects/test_llvm.py
@@ -610,6 +610,9 @@ def test_fsqrt_op():
 def test_ffloor_op():
     val = create_ssa_value(builtin.f32)
     op = llvm.FFloorOp(val)
+def test_fexp2_op():
+    val = create_ssa_value(builtin.f32)
+    op = llvm.FExp2Op(val)
     assert op.arg == val
     assert op.res.type == builtin.f32
 

--- a/tests/filecheck/backend/llvm/convert_op.mlir
+++ b/tests/filecheck/backend/llvm/convert_op.mlir
@@ -671,6 +671,21 @@ builtin.module {
   // CHECK-NEXT: {
   // CHECK-NEXT: [[ENTRY:.\d+]]:
   // CHECK-NEXT:   %"[[RES:.\d+]]" = call float @"llvm.sqrt"(float %".1")
+  // CHECK-NEXT:   ret float %"[[RES]]"
+  // CHECK-NEXT: }
+
+  llvm.func @fexp2_op(%arg0: f32) -> f32 {
+    %0 = llvm.intr.exp2(%arg0) : (f32) -> f32
+    llvm.return %0 : f32
+  }
+
+  // CHECK: define float @"fexp2_op"(float %".1")
+  // CHECK-NEXT: {
+  // CHECK-NEXT: [[ENTRY:.\d+]]:
+  // CHECK-NEXT:   %"[[RES:.\d+]]" = call float @"llvm.exp2"(float %".1")
+  // CHECK-NEXT:   ret float %"[[RES]]"
+  // CHECK-NEXT: }
+
   llvm.func @flog_op(%arg0: f32) -> f32 {
     %0 = llvm.intr.log(%arg0) : (f32) -> f32
     llvm.return %0 : f32

--- a/tests/filecheck/backend/llvm/convert_op.mlir
+++ b/tests/filecheck/backend/llvm/convert_op.mlir
@@ -769,6 +769,15 @@ builtin.module {
   // CHECK-NEXT: {
   // CHECK-NEXT: [[ENTRY:.\d+]]:
   // CHECK-NEXT:   %"[[RES:.\d+]]" = call float @"llvm.floor"(float %".1")
+  llvm.func @fexp2_op(%arg0: f32) -> f32 {
+    %0 = llvm.intr.exp2(%arg0) : (f32) -> f32
+    llvm.return %0 : f32
+  }
+
+  // CHECK: define float @"fexp2_op"(float %".1")
+  // CHECK-NEXT: {
+  // CHECK-NEXT: [[ENTRY:.\d+]]:
+  // CHECK-NEXT:   %"[[RES:.\d+]]" = call float @"llvm.exp2"(float %".1")
   // CHECK-NEXT:   ret float %"[[RES]]"
   // CHECK-NEXT: }
 

--- a/tests/filecheck/dialects/irdl/pyrdl-to-irdl/cmath-conversion.py
+++ b/tests/filecheck/dialects/irdl/pyrdl-to-irdl/cmath-conversion.py
@@ -1,7 +1,6 @@
 # RUN: python %s | filecheck %s
 
 from xdsl.dialects.cmath import Cmath
-
 from xdsl.dialects.irdl.pyrdl_to_irdl import dialect_to_irdl
 
 print(dialect_to_irdl(Cmath, "cmath"))

--- a/tests/filecheck/dialects/irdl/pyrdl-to-irdl/cmath-conversion.py
+++ b/tests/filecheck/dialects/irdl/pyrdl-to-irdl/cmath-conversion.py
@@ -1,6 +1,7 @@
 # RUN: python %s | filecheck %s
 
 from xdsl.dialects.cmath import Cmath
+
 from xdsl.dialects.irdl.pyrdl_to_irdl import dialect_to_irdl
 
 print(dialect_to_irdl(Cmath, "cmath"))

--- a/tests/filecheck/dialects/llvm/llvm_intrinsics.mlir
+++ b/tests/filecheck/dialects/llvm/llvm_intrinsics.mlir
@@ -21,6 +21,15 @@
 
 %fsqrt_vec = llvm.intr.sqrt(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
 // CHECK-NEXT: %fsqrt_vec = llvm.intr.sqrt(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
+%fexp2_f32 = llvm.intr.exp2(%f32) : (f32) -> f32
+// CHECK: %fexp2_f32 = llvm.intr.exp2(%f32) : (f32) -> f32
+
+%fexp2_f64 = llvm.intr.exp2(%f64) : (f64) -> f64
+// CHECK-NEXT: %fexp2_f64 = llvm.intr.exp2(%f64) : (f64) -> f64
+
+%fexp2_vec = llvm.intr.exp2(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
+// CHECK-NEXT: %fexp2_vec = llvm.intr.exp2(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
+
 %flog_f32 = llvm.intr.log(%f32) : (f32) -> f32
 // CHECK: %flog_f32 = llvm.intr.log(%f32) : (f32) -> f32
 

--- a/tests/filecheck/dialects/llvm/llvm_intrinsics.mlir
+++ b/tests/filecheck/dialects/llvm/llvm_intrinsics.mlir
@@ -30,6 +30,17 @@
 
 %fsqrt_vec = llvm.intr.sqrt(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
 // CHECK-NEXT: %fsqrt_vec = llvm.intr.sqrt(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
+<<<<<<< HEAD
+=======
+%fexp2_f32 = llvm.intr.exp2(%f32) : (f32) -> f32
+// CHECK: %fexp2_f32 = llvm.intr.exp2(%f32) : (f32) -> f32
+
+%fexp2_f64 = llvm.intr.exp2(%f64) : (f64) -> f64
+// CHECK-NEXT: %fexp2_f64 = llvm.intr.exp2(%f64) : (f64) -> f64
+
+%fexp2_vec = llvm.intr.exp2(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
+// CHECK-NEXT: %fexp2_vec = llvm.intr.exp2(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
+>>>>>>> e9cef71ba (dialects: (llvm) add FExp2Op)
 
 %ffloor_f32 = llvm.intr.floor(%f32) : (f32) -> f32
 // CHECK: %ffloor_f32 = llvm.intr.floor(%f32) : (f32) -> f32

--- a/tests/filecheck/dialects/llvm/llvm_intrinsics.mlir
+++ b/tests/filecheck/dialects/llvm/llvm_intrinsics.mlir
@@ -30,8 +30,6 @@
 
 %fsqrt_vec = llvm.intr.sqrt(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
 // CHECK-NEXT: %fsqrt_vec = llvm.intr.sqrt(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
-<<<<<<< HEAD
-=======
 %fexp2_f32 = llvm.intr.exp2(%f32) : (f32) -> f32
 // CHECK: %fexp2_f32 = llvm.intr.exp2(%f32) : (f32) -> f32
 
@@ -40,7 +38,6 @@
 
 %fexp2_vec = llvm.intr.exp2(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
 // CHECK-NEXT: %fexp2_vec = llvm.intr.exp2(%vec_f32) : (vector<4xf32>) -> vector<4xf32>
->>>>>>> e9cef71ba (dialects: (llvm) add FExp2Op)
 
 %ffloor_f32 = llvm.intr.floor(%f32) : (f32) -> f32
 // CHECK: %ffloor_f32 = llvm.intr.floor(%f32) : (f32) -> f32

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/llvm_intrinsics.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/llvm_intrinsics.mlir
@@ -13,6 +13,15 @@
 %2 = llvm.intr.fabs(%arg2) : (vector<4xf32>) -> vector<4xf32>
 // CHECK: llvm.intr.fabs([[arg2]]) : (vector<4xf32>) -> vector<4xf32>
 
+%exp2_f32 = llvm.intr.exp2(%arg0) : (f32) -> f32
+// CHECK: llvm.intr.exp2([[arg0]]) : (f32) -> f32
+
+%exp2_f64 = llvm.intr.exp2(%arg1) : (f64) -> f64
+// CHECK: llvm.intr.exp2([[arg1]]) : (f64) -> f64
+
+%exp2_vec = llvm.intr.exp2(%arg2) : (vector<4xf32>) -> vector<4xf32>
+// CHECK: llvm.intr.exp2([[arg2]]) : (vector<4xf32>) -> vector<4xf32>
+
 %3 = llvm.fneg %arg0 : f32
 // CHECK: llvm.fneg [[arg0]] : f32
 

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/llvm_intrinsics.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/llvm_intrinsics.mlir
@@ -39,6 +39,15 @@
 %ffloor_vec = llvm.intr.floor(%arg2) : (vector<4xf32>) -> vector<4xf32>
 // CHECK: llvm.intr.floor([[arg2]]) : (vector<4xf32>) -> vector<4xf32>
 
+%exp2_f32 = llvm.intr.exp2(%arg0) : (f32) -> f32
+// CHECK: llvm.intr.exp2([[arg0]]) : (f32) -> f32
+
+%exp2_f64 = llvm.intr.exp2(%arg1) : (f64) -> f64
+// CHECK: llvm.intr.exp2([[arg1]]) : (f64) -> f64
+
+%exp2_vec = llvm.intr.exp2(%arg2) : (vector<4xf32>) -> vector<4xf32>
+// CHECK: llvm.intr.exp2([[arg2]]) : (vector<4xf32>) -> vector<4xf32>
+
 %3 = llvm.fneg %arg0 : f32
 // CHECK: llvm.fneg [[arg0]] : f32
 

--- a/xdsl/backend/llvm/convert_op.py
+++ b/xdsl/backend/llvm/convert_op.py
@@ -167,6 +167,7 @@ def _convert_fcmp(
 
 _UNARY_INTRINSIC_MAP: dict[type[Operation], str] = {
     llvm.FAbsOp: "llvm.fabs",
+    llvm.FExp2Op: "llvm.exp2",
     llvm.FSqrtOp: "llvm.sqrt",
     llvm.FLogOp: "llvm.log",
 }

--- a/xdsl/backend/llvm/convert_op.py
+++ b/xdsl/backend/llvm/convert_op.py
@@ -178,7 +178,6 @@ _UNARY_INTRINSIC_MAP: dict[type[Operation], str] = {
     llvm.FCeilOp: "llvm.ceil",
     llvm.FSinOp: "llvm.sin",
     llvm.FFloorOp: "llvm.floor",
-
     llvm.FExp2Op: "llvm.exp2",
     llvm.FSqrtOp: "llvm.sqrt",
     llvm.FLogOp: "llvm.log",

--- a/xdsl/backend/llvm/convert_op.py
+++ b/xdsl/backend/llvm/convert_op.py
@@ -178,6 +178,8 @@ _UNARY_INTRINSIC_MAP: dict[type[Operation], str] = {
     llvm.FCeilOp: "llvm.ceil",
     llvm.FSinOp: "llvm.sin",
     llvm.FFloorOp: "llvm.floor",
+
+    llvm.FExp2Op: "llvm.exp2",
     llvm.FSqrtOp: "llvm.sqrt",
     llvm.FLogOp: "llvm.log",
 }

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -2326,6 +2326,39 @@ class FSqrtOp(IRDLOperation):
 
 
 @irdl_op_definition
+class FExp2Op(IRDLOperation):
+    T: ClassVar = VarConstraint("T", AnyFloatConstr | VectorType.constr(AnyFloatConstr))
+
+    name = "llvm.intr.exp2"
+
+    arg = operand_def(T)
+    res = result_def(T)
+
+    fastmathFlags = prop_def(FastMathAttr, default_value=FastMathAttr(None))
+
+    assembly_format = (
+        "`(` operands `)` attr-dict `:` functional-type(operands, results)"
+    )
+
+    irdl_options = (ParsePropInAttrDict(),)
+
+    traits = traits_def(Pure())
+
+    def __init__(
+        self,
+        arg: Operation | SSAValue,
+        fast_math: FastMathAttr | FastMathFlag | None = None,
+    ):
+        if isinstance(fast_math, FastMathFlag | str | None):
+            fast_math = FastMathAttr(fast_math)
+        super().__init__(
+            operands=[arg],
+            result_types=[SSAValue.get(arg).type],
+            properties={"fastmathFlags": fast_math},
+        )
+
+
+@irdl_op_definition
 class FLogOp(IRDLOperation):
     T: ClassVar = VarConstraint("T", AnyFloatConstr | VectorType.constr(AnyFloatConstr))
 
@@ -2566,6 +2599,7 @@ LLVM = Dialect(
         FAddOp,
         FCmpOp,
         FDivOp,
+        FExp2Op,
         FLogOp,
         FMulOp,
         FNegOp,

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -3138,6 +3138,39 @@ class FFloorOp(IRDLOperation):
 
 
 @irdl_op_definition
+class FExp2Op(IRDLOperation):
+    T: ClassVar = VarConstraint("T", AnyFloatConstr | VectorType.constr(AnyFloatConstr))
+
+    name = "llvm.intr.exp2"
+
+    arg = operand_def(T)
+    res = result_def(T)
+
+    fastmathFlags = prop_def(FastMathAttr, default_value=FastMathAttr(None))
+
+    assembly_format = (
+        "`(` operands `)` attr-dict `:` functional-type(operands, results)"
+    )
+
+    irdl_options = (ParsePropInAttrDict(),)
+
+    traits = traits_def(Pure())
+
+    def __init__(
+        self,
+        arg: Operation | SSAValue,
+        fast_math: FastMathAttr | FastMathFlag | None = None,
+    ):
+        if isinstance(fast_math, FastMathFlag | str | None):
+            fast_math = FastMathAttr(fast_math)
+        super().__init__(
+            operands=[arg],
+            result_types=[SSAValue.get(arg).type],
+            properties={"fastmathFlags": fast_math},
+        )
+
+
+@irdl_op_definition
 class FLogOp(IRDLOperation):
     T: ClassVar = VarConstraint("T", AnyFloatConstr | VectorType.constr(AnyFloatConstr))
 
@@ -3484,6 +3517,8 @@ LLVM = Dialect(
         FDivOp,
         FExpOp,
         FFloorOp,
+
+        FExp2Op,
         FLogOp,
         FMAOp,
         FMulOp,

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -3161,7 +3161,7 @@ class FExp2Op(IRDLOperation):
         arg: Operation | SSAValue,
         fast_math: FastMathAttr | FastMathFlag | None = None,
     ):
-        if isinstance(fast_math, FastMathFlag | str | None):
+        if not isinstance(fast_math, FastMathAttr):
             fast_math = FastMathAttr(fast_math)
         super().__init__(
             operands=[arg],

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -3517,7 +3517,6 @@ LLVM = Dialect(
         FDivOp,
         FExpOp,
         FFloorOp,
-
         FExp2Op,
         FLogOp,
         FMAOp,


### PR DESCRIPTION
- Add \`llvm.intr.exp2\` (\`FExp2Op\`) to the LLVM dialect; accepts scalar or vector-of-float
- Wire into \`_UNARY_INTRINSIC_MAP\` in \`convert_op.py\` (refactored from per-op \`_convert_fabs\` into shared dispatch)
- Dialect + MLIR + backend + pytest coverage mirroring \`FAbsOp\`

Refs:
- MLIR: https://mlir.llvm.org/docs/Dialects/LLVM/#llvmintrexp2-llvmexp2op
- LangRef: https://llvm.org/docs/LangRef.html#llvm-exp2-intrinsic