### PR TITLE
core: (attr assembly fmt) add params directive (pt5)

### DIFF
--- a/tests/irdl/test_attr_declarative_assembly_format.py
+++ b/tests/irdl/test_attr_declarative_assembly_format.py
@@ -565,6 +565,58 @@ def test_qualified_roundtrip():
 
 
 # ============================================================================
+# Integration tests — params directive
+# ============================================================================
+
+
+def test_params_directive_roundtrip():
+    """params captures all parameters, printed comma-separated."""
+
+    @irdl_attr_definition
+    class ParamsType(ParametrizedAttribute, TypeAttribute):
+        name = "test_af.params_all"
+        a: IntegerType = param_def()
+        b: IntegerType = param_def()
+        assembly_format = "params"
+
+    ctx = Context(allow_unregistered=True)
+    ctx.load_attr_or_type(ParamsType)
+    check_roundtrip(ParamsType, "i32, i64", ctx)
+
+
+def test_params_directive_three_params():
+    """params with three parameters."""
+
+    @irdl_attr_definition
+    class Params3Type(ParametrizedAttribute, TypeAttribute):
+        name = "test_af.params3"
+        a: IntegerType = param_def()
+        b: IntegerType = param_def()
+        c: IntegerType = param_def()
+        assembly_format = "params"
+
+    ctx = Context(allow_unregistered=True)
+    ctx.load_attr_or_type(Params3Type)
+    check_roundtrip(Params3Type, "i1, i32, i64", ctx)
+
+
+def test_params_with_optional():
+    """params with optional parameter omitted."""
+
+    @irdl_attr_definition
+    class ParamsOptType(ParametrizedAttribute, TypeAttribute):
+        name = "test_af.params_opt"
+        req: IntegerType = param_def()
+        opt: IntegerType | NoneAttr = param_def()
+        assembly_format = "params"
+
+    ctx = Context(allow_unregistered=True)
+    ctx.load_attr_or_type(ParamsOptType)
+    check_roundtrip(ParamsOptType, "i32, i64", ctx)
+    check_roundtrip(ParamsOptType, "i32", ctx)
+
+
+# ============================================================================
 # Integration tests — printing correctness
 # ============================================================================
 

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -1699,6 +1699,41 @@ class QualifiedParameterVariable(ParameterVariable):
 
 
 @dataclass(frozen=True)
+class ParamsDirective(AttrFormatDirective):
+    """Captures all parameters of an attribute, printed comma-separated."""
+
+    params: tuple[ParameterVariable, ...]
+
+    def parse(self, parser: AttrParser, state: AttrParsingState) -> bool:
+        non_optional = [p for p in self.params if not p.is_optional]
+        optional = [p for p in self.params if p.is_optional]
+        for i, pv in enumerate(non_optional):
+            if i:
+                parser.parse_punctuation(",")
+            pv.parse(parser, state)
+        for pv in optional:
+            if not parser.parse_optional_punctuation(","):
+                pv.set_empty(state)
+                continue
+            pv.parse(parser, state)
+        return True
+
+    def print(
+        self, printer: Printer, state: PrintingState, attr: ParametrizedAttribute, /
+    ) -> None:
+        first = True
+        for pv in self.params:
+            if not pv.is_present(attr):
+                continue
+            if not first:
+                printer.print_string(", ")
+                state.should_emit_space = False
+                state.last_was_punctuation = True
+            first = False
+            pv.print(printer, state, attr)
+
+
+@dataclass(frozen=True)
 class AttrOptionalGroupDirective(AttrFormatDirective):
     """An optional group in attribute assembly format."""
 

--- a/xdsl/irdl/declarative_assembly_format_parser.py
+++ b/xdsl/irdl/declarative_assembly_format_parser.py
@@ -70,6 +70,7 @@ from xdsl.irdl.declarative_assembly_format import (
     OptionalSuccessorVariable,
     OptionalUnitAttrVariable,
     ParameterVariable,
+    ParamsDirective,
     PunctuationDirective,
     QualifiedParameterVariable,
     RegionDirective,
@@ -948,6 +949,8 @@ class AttrFormatParser(BaseParser):
             return self.parse_variable()
         if self.parse_optional_keyword("qualified"):
             return self.parse_qualified_directive()
+        if self.parse_optional_keyword("params"):
+            return self.parse_params_directive()
         self.raise_error(f"unexpected token '{self._current_token.text}'")
 
     def parse_variable(self, inside_ref: bool = False) -> ParameterVariable:
@@ -1061,3 +1064,17 @@ class AttrFormatParser(BaseParser):
         with self.in_parens():
             pv = self.parse_variable()
             return QualifiedParameterVariable(pv.name, pv.index, pv.is_optional)
+
+    def _all_param_variables(self) -> tuple[ParameterVariable, ...]:
+        """Create ParameterVariable instances for all parameters."""
+        params: list[ParameterVariable] = []
+        for idx, (name, param_def) in enumerate(self.attr_def.parameters):
+            if name in self.seen_parameters:
+                self.raise_error(f"parameter '{name}' is already bound")
+            self.seen_parameters.add(name)
+            is_optional = param_def.constr.verifies(NoneAttr())
+            params.append(ParameterVariable(name, idx, is_optional))
+        return tuple(params)
+
+    def parse_params_directive(self) -> ParamsDirective:
+        return ParamsDirective(self._all_param_variables())


### PR DESCRIPTION
Add `ParamsDirective` that captures all parameters of an attribute and prints them comma-separated. Includes `_all_param_variables` helper in `AttrFormatParser`, with tests for basic, three-param, and optional cases.