### PR TITLE
core: attr declarative assembly format

### DIFF
--- a/tests/filecheck/parser-printer/unregistered_dialect.mlir
+++ b/tests/filecheck/parser-printer/unregistered_dialect.mlir
@@ -7,6 +7,13 @@
     %y = "op_with_res"() {otherattr = #unknowndialect<b2 ...2 [] <<>>>} : () -> (i32)
     %z = "op_with_operands"(%y, %y) : (i32, i32) -> !unknowndialect.unknown_type<{[<()>]}>
     "op"() {ab = !unknowndialect.unknown_singleton_type} : () -> ()
+    %w = "op_with_res"() : () -> !unknowndialect.type_with_slash<a / b>
+    %v = "op_with_res"() : () -> !unknowndialect.type_with_slashes<valid / mlir // syntax ///>
+    %u = "op_with_res"() : () -> !unknowndialect.type_with_nested_slash<a, [b // c], d>
+    %t = "op_with_res"() : () -> !unknowndialect.type_with_slashes<a // b> // comment after attribute
+    "op"() {slash_attr = #unknowndialect.attr_with_slash<x // y>} : () -> ()
+    "op"() {arrow_attr = #unknowndialect.attr_with_arrow<a -> b>} : () -> ()
+    "op"() {str_attr = #unknowndialect.attr_with_str<"hello // world">} : () -> ()
   }) {testattr = "foo"} : () -> i32
   "builtin.unimplemented_op"() {"attr" = #builtin.unimplemented_attr} : () -> ()
 
@@ -16,6 +23,13 @@
   // CHECK-NEXT:   %{{.*}} = "op_with_res"() {otherattr = #unknowndialect<b2 ...2 [] <<>>>} : () -> i32
   // CHECK-NEXT:   %{{.*}} = "op_with_operands"(%{{.*}}, %{{.*}}) : (i32, i32) -> !unknowndialect.unknown_type<{[<()>]}>
   // CHECK-NEXT:   "op"() {ab = !unknowndialect.unknown_singleton_type} : () -> ()
+  // CHECK-NEXT:   %{{.*}} = "op_with_res"() : () -> !unknowndialect.type_with_slash<a / b>
+  // CHECK-NEXT:   %{{.*}} = "op_with_res"() : () -> !unknowndialect.type_with_slashes<valid / mlir // syntax ///>
+  // CHECK-NEXT:   %{{.*}} = "op_with_res"() : () -> !unknowndialect.type_with_nested_slash<a, [b // c], d>
+  // CHECK-NEXT:   %{{.*}} = "op_with_res"() : () -> !unknowndialect.type_with_slashes<a // b>
+  // CHECK-NEXT:   "op"() {slash_attr = #unknowndialect.attr_with_slash<x // y>} : () -> ()
+  // CHECK-NEXT:   "op"() {arrow_attr = #unknowndialect.attr_with_arrow<a -> b>} : () -> ()
+  // CHECK-NEXT:   "op"() {str_attr = #unknowndialect.attr_with_str<"hello // world">} : () -> ()
   // CHECK-NEXT:  }) {testattr = "foo"} : () -> i32
   // CHECK-NEXT:  "builtin.unimplemented_op"() {attr = #builtin.unimplemented_attr} : () -> ()
 

--- a/tests/irdl/test_attr_declarative_assembly_format.py
+++ b/tests/irdl/test_attr_declarative_assembly_format.py
@@ -174,7 +174,9 @@ def print_attr(attr: Attribute) -> str:
     return output.getvalue()
 
 
-def check_roundtrip(attr_type: type[ParametrizedAttribute], body: str, ctx: Context) -> None:
+def check_roundtrip(
+    attr_type: type[ParametrizedAttribute], body: str, ctx: Context
+) -> None:
     """Parse !type<body>, print it, verify the body matches."""
     type_str = f"!{attr_type.name}<{body}>"
     parsed = parse_type(type_str, ctx)
@@ -182,7 +184,9 @@ def check_roundtrip(attr_type: type[ParametrizedAttribute], body: str, ctx: Cont
     assert printed == type_str, f"Round-trip failed: {printed!r} != {type_str!r}"
 
 
-def check_attr_roundtrip(attr_type: type[ParametrizedAttribute], body: str, ctx: Context) -> None:
+def check_attr_roundtrip(
+    attr_type: type[ParametrizedAttribute], body: str, ctx: Context
+) -> None:
     """Round-trip for #-prefixed attributes."""
     attr_str = f"#{attr_type.name}<{body}>"
     parsed = parse_attr(attr_str, ctx)
@@ -566,9 +570,7 @@ def test_error_assembly_format_with_parse_parameters():
             assembly_format = "$value"
 
             @classmethod
-            def parse_parameters(
-                cls, parser: AttrParser
-            ) -> list[Attribute]:
+            def parse_parameters(cls, parser: AttrParser) -> list[Attribute]:
                 return []
 
 

--- a/tests/irdl/test_attr_declarative_assembly_format.py
+++ b/tests/irdl/test_attr_declarative_assembly_format.py
@@ -1,0 +1,866 @@
+"""Tests for declarative assembly format for ParametrizedAttribute types."""
+
+from __future__ import annotations
+
+from io import StringIO
+
+import pytest
+
+from xdsl.context import Context
+from xdsl.dialects.builtin import (
+    IntegerType,
+    NoneAttr,
+    i1,
+    i32,
+    i64,
+)
+from xdsl.ir import Attribute, ParametrizedAttribute, TypeAttribute
+from xdsl.irdl import irdl_attr_definition, param_def
+from xdsl.irdl.declarative_assembly_format import (
+    AttrCustomDirective,
+    AttrParsingState,
+    ParameterVariable,
+    PrintingState,
+    irdl_attr_custom_directive,
+)
+from xdsl.parser import AttrParser, Parser
+from xdsl.printer import Printer
+from xdsl.utils.exceptions import ParseError, PyRDLAttrDefinitionError
+
+# ============================================================================
+# Test attribute definitions
+# ============================================================================
+
+
+@irdl_attr_definition
+class SimpleType(ParametrizedAttribute, TypeAttribute):
+    name = "test_af.simple"
+    value: IntegerType = param_def()
+    assembly_format = "$value"
+
+
+@irdl_attr_definition
+class TwoParamType(ParametrizedAttribute, TypeAttribute):
+    name = "test_af.two_param"
+    first: IntegerType = param_def()
+    second: IntegerType = param_def()
+    assembly_format = "$first `,` $second"
+
+
+@irdl_attr_definition
+class OptionalParamType(ParametrizedAttribute, TypeAttribute):
+    name = "test_af.optional"
+    elem: IntegerType = param_def()
+    layout: NoneAttr | IntegerType = param_def()
+    assembly_format = "$elem (`,` $layout^)?"
+
+
+@irdl_attr_definition
+class KeywordType(ParametrizedAttribute, TypeAttribute):
+    name = "test_af.keyword"
+    value: IntegerType = param_def()
+    assembly_format = "`stride` `=` $value"
+
+
+@irdl_attr_definition
+class InnerType(ParametrizedAttribute, TypeAttribute):
+    """An inner type with its own assembly_format, for composition testing."""
+
+    name = "test_af.inner"
+    elem: IntegerType = param_def()
+    assembly_format = "$elem"
+
+
+@irdl_attr_definition
+class OuterType(ParametrizedAttribute, TypeAttribute):
+    """Contains an InnerType parameter to test sub-attribute composition."""
+
+    name = "test_af.outer"
+    wrapped: InnerType = param_def()
+    tag: IntegerType = param_def()
+    assembly_format = "$wrapped `,` $tag"
+
+
+@irdl_attr_definition
+class WrapperType(ParametrizedAttribute, TypeAttribute):
+    """Wraps a generic Attribute — accepts any type including complex ones."""
+
+    name = "test_af.wrapper"
+    inner: Attribute = param_def()
+    assembly_format = "$inner"
+
+
+@irdl_attr_definition
+class PairType(ParametrizedAttribute, TypeAttribute):
+    """A pair of generic attributes."""
+
+    name = "test_af.pair"
+    left: Attribute = param_def()
+    right: Attribute = param_def()
+    assembly_format = "$left `,` $right"
+
+
+@irdl_attr_definition
+class PairAttr(ParametrizedAttribute):
+    """A pair attribute (not a type) — uses # prefix."""
+
+    name = "test_af.pair_attr"
+    left: Attribute = param_def()
+    right: Attribute = param_def()
+    assembly_format = "$left `,` $right"
+
+
+@irdl_attr_definition
+class DoubleOptionalType(ParametrizedAttribute, TypeAttribute):
+    """Type with two independent optional groups."""
+
+    name = "test_af.double_optional"
+    base: IntegerType = param_def()
+    opt_a: NoneAttr | IntegerType = param_def()
+    opt_b: NoneAttr | IntegerType = param_def()
+    assembly_format = "$base (`a` `=` $opt_a^)? (`b` `=` $opt_b^)?"
+
+
+@irdl_attr_definition
+class ElseBranchType(ParametrizedAttribute, TypeAttribute):
+    """Type with an optional group that has an else branch."""
+
+    name = "test_af.else_branch"
+    base: IntegerType = param_def()
+    opt: NoneAttr | IntegerType = param_def()
+    fallback: NoneAttr | IntegerType = param_def()
+    assembly_format = "$base (`opt` `=` $opt^) : (`fallback` `=` $fallback)?"
+
+
+@irdl_attr_definition
+class ThreeParamType(ParametrizedAttribute, TypeAttribute):
+    """Three params for more complex tests."""
+
+    name = "test_af.three_param"
+    a: IntegerType = param_def()
+    b: IntegerType = param_def()
+    c: IntegerType = param_def()
+    assembly_format = "$a `,` $b `,` $c"
+
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+
+def parse_type(type_str: str, ctx: Context) -> Attribute:
+    """Parse a type like '!test_af.simple<i32>' and return the type attribute."""
+    program = f'"test.op"() : () -> {type_str}'
+    parser = Parser(ctx, program)
+    op = parser.parse_optional_operation()
+    assert op is not None, f"Failed to parse operation with type {type_str}"
+    return op.results[0].type
+
+
+def parse_attr(attr_str: str, ctx: Context) -> Attribute:
+    """Parse an attribute like '#test_af.pair_attr<i32, i64>'."""
+    program = f'"test.op"() {{attr = {attr_str}}} : () -> ()'
+    parser = Parser(ctx, program)
+    op = parser.parse_optional_operation()
+    assert op is not None, f"Failed to parse operation with attr {attr_str}"
+    return op.attributes["attr"]
+
+
+def print_attr(attr: Attribute) -> str:
+    """Print an attribute to a string."""
+    output = StringIO()
+    printer = Printer(stream=output)
+    printer.print_attribute(attr)
+    return output.getvalue()
+
+
+def check_roundtrip(attr_type: type, body: str, ctx: Context) -> None:
+    """Parse !type<body>, print it, verify the body matches."""
+    type_str = f"!{attr_type.name}<{body}>"
+    parsed = parse_type(type_str, ctx)
+    printed = print_attr(parsed)
+    assert printed == type_str, f"Round-trip failed: {printed!r} != {type_str!r}"
+
+
+def check_attr_roundtrip(attr_type: type, body: str, ctx: Context) -> None:
+    """Round-trip for #-prefixed attributes."""
+    attr_str = f"#{attr_type.name}<{body}>"
+    parsed = parse_attr(attr_str, ctx)
+    printed = print_attr(parsed)
+    assert printed == attr_str, f"Attr round-trip failed: {printed!r} != {attr_str!r}"
+
+
+# ============================================================================
+# Fixture
+# ============================================================================
+
+
+@pytest.fixture
+def ctx() -> Context:
+    ctx = Context(allow_unregistered=True)
+    ctx.load_attr_or_type(SimpleType)
+    ctx.load_attr_or_type(TwoParamType)
+    ctx.load_attr_or_type(OptionalParamType)
+    ctx.load_attr_or_type(KeywordType)
+    ctx.load_attr_or_type(InnerType)
+    ctx.load_attr_or_type(OuterType)
+    ctx.load_attr_or_type(WrapperType)
+    ctx.load_attr_or_type(PairType)
+    ctx.load_attr_or_type(PairAttr)
+    ctx.load_attr_or_type(DoubleOptionalType)
+    ctx.load_attr_or_type(ElseBranchType)
+    ctx.load_attr_or_type(ThreeParamType)
+    return ctx
+
+
+# ============================================================================
+# Basic round-trip tests
+# ============================================================================
+
+
+@pytest.mark.parametrize("body", ["i32", "i64"])
+def test_simple_param_roundtrip(body: str, ctx: Context):
+    check_roundtrip(SimpleType, body, ctx)
+
+
+@pytest.mark.parametrize("body", ["i32, i64", "i1, i32"])
+def test_two_param_roundtrip(body: str, ctx: Context):
+    check_roundtrip(TwoParamType, body, ctx)
+
+
+def test_optional_param_absent(ctx: Context):
+    check_roundtrip(OptionalParamType, "i32", ctx)
+
+
+def test_optional_param_present(ctx: Context):
+    check_roundtrip(OptionalParamType, "i32, i64", ctx)
+
+
+def test_optional_constructs_correctly(ctx: Context):
+    """Absent optional parameter becomes NoneAttr; present one is parsed."""
+    absent = parse_type("!test_af.optional<i32>", ctx)
+    assert isinstance(absent, OptionalParamType)
+    assert absent.elem == i32
+    assert isinstance(absent.layout, NoneAttr)
+
+    present = parse_type("!test_af.optional<i32, i64>", ctx)
+    assert isinstance(present, OptionalParamType)
+    assert present.elem == i32
+    assert present.layout == i64
+
+
+@pytest.mark.parametrize("body", ["stride = i32", "stride = i64"])
+def test_keyword_roundtrip(body: str, ctx: Context):
+    check_roundtrip(KeywordType, body, ctx)
+
+
+def test_three_param_roundtrip(ctx: Context):
+    check_roundtrip(ThreeParamType, "i1, i32, i64", ctx)
+
+
+# ============================================================================
+# Sub-attribute composition (inner type with its own assembly_format)
+# ============================================================================
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "!test_af.inner<i32>, i64",
+        "!test_af.inner<i1>, i32",
+    ],
+)
+def test_outer_type_roundtrip(body: str, ctx: Context):
+    check_roundtrip(OuterType, body, ctx)
+
+
+def test_outer_type_constructs_correctly(ctx: Context):
+    """Verify the outer type correctly nests the inner type."""
+    parsed = parse_type("!test_af.outer<!test_af.inner<i32>, i64>", ctx)
+    assert isinstance(parsed, OuterType)
+    assert isinstance(parsed.wrapped, InnerType)
+    assert parsed.wrapped.elem == i32
+    assert parsed.tag == i64
+
+
+# ============================================================================
+# Complex nesting (builtin complex types as parameters)
+# ============================================================================
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "i32",
+        "f32",
+        "vector<4xi32>",
+        "tensor<2x3xf32>",
+    ],
+)
+def test_wrapper_complex_types(body: str, ctx: Context):
+    check_roundtrip(WrapperType, body, ctx)
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "i32, i64",
+        "tensor<2x3xf32>, memref<16xi32>",
+    ],
+)
+def test_pair_complex_types(body: str, ctx: Context):
+    check_roundtrip(PairType, body, ctx)
+
+
+def test_deeply_nested_types(ctx: Context):
+    """Wrapper wrapping a pair wrapping inner types."""
+    check_roundtrip(
+        WrapperType,
+        "!test_af.pair<!test_af.inner<i32>, !test_af.inner<i64>>",
+        ctx,
+    )
+
+
+# ============================================================================
+# Attribute parameters (# prefix, not just ! types)
+# ============================================================================
+
+
+def test_pair_attr_roundtrip(ctx: Context):
+    check_attr_roundtrip(PairAttr, "i32, i64", ctx)
+
+
+def test_pair_attr_constructs_correctly(ctx: Context):
+    parsed = parse_attr("#test_af.pair_attr<i32, i64>", ctx)
+    assert isinstance(parsed, PairAttr)
+    assert parsed.left == i32
+    assert parsed.right == i64
+
+
+def test_wrapper_with_attr_parameter(ctx: Context):
+    """A type parameter that is a #-prefixed attribute."""
+    check_roundtrip(WrapperType, "#test_af.pair_attr<i32, i64>", ctx)
+
+
+# ============================================================================
+# Multiple optional groups
+# ============================================================================
+
+
+@pytest.mark.parametrize(
+    "body, expected_a, expected_b",
+    [
+        ("i32", NoneAttr, NoneAttr),
+        ("i32 a = i64", IntegerType, NoneAttr),
+        ("i32 b = i64", NoneAttr, IntegerType),
+        ("i32 a = i64 b = i1", IntegerType, IntegerType),
+    ],
+)
+def test_double_optional_group(
+    body: str,
+    expected_a: type,
+    expected_b: type,
+    ctx: Context,
+):
+    parsed = parse_type(f"!test_af.double_optional<{body}>", ctx)
+    assert isinstance(parsed, DoubleOptionalType)
+    assert isinstance(parsed.opt_a, expected_a)
+    assert isinstance(parsed.opt_b, expected_b)
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "i32",
+        "i32 a = i64",
+        "i32 b = i64",
+        "i32 a = i64 b = i1",
+    ],
+)
+def test_double_optional_roundtrip(body: str, ctx: Context):
+    check_roundtrip(DoubleOptionalType, body, ctx)
+
+
+# ============================================================================
+# Else branch in optional groups
+# ============================================================================
+
+
+def test_else_branch_then_path(ctx: Context):
+    """When optional is present, then-branch is taken."""
+    parsed = parse_type("!test_af.else_branch<i32 opt = i64>", ctx)
+    assert isinstance(parsed, ElseBranchType)
+    assert parsed.opt == i64
+    assert isinstance(parsed.fallback, NoneAttr)
+
+
+def test_else_branch_else_path(ctx: Context):
+    """When optional is absent, else-branch is taken."""
+    parsed = parse_type("!test_af.else_branch<i32 fallback = i64>", ctx)
+    assert isinstance(parsed, ElseBranchType)
+    assert isinstance(parsed.opt, NoneAttr)
+    assert parsed.fallback == i64
+
+
+@pytest.mark.parametrize("body", ["i32 opt = i64", "i32 fallback = i64"])
+def test_else_branch_roundtrip(body: str, ctx: Context):
+    check_roundtrip(ElseBranchType, body, ctx)
+
+
+# ============================================================================
+# Whitespace directives
+# ============================================================================
+
+
+def test_whitespace_suppress():
+    """`` `` (empty backtick) suppresses whitespace."""
+
+    @irdl_attr_definition
+    class SuppressType(ParametrizedAttribute, TypeAttribute):
+        name = "test_af.suppress"
+        a: IntegerType = param_def()
+        b: IntegerType = param_def()
+        assembly_format = "$a `` $b"
+
+    attr = SuppressType(i32, i64)
+    printed = print_attr(attr)
+    assert printed == "!test_af.suppress<i32i64>"
+
+
+def test_whitespace_newline():
+    r"""`\n` inserts newline."""
+
+    @irdl_attr_definition
+    class NewlineType(ParametrizedAttribute, TypeAttribute):
+        name = "test_af.newline"
+        a: IntegerType = param_def()
+        b: IntegerType = param_def()
+        assembly_format = "$a `` `\\n` `` $b"
+
+    attr = NewlineType(i32, i64)
+    printed = print_attr(attr)
+    assert printed == "!test_af.newline<i32\ni64>"
+
+
+# ============================================================================
+# Printing correctness — construct programmatically and verify output
+# ============================================================================
+
+
+@pytest.mark.parametrize(
+    "attr, expected",
+    [
+        (SimpleType(i32), "!test_af.simple<i32>"),
+        (TwoParamType(i32, i64), "!test_af.two_param<i32, i64>"),
+        (OptionalParamType(i32, NoneAttr()), "!test_af.optional<i32>"),
+        (OptionalParamType(i32, i64), "!test_af.optional<i32, i64>"),
+        (KeywordType(i32), "!test_af.keyword<stride = i32>"),
+        (ThreeParamType(i1, i32, i64), "!test_af.three_param<i1, i32, i64>"),
+        (PairAttr(i32, i64), "#test_af.pair_attr<i32, i64>"),
+    ],
+)
+def test_print_correctness(attr: Attribute, expected: str):
+    assert print_attr(attr) == expected
+
+
+@pytest.mark.parametrize(
+    "attr, expected",
+    [
+        (
+            DoubleOptionalType(i32, NoneAttr(), NoneAttr()),
+            "!test_af.double_optional<i32>",
+        ),
+        (
+            DoubleOptionalType(i32, i64, NoneAttr()),
+            "!test_af.double_optional<i32 a = i64>",
+        ),
+        (
+            DoubleOptionalType(i32, NoneAttr(), i64),
+            "!test_af.double_optional<i32 b = i64>",
+        ),
+        (
+            DoubleOptionalType(i32, i64, i1),
+            "!test_af.double_optional<i32 a = i64 b = i1>",
+        ),
+    ],
+)
+def test_print_double_optional(attr: Attribute, expected: str):
+    assert print_attr(attr) == expected
+
+
+@pytest.mark.parametrize(
+    "attr, expected",
+    [
+        (
+            ElseBranchType(i32, i64, NoneAttr()),
+            "!test_af.else_branch<i32 opt = i64>",
+        ),
+        (
+            ElseBranchType(i32, NoneAttr(), i64),
+            "!test_af.else_branch<i32 fallback = i64>",
+        ),
+    ],
+)
+def test_print_else_branch(attr: Attribute, expected: str):
+    assert print_attr(attr) == expected
+
+
+# ============================================================================
+# Error tests
+# ============================================================================
+
+
+def test_error_missing_parameter():
+    """Format string missing a parameter should fail at definition time."""
+    with pytest.raises(PyRDLAttrDefinitionError, match="parameter 'second' not found"):
+
+        @irdl_attr_definition
+        class BadType(ParametrizedAttribute, TypeAttribute):
+            name = "test_af.bad_missing"
+            first: IntegerType = param_def()
+            second: IntegerType = param_def()
+            assembly_format = "$first"
+
+
+def test_error_duplicate_parameter():
+    """Duplicate parameter in format string should fail at definition time."""
+    with pytest.raises(PyRDLAttrDefinitionError, match="is already bound"):
+
+        @irdl_attr_definition
+        class BadType(ParametrizedAttribute, TypeAttribute):
+            name = "test_af.bad_dup"
+            value: IntegerType = param_def()
+            assembly_format = "$value `,` $value"
+
+
+def test_error_unknown_variable():
+    """Unknown variable in format string should fail at definition time."""
+    with pytest.raises(PyRDLAttrDefinitionError, match="does not refer to a parameter"):
+
+        @irdl_attr_definition
+        class BadType(ParametrizedAttribute, TypeAttribute):
+            name = "test_af.bad_unknown"
+            value: IntegerType = param_def()
+            assembly_format = "$nonexistent"
+
+
+def test_error_assembly_format_with_parse_parameters():
+    """assembly_format with custom parse_parameters should fail."""
+    with pytest.raises(
+        PyRDLAttrDefinitionError,
+        match="Cannot use assembly_format with custom parse_parameters",
+    ):
+
+        @irdl_attr_definition
+        class BadType(ParametrizedAttribute, TypeAttribute):
+            name = "test_af.bad_custom_parse"
+            value: IntegerType = param_def()
+            assembly_format = "$value"
+
+            @classmethod
+            def parse_parameters(cls, parser):
+                return []
+
+
+def test_error_assembly_format_with_print_parameters():
+    """assembly_format with custom print_parameters should fail."""
+    with pytest.raises(
+        PyRDLAttrDefinitionError,
+        match="Cannot use assembly_format with custom print_parameters",
+    ):
+
+        @irdl_attr_definition
+        class BadType(ParametrizedAttribute, TypeAttribute):
+            name = "test_af.bad_custom_print"
+            value: IntegerType = param_def()
+            assembly_format = "$value"
+
+            def print_parameters(self, printer):
+                pass
+
+
+def test_error_assembly_format_on_singleton():
+    """assembly_format on attribute with no parameters should fail."""
+    with pytest.raises(
+        PyRDLAttrDefinitionError,
+        match="Cannot use assembly_format on attribute with no parameters",
+    ):
+
+        @irdl_attr_definition
+        class BadType(ParametrizedAttribute, TypeAttribute):
+            name = "test_af.bad_singleton"
+            assembly_format = ""
+
+
+# ============================================================================
+# Directive tests: params, struct, qualified, custom, ref
+# ============================================================================
+
+# --- params directive attribute definitions ---
+
+
+@irdl_attr_definition
+class ParamsTwoType(ParametrizedAttribute, TypeAttribute):
+    name = "test_af.params_two"
+    first: IntegerType = param_def()
+    second: IntegerType = param_def()
+    assembly_format = "params"
+
+
+@irdl_attr_definition
+class ParamsThreeType(ParametrizedAttribute, TypeAttribute):
+    name = "test_af.params_three"
+    a: IntegerType = param_def()
+    b: IntegerType = param_def()
+    c: IntegerType = param_def()
+    assembly_format = "params"
+
+
+@irdl_attr_definition
+class ParamsOptType(ParametrizedAttribute, TypeAttribute):
+    name = "test_af.params_opt"
+    required: IntegerType = param_def()
+    opt: NoneAttr | IntegerType = param_def()
+    assembly_format = "params"
+
+
+@irdl_attr_definition
+class ParamsBracketedType(ParametrizedAttribute, TypeAttribute):
+    name = "test_af.params_brack"
+    a: IntegerType = param_def()
+    b: IntegerType = param_def()
+    assembly_format = "`<` params `>`"
+
+
+# --- struct directive attribute definitions ---
+
+
+@irdl_attr_definition
+class StructAllType(ParametrizedAttribute, TypeAttribute):
+    name = "test_af.struct_all"
+    a: IntegerType = param_def()
+    b: IntegerType = param_def()
+    assembly_format = "struct(params)"
+
+
+@irdl_attr_definition
+class StructSelectType(ParametrizedAttribute, TypeAttribute):
+    name = "test_af.struct_sel"
+    a: IntegerType = param_def()
+    b: IntegerType = param_def()
+    assembly_format = "struct($a, $b)"
+
+
+@irdl_attr_definition
+class StructOptType(ParametrizedAttribute, TypeAttribute):
+    name = "test_af.struct_opt"
+    a: IntegerType = param_def()
+    b: NoneAttr | IntegerType = param_def()
+    assembly_format = "struct(params)"
+
+
+# --- qualified directive attribute definitions ---
+
+
+@irdl_attr_definition
+class QualifiedParamType(ParametrizedAttribute, TypeAttribute):
+    name = "test_af.qual_param"
+    value: IntegerType = param_def()
+    assembly_format = "qualified($value)"
+
+
+# --- custom directive class definitions ---
+
+
+@irdl_attr_custom_directive
+class PassthroughDir(AttrCustomDirective):
+    param: ParameterVariable
+
+    def parse(self, parser: AttrParser, state: AttrParsingState) -> bool:
+        return self.param.parse(parser, state)
+
+    def print(
+        self, printer: Printer, state: PrintingState, attr: ParametrizedAttribute
+    ) -> None:
+        self.param.print(printer, state, attr)
+
+
+@irdl_attr_custom_directive
+class RefTestDir(AttrCustomDirective):
+    first: ParameterVariable
+    second_ref: ParameterVariable
+
+    def parse(self, parser: AttrParser, state: AttrParsingState) -> bool:
+        return self.first.parse(parser, state)
+
+    def print(
+        self, printer: Printer, state: PrintingState, attr: ParametrizedAttribute
+    ) -> None:
+        self.first.print(printer, state, attr)
+
+
+# --- custom directive attribute definitions ---
+
+
+@irdl_attr_definition
+class CustomDirType(ParametrizedAttribute, TypeAttribute):
+    name = "test_af.custom_dir"
+    value: IntegerType = param_def()
+    assembly_format = "custom<PassthroughDir>($value)"
+    custom_directives = (PassthroughDir,)
+
+
+@irdl_attr_definition
+class RefTestType(ParametrizedAttribute, TypeAttribute):
+    name = "test_af.ref_test"
+    a: IntegerType = param_def()
+    b: IntegerType = param_def()
+    assembly_format = "$b `,` custom<RefTestDir>($a, ref($b))"
+    custom_directives = (RefTestDir,)
+
+
+# --- Fixture ---
+
+
+@pytest.fixture
+def ctx_directives() -> Context:
+    ctx = Context(allow_unregistered=True)
+    for t in [
+        ParamsTwoType,
+        ParamsThreeType,
+        ParamsOptType,
+        ParamsBracketedType,
+        StructAllType,
+        StructSelectType,
+        StructOptType,
+        QualifiedParamType,
+        CustomDirType,
+        RefTestType,
+    ]:
+        ctx.load_attr_or_type(t)
+    return ctx
+
+
+# --- Helper ---
+
+
+def _roundtrip_constructed(attr: ParametrizedAttribute, ctx: Context) -> None:
+    """Print → parse → compare."""
+    printed = print_attr(attr)
+    if isinstance(attr, TypeAttribute):
+        parsed = parse_type(printed, ctx)
+    else:
+        parsed = parse_attr(printed, ctx)
+    assert attr == parsed, f"Round-trip failed: {printed!r}"
+
+
+# ============================================================================
+# params directive tests
+# ============================================================================
+
+
+def test_params_two_roundtrip(ctx_directives: Context):
+    _roundtrip_constructed(ParamsTwoType(i32, i64), ctx_directives)
+
+
+def test_params_three_roundtrip(ctx_directives: Context):
+    _roundtrip_constructed(ParamsThreeType(i1, i32, i64), ctx_directives)
+
+
+def test_params_optional_absent(ctx_directives: Context):
+    attr = ParamsOptType(i32, NoneAttr())
+    _roundtrip_constructed(attr, ctx_directives)
+    printed = print_attr(attr)
+    parsed = parse_type(printed, ctx_directives)
+    assert isinstance(parsed, ParamsOptType)
+    assert isinstance(parsed.opt, NoneAttr)
+
+
+def test_params_optional_present(ctx_directives: Context):
+    attr = ParamsOptType(i32, i64)
+    _roundtrip_constructed(attr, ctx_directives)
+    printed = print_attr(attr)
+    parsed = parse_type(printed, ctx_directives)
+    assert isinstance(parsed, ParamsOptType)
+    assert parsed.opt == i64
+
+
+def test_params_bracketed_roundtrip(ctx_directives: Context):
+    _roundtrip_constructed(ParamsBracketedType(i32, i64), ctx_directives)
+
+
+def test_params_bracketed_has_nested_brackets():
+    printed = print_attr(ParamsBracketedType(i32, i64))
+    assert printed.startswith("!test_af.params_brack<<")
+    assert printed.endswith(">>")
+
+
+# ============================================================================
+# struct directive tests
+# ============================================================================
+
+
+def test_struct_all_roundtrip(ctx_directives: Context):
+    _roundtrip_constructed(StructAllType(i32, i64), ctx_directives)
+
+
+def test_struct_select_roundtrip(ctx_directives: Context):
+    _roundtrip_constructed(StructSelectType(i32, i64), ctx_directives)
+
+
+def test_struct_prints_key_value():
+    printed = print_attr(StructAllType(i32, i64))
+    assert "a =" in printed or "a=" in printed
+    assert "b =" in printed or "b=" in printed
+
+
+def test_struct_any_order(ctx_directives: Context):
+    """Struct accepts parameters in any order during parsing."""
+    forward = parse_type("!test_af.struct_all<a = i32, b = i64>", ctx_directives)
+    reverse = parse_type("!test_af.struct_all<b = i64, a = i32>", ctx_directives)
+    assert forward == reverse
+
+
+def test_struct_optional_absent(ctx_directives: Context):
+    attr = StructOptType(i32, NoneAttr())
+    _roundtrip_constructed(attr, ctx_directives)
+    printed = print_attr(attr)
+    assert "b" not in printed
+
+
+def test_struct_optional_present(ctx_directives: Context):
+    _roundtrip_constructed(StructOptType(i32, i64), ctx_directives)
+
+
+def test_struct_missing_required_param(ctx_directives: Context):
+    with pytest.raises(ParseError, match="missing required parameter"):
+        parse_type("!test_af.struct_all<b = i64>", ctx_directives)
+
+
+# ============================================================================
+# qualified directive tests
+# ============================================================================
+
+
+@pytest.mark.parametrize("value", [i32, i64])
+def test_qualified_roundtrip(value: IntegerType, ctx_directives: Context):
+    _roundtrip_constructed(QualifiedParamType(value), ctx_directives)
+
+
+# ============================================================================
+# custom directive tests
+# ============================================================================
+
+
+@pytest.mark.parametrize("value", [i32, i64])
+def test_custom_directive_roundtrip(value: IntegerType, ctx_directives: Context):
+    _roundtrip_constructed(CustomDirType(value), ctx_directives)
+
+
+# ============================================================================
+# ref directive tests
+# ============================================================================
+
+
+def test_ref_directive_roundtrip(ctx_directives: Context):
+    _roundtrip_constructed(RefTestType(i32, i64), ctx_directives)

