### PR TITLE
dialects: (riscv) add RISC-V canonicalization patterns for rem, remu, slt, sltu

### DIFF
--- a/tests/filecheck/backend/riscv/canonicalize.mlir
+++ b/tests/filecheck/backend/riscv/canonicalize.mlir
@@ -192,6 +192,22 @@ builtin.module {
 
   // scfgw immediates
   riscv_snitch.scfgw %i1, %c1 : (!riscv.reg<a1>, !riscv.reg) -> ()
+
+  // rem x, 1 = 0
+  %rem_result = riscv.rem %i2, %c1 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+  "test.op"(%rem_result) : (!riscv.reg) -> ()
+
+  // remu x, 1 = 0
+  %remu_result = riscv.remu %i2, %c1 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+  "test.op"(%remu_result) : (!riscv.reg) -> ()
+
+  // slt x, x = 0
+  %slt_result = riscv.slt %i2, %i2 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+  "test.op"(%slt_result) : (!riscv.reg) -> ()
+
+  // sltu x, x = 0
+  %sltu_result = riscv.sltu %i2, %i2 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+  "test.op"(%sltu_result) : (!riscv.reg) -> ()
 }
 
 // CHECK: builtin.module {
@@ -380,6 +396,19 @@ builtin.module {
 // CHECK-NEXT:   "test.op"(%ori_immediate_zero) : (!riscv.reg<a0>) -> ()
 
 // CHECK-NEXT:   riscv_snitch.scfgwi %i1, 1 : (!riscv.reg<a1>) -> ()
+
+// CHECK-NEXT:   %rem_result = rv32.get_register : !riscv.reg<zero>
+// CHECK-NEXT:   %rem_result_1 = riscv.mv %rem_result : (!riscv.reg<zero>) -> !riscv.reg
+// CHECK-NEXT:   "test.op"(%rem_result_1) : (!riscv.reg) -> ()
+// CHECK-NEXT:   %remu_result = rv32.get_register : !riscv.reg<zero>
+// CHECK-NEXT:   %remu_result_1 = riscv.mv %remu_result : (!riscv.reg<zero>) -> !riscv.reg
+// CHECK-NEXT:   "test.op"(%remu_result_1) : (!riscv.reg) -> ()
+// CHECK-NEXT:   %slt_result = rv32.get_register : !riscv.reg<zero>
+// CHECK-NEXT:   %slt_result_1 = riscv.mv %slt_result : (!riscv.reg<zero>) -> !riscv.reg
+// CHECK-NEXT:   "test.op"(%slt_result_1) : (!riscv.reg) -> ()
+// CHECK-NEXT:   %sltu_result = rv32.get_register : !riscv.reg<zero>
+// CHECK-NEXT:   %sltu_result_1 = riscv.mv %sltu_result : (!riscv.reg<zero>) -> !riscv.reg
+// CHECK-NEXT:   "test.op"(%sltu_result_1) : (!riscv.reg) -> ()
 
 // CHECK-NEXT: }
 

--- a/xdsl/dialects/riscv/ops.py
+++ b/xdsl/dialects/riscv/ops.py
@@ -632,6 +632,16 @@ class AddOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
     )
 
 
+class SltOpHasCanonicalizationPatternsTrait(HasCanonicalizationPatternsTrait):
+    @classmethod
+    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+        from xdsl.transforms.canonicalization_patterns.riscv import (
+            SltSameOperand,
+        )
+
+        return (SltSameOperand(),)
+
+
 @irdl_op_definition
 class SltOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
     """
@@ -644,6 +654,17 @@ class SltOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
     """
 
     name = "riscv.slt"
+    traits = traits_def(SltOpHasCanonicalizationPatternsTrait())
+
+
+class SltuOpHasCanonicalizationPatternsTrait(HasCanonicalizationPatternsTrait):
+    @classmethod
+    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+        from xdsl.transforms.canonicalization_patterns.riscv import (
+            SltuSameOperand,
+        )
+
+        return (SltuSameOperand(),)
 
 
 @irdl_op_definition
