### PR TITLE
testing: use only float ops in frep bodies in tests [NFC]

### DIFF
--- a/tests/filecheck/backend/riscv/register-allocation/frep.mlir
+++ b/tests/filecheck/backend/riscv/register-allocation/frep.mlir
@@ -11,26 +11,26 @@ riscv_func.func @main() {
   riscv_snitch.frep_outer %0 {
   }
 
-  %7 = riscv_snitch.frep_outer %0 iter_args(%6 = %5) -> (!riscv.reg) {
-    %8 = riscv.mv %6 : (!riscv.reg) -> !riscv.reg
-    riscv_snitch.frep_yield %8 : !riscv.reg
+  %7 = riscv_snitch.frep_outer %0 iter_args(%6 = %4) -> (!riscv.freg) {
+    %8 = riscv.fmv.d %6 : (!riscv.freg) -> !riscv.freg
+    riscv_snitch.frep_yield %8 : !riscv.freg
   }
   riscv_func.return
 }
 
 //   CHECK-LIVENESS-BLOCK-NAIVE:       builtin.module {
 //   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:    riscv_func.func @main() {
-//   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:      %{{\d+}} = rv32.li 6 : !riscv.reg<t1>
+//   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:      %{{\d+}} = rv32.li 6 : !riscv.reg<t0>
 //   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:      %{{\d+}} = rv32.li 5 : !riscv.reg<s0>
-//   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:      %{{\d+}} = riscv.fcvt.s.w %{{\d+}} : (!riscv.reg<t1>) -> !riscv.freg<ft0>
+//   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:      %{{\d+}} = riscv.fcvt.s.w %{{\d+}} : (!riscv.reg<t0>) -> !riscv.freg<ft0>
 //   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:      %{{\d+}} = riscv.fcvt.s.w %{{\d+}} : (!riscv.reg<s0>) -> !riscv.freg<ft1>
 //   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:      %{{\d+}} = riscv.fadd.s %{{\d+}}, %{{\d+}} : (!riscv.freg<ft0>, !riscv.freg<ft1>) -> !riscv.freg<ft0>
-//   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:      %{{\d+}} = riscv.add %{{\d+}}, %{{\d+}} : (!riscv.reg<t1>, !riscv.reg<s0>) -> !riscv.reg<t0>
+//   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:      %{{\d+}} = riscv.add %{{\d+}}, %{{\d+}} : (!riscv.reg<t0>, !riscv.reg<s0>) -> !riscv.reg<t1>
 //   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:      riscv_snitch.frep_outer %{{\d+}} {
 //   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:      }
-//   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:      %{{\d+}} = riscv_snitch.frep_outer %{{\d+}} iter_args(%{{\d+}} = %{{\d+}}) -> (!riscv.reg<t0>) {
-//   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:        %{{\d+}} = riscv.mv %{{\d+}} : (!riscv.reg<t0>) -> !riscv.reg<t0>
-//   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:        riscv_snitch.frep_yield %{{\d+}} : !riscv.reg<t0>
+//   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:      %{{\d+}} = riscv_snitch.frep_outer %{{\d+}} iter_args(%{{\d+}} = %{{\d+}}) -> (!riscv.freg<ft0>) {
+//   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:        %{{\d+}} = riscv.fmv.d %{{\d+}} : (!riscv.freg<ft0>) -> !riscv.freg<ft0>
+//   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:        riscv_snitch.frep_yield %{{\d+}} : !riscv.freg<ft0>
 //   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:      }
 //   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:      riscv_func.return
 //   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:    }

--- a/tests/filecheck/dialects/riscv/riscv_assembly_emission.mlir
+++ b/tests/filecheck/dialects/riscv/riscv_assembly_emission.mlir
@@ -183,20 +183,22 @@
 
 
     // RISC-V Extensions
+    %fa0 = riscv.get_float_register : !riscv.freg<fa0>
+    %fa1 = riscv.get_float_register : !riscv.freg<fa1>
 
     riscv_snitch.frep_outer %0 {
-      %add_o = riscv.add %0, %1 : (!riscv.reg<zero>, !riscv.reg<j_1>) -> !riscv.reg<j_2>
+      %add_o = riscv.fadd.s %fa0, %fa1 : (!riscv.freg<fa0>, !riscv.freg<fa1>) -> !riscv.freg<fa2>
     }
 
     // CHECK:          frep.o zero, 1, 0, 0
-    // CHECK-NEXT:     add  j_2, zero, j_1
+    // CHECK-NEXT:     fadd.s  fa2, fa0, fa1
 
     riscv_snitch.frep_inner %0 {
-      %add_i = riscv.add %0, %1 : (!riscv.reg<zero>, !riscv.reg<j_1>) -> !riscv.reg<j_2>
+      %add_o = riscv.fadd.s %fa0, %fa1 : (!riscv.freg<fa0>, !riscv.freg<fa1>) -> !riscv.freg<fa2>
     }
     // CHECK:          frep.i zero, 1, 0, 0
-    // CHECK-NEXT:     add  j_2, zero, j_1
-    
+    // CHECK-NEXT:     fadd.s  fa2, fa0, fa1
+
     //RV32B/RV64B: "B" Extension for Bit Manipulation, Version 1.0.0
     %rol = riscv.rol %2, %1 : (!riscv.reg<j_2>, !riscv.reg<j_1>) -> !riscv.reg<j_2>
     // CHECK-NEXT: rol j_2, j_2, j_1
@@ -246,7 +248,7 @@
     // CHECK-NEXT: min j_2, j_2, j_1
     %minu = riscv.minu %2, %1 : (!riscv.reg<j_2>, !riscv.reg<j_1>) -> !riscv.reg<j_2>
     // CHECK-NEXT: minu j_2, j_2, j_1
-    
+
     // "ZiCond" Conditional" operations extension
     %czeroeqz = riscv.czero.eqz %2, %1 : (!riscv.reg<j_2>, !riscv.reg<j_1>) -> !riscv.reg<j_2>
     // CHECK-NEXT: czero.eqz j_2, j_2, j_1


### PR DESCRIPTION
Another small change towards #5882, making the tests for things that involve the frep op only use things that are actually legal in the frep op.