--- a/tests/irdl/test_attr_declarative_assembly_format.py
+++ b/tests/irdl/test_attr_declarative_assembly_format.py
@@ -174,7 +174,7 @@ def print_attr(attr: Attribute) -> str:
     return output.getvalue()
 
 
-def check_roundtrip(attr_type: type, body: str, ctx: Context) -> None:
+def check_roundtrip(attr_type: type[ParametrizedAttribute], body: str, ctx: Context) -> None:
     """Parse !type<body>, print it, verify the body matches."""
     type_str = f"!{attr_type.name}<{body}>"
     parsed = parse_type(type_str, ctx)
@@ -182,7 +182,7 @@ def check_roundtrip(attr_type: type, body: str, ctx: Context) -> None:
     assert printed == type_str, f"Round-trip failed: {printed!r} != {type_str!r}"
 
 
-def check_attr_roundtrip(attr_type: type, body: str, ctx: Context) -> None:
+def check_attr_roundtrip(attr_type: type[ParametrizedAttribute], body: str, ctx: Context) -> None:
     """Round-trip for #-prefixed attributes."""
     attr_str = f"#{attr_type.name}<{body}>"
     parsed = parse_attr(attr_str, ctx)
@@ -515,7 +515,9 @@ def test_error_missing_parameter():
     with pytest.raises(PyRDLAttrDefinitionError, match="parameter 'second' not found"):
 
         @irdl_attr_definition