@@ -658,6 +679,7 @@ class SltuOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
     """
 
     name = "riscv.sltu"
+    traits = traits_def(SltuOpHasCanonicalizationPatternsTrait())
 
 
 class BitwiseAndHasCanonicalizationPatternsTrait(HasCanonicalizationPatternsTrait):
@@ -1446,6 +1468,16 @@ class DivwOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
     name = "riscv.divw"
 
 
+class RemOpHasCanonicalizationPatternsTrait(HasCanonicalizationPatternsTrait):
+    @classmethod
+    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+        from xdsl.transforms.canonicalization_patterns.riscv import (
+            RemByOne,
+        )
+
+        return (RemByOne(),)
+
+
 @irdl_op_definition
 class RemOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
     """
@@ -1456,6 +1488,17 @@ class RemOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
     """
 
     name = "riscv.rem"
+    traits = traits_def(RemOpHasCanonicalizationPatternsTrait())
+
+
+class RemuOpHasCanonicalizationPatternsTrait(HasCanonicalizationPatternsTrait):
+    @classmethod
+    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+        from xdsl.transforms.canonicalization_patterns.riscv import (
+            RemuByOne,
+        )
+
+        return (RemuByOne(),)
 
 
 @irdl_op_definition
@@ -1468,6 +1511,7 @@ class RemuOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
     """
 
     name = "riscv.remu"
+    traits = traits_def(RemuOpHasCanonicalizationPatternsTrait())
 
 
 @irdl_op_definition

--- a/xdsl/transforms/canonicalization_patterns/riscv.py
+++ b/xdsl/transforms/canonicalization_patterns/riscv.py
@@ -657,6 +657,74 @@ _I32_I64_CONSTRAINT = irdl_to_attr_constraint(
 )
 
 
+class RemByOne(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: riscv.RemOp, rewriter: PatternRewriter) -> None:
+        """
+        x % 1 = 0
+        """
+        if (rs2 := get_constant_value(op.rs2)) is not None and rs2.value.data == 1:
+            rd = op.rd.type
+            rewriter.replace_op(
+                op,
+                (
+                    zero := rv32.GetRegisterOp(riscv.Registers.ZERO),
+                    riscv.MVOp(zero.res, rd=rd),
+                ),
+            )
+
+
+class RemuByOne(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: riscv.RemuOp, rewriter: PatternRewriter) -> None:
+        """
+        x %u 1 = 0
+        """
+        if (rs2 := get_constant_value(op.rs2)) is not None and rs2.value.data == 1:
+            rd = op.rd.type
+            rewriter.replace_op(
+                op,
+                (
+                    zero := rv32.GetRegisterOp(riscv.Registers.ZERO),
+                    riscv.MVOp(zero.res, rd=rd),
+                ),
+            )
+
+
+class SltSameOperand(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: riscv.SltOp, rewriter: PatternRewriter) -> None:
+        """
+        x <s x = 0
+        """
+        if op.rs1 == op.rs2:
+            rd = op.rd.type
+            rewriter.replace_op(
+                op,
+                (
+                    zero := rv32.GetRegisterOp(riscv.Registers.ZERO),
+                    riscv.MVOp(zero.res, rd=rd),
+                ),
+            )
+
+
+class SltuSameOperand(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: riscv.SltuOp, rewriter: PatternRewriter) -> None:
+        """
+        x <u x = 0
+        """
+        if op.rs1 == op.rs2:
+            rd = op.rd.type
+            rewriter.replace_op(
+                op,
+                (
+                    zero := rv32.GetRegisterOp(riscv.Registers.ZERO),
+                    riscv.MVOp(zero.res, rd=rd),
+                ),
+            )
+
+
 def get_constant_value(
     value: SSAValue,
 ) -> IntegerAttr[I32] | IntegerAttr[I64] | None:


### PR DESCRIPTION
## Summary
- Add 4 new RISC-V canonicalization patterns:
  - `RemByOne`: `rem(x, 1) → 0`
  - `RemuByOne`: `remu(x, 1) → 0`
  - `SltSameOperand`: `slt(x, x) → 0`
  - `SltuSameOperand`: `sltu(x, x) → 0`
- Register `HasCanonicalizationPatternsTrait` on `RemOp`, `RemuOp`, `SltOp`, `SltuOp`
- Add filecheck tests for all 4 patterns

## Test plan
- [x] Filecheck test passes (`xdsl-opt --split-input-file -p canonicalize | filecheck`)
- [x] Canonicalization unit test passes (`test_canonicalization.py`)
- [x] All 74 RISC-V tests pass with zero regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)