### PR TITLE
dialects: (riscv_snitch) add recursive memory effects to frep

### DIFF
--- a/tests/dialects/test_riscv_snitch.py
+++ b/tests/dialects/test_riscv_snitch.py
@@ -1,8 +1,18 @@
 import pytest
 
-from xdsl.dialects import riscv_snitch
+from xdsl import ir, irdl
+from xdsl.backend.register_type import RegisterAllocatedMemoryEffect
+from xdsl.builder import ImplicitBuilder
+from xdsl.dialects import riscv, riscv_snitch
 from xdsl.dialects.riscv import RISCVInstruction
-from xdsl.traits import HasInsnRepresentation
+from xdsl.traits import (
+    EffectInstance,
+    HasInsnRepresentation,
+    MemoryEffectKind,
+    MemoryReadEffect,
+    get_effects,
+)
+from xdsl.utils.test_value import create_ssa_value
 
 ground_truth = {
     "dmsrc": ".insn r 0x2b, 0, 0, x0, {0}, {1}",
@@ -32,7 +42,46 @@ ground_truth = {
 def test_insn_repr(op: RISCVInstruction):
     trait = op.get_trait(HasInsnRepresentation)
     assert trait is not None
-    # Limitation of Pyright, see https://github.com/microsoft/pyright/issues/7105
-    # We are currently stuck on an older version of Pyright, the update is
-    # tracked in https://github.com/xdslproject/xdsl/issues/2791
     assert trait.get_insn(op) == ground_truth[op.name[13:]]
+
+
+def test_frep_recursive_effects():
+
+    @irdl.irdl_op_definition
+    class TestInstr(irdl.IRDLOperation):
+        name = "test.instr"
+
+        rd = irdl.result_def(riscv.FloatRegisterType)
+        rs1 = irdl.operand_def(riscv.FloatRegisterType)
+        rs2 = irdl.operand_def(riscv.FloatRegisterType)
+
+        traits = irdl.traits_def(RegisterAllocatedMemoryEffect())
+
+    block = ir.Block(
+        arg_types=(riscv.Registers.UNALLOCATED_FLOAT, riscv.Registers.UNALLOCATED_FLOAT)
+    )
+
+    with ImplicitBuilder(block) as (a, b):
+        inner_op = TestInstr.build(
+            operands=(a, b), result_types=(riscv.Registers.UNALLOCATED_FLOAT,)
+        )
+        riscv_snitch.FrepYieldOp(inner_op.rd, a)
+
+    iters = create_ssa_value(riscv.Registers.UNALLOCATED_INT)
+    iter_args = (
+        create_ssa_value(riscv.Registers.UNALLOCATED_FLOAT),
+        create_ssa_value(riscv.Registers.UNALLOCATED_FLOAT),
+    )
+
+    frep_op = riscv_snitch.FrepOuterOp(iters, (block,), iter_args)
+
+    # Verify for completeness
+    frep_op.verify()
+
+    assert get_effects(inner_op) == set()
+    assert get_effects(frep_op) == set()
+
+    TestInstr.traits.add_trait(MemoryReadEffect())
+
+    assert get_effects(inner_op) == {EffectInstance(MemoryEffectKind.READ)}
+    assert get_effects(frep_op) == {EffectInstance(MemoryEffectKind.READ)}

--- a/xdsl/dialects/riscv_snitch.py
+++ b/xdsl/dialects/riscv_snitch.py
@@ -69,6 +69,8 @@ from xdsl.traits import (
     IsTerminator,
     MemoryReadEffect,
     MemoryWriteEffect,
+    NoMemoryEffect,
+    RecursiveMemoryEffect,
     SingleBlockImplicitTerminator,
     ensure_terminator,
     get_effects,
@@ -163,7 +165,7 @@ class FrepYieldOp(
     name = "riscv_snitch.frep_yield"
 
     traits = lazy_traits_def(
-        lambda: (IsTerminator(), HasParent(FrepInnerOp, FrepOuterOp))
+        lambda: (IsTerminator(), HasParent(FrepInnerOp, FrepOuterOp), NoMemoryEffect())
     )
 
     def assembly_line(self) -> str | None:
@@ -231,7 +233,6 @@ class WriteOp(RISCVAsmOperation, RISCVRegallocOperation):
 
 
 ALLOWED_FREP_OP_TYPES: tuple[type[Operation], ...] = (
-    FrepYieldOp,
     ReadOp,
     WriteOp,
     UnrealizedConversionCastOp,
@@ -311,7 +312,9 @@ class FRepOperation(RISCVInstruction):
     Loop-carried variable initial values.
     """
 
-    traits = lazy_traits_def(lambda: (SingleBlockImplicitTerminator(FrepYieldOp),))
+    traits = lazy_traits_def(
+        lambda: (SingleBlockImplicitTerminator(FrepYieldOp), RecursiveMemoryEffect())
+    )
 
     def __init__(
         self,


### PR DESCRIPTION
Another step towards #5882, don't dce frep ops if they contain operations with memory effects.