-        class BadType(ParametrizedAttribute, TypeAttribute):
+        class BadType(  # pyright: ignore[reportUnusedClass]
+            ParametrizedAttribute, TypeAttribute
+        ):
             name = "test_af.bad_missing"
             first: IntegerType = param_def()
             second: IntegerType = param_def()
@@ -527,7 +529,9 @@ def test_error_duplicate_parameter():
     with pytest.raises(PyRDLAttrDefinitionError, match="is already bound"):
 
         @irdl_attr_definition
-        class BadType(ParametrizedAttribute, TypeAttribute):
+        class BadType(  # pyright: ignore[reportUnusedClass]
+            ParametrizedAttribute, TypeAttribute
+        ):
             name = "test_af.bad_dup"
             value: IntegerType = param_def()
             assembly_format = "$value `,` $value"
@@ -538,7 +542,9 @@ def test_error_unknown_variable():
     with pytest.raises(PyRDLAttrDefinitionError, match="does not refer to a parameter"):
 
         @irdl_attr_definition
-        class BadType(ParametrizedAttribute, TypeAttribute):
+        class BadType(  # pyright: ignore[reportUnusedClass]
+            ParametrizedAttribute, TypeAttribute
+        ):
             name = "test_af.bad_unknown"
             value: IntegerType = param_def()
             assembly_format = "$nonexistent"
@@ -552,13 +558,17 @@ def test_error_assembly_format_with_parse_parameters():
     ):
 
         @irdl_attr_definition
-        class BadType(ParametrizedAttribute, TypeAttribute):
+        class BadType(  # pyright: ignore[reportUnusedClass]
+            ParametrizedAttribute, TypeAttribute
+        ):
             name = "test_af.bad_custom_parse"
             value: IntegerType = param_def()
             assembly_format = "$value"
 
             @classmethod
-            def parse_parameters(cls, parser):
+            def parse_parameters(
+                cls, parser: AttrParser
+            ) -> list[Attribute]:
                 return []
 
 
@@ -570,12 +580,14 @@ def test_error_assembly_format_with_print_parameters():
     ):
 
         @irdl_attr_definition
-        class BadType(ParametrizedAttribute, TypeAttribute):
+        class BadType(  # pyright: ignore[reportUnusedClass]
+            ParametrizedAttribute, TypeAttribute
+        ):
             name = "test_af.bad_custom_print"
             value: IntegerType = param_def()
             assembly_format = "$value"
 
-            def print_parameters(self, printer):
+            def print_parameters(self, printer: Printer) -> None:
                 pass
 
 
@@ -587,7 +599,9 @@ def test_error_assembly_format_on_singleton():
     ):
 
         @irdl_attr_definition
-        class BadType(ParametrizedAttribute, TypeAttribute):
+        class BadType(  # pyright: ignore[reportUnusedClass]
+            ParametrizedAttribute, TypeAttribute
+        ):
             name = "test_af.bad_singleton"
             assembly_format = ""
 

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -50,6 +50,7 @@ def assert_token_fail(input: str):
         ("}", MLIRTokenKind.R_BRACE),
         (")", MLIRTokenKind.R_PAREN),
         ("]", MLIRTokenKind.R_SQUARE),
+        ("/", MLIRTokenKind.SLASH),
         ("*", MLIRTokenKind.STAR),
         ("|", MLIRTokenKind.VERTICAL_BAR),
         ("{-#", MLIRTokenKind.FILE_METADATA_BEGIN),
@@ -60,7 +61,7 @@ def test_punctuation(text: str, kind: MLIRTokenKind):
     assert_single_token(text, kind)
 
 
-@pytest.mark.parametrize("text", [".", "&", "/"])
+@pytest.mark.parametrize("text", [".", "&"])
 def test_punctuation_fail(text: str):
     assert_token_fail(text)
 
@@ -185,6 +186,17 @@ def test_float_literal(text: str):
 )
 def test_float_literal_split(text: str, expected: str):
     assert_single_token(text, MLIRTokenKind.FLOAT_LIT, expected)
+
+
+def test_slash_vs_comment():
+    """A single `/` produces SLASH; `//` is consumed as a comment."""
+    assert_single_token("/", MLIRTokenKind.SLASH)
+
+    file = Input("// this is a comment\n0", "<unknown>")
+    lexer = MLIRLexer(file)
+    token = lexer.lex()
+    assert token.kind == MLIRTokenKind.INTEGER_LIT
+    assert token.text == "0"
 
 
 @pytest.mark.parametrize("text", ["0", " 0", "   0", "\n0", "\t0", "// Comment\n0"])

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -2,7 +2,7 @@ import pytest
 
 from xdsl.utils.exceptions import ParseError
 from xdsl.utils.lexer import Input, Position
-from xdsl.utils.mlir_lexer import AttrBodyLexer, MLIRLexer, MLIRToken, MLIRTokenKind
+from xdsl.utils.mlir_lexer import MLIRLexer, MLIRToken, MLIRTokenKind
 
 
 def get_token(input: str) -> MLIRToken:
