### PR TITLE
CI: add pre-commit hook to format yaml files with prettier

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,46 +1,45 @@
-
-name-template: 'v$NEXT_PATCH_VERSION'
-tag-template: 'v$NEXT_PATCH_VERSION'
+name-template: "v$NEXT_PATCH_VERSION"
+tag-template: "v$NEXT_PATCH_VERSION"
 categories:
-  - title: '⚠Breaking Changes⚠'
-    label: 'breaking'
-  - title: 'xDSL framework'
-    label: 'core'
-  - title: 'Frontend'
-    label: 'frontend'
-  - title: 'Dialects'
-    label: 'dialects'
-  - title: 'Transformations'
-    label: 'transformations'
-  - title: 'Backend'
-    label: 'backend'
-  - title: 'Benchmarking'
-    label: 'bench'
-  - title: 'Interpreter'
-    label: 'interpreter'
-  - title: '🗎 Documentation'
-    label: 'documentation'
-  - title: '🐛 Bug Fixes'
-    label: 'bug'
-  - title: 'Testing'
-    label: 'testing'
-  - title: 'Continuous Integration'
-    label: 'CI'
-  - title: 'Installation'
-    label: 'installation'
-  - title: 'Dependencies'
-    label: 'dependencies'
-  - title: 'Miscellaneous'
+  - title: "⚠Breaking Changes⚠"
+    label: "breaking"
+  - title: "xDSL framework"
+    label: "core"
+  - title: "Frontend"
+    label: "frontend"
+  - title: "Dialects"
+    label: "dialects"
+  - title: "Transformations"
+    label: "transformations"
+  - title: "Backend"
+    label: "backend"
+  - title: "Benchmarking"
+    label: "bench"
+  - title: "Interpreter"
+    label: "interpreter"
+  - title: "🗎 Documentation"
+    label: "documentation"
+  - title: "🐛 Bug Fixes"
+    label: "bug"
+  - title: "Testing"
+    label: "testing"
+  - title: "Continuous Integration"
+    label: "CI"
+  - title: "Installation"
+    label: "installation"
+  - title: "Dependencies"
+    label: "dependencies"
+  - title: "Miscellaneous"
     labels:
-      - 'minor'
-      - 'misc'
-  - title: 'Interactive'
-    label: 'interactive'
-  - title: 'Rewriting'
-    label: 'rewriting'
-  - title: 'Tool'
-    label: 'tool'
-change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+      - "minor"
+      - "misc"
+  - title: "Interactive"
+    label: "interactive"
+  - title: "Rewriting"
+    label: "rewriting"
+  - title: "Tool"
+    label: "tool"
+change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
 template: |
   ## Changes
   $CHANGES

--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6
-    - name: Install Nix
-      uses: cachix/install-nix-action@v31
-      with:
-        github_access_token: ${{ secrets.GITHUB_TOKEN }}
-    - name: Build venv
-      run: nix develop --command make venv
-    - name: Run tests
-      run: nix develop --command make tests
+      - uses: actions/checkout@v6
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build venv
+        run: nix develop --command make venv
+      - name: Run tests
+        run: nix develop --command make tests

--- a/.github/workflows/markdown-formatting.yml
+++ b/.github/workflows/markdown-formatting.yml
@@ -6,14 +6,13 @@ on:
 
 jobs:
   code-formatting:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6
+      - uses: actions/checkout@v6
 
-    - name: markdownlint-cli2-action
-      uses: DavidAnson/markdownlint-cli2-action@v23
-      with:
-        config: '.markdownlint.json'
-        globs: '**/*.{md,markdown}'
+      - name: markdownlint-cli2-action
+        uses: DavidAnson/markdownlint-cli2-action@v23
+        with:
+          config: ".markdownlint.json"
+          globs: "**/*.{md,markdown}"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,22 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:
-    -   id: check-yaml
-    -   id: end-of-file-fixer
-    -   id: mixed-line-ending
--   repo: https://github.com/astral-sh/ruff-pre-commit
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+  - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.11
     hooks:
-    -   id: ruff-check
-        types_or: [ python, pyi, jupyter ]
-        args: [ --fix, --exit-non-zero-on-fix ]
-    -   id: ruff-format
-        types_or: [ python, pyi, jupyter ]
+      - id: ruff-check
+        types_or: [python, pyi, jupyter]
+        args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff-format
+        types_or: [python, pyi, jupyter]
+  - repo: https://github.com/rbubley/mirrors-prettier
+    rev: 515f543f5718ebfd6ce22e16708bb32c68ff96e1
+    hooks:
+      - id: prettier
+        types_or: [yaml]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@ site_url: https://xdsl.dev/
 site_description: xDSL -- a Python-native compiler framework
 site_author: xDSL developers
 copyright: Copyright &copy xDSL developers
-repo_name:  xdslproject/xdsl
+repo_name: xdslproject/xdsl
 repo_url: https://github.com/xdslproject/xdsl
 
 strict: true
@@ -42,25 +42,25 @@ extra_css:
   - stylesheets/extra.css
 
 plugins:
-- search
-- gen-files:
-    scripts:
-    - scripts/gen_ref_pages.py
-- awesome-nav
-- marimo
-- mkdocstrings:
-    handlers:
-      python:
-        options:
-          docstring_style: google
-          members_order: source
-          show_root_heading: true
-          show_root_full_path: false
-          show_signature_annotations: true
-          show_if_no_docstring: true
-- mkdocs-simple-hooks:
-    hooks:
-      on_post_build: "scripts.hooks:build_xdsl_wheel"
+  - search
+  - gen-files:
+      scripts:
+        - scripts/gen_ref_pages.py
+  - awesome-nav
+  - marimo
+  - mkdocstrings:
+      handlers:
+        python:
+          options:
+            docstring_style: google
+            members_order: source
+            show_root_heading: true
+            show_root_full_path: false
+            show_signature_annotations: true
+            show_if_no_docstring: true
+  - mkdocs-simple-hooks:
+      hooks:
+        on_post_build: "scripts.hooks:build_xdsl_wheel"
 
 extra:
   social:


### PR DESCRIPTION
Zed has this formatter by default, I find that it's basically instant.