### PR TITLE
dialects: (llvm) add custom format to PtrToIntOp

### DIFF
--- a/tests/filecheck/transforms/convert_ptr_to_llvm.mlir
+++ b/tests/filecheck/transforms/convert_ptr_to_llvm.mlir
@@ -10,7 +10,7 @@
 ptr_xdsl.store %2, %0  : i32, !ptr_xdsl.ptr
 
 // CHECK-NEXT: %3 = arith.index_cast %1 : index to i64
-// CHECK-NEXT: %4 = "llvm.ptrtoint"(%0) : (!llvm.ptr) -> i64
+// CHECK-NEXT: %4 = llvm.ptrtoint %0 : !llvm.ptr to i64
 // CHECK-NEXT: %5 = arith.addi %4, %3 : i64
 // CHECK-NEXT: %6 = "llvm.inttoptr"(%5) : (i64) -> !llvm.ptr
 // CHECK-NEXT: "test.op"(%6) : (!llvm.ptr) -> ()

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -1288,6 +1288,8 @@ class InlineAsmOp(IRDLOperation):
 class PtrToIntOp(IRDLOperation):
     name = "llvm.ptrtoint"
 
+    assembly_format = "$input attr-dict `:` type($input) `to` type($output)"
+
     input = operand_def(LLVMPointerType)
 
     output = result_def(IntegerType)


### PR DESCRIPTION
Follow-up to #5881 -> add `assembly_format` to `llvm.ptrtoint`.