@@ -270,48 +270,3 @@ def test_get_start_of_line(
     input = Input(START_END_LINE_CONTENT, "<>")
     assert input.get_start_of_line(pos) == expected_start
     assert input.get_end_of_line(pos) == expected_end
-
-
-def _get_all_tokens(lexer: MLIRLexer) -> list[MLIRToken]:
-    tokens: list[MLIRToken] = []
-    while True:
-        tok = lexer.lex()
-        tokens.append(tok)
-        if tok.kind == MLIRTokenKind.EOF:
-            break
-    return tokens
-
-
-def test_attr_body_lexer_slash():
-    """AttrBodyLexer produces SLASH tokens for /."""
-    inp = Input("a / b", "<>")
-    tokens = _get_all_tokens(AttrBodyLexer(inp))
-    kinds = [t.kind for t in tokens]
-    assert kinds == [
-        MLIRTokenKind.BARE_IDENT,
-        MLIRTokenKind.SLASH,
-        MLIRTokenKind.BARE_IDENT,
-        MLIRTokenKind.EOF,
-    ]
-
-
-def test_attr_body_lexer_double_slash():
-    """AttrBodyLexer treats // as two SLASH tokens, not a comment."""
-    inp = Input("a // b", "<>")
-    tokens = _get_all_tokens(AttrBodyLexer(inp))
-    kinds = [t.kind for t in tokens]
-    assert kinds == [
-        MLIRTokenKind.BARE_IDENT,
-        MLIRTokenKind.SLASH,
-        MLIRTokenKind.SLASH,
-        MLIRTokenKind.BARE_IDENT,
-        MLIRTokenKind.EOF,
-    ]
-
-
-def test_main_lexer_double_slash_is_comment():
-    """The main MLIRLexer treats // as a comment."""
-    inp = Input("a // b", "<>")
-    tokens = _get_all_tokens(MLIRLexer(inp))
-    kinds = [t.kind for t in tokens]
-    assert kinds == [MLIRTokenKind.BARE_IDENT, MLIRTokenKind.EOF]

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -2,7 +2,7 @@ import pytest
 
 from xdsl.utils.exceptions import ParseError
 from xdsl.utils.lexer import Input, Position
-from xdsl.utils.mlir_lexer import MLIRLexer, MLIRToken, MLIRTokenKind
+from xdsl.utils.mlir_lexer import AttrBodyLexer, MLIRLexer, MLIRToken, MLIRTokenKind
 
 
 def get_token(input: str) -> MLIRToken:
@@ -270,3 +270,48 @@ def test_get_start_of_line(
     input = Input(START_END_LINE_CONTENT, "<>")
     assert input.get_start_of_line(pos) == expected_start
     assert input.get_end_of_line(pos) == expected_end
+
+
+def _get_all_tokens(lexer: MLIRLexer) -> list[MLIRToken]:
+    tokens: list[MLIRToken] = []
+    while True:
+        tok = lexer.lex()
+        tokens.append(tok)
+        if tok.kind == MLIRTokenKind.EOF:
+            break
+    return tokens
+
+
+def test_attr_body_lexer_slash():
+    """AttrBodyLexer produces SLASH tokens for /."""
+    inp = Input("a / b", "<>")
+    tokens = _get_all_tokens(AttrBodyLexer(inp))
+    kinds = [t.kind for t in tokens]
+    assert kinds == [
+        MLIRTokenKind.BARE_IDENT,
+        MLIRTokenKind.SLASH,
+        MLIRTokenKind.BARE_IDENT,
+        MLIRTokenKind.EOF,
+    ]
+
+
+def test_attr_body_lexer_double_slash():
+    """AttrBodyLexer treats // as two SLASH tokens, not a comment."""
+    inp = Input("a // b", "<>")
+    tokens = _get_all_tokens(AttrBodyLexer(inp))
+    kinds = [t.kind for t in tokens]
+    assert kinds == [
+        MLIRTokenKind.BARE_IDENT,
+        MLIRTokenKind.SLASH,
+        MLIRTokenKind.SLASH,
+        MLIRTokenKind.BARE_IDENT,
+        MLIRTokenKind.EOF,
+    ]
+
+
+def test_main_lexer_double_slash_is_comment():
+    """The main MLIRLexer treats // as a comment."""
+    inp = Input("a // b", "<>")
+    tokens = _get_all_tokens(MLIRLexer(inp))
+    kinds = [t.kind for t in tokens]
+    assert kinds == [MLIRTokenKind.BARE_IDENT, MLIRTokenKind.EOF]

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -38,6 +38,7 @@ from xdsl.irdl import (
     region_def,
 )
 from xdsl.parser import Parser
+from xdsl.parser.attribute_parser import AttrParser
 from xdsl.printer import Printer
 from xdsl.utils.exceptions import ParseError
 from xdsl.utils.mlir_lexer import (

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1440,7 +1440,7 @@ class SlashAttr(ParametrizedAttribute):
     @classmethod
     def parse_parameters(
         cls,
-        parser: Parser,  # type: ignore[override]
+        parser: AttrParser,
     ) -> Sequence[Attribute]:
         with parser.in_angle_brackets():
             parser.parse_punctuation("/")

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -37,8 +37,7 @@ from xdsl.irdl import (
     prop_def,
     region_def,
 )
-from xdsl.parser import Parser
-from xdsl.parser.attribute_parser import AttrParser
+from xdsl.parser import AttrParser, Parser
 from xdsl.printer import Printer
 from xdsl.utils.exceptions import ParseError
 from xdsl.utils.mlir_lexer import (

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,5 +1,6 @@
 import builtins
 import re
+from collections.abc import Sequence
 from io import StringIO
 from typing import cast
 
@@ -1428,3 +1429,36 @@ def test_unregistered_attr_name_rejected():
     with pytest.raises(ParseError, match="is not registered"):
         parser = Parser(ctx, '"test.op"() : () -> !nonexistent.type<foo>')
         parser.parse_optional_operation()
+
+
+@irdl_attr_definition
+class SlashAttr(ParametrizedAttribute):
+    """Test attribute whose parameter syntax contains a `/`."""
+
+    name = "test_slash.attr"
+
+    @classmethod
+    def parse_parameters(
+        cls,
+        parser: Parser,  # type: ignore[override]
+    ) -> Sequence[Attribute]:
+        with parser.in_angle_brackets():
+            parser.parse_punctuation("/")
+        return ()
+
+    def print_parameters(self, printer: Printer) -> None:
+        printer.print_string("</>")
+
+
+def test_slash_punctuation_in_registered_attr():
+    """parse_punctuation('/') works inside a registered attribute."""
+    ctx = Context()
+    ctx.load_attr_or_type(SlashAttr)
+
+    parser = Parser(ctx, "#test_slash.attr</>")
+    attr = parser.parse_attribute()
+    assert isinstance(attr, SlashAttr)
+
+    with StringIO() as io:
+        Printer(io).print_attribute(attr)
+        assert io.getvalue() == "#test_slash.attr</>"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -28,15 +28,16 @@ from xdsl.dialects.builtin import (
 )
 from xdsl.dialects.func import Func, FuncOp
 from xdsl.dialects.test import Test
-from xdsl.ir import Attribute, Block, ParametrizedAttribute
+from xdsl.ir import Attribute, Block, Data, ParametrizedAttribute, TypeAttribute
 from xdsl.irdl import (
     IRDLOperation,
     irdl_attr_definition,
     irdl_op_definition,
+    param_def,
     prop_def,
     region_def,
 )
-from xdsl.parser import Parser
+from xdsl.parser import AttrParser, Parser
 from xdsl.printer import Printer
 from xdsl.utils.exceptions import ParseError
 from xdsl.utils.mlir_lexer import (
@@ -663,7 +664,10 @@ def test_get_punctuation_kind(punctuation: MLIRTokenKind):
     assert punctuation.get_punctuation_kind_from_name(value) == punctuation
 
 
-@pytest.mark.parametrize("punctuation", list(KIND_BY_PUNCTUATION_SPELLING.keys()))
+@pytest.mark.parametrize(
+    "punctuation",
+    [p for p in KIND_BY_PUNCTUATION_SPELLING if p != "/"],
+)
 def test_parse_punctuation(punctuation: PunctuationSpelling):
     parser = Parser(Context(), punctuation)
 
@@ -681,7 +685,10 @@ def test_parse_punctuation_fail(punctuation: PunctuationSpelling):
     assert e.value.msg == "Expected '" + punctuation + "' in test"
 
 
-@pytest.mark.parametrize("punctuation", list(KIND_BY_PUNCTUATION_SPELLING.keys()))
+@pytest.mark.parametrize(
+    "punctuation",
+    [p for p in KIND_BY_PUNCTUATION_SPELLING if p != "/"],
+)
 def test_parse_optional_punctuation(punctuation: PunctuationSpelling):
     parser = Parser(Context(), punctuation)
     res = parser.parse_optional_punctuation(punctuation)
@@ -1379,3 +1386,129 @@ def test_parse_dimension_list(input: str, expected: list[int]):
 
     result = parser.parse_dimension_list()
     assert result == expected
+
+
+@irdl_attr_definition
+class SlashType(Data[str], TypeAttribute):
+    """A test type that stores raw text which may contain `/` characters."""
+
+    name = "test_slash.type"
+
+    @classmethod
+    def parse_parameter(cls, parser: AttrParser) -> str:
+        with parser.in_angle_brackets():
+            tokens: list[str] = []
+            if (ident := parser.parse_optional_identifier()) is not None:
+                tokens.append(ident)
+            while parser.parse_optional_punctuation("/") is not None:
+                tokens.append("/")
+                if (ident := parser.parse_optional_identifier()) is not None:
+                    tokens.append(ident)
+            return " ".join(tokens)
+
+    def print_parameter(self, printer: Printer) -> None:
+        with printer.in_angle_brackets():
+            printer.print_string(self.data)
+
+
+@pytest.mark.parametrize(
+    "body, expected",
+    [
+        ("a // b", "a / / b"),
+        ("valid / mlir // syntax ///", "valid / mlir / / syntax / / /"),
+    ],
+)
+def test_slash_in_registered_data_type(body: str, expected: str):
+    """Verify that // inside <...> works for registered Data types."""
+    ctx = Context(allow_unregistered=True)
+    ctx.load_attr_or_type(SlashType)
+    parser = Parser(ctx, f'"test.op"() : () -> !test_slash.type<{body}>')
+    op = parser.parse_optional_operation()
+    assert op is not None
+    res_type = op.results[0].type
+    assert isinstance(res_type, SlashType)
+    assert res_type.data == expected
+
+
+@irdl_attr_definition
+class SlashParamType(ParametrizedAttribute, TypeAttribute):
+    """A test ParametrizedAttribute that parses slash-separated identifiers."""
+
+    name = "test_slash_param.type"
+
+    value: StringAttr = param_def()
+
+    @classmethod
+    def parse_parameters(cls, parser: AttrParser) -> list[Attribute]:
+        parser.parse_punctuation("<")
+        tokens: list[str] = []
+        if (ident := parser.parse_optional_identifier()) is not None:
+            tokens.append(ident)
+        while parser.parse_optional_punctuation("/") is not None:
+            tokens.append("/")
+            if (ident := parser.parse_optional_identifier()) is not None:
+                tokens.append(ident)
+        parser.parse_punctuation(">")
+        return [StringAttr(" ".join(tokens))]
+
+    def print_parameters(self, printer: Printer) -> None:
+        printer.print_string("<")
+        printer.print_string(self.value.data)
+        printer.print_string(">")
+
+
+@pytest.mark.parametrize(
+    "body, expected",
+    [
+        ("a // b", "a / / b"),
+        ("valid / mlir // syntax ///", "valid / mlir / / syntax / / /"),
+    ],
+)
+def test_slash_in_registered_param_type(body: str, expected: str):
+    """Verify that // inside <...> works for registered ParametrizedAttribute types."""
+    ctx = Context(allow_unregistered=True)
+    ctx.load_attr_or_type(SlashParamType)
+    parser = Parser(ctx, f'"test.op"() : () -> !test_slash_param.type<{body}>')
+    op = parser.parse_optional_operation()
+    assert op is not None
+    res_type = op.results[0].type
+    assert isinstance(res_type, SlashParamType)
+    assert res_type.value.data == expected
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "a (] b",
+        "a [} b",
+        "a {) b",
+    ],
+)
+def test_unregistered_type_unbalanced_brackets(body: str):
+    """_raw_scan_balanced rejects mismatched bracket pairs."""
+    ctx = Context(allow_unregistered=True)
+    with pytest.raises(ParseError, match="Unbalanced"):
+        parser = Parser(
+            ctx, f'"test.op"() : () -> !unknowndialect.t<{body}>'
+        )
+        parser.parse_optional_operation()
+
+
+def test_unregistered_type_unterminated_string():
+    """_raw_scan_balanced rejects unterminated string literals."""
+    ctx = Context(allow_unregistered=True)
+    with pytest.raises(ParseError, match="Unterminated string literal"):
+        parser = Parser(
+            ctx, '"test.op"() : () -> !unknowndialect.t<"no end>'
+        )
+        parser.parse_optional_operation()
+
+
+def test_unregistered_type_unexpected_eof():
+    """_raw_scan_balanced rejects unexpected end of file."""
+    ctx = Context(allow_unregistered=True)
+    with pytest.raises(ParseError, match="end of file"):
+        parser = Parser(
+            ctx, '"test.op"() : () -> !unknowndialect.t<no close'
+        )
+        parser.parse_optional_operation()

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -28,16 +28,15 @@ from xdsl.dialects.builtin import (
 )
 from xdsl.dialects.func import Func, FuncOp
 from xdsl.dialects.test import Test
-from xdsl.ir import Attribute, Block, Data, ParametrizedAttribute, TypeAttribute
+from xdsl.ir import Attribute, Block, ParametrizedAttribute
 from xdsl.irdl import (
     IRDLOperation,
     irdl_attr_definition,
     irdl_op_definition,
-    param_def,
     prop_def,
     region_def,
 )
-from xdsl.parser import AttrParser, Parser
+from xdsl.parser import Parser
 from xdsl.printer import Printer
 from xdsl.utils.exceptions import ParseError
 from xdsl.utils.mlir_lexer import (
@@ -664,10 +663,7 @@ def test_get_punctuation_kind(punctuation: MLIRTokenKind):
     assert punctuation.get_punctuation_kind_from_name(value) == punctuation
 
 
-@pytest.mark.parametrize(
-    "punctuation",
-    [p for p in KIND_BY_PUNCTUATION_SPELLING if p != "/"],
-)
+@pytest.mark.parametrize("punctuation", list(KIND_BY_PUNCTUATION_SPELLING.keys()))
 def test_parse_punctuation(punctuation: PunctuationSpelling):
     parser = Parser(Context(), punctuation)
 
@@ -685,10 +681,7 @@ def test_parse_punctuation_fail(punctuation: PunctuationSpelling):
     assert e.value.msg == "Expected '" + punctuation + "' in test"
 
 
-@pytest.mark.parametrize(
-    "punctuation",
-    [p for p in KIND_BY_PUNCTUATION_SPELLING if p != "/"],
-)
+@pytest.mark.parametrize("punctuation", list(KIND_BY_PUNCTUATION_SPELLING.keys()))
 def test_parse_optional_punctuation(punctuation: PunctuationSpelling):
     parser = Parser(Context(), punctuation)
     res = parser.parse_optional_punctuation(punctuation)
@@ -1386,94 +1379,6 @@ def test_parse_dimension_list(input: str, expected: list[int]):
 
     result = parser.parse_dimension_list()
     assert result == expected
-
-
-@irdl_attr_definition
-class SlashType(Data[str], TypeAttribute):
-    """A test type that stores raw text which may contain `/` characters."""
-
-    name = "test_slash.type"
-
-    @classmethod
-    def parse_parameter(cls, parser: AttrParser) -> str:
-        with parser.in_angle_brackets():
-            tokens: list[str] = []
-            if (ident := parser.parse_optional_identifier()) is not None:
-                tokens.append(ident)
-            while parser.parse_optional_punctuation("/") is not None:
-                tokens.append("/")
-                if (ident := parser.parse_optional_identifier()) is not None:
-                    tokens.append(ident)
-            return " ".join(tokens)
-
-    def print_parameter(self, printer: Printer) -> None:
-        with printer.in_angle_brackets():
-            printer.print_string(self.data)
-
-
-@pytest.mark.parametrize(
-    "body, expected",
-    [
-        ("a // b", "a / / b"),
-        ("valid / mlir // syntax ///", "valid / mlir / / syntax / / /"),
-    ],
-)
-def test_slash_in_registered_data_type(body: str, expected: str):
-    """Verify that // inside <...> works for registered Data types."""
-    ctx = Context(allow_unregistered=True)
-    ctx.load_attr_or_type(SlashType)
-    parser = Parser(ctx, f'"test.op"() : () -> !test_slash.type<{body}>')
-    op = parser.parse_optional_operation()
-    assert op is not None
-    res_type = op.results[0].type
-    assert isinstance(res_type, SlashType)
-    assert res_type.data == expected
-
-
-@irdl_attr_definition
-class SlashParamType(ParametrizedAttribute, TypeAttribute):
-    """A test ParametrizedAttribute that parses slash-separated identifiers."""
-
-    name = "test_slash_param.type"
-
-    value: StringAttr = param_def()
-
-    @classmethod
-    def parse_parameters(cls, parser: AttrParser) -> list[Attribute]:
-        parser.parse_punctuation("<")
-        tokens: list[str] = []
-        if (ident := parser.parse_optional_identifier()) is not None:
-            tokens.append(ident)
-        while parser.parse_optional_punctuation("/") is not None:
-            tokens.append("/")
-            if (ident := parser.parse_optional_identifier()) is not None:
-                tokens.append(ident)
-        parser.parse_punctuation(">")
-        return [StringAttr(" ".join(tokens))]
-
-    def print_parameters(self, printer: Printer) -> None:
-        printer.print_string("<")
-        printer.print_string(self.value.data)
-        printer.print_string(">")
-
-
-@pytest.mark.parametrize(
-    "body, expected",
-    [
-        ("a // b", "a / / b"),
-        ("valid / mlir // syntax ///", "valid / mlir / / syntax / / /"),
-    ],
-)
-def test_slash_in_registered_param_type(body: str, expected: str):
-    """Verify that // inside <...> works for registered ParametrizedAttribute types."""
-    ctx = Context(allow_unregistered=True)
-    ctx.load_attr_or_type(SlashParamType)
-    parser = Parser(ctx, f'"test.op"() : () -> !test_slash_param.type<{body}>')
-    op = parser.parse_optional_operation()
-    assert op is not None
-    res_type = op.results[0].type
-    assert isinstance(res_type, SlashParamType)
-    assert res_type.value.data == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1506,3 +1506,20 @@ def test_unregistered_type_unexpected_eof():
     with pytest.raises(ParseError, match="end of file"):
         parser = Parser(ctx, '"test.op"() : () -> !unknowndialect.t<no close')
         parser.parse_optional_operation()
+
+
+def test_opaque_syntax_attr():
+    """Opaque syntax (#dialect<name ...>) goes through the non-pretty path."""
+    ctx = Context(allow_unregistered=True)
+    parser = Parser(ctx, '"test.op"() {x = #unknowndialect<myattr a / b>} : () -> ()')
+    op = parser.parse_optional_operation()
+    assert op is not None
+
+
+def test_unregistered_attr_name_rejected():
+    """An unknown attr name is rejected when allow_unregistered is False."""
+    ctx = Context(allow_unregistered=False)
+    ctx.load_dialect(Test)
+    with pytest.raises(ParseError, match="is not registered"):
+        parser = Parser(ctx, '"test.op"() : () -> !nonexistent.type<foo>')
+        parser.parse_optional_operation()

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1488,9 +1488,7 @@ def test_unregistered_type_unbalanced_brackets(body: str):
     """_raw_scan_balanced rejects mismatched bracket pairs."""
     ctx = Context(allow_unregistered=True)
     with pytest.raises(ParseError, match="Unbalanced"):
-        parser = Parser(
-            ctx, f'"test.op"() : () -> !unknowndialect.t<{body}>'
-        )
+        parser = Parser(ctx, f'"test.op"() : () -> !unknowndialect.t<{body}>')
         parser.parse_optional_operation()
 
 
@@ -1498,9 +1496,7 @@ def test_unregistered_type_unterminated_string():
     """_raw_scan_balanced rejects unterminated string literals."""
     ctx = Context(allow_unregistered=True)
     with pytest.raises(ParseError, match="Unterminated string literal"):
-        parser = Parser(
-            ctx, '"test.op"() : () -> !unknowndialect.t<"no end>'
-        )
+        parser = Parser(ctx, '"test.op"() : () -> !unknowndialect.t<"no end>')
         parser.parse_optional_operation()
 
 
@@ -1508,7 +1504,5 @@ def test_unregistered_type_unexpected_eof():
     """_raw_scan_balanced rejects unexpected end of file."""
     ctx = Context(allow_unregistered=True)
     with pytest.raises(ParseError, match="end of file"):
-        parser = Parser(
-            ctx, '"test.op"() : () -> !unknowndialect.t<no close'
-        )
+        parser = Parser(ctx, '"test.op"() : () -> !unknowndialect.t<no close')
         parser.parse_optional_operation()

--- a/xdsl/irdl/attributes.py
+++ b/xdsl/irdl/attributes.py
@@ -366,9 +366,7 @@ def irdl_param_attr_definition(cls: _PAttrTT) -> _PAttrTT:
             with parser.in_angle_brackets():
                 return program.parse(parser, attr_def)
 
-        def print_with_format(
-            self: ParametrizedAttribute, printer: "Printer"
-        ) -> None:
+        def print_with_format(self: ParametrizedAttribute, printer: "Printer") -> None:
             with printer.in_angle_brackets():
                 program.print(printer, self)
 

--- a/xdsl/irdl/attributes.py
+++ b/xdsl/irdl/attributes.py
@@ -8,10 +8,11 @@
 import sys
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Hashable, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from inspect import get_annotations, isclass
 from types import FunctionType, GenericAlias, UnionType
 from typing import (
+    TYPE_CHECKING,
     Annotated,
     Any,
     Generic,
@@ -30,11 +31,12 @@ from typing_extensions import TypeVar, dataclass_transform
 if sys.version_info >= (3, 14, 0):
     from typing_extensions import TypeForm
 else:
-    from typing import TYPE_CHECKING
-
     if TYPE_CHECKING:
         from typing_extensions import TypeForm
 
+if TYPE_CHECKING:
+    from xdsl.parser import AttrParser
+    from xdsl.printer import Printer
 
 from xdsl.ir import (
     Attribute,
@@ -46,7 +48,7 @@ from xdsl.ir import (
     TypedAttribute,
 )
 from xdsl.utils.classvar import is_const_classvar
-from xdsl.utils.exceptions import PyRDLAttrDefinitionError, PyRDLTypeError
+from xdsl.utils.exceptions import ParseError, PyRDLAttrDefinitionError, PyRDLTypeError
 from xdsl.utils.hints import (
     PropertyType,
     get_type_var_from_generic_class,
@@ -186,6 +188,7 @@ class ParamAttrDef:
 
     name: str
     parameters: list[tuple[str, ParamDef]]
+    custom_directives: dict[str, type[Any]] = field(default_factory=lambda: {})
 
     @staticmethod
     def from_pyrdl(
@@ -225,6 +228,9 @@ class ParamAttrDef:
             if (
                 # Ignore name field
                 field_name != "name"
+                # Ignore assembly_format and custom_directives (handled separately)
+                and field_name != "assembly_format"
+                and field_name != "custom_directives"
                 # Ignore functions
                 and not isinstance(
                     field_value,
@@ -299,14 +305,17 @@ class ParamAttrDef:
                     f"Missing field type for parameter name {field_name}"
                 )
 
-        return ParamAttrDef(name, list(parameters.items()))
+        custom_dirs = getattr(pyrdl_def, "custom_directives", ())
+        custom_directives = {d.__name__: d for d in custom_dirs}
+
+        return ParamAttrDef(name, list(parameters.items()), custom_directives)
 
     def verify(self, attr: ParametrizedAttribute):
         """Verify that `attr` satisfies the invariants."""
 
         constraint_context = ConstraintContext()
-        for field, param_def in self.parameters:
-            param_def.constr.verify(getattr(attr, field), constraint_context)
+        for param_name, param_def in self.parameters:
+            param_def.constr.verify(getattr(attr, param_name), constraint_context)
 
 
 _PAttrTT = TypeVar("_PAttrTT", bound=type[ParametrizedAttribute])
@@ -325,6 +334,46 @@ def irdl_param_attr_definition(cls: _PAttrTT) -> _PAttrTT:
 
     attr_def = ParamAttrDef.from_pyrdl(cls)
     new_fields = get_accessors_from_param_attr_def(attr_def)
+
+    assembly_format = getattr(cls, "assembly_format", None)
+    if assembly_format is not None:
+        if not attr_def.parameters:
+            raise PyRDLAttrDefinitionError(
+                "Cannot use assembly_format on attribute with no parameters"
+            )
+        if "parse_parameters" in cls.__dict__:
+            raise PyRDLAttrDefinitionError(
+                "Cannot use assembly_format with custom parse_parameters"
+            )
+        if "print_parameters" in cls.__dict__:
+            raise PyRDLAttrDefinitionError(
+                "Cannot use assembly_format with custom print_parameters"
+            )
+
+        from xdsl.irdl.declarative_assembly_format import AttrFormatProgram
+
+        try:
+            program = AttrFormatProgram.from_str(assembly_format, attr_def)
+        except ParseError as e:
+            raise PyRDLAttrDefinitionError(
+                "Error during the parsing of the assembly format: ", e.args
+            ) from e
+
+        @classmethod
+        def parse_with_format(
+            cls: type[ParametrizedAttribute], parser: "AttrParser"
+        ) -> list[Attribute]:
+            with parser.in_angle_brackets():
+                return program.parse(parser, attr_def)
+
+        def print_with_format(
+            self: ParametrizedAttribute, printer: "Printer"
+        ) -> None:
+            with printer.in_angle_brackets():
+                program.print(printer, self)
+
+        new_fields["parse_parameters"] = parse_with_format
+        new_fields["print_parameters"] = print_with_format
 
     if issubclass(cls, TypedAttribute):
         type_indexes = tuple(

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -19,6 +19,7 @@ from xdsl.dialects.builtin import (
     BytesAttr,
     DenseArrayBase,
     IntegerType,
+    NoneAttr,
     StringAttr,
     UnitAttr,
 )
@@ -30,13 +31,14 @@ from xdsl.ir import (
     SSAValue,
     TypedAttribute,
 )
-from xdsl.irdl import (
+from xdsl.irdl import (  # noqa: TID251
     BaseAccessor,
     ConstraintContext,
     IRDLOperation,
     IRDLOperationInvT,
     OpDef,
     OptionalDef,
+    ParamAttrDef,
     Successor,
     VarIRConstruct,
     VarOperand,
@@ -44,7 +46,7 @@ from xdsl.irdl import (
     is_const_classvar,
     verify_variadic_same_size,
 )
-from xdsl.parser import Parser, UnresolvedOperand
+from xdsl.parser import AttrParser, Parser, UnresolvedOperand
 from xdsl.printer import Printer
 from xdsl.utils.exceptions import PyRDLError, VerifyException
 from xdsl.utils.hints import isa
@@ -1358,6 +1360,107 @@ class OptionalUnitAttrVariable(AttributeVariable):
         return False
 
 
+# ===========================================================================
+# Attribute/Type declarative assembly format
+# ===========================================================================
+
+
+@dataclass
+class AttrParsingState:
+    """State during parsing of a ParametrizedAttribute using declarative format."""
+
+    parameters: list[Attribute | None]
+    attr_def: ParamAttrDef
+
+    def __init__(self, attr_def: ParamAttrDef):
+        self.attr_def = attr_def
+        self.parameters = [None] * len(attr_def.parameters)
+
+
+@dataclass(frozen=True)
+class AttrFormatDirective(ABC):
+    """Base class for attribute/type format directives.
+
+    Separate from FormatDirective because operation formats parse full ops
+    (operands, results, regions, etc.) using Parser and ParsingState, while
+    attribute/type formats only fill parameter slots of a ParametrizedAttribute
+    using AttrParser and AttrParsingState.
+    """
+
+    @abstractmethod
+    def parse(self, parser: AttrParser, state: AttrParsingState) -> bool: ...
+
+    def parse_optional(self, parser: AttrParser, state: AttrParsingState) -> bool:
+        return self.parse(parser, state)
+
+    @abstractmethod
+    def print(
+        self, printer: Printer, state: PrintingState, attr: ParametrizedAttribute, /
+    ) -> None: ...
+
+    def set_empty(self, state: AttrParsingState) -> None:
+        """
+        Set the appropriate field of the parsing state to be empty.
+        Used when a variable appears in an optional group which is not parsed.
+        """
+        return
+
+    def is_present(self, attr: ParametrizedAttribute, /) -> bool:
+        return True
+
+    def is_anchorable(self) -> bool:
+        return False
+
+    def is_optional_like(self) -> bool:
+        return False
+
+
+# ===========================================================================
+# Shared print helpers for structural directives (whitespace, punctuation,
+# keyword). These are used by both the op-side and attr-side directive classes.
+# ===========================================================================
+
+
+def _print_whitespace(printer: Printer, state: PrintingState, whitespace: str) -> None:
+    printer.print_string(whitespace)
+    state.last_was_punctuation = whitespace == ""
+    state.should_emit_space = False
+
+
+def _print_punctuation(
+    printer: Printer, state: PrintingState, punctuation: PunctuationSpelling
+) -> None:
+    emit_space = False
+    if state.should_emit_space:
+        if state.last_was_punctuation:
+            if punctuation not in (">", ")", "}", "]", ","):
+                emit_space = True
+        elif punctuation not in ("<", ">", "(", ")", "{", "}", "[", "]", ","):
+            emit_space = True
+
+        if emit_space:
+            printer.print_string(" ")
+
+    printer.print_string(punctuation)
+
+    state.should_emit_space = punctuation not in ("<", "(", "{", "[")
+    state.last_was_punctuation = True
+
+
+def _print_keyword(printer: Printer, state: PrintingState, keyword: str) -> None:
+    if state.should_emit_space:
+        printer.print_string(" ")
+    state.should_emit_space = True
+    state.last_was_punctuation = False
+
+    printer.print_string(keyword)
+
+
+# ===========================================================================
+# Op-side structural directives
+# ===========================================================================
+
+
 @dataclass(frozen=True)
 class WhitespaceDirective(FormatDirective):
     """
@@ -1486,3 +1589,311 @@ class OptionalGroupDirective(FormatDirective):
             element.set_empty(state)
         for element in self.else_elements:
             element.set_empty(state)
+
+
+# ===========================================================================
+# Attr-side structural directives
+# ===========================================================================
+
+
+@dataclass(frozen=True)
+class AttrWhitespaceDirective(AttrFormatDirective):
+    """Whitespace directive for attribute/type assembly format."""
+
+    whitespace: Literal[" ", "\n", ""]
+
+    def parse(self, parser: AttrParser, state: AttrParsingState) -> bool:
+        return False
+
+    def print(
+        self, printer: Printer, state: PrintingState, attr: ParametrizedAttribute, /
+    ) -> None:
+        _print_whitespace(printer, state, self.whitespace)
+
+
+@dataclass(frozen=True)
+class AttrPunctuationDirective(AttrFormatDirective):
+    """Punctuation directive for attribute/type assembly format."""
+
+    punctuation: PunctuationSpelling
+
+    def parse(self, parser: AttrParser, state: AttrParsingState) -> bool:
+        return parser.parse_optional_punctuation(self.punctuation) is not None
+
+    def print(
+        self, printer: Printer, state: PrintingState, attr: ParametrizedAttribute, /
+    ) -> None:
+        _print_punctuation(printer, state, self.punctuation)
+
+    def is_optional_like(self) -> bool:
+        return True
+
+
+@dataclass(frozen=True)
+class AttrKeywordDirective(AttrFormatDirective):
+    """Keyword directive for attribute/type assembly format."""
+
+    keyword: str
+
+    def parse(self, parser: AttrParser, state: AttrParsingState) -> bool:
+        return parser.parse_optional_keyword(self.keyword) is not None
+
+    def print(
+        self, printer: Printer, state: PrintingState, attr: ParametrizedAttribute, /
+    ) -> None:
+        _print_keyword(printer, state, self.keyword)
+
+    def is_optional_like(self) -> bool:
+        return True
+
+
+@dataclass(frozen=True)
+class ParameterVariable(AttrFormatDirective):
+    """A parameter variable directive for attribute assembly format."""
+
+    name: str
+    index: int
+    is_optional: bool
+
+    def parse(self, parser: AttrParser, state: AttrParsingState) -> bool:
+        if self.is_optional:
+            attr = parser.parse_optional_attribute()
+        else:
+            attr = parser.parse_attribute()
+        if attr is None:
+            return False
+        state.parameters[self.index] = attr
+        return True
+
+    def parse_optional(self, parser: AttrParser, state: AttrParsingState) -> bool:
+        attr = parser.parse_optional_attribute()
+        if attr is None:
+            return False
+        state.parameters[self.index] = attr
+        return True
+
+    def print(
+        self, printer: Printer, state: PrintingState, attr: ParametrizedAttribute, /
+    ) -> None:
+        param = attr.parameters[self.index]
+        if isinstance(param, NoneAttr):
+            return
+        state.print_whitespace(printer)
+        printer.print_attribute(param)
+
+    def is_present(self, attr: ParametrizedAttribute, /) -> bool:
+        return not isinstance(attr.parameters[self.index], NoneAttr)
+
+    def is_anchorable(self) -> bool:
+        return self.is_optional
+
+    def is_optional_like(self) -> bool:
+        return self.is_optional
+
+    def set_empty(self, state: AttrParsingState) -> None:
+        state.parameters[self.index] = NoneAttr()
+
+
+@dataclass(frozen=True)
+class QualifiedParameterVariable(ParameterVariable):
+    """Wraps a ParameterVariable to print with full dialect qualification.
+
+    In xdsl, print_attribute() always qualifies, so this is currently
+    identical to ParameterVariable. Exists for MLIR format compatibility.
+    """
+
+
+class AttrCustomDirective(AttrFormatDirective, ABC):
+    """A user defined assembly format directive for attribute/type formats.
+
+    Mirrors CustomDirective for operations. Custom directives can have
+    multiple parameters, whose types should be declared in the
+    `parameters` field.
+    """
+
+    parameters: ClassVar[dict[str, type[AttrFormatDirective]]]
+
+
+AttrCustomDirectiveInvT = TypeVar("AttrCustomDirectiveInvT", bound=AttrCustomDirective)
+
+
+def irdl_attr_custom_directive(
+    cls: type[AttrCustomDirectiveInvT],
+) -> type[AttrCustomDirectiveInvT]:
+    """Decorator used on custom attr directives to define the `parameters`
+    class variable."""
+
+    cls.parameters = {}
+    param_types = inspect.get_annotations(cls, eval_str=True)
+    for field_name, ty in param_types.items():
+        if is_const_classvar(field_name, ty, PyRDLError):
+            continue
+        if not issubclass(ty, AttrFormatDirective):
+            raise PyRDLError(
+                f"Custom attr directive {cls.__name__} has parameter "
+                f"{field_name} which is not an attr format directive."
+            )
+        cls.parameters[field_name] = ty
+    return dataclass(frozen=True)(cls)
+
+
+@dataclass(frozen=True)
+class ParamsDirective(AttrFormatDirective):
+    """Captures all parameters of an attribute, printed comma-separated."""
+
+    params: tuple[ParameterVariable, ...]
+
+    def parse(self, parser: AttrParser, state: AttrParsingState) -> bool:
+        non_optional = [p for p in self.params if not p.is_optional]
+        optional = [p for p in self.params if p.is_optional]
+        for i, pv in enumerate(non_optional):
+            if i:
+                parser.parse_punctuation(",")
+            pv.parse(parser, state)
+        for pv in optional:
+            if not parser.parse_optional_punctuation(","):
+                pv.set_empty(state)
+                continue
+            pv.parse(parser, state)
+        return True
+
+    def print(
+        self, printer: Printer, state: PrintingState, attr: ParametrizedAttribute, /
+    ) -> None:
+        first = True
+        for pv in self.params:
+            if not pv.is_present(attr):
+                continue
+            if not first:
+                printer.print_string(", ")
+            first = False
+            pv.print(printer, state, attr)
+
+
+@dataclass(frozen=True)
+class StructDirective(AttrFormatDirective):
+    """Prints parameters as key = value pairs, parseable in any order."""
+
+    params: tuple[ParameterVariable, ...]
+
+    def parse(self, parser: AttrParser, state: AttrParsingState) -> bool:
+        remaining = {pv.name: pv for pv in self.params}
+        first = True
+        while remaining:
+            if not first:
+                if not parser.parse_optional_punctuation(","):
+                    break
+            name = parser.parse_optional_identifier()
+            if name is None:
+                if first:
+                    break
+                parser.raise_error("expected parameter name in struct")
+            first = False
+            if name not in remaining:
+                parser.raise_error(
+                    f"unexpected parameter '{name}', "
+                    f"expected one of {list(remaining.keys())}"
+                )
+            parser.parse_punctuation("=")
+            remaining[name].parse(parser, state)
+            del remaining[name]
+        for pv in remaining.values():
+            if pv.is_optional:
+                pv.set_empty(state)
+            else:
+                parser.raise_error(f"missing required parameter '{pv.name}' in struct")
+        return True
+
+    def print(
+        self, printer: Printer, state: PrintingState, attr: ParametrizedAttribute, /
+    ) -> None:
+        first = True
+        for pv in self.params:
+            if not pv.is_present(attr):
+                continue
+            if not first:
+                printer.print_string(", ")
+            first = False
+            printer.print_string(f"{pv.name} = ")
+            pv.print(printer, state, attr)
+
+
+@dataclass(frozen=True)
+class AttrOptionalGroupDirective(AttrFormatDirective):
+    """An optional group in attribute assembly format."""
+
+    anchor: AttrFormatDirective
+    then_whitespace: tuple[AttrWhitespaceDirective, ...]
+    then_first: AttrFormatDirective
+    then_elements: tuple[AttrFormatDirective, ...]
+    else_elements: tuple[AttrFormatDirective, ...]
+
+    def parse(self, parser: AttrParser, state: AttrParsingState) -> bool:
+        if ret := self.then_first.parse_optional(parser, state):
+            for element in self.then_elements:
+                element.parse(parser, state)
+            for element in self.else_elements:
+                element.set_empty(state)
+        else:
+            for element in self.then_elements:
+                element.set_empty(state)
+            for element in self.else_elements:
+                element.parse(parser, state)
+        return ret
+
+    def print(
+        self, printer: Printer, state: PrintingState, attr: ParametrizedAttribute, /
+    ) -> None:
+        if self.anchor.is_present(attr):
+            for element in (
+                *self.then_whitespace,
+                self.then_first,
+                *self.then_elements,
+            ):
+                element.print(printer, state, attr)
+        else:
+            for element in self.else_elements:
+                element.print(printer, state, attr)
+
+    def set_empty(self, state: AttrParsingState) -> None:
+        self.then_first.set_empty(state)
+        for element in self.then_elements:
+            element.set_empty(state)
+        for element in self.else_elements:
+            element.set_empty(state)
+
+
+@dataclass(frozen=True)
+class AttrFormatProgram:
+    """
+    The toplevel data structure of a declarative assembly format program
+    for attributes/types.
+    """
+
+    stmts: tuple[AttrFormatDirective, ...]
+    """The statements composing the program. They are executed in order."""
+
+    @staticmethod
+    def from_str(format_str: str, attr_def: ParamAttrDef) -> AttrFormatProgram:
+        from xdsl.irdl.declarative_assembly_format_parser import AttrFormatParser
+
+        return AttrFormatParser(format_str, attr_def).parse_format()
+
+    def parse(self, parser: AttrParser, attr_def: ParamAttrDef) -> list[Attribute]:
+        """Parse parameter values and check that every slot was assigned.
+
+        IRDL constraint verification runs when the attribute is constructed,
+        not during this parse step.
+        """
+        state = AttrParsingState(attr_def)
+        for stmt in self.stmts:
+            stmt.parse(parser, state)
+        for i, (name, _) in enumerate(attr_def.parameters):
+            if state.parameters[i] is None:
+                parser.raise_error(f"parameter '{name}' was not parsed")
+        return cast(list[Attribute], state.parameters)
+
+    def print(self, printer: Printer, attr: ParametrizedAttribute) -> None:
+        state = PrintingState(last_was_punctuation=True, should_emit_space=False)
+        for stmt in self.stmts:
+            stmt.print(printer, state, attr)

--- a/xdsl/irdl/declarative_assembly_format_parser.py
+++ b/xdsl/irdl/declarative_assembly_format_parser.py
@@ -16,6 +16,7 @@ from xdsl.dialects.builtin import (
     Builtin,
     DenseArrayBase,
     IntegerType,
+    NoneAttr,
     SymbolNameConstraint,
     UnitAttr,
 )
@@ -32,6 +33,7 @@ from xdsl.irdl import (
     OptSingleBlockRegionDef,
     OptSuccessorDef,
     ParamAttrConstraint,
+    ParamAttrDef,
     ParsePropInAttrDict,
     SameVariadicOperandSize,
     SameVariadicResultSize,
@@ -45,7 +47,13 @@ from xdsl.irdl import (
 )
 from xdsl.irdl.declarative_assembly_format import (
     AttrDictDirective,
+    AttrFormatDirective,
+    AttrFormatProgram,
     AttributeVariable,
+    AttrKeywordDirective,
+    AttrOptionalGroupDirective,
+    AttrPunctuationDirective,
+    AttrWhitespaceDirective,
     DenseArrayAttributeVariable,
     Directive,
     FormatDirective,
@@ -61,11 +69,15 @@ from xdsl.irdl.declarative_assembly_format import (
     OptionalResultVariable,
     OptionalSuccessorVariable,
     OptionalUnitAttrVariable,
+    ParameterVariable,
+    ParamsDirective,
     PunctuationDirective,
+    QualifiedParameterVariable,
     RegionDirective,
     RegionVariable,
     ResultsDirective,
     ResultVariable,
+    StructDirective,
     SuccessorDirective,
     SuccessorVariable,
     SymbolNameAttributeVariable,
@@ -900,3 +912,217 @@ class FormatParser(BaseParser):
         if not inside_ref:
             self.seen_result_types = [True] * len(self.seen_result_types)
         return ResultsDirective()
+
+
+@dataclass(init=False)
+class AttrFormatParser(BaseParser):
+    """Parser for attribute/type declarative assembly format strings."""
+
+    attr_def: ParamAttrDef
+    seen_parameters: set[str]
+
+    def __init__(self, input_str: str, attr_def: ParamAttrDef):
+        super().__init__(ParserState(FormatLexer(Input(input_str, "<attr-format>"))))
+        self.attr_def = attr_def
+        self.seen_parameters = set()
+
+    def parse_format(self) -> AttrFormatProgram:
+        elements: list[AttrFormatDirective] = []
+        while self._current_token.kind != MLIRTokenKind.EOF:
+            elements.append(self.parse_format_directive())
+        self.verify_parameters()
+        return AttrFormatProgram(tuple(elements))
+
+    def verify_parameters(self) -> None:
+        for name, _ in self.attr_def.parameters:
+            if name not in self.seen_parameters:
+                self.raise_error(
+                    f"parameter '{name}' not found in format string, "
+                    f"consider adding a '${name}' directive"
+                )
+
+    def parse_format_directive(self) -> AttrFormatDirective:
+        if self._current_token.text == "`":
+            return self.parse_keyword_or_punctuation()
+        if self.parse_optional_punctuation("("):
+            return self.parse_optional_group()
+        if self._current_token.text == "$":
+            return self.parse_variable()
+        if self.parse_optional_keyword("params"):
+            return self.parse_params_directive()
+        if self.parse_optional_keyword("struct"):
+            return self.parse_struct_directive()
+        if self.parse_optional_keyword("qualified"):
+            return self.parse_qualified_directive()
+        if self.parse_optional_keyword("custom"):
+            return self.parse_attr_custom_directive()
+        self.raise_error(f"unexpected token '{self._current_token.text}'")
+
+    def parse_variable(self, inside_ref: bool = False) -> ParameterVariable:
+        self._consume_token(MLIRTokenKind.BARE_IDENT)
+        token = self._current_token
+        name = self.parse_identifier(" after '$'")
+
+        for idx, (param_name, param_def) in enumerate(self.attr_def.parameters):
+            if name == param_name:
+                if not inside_ref:
+                    if name in self.seen_parameters:
+                        self.raise_error(
+                            f"parameter '{name}' is already bound", token.span
+                        )
+                    self.seen_parameters.add(name)
+                is_optional = param_def.constr.verifies(NoneAttr())
+                return ParameterVariable(name, idx, is_optional)
+
+        self.raise_error(
+            f"'{name}' does not refer to a parameter of this attribute", token.span
+        )
+
+    def _all_param_variables(self) -> tuple[ParameterVariable, ...]:
+        """Create ParameterVariable instances for all parameters."""
+        params: list[ParameterVariable] = []
+        for idx, (name, param_def) in enumerate(self.attr_def.parameters):
+            if name in self.seen_parameters:
+                self.raise_error(f"parameter '{name}' is already bound")
+            self.seen_parameters.add(name)
+            is_optional = param_def.constr.verifies(NoneAttr())
+            params.append(ParameterVariable(name, idx, is_optional))
+        return tuple(params)
+
+    def _parse_struct_variables(self) -> tuple[ParameterVariable, ...]:
+        """Parse the argument list for struct(): either `params` or `$a, $b, ...`."""
+        with self.in_parens():
+            if self.parse_optional_keyword("params"):
+                return self._all_param_variables()
+            params: list[ParameterVariable] = []
+            params.append(self.parse_variable())
+            while self.parse_optional_punctuation(","):
+                params.append(self.parse_variable())
+            return tuple(params)
+
+    def parse_params_directive(self) -> ParamsDirective:
+        return ParamsDirective(self._all_param_variables())
+
+    def parse_struct_directive(self) -> StructDirective:
+        return StructDirective(self._parse_struct_variables())
+
+    def parse_qualified_directive(self) -> QualifiedParameterVariable:
+        with self.in_parens():
+            pv = self.parse_variable()
+            return QualifiedParameterVariable(pv.name, pv.index, pv.is_optional)
+
+    def parse_possible_ref_directive(self) -> AttrFormatDirective:
+        """Parse a ref directive or variable: `ref` `(` `$var` `)` | `$var`."""
+        if self.parse_optional_keyword("ref"):
+            with self.in_parens():
+                return self.parse_variable(inside_ref=True)
+        return self.parse_variable()
+
+    def parse_attr_custom_directive(self) -> AttrFormatDirective:
+        """Parse `custom` `<` name `>` `(` args `)` for attr format."""
+        with self.in_angle_brackets():
+            name = self.parse_identifier()
+            if name not in self.attr_def.custom_directives:
+                self.raise_error(f"Custom attr directive '{name}' cannot be found.")
+        directive = self.attr_def.custom_directives[name]
+        param_types = directive.parameters
+        params: list[AttrFormatDirective] = []
+        with self.in_parens():
+            for i, (field_name, ty) in enumerate(param_types.items()):
+                if i:
+                    self.parse_punctuation(",")
+                param = self.parse_possible_ref_directive()
+                if not isinstance(param, ty):
+                    self.raise_error(
+                        f"{name}.{field_name} was expected to be of type "
+                        f"{ty.__name__}, but got {type(param).__name__}"
+                    )
+                params.append(param)
+        return directive(*params)
+
+    def parse_keyword_or_punctuation(self) -> AttrFormatDirective:
+        start_token = self._current_token
+        self.parse_characters("`")
+
+        # \n case
+        if self.parse_optional_keyword("\\"):
+            self.parse_keyword("n")
+            self.parse_characters("`")
+            return AttrWhitespaceDirective("\n")
+
+        # Space or empty backtick case
+        end_token = self._current_token
+        if self.parse_optional_characters("`"):
+            whitespace = self.lexer.input.content[
+                start_token.span.end : end_token.span.start
+            ]
+            if whitespace != " " and whitespace != "":
+                self.raise_error(
+                    "unexpected whitespace in directive, "
+                    "only ` ` or `` whitespace is allowed"
+                )
+            return AttrWhitespaceDirective(whitespace)
+
+        # Punctuation case
+        if self._current_token.kind.is_punctuation():
+            punctuation = self._consume_token().text
+            self.parse_characters("`")
+            assert MLIRTokenKind.is_spelling_of_punctuation(punctuation)
+            return AttrPunctuationDirective(punctuation)
+
+        # Identifier case
+        ident = self.parse_optional_identifier()
+        if ident is None or ident == "`":
+            self.raise_error("punctuation or identifier expected")
+
+        self.parse_characters("`")
+        return AttrKeywordDirective(ident)
+
+    def parse_optional_group(self) -> AttrFormatDirective:
+        then_elements = tuple[AttrFormatDirective, ...]()
+        else_elements = tuple[AttrFormatDirective, ...]()
+        anchor: AttrFormatDirective | None = None
+
+        while not self.parse_optional_punctuation(")"):
+            then_elements += (self.parse_format_directive(),)
+            if self.parse_optional_keyword("^"):
+                if anchor is not None:
+                    self.raise_error("An optional group can only have one anchor.")
+                anchor = then_elements[-1]
+
+        if self.parse_optional_punctuation(":"):
+            self.parse_punctuation("(")
+            while not self.parse_optional_punctuation(")"):
+                else_elements += (self.parse_format_directive(),)
+
+        self.parse_punctuation("?")
+
+        first_non_whitespace_index = None
+        for i, x in enumerate(then_elements):
+            if not isinstance(x, AttrWhitespaceDirective):
+                first_non_whitespace_index = i
+                break
+
+        if first_non_whitespace_index is None:
+            self.raise_error("An optional group must have a non-whitespace directive")
+        if anchor is None:
+            self.raise_error("Every optional group must have an anchor.")
+        if not then_elements[first_non_whitespace_index].is_optional_like():
+            self.raise_error(
+                "First element of an optional group must be optionally parsable."
+            )
+        if not anchor.is_anchorable():
+            self.raise_error(
+                "An optional group's anchor must be an anchorable directive."
+            )
+
+        return AttrOptionalGroupDirective(
+            anchor,
+            cast(
+                tuple[AttrWhitespaceDirective, ...],
+                then_elements[:first_non_whitespace_index],
+            ),
+            then_elements[first_non_whitespace_index],
+            then_elements[first_non_whitespace_index + 1 :],
+            else_elements,
+        )

--- a/xdsl/parser/attribute_parser.py
+++ b/xdsl/parser/attribute_parser.py
@@ -258,15 +258,6 @@ class AttrParser(BaseParser):
         after the mnemonic.  ``None`` means the pretty syntax was used.
         """
         is_opaque = starting_opaque_pos is not None
-        pretty = "." in attr_name
-        if not pretty:
-            self.parse_punctuation("<")
-            attr_name += (
-                "."
-                + self._parse_token(
-                    MLIRTokenKind.BARE_IDENT, "Expected attribute name."
-                ).text
-            )
         if is_type:
             attr_def = self.ctx.get_optional_type(
                 attr_name,

--- a/xdsl/parser/attribute_parser.py
+++ b/xdsl/parser/attribute_parser.py
@@ -380,10 +380,10 @@ class AttrParser(BaseParser):
 
     def _raw_scan_balanced(self, pos: Position) -> Position:
         """
-        Scan raw characters for balanced brackets starting from `pos`.
+        Scan raw characters for balanced brackets starting from ``pos``.
 
-        `pos` must point to the first character after an opening `<`.
-        Returns the position of the matching closing `>`.
+        ``pos`` must point to the first character after an opening ``<``.
+        Returns the position of the matching closing ``>``.
         """
         content = self.lexer.input.content
         length = self.lexer.input.len
@@ -397,21 +397,23 @@ class AttrParser(BaseParser):
             if c in "<([{":
                 nesting.append(c)
             elif c == "-" and pos < length and content[pos] == ">":
-                pos += 1  # '->' is not a closing bracket
+                pos += 1
             elif c in closers:
-                expected = closers[c]
                 if not nesting:
                     if c == ">":
-                        return pos - 1  # position of '>'
+                        return pos - 1
                     self.raise_error(
-                        f"Unbalanced '{c}' in dialect symbol body"
+                        f"Unbalanced '{c}' in dialect symbol body",
+                        pos - 1,
                     )
-                if nesting[-1] != expected:
+                if nesting[-1] != closers[c]:
                     self.raise_error(
-                        f"Unbalanced '{c}' in dialect symbol body"
+                        f"Unbalanced '{c}' in dialect symbol body",
+                        pos - 1,
                     )
                 nesting.pop()
             elif c == '"':
+                str_start = pos - 1
                 while pos < length:
                     sc = content[pos]
                     pos += 1
@@ -421,7 +423,8 @@ class AttrParser(BaseParser):
                         break
                 else:
                     self.raise_error(
-                        "Unterminated string literal in dialect symbol body"
+                        "Unterminated string literal in dialect symbol body",
+                        str_start,
                     )
 
         self.raise_error("Unexpected end of file in dialect symbol body")

--- a/xdsl/parser/attribute_parser.py
+++ b/xdsl/parser/attribute_parser.py
@@ -78,7 +78,7 @@ from xdsl.utils.bitwise_casts import (
 from xdsl.utils.exceptions import ParseError, VerifyException
 from xdsl.utils.hints import isa
 from xdsl.utils.lexer import Position, Span
-from xdsl.utils.mlir_lexer import AttrBodyLexer, MLIRTokenKind, StringLiteral
+from xdsl.utils.mlir_lexer import MLIRTokenKind, StringLiteral
 
 from .base_parser import BaseParser  # noqa: TID251
 
@@ -115,18 +115,6 @@ class AttrParser(BaseParser):
     """
     Set of resource references encountered during parsing.
     """
-
-    _attr_body_lexer: AttrBodyLexer | None = field(default=None, init=False)
-
-    @property
-    def attr_body_lexer(self) -> AttrBodyLexer:
-        """
-        A cached AttrBodyLexer over the same input, for re-parsing
-        attribute bodies without comment handling.
-        """
-        if self._attr_body_lexer is None:
-            self._attr_body_lexer = AttrBodyLexer(self.lexer.input)
-        return self._attr_body_lexer
 
     def parse_optional_type(self) -> TypeAttribute | None:
         """
@@ -271,7 +259,6 @@ class AttrParser(BaseParser):
 
         if issubclass(attr_def, UnregisteredAttr):
             if starting_opaque_pos is not None:
-                # this is opaque
                 gt_pos = self._raw_scan_balanced(starting_opaque_pos)
                 body = self.lexer.input.content[starting_opaque_pos:gt_pos]
                 self.lexer.pos = gt_pos
@@ -282,24 +269,6 @@ class AttrParser(BaseParser):
             body_text = self._parse_dialect_symbol_body()
             return attr_def(attr_name, is_type, is_opaque, body_text)
 
-        # Registered attribute — swap to AttrBodyLexer (no // comments)
-        # so that slashes inside <...> are tokenized, not treated as comments.
-        # We resume from wherever parse_parameters stops, since some attributes
-        # (e.g. ComplexNumberAttr) parse beyond the closing '>'.
-        if self._current_token.kind == MLIRTokenKind.LESS:
-            lt_pos = self._current_token.span.start
-            old_lexer = self._parser_state.lexer
-            self._parser_state.lexer = self.attr_body_lexer
-            self._resume_from(lt_pos)
-            attr = self._dispatch_registered_attr(attr_def)
-            resume_pos = self._current_token.span.start
-            self._parser_state.lexer = old_lexer
-            self._resume_from(resume_pos)
-            return attr
-
-        return self._dispatch_registered_attr(attr_def)
-
-    def _dispatch_registered_attr(self, attr_def: type[Attribute]) -> Attribute:
         if issubclass(attr_def, ParametrizedAttribute):
             return attr_def.new(attr_def.parse_parameters(self))
         elif issubclass(attr_def, Data):

--- a/xdsl/parser/attribute_parser.py
+++ b/xdsl/parser/attribute_parser.py
@@ -231,6 +231,7 @@ class AttrParser(BaseParser):
         self,
         attr_name: str,
         is_type: bool,
+        is_opaque: bool,
         starting_opaque_pos: Position | None,
     ):
         """
@@ -240,12 +241,18 @@ class AttrParser(BaseParser):
                                     | `[` dialect-attr-contents+ `]`
                                     | `{` dialect-attr-contents+ `}`
                                     | [^[]<>(){}\0]+
-
-        ``starting_opaque_pos`` is set when the attribute uses the opaque
-        syntax (``#dialect<name ...>``), pointing to the first character
-        after the mnemonic.  ``None`` means the pretty syntax was used.
+        In the case where the attribute or type is using the opaque syntax,
+        the attribute or type mnemonic should have already been parsed.
         """
-        is_opaque = starting_opaque_pos is not None
+        pretty = "." in attr_name
+        if not pretty:
+            self.parse_punctuation("<")
+            attr_name += (
+                "."
+                + self._parse_token(
+                    MLIRTokenKind.BARE_IDENT, "Expected attribute name."
+                ).text
+            )
         if is_type:
             attr_def = self.ctx.get_optional_type(
                 attr_name,
@@ -256,24 +263,25 @@ class AttrParser(BaseParser):
             )
         if attr_def is None:
             self.raise_error(f"'{attr_name}' is not registered")
-
         if issubclass(attr_def, UnregisteredAttr):
             if starting_opaque_pos is not None:
                 gt_pos = self._raw_scan_balanced(starting_opaque_pos)
                 body = self.lexer.input.content[starting_opaque_pos:gt_pos]
                 self.lexer.pos = gt_pos
                 self._parser_state.current_token = self.lexer.lex()
-                return attr_def(attr_name, is_type, is_opaque, body)
-            if self._current_token.kind != MLIRTokenKind.LESS:
+            elif self._current_token.kind != MLIRTokenKind.LESS:
                 return attr_def(attr_name, is_type, is_opaque, "")
-            body_text = self._parse_dialect_symbol_body()
-            return attr_def(attr_name, is_type, is_opaque, body_text)
+            else:
+                body = self._parse_dialect_symbol_body()
+            return attr_def(attr_name, is_type, is_opaque, body)
 
-        if issubclass(attr_def, ParametrizedAttribute):
-            return attr_def.new(attr_def.parse_parameters(self))
+        elif issubclass(attr_def, ParametrizedAttribute):
+            param_list = attr_def.parse_parameters(self)
+            return attr_def.new(param_list)
         elif issubclass(attr_def, Data):
             _attr_def = cast(type[Data[Any]], attr_def)
-            return _attr_def(_attr_def.parse_parameter(self))
+            param = _attr_def.parse_parameter(self)
+            return _attr_def(param)
         else:
             raise TypeError("Attributes are either ParametrizedAttribute or Data.")
 
@@ -330,7 +338,7 @@ class AttrParser(BaseParser):
                 attr_or_dialect_name += "." + attr_name_token.text
 
         attr = self._parse_dialect_type_or_attribute_body(
-            attr_or_dialect_name, is_type, starting_opaque_pos
+            attr_or_dialect_name, is_type, not is_pretty_name, starting_opaque_pos
         )
 
         if not is_pretty_name:

--- a/xdsl/parser/attribute_parser.py
+++ b/xdsl/parser/attribute_parser.py
@@ -78,7 +78,7 @@ from xdsl.utils.bitwise_casts import (
 from xdsl.utils.exceptions import ParseError, VerifyException
 from xdsl.utils.hints import isa
 from xdsl.utils.lexer import Position, Span
-from xdsl.utils.mlir_lexer import MLIRTokenKind, StringLiteral
+from xdsl.utils.mlir_lexer import AttrBodyLexer, MLIRTokenKind, StringLiteral
 
 from .base_parser import BaseParser  # noqa: TID251
 
@@ -115,6 +115,18 @@ class AttrParser(BaseParser):
     """
     Set of resource references encountered during parsing.
     """
+
+    _attr_body_lexer: AttrBodyLexer | None = field(default=None, init=False)
+
+    @property
+    def attr_body_lexer(self) -> AttrBodyLexer:
+        """
+        A cached AttrBodyLexer over the same input, for re-parsing
+        attribute bodies without comment handling.
+        """
+        if self._attr_body_lexer is None:
+            self._attr_body_lexer = AttrBodyLexer(self.lexer.input)
+        return self._attr_body_lexer
 
     def parse_optional_type(self) -> TypeAttribute | None:
         """
@@ -231,7 +243,6 @@ class AttrParser(BaseParser):
         self,
         attr_name: str,
         is_type: bool,
-        is_opaque: bool,
         starting_opaque_pos: Position | None,
     ):
         """
@@ -241,9 +252,12 @@ class AttrParser(BaseParser):
                                     | `[` dialect-attr-contents+ `]`
                                     | `{` dialect-attr-contents+ `}`
                                     | [^[]<>(){}\0]+
-        In the case where the attribute or type is using the opaque syntax,
-        the attribute or type mnemonic should have already been parsed.
+
+        ``starting_opaque_pos`` is set when the attribute uses the opaque
+        syntax (``#dialect<name ...>``), pointing to the first character
+        after the mnemonic.  ``None`` means the pretty syntax was used.
         """
+        is_opaque = starting_opaque_pos is not None
         pretty = "." in attr_name
         if not pretty:
             self.parse_punctuation("<")
@@ -263,23 +277,43 @@ class AttrParser(BaseParser):
             )
         if attr_def is None:
             self.raise_error(f"'{attr_name}' is not registered")
+
         if issubclass(attr_def, UnregisteredAttr):
-            if not is_opaque:
-                if self.parse_optional_punctuation("<") is None:
-                    return attr_def(attr_name, is_type, is_opaque, "")
-            body = self._parse_unregistered_attr_body(starting_opaque_pos)
-            attr = attr_def(attr_name, is_type, is_opaque, body)
-            if not is_opaque:
-                self.parse_punctuation(">")
+            if starting_opaque_pos is not None:
+                # this is opaque
+                gt_pos = self._raw_scan_balanced(starting_opaque_pos)
+                body = self.lexer.input.content[starting_opaque_pos:gt_pos]
+                self.lexer.pos = gt_pos
+                self._parser_state.current_token = self.lexer.lex()
+                return attr_def(attr_name, is_type, is_opaque, body)
+            if self._current_token.kind != MLIRTokenKind.LESS:
+                return attr_def(attr_name, is_type, is_opaque, "")
+            body_text = self._parse_dialect_symbol_body()
+            return attr_def(attr_name, is_type, is_opaque, body_text)
+
+        # Registered attribute — swap to AttrBodyLexer (no // comments)
+        # so that slashes inside <...> are tokenized, not treated as comments.
+        # We resume from wherever parse_parameters stops, since some attributes
+        # (e.g. ComplexNumberAttr) parse beyond the closing '>'.
+        if self._current_token.kind == MLIRTokenKind.LESS:
+            lt_pos = self._current_token.span.start
+            old_lexer = self._parser_state.lexer
+            self._parser_state.lexer = self.attr_body_lexer
+            self._resume_from(lt_pos)
+            attr = self._dispatch_registered_attr(attr_def)
+            resume_pos = self._current_token.span.start
+            self._parser_state.lexer = old_lexer
+            self._resume_from(resume_pos)
             return attr
 
-        elif issubclass(attr_def, ParametrizedAttribute):
-            param_list = attr_def.parse_parameters(self)
-            return attr_def.new(param_list)
+        return self._dispatch_registered_attr(attr_def)
+
+    def _dispatch_registered_attr(self, attr_def: type[Attribute]) -> Attribute:
+        if issubclass(attr_def, ParametrizedAttribute):
+            return attr_def.new(attr_def.parse_parameters(self))
         elif issubclass(attr_def, Data):
             _attr_def = cast(type[Data[Any]], attr_def)
-            param = _attr_def.parse_parameter(self)
-            return _attr_def(param)
+            return _attr_def(_attr_def.parse_parameter(self))
         else:
             raise TypeError("Attributes are either ParametrizedAttribute or Data.")
 
@@ -336,13 +370,80 @@ class AttrParser(BaseParser):
                 attr_or_dialect_name += "." + attr_name_token.text
 
         attr = self._parse_dialect_type_or_attribute_body(
-            attr_or_dialect_name, is_type, not is_pretty_name, starting_opaque_pos
+            attr_or_dialect_name, is_type, starting_opaque_pos
         )
 
         if not is_pretty_name:
             self.parse_punctuation(">")
 
         return attr
+
+    def _raw_scan_balanced(self, pos: Position) -> Position:
+        """
+        Scan raw characters for balanced brackets starting from `pos`.
+
+        `pos` must point to the first character after an opening `<`.
+        Returns the position of the matching closing `>`.
+        """
+        content = self.lexer.input.content
+        length = self.lexer.input.len
+        closers = {">": "<", ")": "(", "]": "[", "}": "{"}
+        nesting: list[str] = []
+
+        while pos < length:
+            c = content[pos]
+            pos += 1
+
+            if c in "<([{":
+                nesting.append(c)
+            elif c == "-" and pos < length and content[pos] == ">":
+                pos += 1  # '->' is not a closing bracket
+            elif c in closers:
+                expected = closers[c]
+                if not nesting:
+                    if c == ">":
+                        return pos - 1  # position of '>'
+                    self.raise_error(
+                        f"Unbalanced '{c}' in dialect symbol body"
+                    )
+                if nesting[-1] != expected:
+                    self.raise_error(
+                        f"Unbalanced '{c}' in dialect symbol body"
+                    )
+                nesting.pop()
+            elif c == '"':
+                while pos < length:
+                    sc = content[pos]
+                    pos += 1
+                    if sc == "\\":
+                        pos += 1
+                    elif sc == '"':
+                        break
+                else:
+                    self.raise_error(
+                        "Unterminated string literal in dialect symbol body"
+                    )
+
+        self.raise_error("Unexpected end of file in dialect symbol body")
+
+    def _parse_dialect_symbol_body(self) -> str:
+        """
+        Extract a dialect symbol body via raw character scanning.
+
+        The current token must be `<`.  Scans the input directly (bypassing
+        the tokenizer) to find the matching `>`, handling nested brackets
+        and string literals.  This matches MLIR's `parseDialectSymbolBody`.
+
+        After this call the lexer is positioned past the closing `>`.
+
+        Returns the body text between the outer `<` and `>` (exclusive).
+        """
+        body_start = self._current_token.span.start + 1
+        gt_pos = self._raw_scan_balanced(body_start)
+
+        self.lexer.pos = gt_pos + 1
+        self._parser_state.current_token = self.lexer.lex()
+        return self.lexer.input.content[body_start:gt_pos]
 
     def _parse_unregistered_attr_body(self, start_pos: Position | None) -> str:
         """

--- a/xdsl/utils/mlir_lexer.py
+++ b/xdsl/utils/mlir_lexer.py
@@ -23,6 +23,7 @@ PunctuationSpelling: TypeAlias = Literal[
     "-",
     "+",
     "?",
+    "/",
     "}",
     ")",
     "]",
@@ -165,6 +166,7 @@ class MLIRTokenKind(Enum):
     R_BRACE = "}"
     R_PAREN = ")"
     R_SQUARE = "]"
+    SLASH = "/"
     STAR = "*"
     VERTICAL_BAR = "|"
     FILE_METADATA_BEGIN = "{-#"
@@ -240,6 +242,7 @@ KIND_BY_PUNCTUATION_SPELLING = {
     "}": MLIRTokenKind.R_BRACE,
     ")": MLIRTokenKind.R_PAREN,
     "]": MLIRTokenKind.R_SQUARE,
+    "/": MLIRTokenKind.SLASH,
     "*": MLIRTokenKind.STAR,
     "|": MLIRTokenKind.VERTICAL_BAR,
     "{-#": MLIRTokenKind.FILE_METADATA_BEGIN,
@@ -336,6 +339,7 @@ class MLIRLexer(Lexer[MLIRTokenKind]):
             ">": MLIRTokenKind.GREATER,
             "=": MLIRTokenKind.EQUAL,
             "+": MLIRTokenKind.PLUS,
+            "/": MLIRTokenKind.SLASH,
             "*": MLIRTokenKind.STAR,
             "?": MLIRTokenKind.QUESTION,
             "|": MLIRTokenKind.VERTICAL_BAR,

--- a/xdsl/utils/mlir_lexer.py
+++ b/xdsl/utils/mlir_lexer.py
@@ -4,7 +4,7 @@ import re
 from dataclasses import dataclass
 from enum import Enum
 from string import hexdigits
-from typing import ClassVar, Literal, TypeAlias, TypeGuard, cast, overload
+from typing import Literal, TypeAlias, TypeGuard, cast, overload
 
 from xdsl.utils.exceptions import ParseError
 from xdsl.utils.lexer import Lexer, Position, Span, Token
@@ -27,7 +27,6 @@ PunctuationSpelling: TypeAlias = Literal[
     ")",
     "]",
     "*",
-    "/",
     "|",
     "{-#",
     "#-}",
@@ -166,7 +165,6 @@ class MLIRTokenKind(Enum):
     R_BRACE = "}"
     R_PAREN = ")"
     R_SQUARE = "]"
-    SLASH = "/"
     STAR = "*"
     VERTICAL_BAR = "|"
     FILE_METADATA_BEGIN = "{-#"
@@ -243,7 +241,6 @@ KIND_BY_PUNCTUATION_SPELLING = {
     ")": MLIRTokenKind.R_PAREN,
     "]": MLIRTokenKind.R_SQUARE,
     "*": MLIRTokenKind.STAR,
-    "/": MLIRTokenKind.SLASH,
     "|": MLIRTokenKind.VERTICAL_BAR,
     "{-#": MLIRTokenKind.FILE_METADATA_BEGIN,
     "#-}": MLIRTokenKind.FILE_METADATA_END,
@@ -255,23 +252,6 @@ MLIRToken = Token[MLIRTokenKind]
 
 @dataclass
 class MLIRLexer(Lexer[MLIRTokenKind]):
-    _single_char_punctuation: ClassVar[dict[str, MLIRTokenKind]] = {
-        ":": MLIRTokenKind.COLON,
-        ",": MLIRTokenKind.COMMA,
-        "(": MLIRTokenKind.L_PAREN,
-        ")": MLIRTokenKind.R_PAREN,
-        "}": MLIRTokenKind.R_BRACE,
-        "[": MLIRTokenKind.L_SQUARE,
-        "]": MLIRTokenKind.R_SQUARE,
-        "<": MLIRTokenKind.LESS,
-        ">": MLIRTokenKind.GREATER,
-        "=": MLIRTokenKind.EQUAL,
-        "+": MLIRTokenKind.PLUS,
-        "*": MLIRTokenKind.STAR,
-        "?": MLIRTokenKind.QUESTION,
-        "|": MLIRTokenKind.VERTICAL_BAR,
-    }
-
     def _is_in_bounds(self, size: Position = 1) -> bool:
         """
         Check if the current position is within the bounds of the input.
@@ -344,10 +324,24 @@ class MLIRLexer(Lexer[MLIRTokenKind]):
             return self._lex_bare_identifier(start_pos)
 
         # single-char punctuation that are not part of a multi-char token
-        if current_char in self._single_char_punctuation:
-            return self._form_token(
-                self._single_char_punctuation[current_char], start_pos
-            )
+        single_char_punctuation = {
+            ":": MLIRTokenKind.COLON,
+            ",": MLIRTokenKind.COMMA,
+            "(": MLIRTokenKind.L_PAREN,
+            ")": MLIRTokenKind.R_PAREN,
+            "}": MLIRTokenKind.R_BRACE,
+            "[": MLIRTokenKind.L_SQUARE,
+            "]": MLIRTokenKind.R_SQUARE,
+            "<": MLIRTokenKind.LESS,
+            ">": MLIRTokenKind.GREATER,
+            "=": MLIRTokenKind.EQUAL,
+            "+": MLIRTokenKind.PLUS,
+            "*": MLIRTokenKind.STAR,
+            "?": MLIRTokenKind.QUESTION,
+            "|": MLIRTokenKind.VERTICAL_BAR,
+        }
+        if current_char in single_char_punctuation:
+            return self._form_token(single_char_punctuation[current_char], start_pos)
 
         # '...'
         if current_char == ".":
@@ -551,22 +545,3 @@ class MLIRLexer(Lexer[MLIRTokenKind]):
         if match is not None:
             return self._form_token(MLIRTokenKind.FLOAT_LIT, start_pos)
         return self._form_token(MLIRTokenKind.INTEGER_LIT, start_pos)
-
-
-@dataclass
-class AttrBodyLexer(MLIRLexer):
-    """Lexer for attribute/type bodies that treats // as slash tokens, not comments.
-
-    This matches MLIR's behavior where the attribute body is extracted via raw
-    character scanning and then re-tokenized without comment handling.
-    """
-
-    _single_char_punctuation: ClassVar[dict[str, MLIRTokenKind]] = {
-        **MLIRLexer._single_char_punctuation,
-        "/": MLIRTokenKind.SLASH,
-    }
-
-    _whitespace_no_comments_regex = re.compile(r"\s*", re.ASCII)
-
-    def _consume_whitespace(self) -> None:
-        self._consume_regex(self._whitespace_no_comments_regex)

--- a/xdsl/utils/mlir_lexer.py
+++ b/xdsl/utils/mlir_lexer.py
@@ -4,7 +4,7 @@ import re
 from dataclasses import dataclass
 from enum import Enum
 from string import hexdigits
-from typing import Literal, TypeAlias, TypeGuard, cast, overload
+from typing import ClassVar, Literal, TypeAlias, TypeGuard, cast, overload
 
 from xdsl.utils.exceptions import ParseError
 from xdsl.utils.lexer import Lexer, Position, Span, Token
@@ -27,6 +27,7 @@ PunctuationSpelling: TypeAlias = Literal[
     ")",
     "]",
     "*",
+    "/",
     "|",
     "{-#",
     "#-}",
@@ -165,6 +166,7 @@ class MLIRTokenKind(Enum):
     R_BRACE = "}"
     R_PAREN = ")"
     R_SQUARE = "]"
+    SLASH = "/"
     STAR = "*"
     VERTICAL_BAR = "|"
     FILE_METADATA_BEGIN = "{-#"
@@ -241,6 +243,7 @@ KIND_BY_PUNCTUATION_SPELLING = {
     ")": MLIRTokenKind.R_PAREN,
     "]": MLIRTokenKind.R_SQUARE,
     "*": MLIRTokenKind.STAR,
+    "/": MLIRTokenKind.SLASH,
     "|": MLIRTokenKind.VERTICAL_BAR,
     "{-#": MLIRTokenKind.FILE_METADATA_BEGIN,
     "#-}": MLIRTokenKind.FILE_METADATA_END,
@@ -252,6 +255,23 @@ MLIRToken = Token[MLIRTokenKind]
 
 @dataclass
 class MLIRLexer(Lexer[MLIRTokenKind]):
+    _single_char_punctuation: ClassVar[dict[str, MLIRTokenKind]] = {
+        ":": MLIRTokenKind.COLON,
+        ",": MLIRTokenKind.COMMA,
+        "(": MLIRTokenKind.L_PAREN,
+        ")": MLIRTokenKind.R_PAREN,
+        "}": MLIRTokenKind.R_BRACE,
+        "[": MLIRTokenKind.L_SQUARE,
+        "]": MLIRTokenKind.R_SQUARE,
+        "<": MLIRTokenKind.LESS,
+        ">": MLIRTokenKind.GREATER,
+        "=": MLIRTokenKind.EQUAL,
+        "+": MLIRTokenKind.PLUS,
+        "*": MLIRTokenKind.STAR,
+        "?": MLIRTokenKind.QUESTION,
+        "|": MLIRTokenKind.VERTICAL_BAR,
+    }
+
     def _is_in_bounds(self, size: Position = 1) -> bool:
         """
         Check if the current position is within the bounds of the input.
@@ -324,24 +344,10 @@ class MLIRLexer(Lexer[MLIRTokenKind]):
             return self._lex_bare_identifier(start_pos)
 
         # single-char punctuation that are not part of a multi-char token
-        single_char_punctuation = {
-            ":": MLIRTokenKind.COLON,
-            ",": MLIRTokenKind.COMMA,
-            "(": MLIRTokenKind.L_PAREN,
-            ")": MLIRTokenKind.R_PAREN,
-            "}": MLIRTokenKind.R_BRACE,
-            "[": MLIRTokenKind.L_SQUARE,
-            "]": MLIRTokenKind.R_SQUARE,
-            "<": MLIRTokenKind.LESS,
-            ">": MLIRTokenKind.GREATER,
-            "=": MLIRTokenKind.EQUAL,
-            "+": MLIRTokenKind.PLUS,
-            "*": MLIRTokenKind.STAR,
-            "?": MLIRTokenKind.QUESTION,
-            "|": MLIRTokenKind.VERTICAL_BAR,
-        }
-        if current_char in single_char_punctuation:
-            return self._form_token(single_char_punctuation[current_char], start_pos)
+        if current_char in self._single_char_punctuation:
+            return self._form_token(
+                self._single_char_punctuation[current_char], start_pos
+            )
 
         # '...'
         if current_char == ".":
@@ -545,3 +551,22 @@ class MLIRLexer(Lexer[MLIRTokenKind]):
         if match is not None:
             return self._form_token(MLIRTokenKind.FLOAT_LIT, start_pos)
         return self._form_token(MLIRTokenKind.INTEGER_LIT, start_pos)
+
+
+@dataclass
+class AttrBodyLexer(MLIRLexer):
+    """Lexer for attribute/type bodies that treats // as slash tokens, not comments.
+
+    This matches MLIR's behavior where the attribute body is extracted via raw
+    character scanning and then re-tokenized without comment handling.
+    """
+
+    _single_char_punctuation: ClassVar[dict[str, MLIRTokenKind]] = {
+        **MLIRLexer._single_char_punctuation,
+        "/": MLIRTokenKind.SLASH,
+    }
+
+    _whitespace_no_comments_regex = re.compile(r"\s*", re.ASCII)
+
+    def _consume_whitespace(self) -> None:
+        self._consume_regex(self._whitespace_no_comments_regex)


### PR DESCRIPTION
Adds declarative assembly format support for parameterized attributes and types, similar to what already exists for operations. You can now set assembly_format = "..." on a ParametrizedAttribute subclass and get `parse_parameters`/`print_parameters` generated automatically, with support for the directives (keywords, punctuation, optional groups, params, struct, qualified, custom, ref). The attr-side directive hierarchy and parser generally aim to follow the same structure as the op-side ones, although separate from the existing op-side logic.