### PR TITLE
dialects: (riscv_snitch) factor out is_valid_frep_body_op helper

### DIFF
--- a/xdsl/dialects/riscv_snitch.py
+++ b/xdsl/dialects/riscv_snitch.py
@@ -225,6 +225,18 @@ ALLOWED_FREP_OP_TYPES = (
     UnrealizedConversionCastOp,
 )
 
+
+def is_valid_frep_body_op(operation: Operation) -> bool:
+    """
+    Helper method to determine whether the `frep` loop on the Snitch core can contain
+    the given operation.
+    `frep` loops can only contain instructions that are executed on the FPU, and only
+    contain memory effects via `ReadOp` / `WriteOp`.
+    We also allow `UnrealizedConversionCastOp` to support partial lowering of dialects.
+    """
+    return operation.has_trait(Pure) or isinstance(operation, ALLOWED_FREP_OP_TYPES)
+
+
 I3: TypeAlias = IntegerType[Literal[3]]
 I4: TypeAlias = IntegerType[Literal[4]]
 i3 = I3(3)
@@ -409,9 +421,7 @@ class FRepOperation(RISCVInstruction):
         if self.stagger_mask.value.data:
             raise VerifyException("Non-zero stagger mask currently unsupported")
         for instruction in self.body.ops:
-            if not instruction.has_trait(Pure) and not isinstance(
-                instruction, ALLOWED_FREP_OP_TYPES
-            ):
+            if not is_valid_frep_body_op(instruction):
                 raise VerifyException(
                     "Frep operation body may not contain instructions "
                     f"with side-effects, found {instruction.name}"

--- a/xdsl/transforms/convert_riscv_scf_for_to_frep.py
+++ b/xdsl/transforms/convert_riscv_scf_for_to_frep.py
@@ -10,12 +10,6 @@ from xdsl.pattern_rewriter import (
     RewritePattern,
     op_type_rewrite_pattern,
 )
-from xdsl.traits import Pure
-
-ALLOWED_FREP_OP_LOWERING_TYPES = (
-    *riscv_snitch.ALLOWED_FREP_OP_TYPES,
-    riscv_scf.YieldOp,
-)
 
 
 class ScfForLowering(RewritePattern):
@@ -49,7 +43,7 @@ class ScfForLowering(RewritePattern):
             return
 
         if not all(
-            isinstance(o, ALLOWED_FREP_OP_LOWERING_TYPES) or o.has_trait(Pure)
+            isinstance(o, riscv_scf.YieldOp) or riscv_snitch.is_valid_frep_body_op(o)
             for o in body_block.ops
         ):
             # 4. All operations are pure or one of


### PR DESCRIPTION
Small refactor PR towards #5882, as we need to handle frep loops carefully as we change the memory effects of the ops in the riscv and riscv_snitch dialects.