### PR TITLE
core: (attr assembly fmt) add qualified directive (pt4)

### DIFF
--- a/tests/irdl/test_attr_declarative_assembly_format.py
+++ b/tests/irdl/test_attr_declarative_assembly_format.py
@@ -546,6 +546,25 @@ def test_optional_print_correctness(attr: Attribute, expected: str):
 
 
 # ============================================================================
+# Integration tests — qualified directive
+# ============================================================================
+
+
+def test_qualified_roundtrip():
+    """qualified($x) should parse and print identically to $x in xdsl."""
+
+    @irdl_attr_definition
+    class QualifiedType(ParametrizedAttribute, TypeAttribute):
+        name = "test_af.qualified"
+        value: IntegerType = param_def()
+        assembly_format = "qualified($value)"
+
+    ctx = Context(allow_unregistered=True)
+    ctx.load_attr_or_type(QualifiedType)
+    check_roundtrip(QualifiedType, "i32", ctx)
+
+
+# ============================================================================
 # Integration tests — printing correctness
 # ============================================================================
 

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -1690,6 +1690,15 @@ class ParameterVariable(AttrFormatDirective):
 
 
 @dataclass(frozen=True)
+class QualifiedParameterVariable(ParameterVariable):
+    """Wraps a ParameterVariable to print with full dialect qualification.
+
+    In xdsl, print_attribute() always qualifies, so this is currently
+    identical to ParameterVariable. Exists for MLIR format compatibility.
+    """
+
+
+@dataclass(frozen=True)
 class AttrOptionalGroupDirective(AttrFormatDirective):
     """An optional group in attribute assembly format."""
 

--- a/xdsl/irdl/declarative_assembly_format_parser.py
+++ b/xdsl/irdl/declarative_assembly_format_parser.py
@@ -71,6 +71,7 @@ from xdsl.irdl.declarative_assembly_format import (
     OptionalUnitAttrVariable,
     ParameterVariable,
     PunctuationDirective,
+    QualifiedParameterVariable,
     RegionDirective,
     RegionVariable,
     ResultsDirective,
@@ -945,6 +946,8 @@ class AttrFormatParser(BaseParser):
             return self.parse_optional_group()
         if self._current_token.text == "$":
             return self.parse_variable()
+        if self.parse_optional_keyword("qualified"):
+            return self.parse_qualified_directive()
         self.raise_error(f"unexpected token '{self._current_token.text}'")
 
     def parse_variable(self, inside_ref: bool = False) -> ParameterVariable:
@@ -1053,3 +1056,8 @@ class AttrFormatParser(BaseParser):
             then_elements[first_non_whitespace_index + 1 :],
             else_elements,
         )
+
+    def parse_qualified_directive(self) -> QualifiedParameterVariable:
+        with self.in_parens():
+            pv = self.parse_variable()
+            return QualifiedParameterVariable(pv.name, pv.index, pv.is_optional)


### PR DESCRIPTION
Add `QualifiedParameterVariable` (no-op in xdsl since `print_attribute` always qualifies) and `parse_qualified_directive` for MLIR format compatibility.
