### PR TITLE
dialects: (llvm) add custom format to UndefOp

### DIFF
--- a/tests/filecheck/dialects/llvm/array.mlir
+++ b/tests/filecheck/dialects/llvm/array.mlir
@@ -5,5 +5,5 @@ builtin.module {
 }
 
 // CHECK:     builtin.module {
-// CHECK-NEXT:  %0 = "llvm.mlir.undef"() : () -> !llvm.array<2 x i64>
-// CHECK-NEXT:  %1 = "llvm.mlir.undef"() : () -> !llvm.array<1 x i64>
+// CHECK-NEXT:  %0 = llvm.mlir.undef : !llvm.array<2 x i64>
+// CHECK-NEXT:  %1 = llvm.mlir.undef : !llvm.array<1 x i64>

--- a/tests/filecheck/dialects/llvm/example.mlir
+++ b/tests/filecheck/dialects/llvm/example.mlir
@@ -42,7 +42,7 @@ builtin.module {
   }
 
 // CHECK:       func.func private @array(%0: !llvm.array<2 x i64>) -> !llvm.array<1 x i32> {
-// CHECK-NEXT:    %1 = "llvm.mlir.undef"() : () -> !llvm.array<1 x i32>
+// CHECK-NEXT:    %1 = llvm.mlir.undef : !llvm.array<1 x i32>
 // CHECK-NEXT:    func.return %1 : !llvm.array<1 x i32>
 // CHECK-NEXT:  }
 
@@ -77,7 +77,7 @@ builtin.module {
 
 // CHECK:       func.func public @main() {
 // CHECK-NEXT:      %0 = arith.constant 1 : i32
-// CHECK-NEXT:      %1 = "llvm.mlir.undef"() : () -> !llvm.struct<(i32)>
+// CHECK-NEXT:      %1 = llvm.mlir.undef : !llvm.struct<(i32)>
 // CHECK-NEXT:      %2 = "llvm.insertvalue"(%1, %0) <{position = array<i64: 0>}> : (!llvm.struct<(i32)>, i32) -> !llvm.struct<(i32)>
 // CHECK-NEXT:      %3 = "llvm.extractvalue"(%2) <{position = array<i64: 0>}> : (!llvm.struct<(i32)>) -> i32
 // CHECK-NEXT:      %4 = llvm.mlir.zero : !llvm.struct<(i32, f32)>

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -1449,6 +1449,8 @@ class UndefOp(IRDLOperation):
 
     name = "llvm.mlir.undef"
 
+    assembly_format = "attr-dict `:` type($res)"
+
     res = result_def(Attribute)
 
     traits = traits_def(NoMemoryEffect())


### PR DESCRIPTION
Follow-up to #5881 -> add `assembly_format` to `llvm.mlir.undef`.