### PR TITLE
dialects: (llvm) add custom format to IntToPtrOp

### DIFF
--- a/tests/filecheck/dialects/llvm/pointers.mlir
+++ b/tests/filecheck/dialects/llvm/pointers.mlir
@@ -14,7 +14,7 @@ builtin.module {
 
 // CHECK:       builtin.module {
 // CHECK-NEXT:    %0 = arith.constant 0 : i64
-// CHECK-NEXT:    %1 = "llvm.inttoptr"(%0) : (i64) -> !llvm.ptr
+// CHECK-NEXT:    %1 = llvm.inttoptr %0 : i64 to !llvm.ptr
 // CHECK-NEXT:    %2 = "llvm.mlir.null"() : () -> !llvm.ptr
 // CHECK-NEXT:    %3 = "llvm.alloca"(%0) <{alignment = 32 : i64}> : (i64) -> !llvm.ptr
 // CHECK-NEXT:    %4 = "llvm.getelementptr"(%3, %0) <{elem_type = i32, noWrapFlags = 0 : i32, rawConstantIndices = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr

--- a/tests/filecheck/transforms/convert_ptr_to_llvm.mlir
+++ b/tests/filecheck/transforms/convert_ptr_to_llvm.mlir
@@ -12,7 +12,7 @@ ptr_xdsl.store %2, %0  : i32, !ptr_xdsl.ptr
 // CHECK-NEXT: %3 = arith.index_cast %1 : index to i64
 // CHECK-NEXT: %4 = "llvm.ptrtoint"(%0) : (!llvm.ptr) -> i64
 // CHECK-NEXT: %5 = arith.addi %4, %3 : i64
-// CHECK-NEXT: %6 = "llvm.inttoptr"(%5) : (i64) -> !llvm.ptr
+// CHECK-NEXT: %6 = llvm.inttoptr %5 : i64 to !llvm.ptr
 // CHECK-NEXT: "test.op"(%6) : (!llvm.ptr) -> ()
 %3 = ptr_xdsl.ptradd %0, %1 : (!ptr_xdsl.ptr, index) -> !ptr_xdsl.ptr
 "test.op"(%3) : (!ptr_xdsl.ptr) -> ()

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -1191,6 +1191,8 @@ class AllocaOp(IRDLOperation):
 class IntToPtrOp(IRDLOperation):
     name = "llvm.inttoptr"
 
+    assembly_format = "$input attr-dict `:` type($input) `to` type($output)"
+
     input = operand_def(IntegerType)
 
     output = result_def(LLVMPointerType)


### PR DESCRIPTION
Follow-up to #5881 -> add `assembly_format` to `llvm.inttoptr`.