### PR TITLE
dialects: (llvm) add custom format to AddressOfOp

### DIFF
--- a/tests/filecheck/dialects/llvm/global.mlir
+++ b/tests/filecheck/dialects/llvm/global.mlir
@@ -9,6 +9,6 @@ builtin.module {
 // CHECK: builtin.module {
 // CHECK-NEXT:   "llvm.mlir.global"() <{global_type = !llvm.array<13 x i8>, constant, sym_name = "str0", linkage = #llvm.linkage<"internal">, value = "Hello world!\n", addr_space = 0 : i32, unnamed_addr = 0 : i64}> ({
 // CHECK-NEXT:   }) : () -> ()
-// CHECK-NEXT:   %0 = "llvm.mlir.addressof"() <{global_name = @str0}> : () -> !llvm.ptr
+// CHECK-NEXT:   %0 = llvm.mlir.addressof @str0 : !llvm.ptr
 // CHECK-NEXT:   %1 = "llvm.getelementptr"(%0) <{elem_type = !llvm.array<13 x i8>, noWrapFlags = 0 : i32, rawConstantIndices = array<i32: 0, 0>}> : (!llvm.ptr) -> !llvm.ptr
 // CHECK-NEXT: }

--- a/tests/filecheck/dialects/printf/printf_to_llvm.mlir
+++ b/tests/filecheck/dialects/printf/printf_to_llvm.mlir
@@ -11,7 +11,7 @@ builtin.module {
     }) {sym_name = "main", function_type=() -> ()} : () -> ()
 }
 
-// CHECK:       %{{\d+}} = "llvm.mlir.addressof"() <{global_name = @Hello_f_842f9d94ff2eba9703926bef3c2bc5f427db9871}> : () -> !llvm.ptr
+// CHECK:       %{{\d+}} = llvm.mlir.addressof @Hello_f_842f9d94ff2eba9703926bef3c2bc5f427db9871 : !llvm.ptr
 
 // CHECK:       "llvm.call"(%{{\d+}}, %{{\d+}}, %{{\d+}}) <{callee = @printf{{.*}}}> : (!llvm.ptr, f64, i32) -> ()
 

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -1540,6 +1540,8 @@ class GlobalOp(IRDLOperation):
 class AddressOfOp(IRDLOperation):
     name = "llvm.mlir.addressof"
 
+    assembly_format = "$global_name attr-dict `:` type($result)"
+
     global_name = prop_def(SymbolRefAttr)
     result = result_def(LLVMPointerType)
 


### PR DESCRIPTION
Follow-up to #5881 -> add `assembly_format` to `llvm.mlir.addressof`.