### PR TITLE
documentation: (marimo) remove navigation from embedded notebooks

### DIFF
--- a/scripts/gen_ref_pages.py
+++ b/scripts/gen_ref_pages.py
@@ -77,14 +77,11 @@ Some features are not supported so they have to be opted into it one by one.
 
 
 def gen_marimo_old():
-    def create_marimo_app_url(code: str, mode: str = "read") -> str:
+    def create_marimo_app_url(code: str) -> str:
         from lzstring2 import LZString
 
         encoded_code = LZString.compress_to_encoded_URI_component(code)
-        return (
-            f"https://marimo.app/?embed=true&mode={mode}&show-chrome=false"
-            f"#code/{encoded_code}"
-        )
+        return f"https://marimo.app/?embed=true&show-chrome=false#code/{encoded_code}"
 
     for path in sorted((docs_root / "marimo").rglob("*.py")):
         if path in NEW_MARIMO_NOTEBOOKS:

--- a/scripts/gen_ref_pages.py
+++ b/scripts/gen_ref_pages.py
@@ -81,7 +81,10 @@ def gen_marimo_old():
         from lzstring2 import LZString
 
         encoded_code = LZString.compress_to_encoded_URI_component(code)
-        return f"https://marimo.app/#code/{encoded_code}&embed=true"
+        return (
+            f"https://marimo.app/?embed=true&mode={mode}&show-chrome=false"
+            f"#code/{encoded_code}"
+        )
 
     for path in sorted((docs_root / "marimo").rglob("*.py")):
         if path in NEW_MARIMO_NOTEBOOKS:


### PR DESCRIPTION
- Embedded marimo notebooks served via the `marimo.app` iframe at `/marimo/<name>.html` showed editor chrome (sidebar panel icons, run/stop buttons and top logo bar) that is absent from the html-wasm exported notebooks at `/marimo/html/<name>/`.
- `create_marimo_app_url` appended `&embed=true` inside the URL hash, but these controls are only honoured as query-string parameters, so the header and chrome were never actually hidden.
- Moved the flags into the query string and added `show-chrome=false` to hide the header, editor toolbar and sidebar panels.

Fixes #5634

## Test plan
- [x] `uv run ruff format` / `uv run ruff check scripts/gen_ref_pages.py` clean.
- [x] `make docs-serve` locally, open `/marimo/mlir_ir.html` and other iframe-served notebooks: marimo logo bar, left sidebar panel icons and cell run/stop buttons are hidden, layout now matches `/marimo/html/mlir_introduction/`.
- [x] `/marimo/html/<name>/` notebooks (expressions, eqsat, mlir_introduction, pdl) unaffected.

I found this issue through [Weekly Issue Arena](https://github.com/claudiotancredi/weekly-issue-arena), a gamified hub that publishes open-source issues weekly.