### PR TITLE
CI: (precommit) generate type stubs before running ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,14 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
+  - repo: local
+    hooks:
+      - id: xdsl-stubgen
+        name: generate xDSL type stubs
+        entry: uv run xdsl-stubgen
+        language: system
+        pass_filenames: false
+        always_run: true
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:


### PR DESCRIPTION
- Ruff misclassifies xDSL internals as external dependencies when the generated type stubs are missing, producing spurious formatting diffs (e.g. import-order newlines).
- The stubs were only regenerated by `make pyright`, so fresh clones and cleaned worktrees routinely hit this.
- Add `xdsl-stubgen` as a local prek hook so stubs are present whenever ruff runs via `make precommit`, the installed git hook, or editor integrations.
