### PR TITLE
dialects: (llvm) include expected/found op names in CallOp verify error

### DIFF
--- a/tests/filecheck/dialects/llvm/invalid.mlir
+++ b/tests/filecheck/dialects/llvm/invalid.mlir
@@ -102,4 +102,4 @@ llvm.func @caller(%arg0: i32) -> i32 {
   llvm.return %0 : i32
 }
 
-// CHECK: '@not_llvm_func' does not reference a valid function
+// CHECK: '@not_llvm_func' must reference an 'llvm.func', but found 'func.func'

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -2017,7 +2017,10 @@ class CallOpSymbolUserOpInterface(SymbolUserOpInterface):
             raise VerifyException(f"'{op.callee}' could not be found in symbol table")
 
         if not isinstance(found_callee, FuncOp):
-            raise VerifyException(f"'{op.callee}' does not reference a valid function")
+            raise VerifyException(
+                f"'{op.callee}' must reference an 'llvm.func', "
+                f"but found '{found_callee.name}'"
+            )
 
 
 @irdl_op_definition


### PR DESCRIPTION
Follow-up to #5849: include the expected dialect op (`llvm.func`) and the actual op name in the `CallOp` symbol-user verifier error message.