### PR TITLE
backend: (llvm) convert llvm.mlir.zero instead of llvm.mlir.null

### DIFF
--- a/tests/backend/llvm/test_convert_op.py
+++ b/tests/backend/llvm/test_convert_op.py
@@ -24,10 +24,10 @@ def test_convert_indirect_call_raises():
         convert_op(op, builder, val_map)
 
 
-def test_convert_null():
-    op = llvm.NullOp(llvm.LLVMPointerType())
+def test_convert_zero():
+    op = llvm.ZeroOp.create(result_types=[llvm.LLVMPointerType()])
     val_map: dict[SSAValue, Any] = {}
 
     convert_op(op, MagicMock(), val_map)
 
-    assert str(val_map[op.nullptr]) == "ptr null"
+    assert str(val_map[op.res]) == "ptr null"

--- a/tests/filecheck/backend/llvm/convert_op.mlir
+++ b/tests/filecheck/backend/llvm/convert_op.mlir
@@ -764,12 +764,12 @@ builtin.module {
   // CHECK-NEXT:   ret void
   // CHECK-NEXT: }
 
-  llvm.func @null_op() -> !llvm.ptr {
-    %0 = "llvm.mlir.null"() : () -> !llvm.ptr
+  llvm.func @zero_op() -> !llvm.ptr {
+    %0 = "llvm.mlir.zero"() : () -> !llvm.ptr
     llvm.return %0 : !llvm.ptr
   }
 
-  // CHECK: define ptr @"null_op"()
+  // CHECK: define ptr @"zero_op"()
   // CHECK-NEXT: {
   // CHECK-NEXT: {{.[0-9]+}}:
   // CHECK-NEXT:   ret ptr null

--- a/xdsl/backend/llvm/convert_op.py
+++ b/xdsl/backend/llvm/convert_op.py
@@ -385,12 +385,6 @@ def _convert_return(
         builder.ret_void()
 
 
-def _convert_null(
-    op: llvm.NullOp, builder: ir.IRBuilder, val_map: dict[SSAValue, ir.Value]
-):
-    val_map[op.nullptr] = ir.Constant(convert_type(op.nullptr.type), None)
-
-
 def _convert_addressof(
     op: llvm.AddressOfOp, builder: ir.IRBuilder, val_map: dict[SSAValue, ir.Value]
 ):
@@ -504,8 +498,8 @@ def convert_op(
             _convert_masked_store(op, builder, val_map)
         case llvm.ReturnOp():
             _convert_return(op, builder, val_map)
-        case llvm.NullOp():
-            _convert_null(op, builder, val_map)
+        case llvm.ZeroOp():
+            val_map[op.res] = ir.Constant(convert_type(op.res.type), None)
         case llvm.AddressOfOp():
             _convert_addressof(op, builder, val_map)
         case FMAOp():


### PR DESCRIPTION
Extracted from https://github.com/xdslproject/xdsl/pull/5876: replace NullOp handling with ZeroOp in the llvmlite backend, matching the MLIR pipeline which lowers null pointers to `llvm.mlir.zero`.

See: https://mlir.llvm.org/docs/Dialects/LLVM/#llvmmlirzero-llvmzeroop:~:text=//%20Null%20pointer.,llvm.ptr