### PR TITLE
CI: use uv cache consistently in CI jobs

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -38,3 +38,6 @@ jobs:
       - name: Run all tests
         run: |
           make tests-functional
+
+      - name: Prune uv cache
+        run: uv cache prune --ci

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -38,6 +38,9 @@ jobs:
         run: uv run mkdocs build --strict
         # The --strict flag ensures the build fails on warnings
 
+      - name: Prune uv cache
+        run: uv cache prune --ci
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v5
         with:

--- a/.github/workflows/ci-lockfile.yml
+++ b/.github/workflows/ci-lockfile.yml
@@ -37,3 +37,6 @@ jobs:
           # Install all default extras.
           # Fail if the lockfile dependencies are out of date with pyproject.toml.
           uv sync --all-extras --all-groups --locked
+
+      - name: Prune uv cache
+        run: uv cache prune --ci

--- a/.github/workflows/ci-mlir.yml
+++ b/.github/workflows/ci-mlir.yml
@@ -78,6 +78,9 @@ jobs:
           uv run coverage report
           uv run coverage xml
 
+      - name: Prune uv cache
+        run: uv cache prune --ci
+
       - name: Upload coverage to Codecov
         if: matrix.python-version == '3.13'
         uses: Wandalen/wretry.action@v3

--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -19,7 +19,15 @@ jobs:
       uses: cachix/install-nix-action@v31
       with:
         github_access_token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Cache uv packages
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/uv
+        key: uv-nix-${{ hashFiles('uv.lock') }}
+        restore-keys: uv-nix-
     - name: Build venv
       run: nix develop --command make venv
     - name: Run tests
       run: nix develop --command make tests
+    - name: Prune uv cache
+      run: nix develop --command uv cache prune --ci

--- a/.github/workflows/ci-notebooks.yml
+++ b/.github/workflows/ci-notebooks.yml
@@ -43,3 +43,6 @@ jobs:
       - name: Test marimo notebooks
         run: |
           make tests-marimo
+
+      - name: Prune uv cache
+        run: uv cache prune --ci

--- a/.github/workflows/ci-pyright-fails.yml
+++ b/.github/workflows/ci-pyright-fails.yml
@@ -48,3 +48,6 @@ jobs:
         with:
           version: PATH
           venv-path: .venv
+
+      - name: Prune uv cache
+        run: uv cache prune --ci

--- a/.github/workflows/code-formatting.yml
+++ b/.github/workflows/code-formatting.yml
@@ -33,3 +33,6 @@ jobs:
 
       - name: Run code formatting checks with prek
         uses: j178/prek-action@v2
+
+      - name: Prune uv cache
+        run: uv cache prune --ci


### PR DESCRIPTION
If I understand correctly, we have a repo-wide limit of cache size, each CI job has a separate cache entry, and by never pruning we just accumulate cache until the jobs start potentially pushing each other out of the overall available space. We should instead be consistently pruning the cache in each CI action that uses it.