### PR TITLE
dialects: (llvm) <STACKED> custom print/parse for inline_asm, global, call, call_intrinsic

### DIFF
--- a/tests/filecheck/backend/llvm/convert_op.mlir
+++ b/tests/filecheck/backend/llvm/convert_op.mlir
@@ -361,11 +361,7 @@ builtin.module {
   }
 
   llvm.func @inline_asm(%arg0: i32) {
-    "llvm.inline_asm"(%arg0) <{
-      asm_string = "add $0, 1",
-      constraints = "r",
-      has_side_effects
-    }> : (i32) -> ()
+    llvm.inline_asm has_side_effects "add $0, 1", "r" %arg0 : (i32) -> ()
     llvm.return
   }
 
@@ -773,13 +769,7 @@ builtin.module {
 
   // forward_ref_caller calls forward_ref_callee which is defined AFTER it
   llvm.func @forward_ref_caller(%arg0: i32) -> i32 {
-    %0 = "llvm.call"(%arg0) <{
-      callee = @forward_ref_callee,
-      fastmathFlags = #llvm.fastmath<none>,
-      CConv = #llvm.cconv<ccc>,
-      TailCallKind = #llvm.tailcallkind<none>,
-      operandSegmentSizes = array<i32: 1, 0>
-    }> : (i32) -> i32
+    %0 = llvm.call @forward_ref_callee(%arg0) : (i32) -> i32
     llvm.return %0 : i32
   }
 
@@ -811,13 +801,7 @@ builtin.module {
   // CHECK-NEXT: }
 
   llvm.func @call_op(%arg0: i32) -> i32 {
-    %0 = "llvm.call"(%arg0) <{
-      callee = @helper,
-      fastmathFlags = #llvm.fastmath<nnan, ninf>,
-      CConv = #llvm.cconv<fastcc>,
-      TailCallKind = #llvm.tailcallkind<tail>,
-      operandSegmentSizes = array<i32: 1, 0>
-    }> : (i32) -> i32
+    %0 = llvm.call fastcc tail @helper(%arg0) {fastmathFlags = #llvm.fastmath<nnan, ninf>} : (i32) -> i32
     llvm.return %0 : i32
   }
 
@@ -883,7 +867,7 @@ builtin.module {
 
   llvm.func @addressof_op() {
     %0 = llvm.mlir.addressof @addressof_target : !llvm.ptr
-    "llvm.call"(%0) <{callee = @callee, fastmathFlags = #llvm.fastmath<>, CConv = #llvm.cconv<ccc>, TailCallKind = #llvm.tailcallkind<none>, operandSegmentSizes = array<i32: 1, 0>}> : (!llvm.ptr) -> ()
+    llvm.call @callee(%0) : (!llvm.ptr) -> ()
     llvm.return
   }
 

--- a/tests/filecheck/dialects/llvm/func.mlir
+++ b/tests/filecheck/dialects/llvm/func.mlir
@@ -96,3 +96,36 @@ llvm.func @_mlir_ciface_wrapped_function(i32, i32) attributes {llvm.emit_c_inter
 // CHECK-NEXT:    llvm.return
 // CHECK-NEXT:  }
 // CHECK-NEXT:  llvm.func @_mlir_ciface_wrapped_function(i32, i32) attributes {llvm.emit_c_interface, sym_visibility = "private"}
+
+llvm.func @float_callee(f32) -> f32
+llvm.func @variadic_callee(i32, ...) -> i32
+
+llvm.func @test_calls(%arg0: i32, %fptr: !llvm.ptr, %farg: f32) {
+  llvm.call @_mlir_ciface_wrapped_function(%arg0, %arg0) : (i32, i32) -> ()
+  %0 = llvm.call %fptr(%arg0) : !llvm.ptr, (i32) -> i32
+  llvm.call tail @external_func(%arg0) : (i32) -> ()
+  llvm.call fastcc @external_func(%arg0) : (i32) -> ()
+  %1 = llvm.call @variadic_callee(%arg0) vararg(!llvm.func<i32 (i32, ...)>) : (i32) -> i32
+  %2 = llvm.call @float_callee(%farg) {fastmathFlags = #llvm.fastmath<fast>} : (f32) -> f32
+  llvm.return
+}
+
+// CHECK: llvm.func @float_callee(f32) -> f32
+// CHECK-NEXT: llvm.func @variadic_callee(i32, ...) -> i32
+// CHECK-NEXT: llvm.func @test_calls(%{{.*}}: i32, %{{.*}}: !llvm.ptr, %{{.*}}: f32) {
+// CHECK-NEXT:   llvm.call @_mlir_ciface_wrapped_function(%{{.*}}, %{{.*}}) : (i32, i32) -> ()
+// CHECK-NEXT:   %{{.*}} = llvm.call %{{.*}}(%{{.*}}) : !llvm.ptr, (i32) -> i32
+// CHECK-NEXT:   llvm.call tail @external_func(%{{.*}}) : (i32) -> ()
+// CHECK-NEXT:   llvm.call fastcc @external_func(%{{.*}}) : (i32) -> ()
+// CHECK-NEXT:   %{{.*}} = llvm.call @variadic_callee(%{{.*}}) vararg(!llvm.func<i32 (i32, ...)>) : (i32) -> i32
+// CHECK-NEXT:   %{{.*}} = llvm.call @float_callee(%{{.*}}) {fastmathFlags = #llvm.fastmath<fast>} : (f32) -> f32
+// CHECK-NEXT:   llvm.return
+// CHECK-NEXT: }
+
+%ci0, %ci1 = "test.op"() : () -> (i64, i64)
+%ci2 = llvm.call_intrinsic "llvm.smax"(%ci0, %ci1) : (i64, i64) -> i64
+llvm.call_intrinsic "llvm.donothing"() : () -> ()
+
+// CHECK: %ci0, %ci1 = "test.op"() : () -> (i64, i64)
+// CHECK-NEXT: %ci2 = llvm.call_intrinsic "llvm.smax"(%ci0, %ci1) : (i64, i64) -> i64
+// CHECK-NEXT: llvm.call_intrinsic "llvm.donothing"() : () -> ()

--- a/tests/filecheck/dialects/llvm/func.mlir
+++ b/tests/filecheck/dialects/llvm/func.mlir
@@ -85,14 +85,14 @@ llvm.func @func_with_attrs() attributes {hello = "world"} {
 // CHECK-NEXT: }
 
 llvm.func private @wrapped_function(%arg0: i32, %arg1: i32) attributes {llvm.emit_c_interface, sym_visibility = "private"} {
-   "llvm.call"(%arg0, %arg1) <{CConv = #llvm.cconv<ccc>, TailCallKind = #llvm.tailcallkind<none>, callee = @_mlir_ciface_wrapped_function, fastmathFlags = #llvm.fastmath<none>, op_bundle_sizes = array<i32>, operandSegmentSizes = array<i32: 2, 0>}> : (i32, i32) -> ()
+   llvm.call @_mlir_ciface_wrapped_function(%arg0, %arg1) : (i32, i32) -> ()
    llvm.return
 }
 
 llvm.func @_mlir_ciface_wrapped_function(i32, i32) attributes {llvm.emit_c_interface, sym_visibility = "private"}
 
 // CHECK:  llvm.func private @wrapped_function(%{{.*}}: i32, %{{.*}}: i32) attributes {llvm.emit_c_interface, sym_visibility = "private"} {
-// CHECK-NEXT:    "llvm.call"(%{{.*}}, %{{.*}}) <{CConv = #llvm.cconv<ccc>, TailCallKind = #llvm.tailcallkind<none>, callee = @_mlir_ciface_wrapped_function, fastmathFlags = #llvm.fastmath<none>, op_bundle_sizes = array<i32>, operandSegmentSizes = array<i32: 2, 0>}> : (i32, i32) -> ()
+// CHECK-NEXT:    llvm.call @_mlir_ciface_wrapped_function(%{{.*}}, %{{.*}}) : (i32, i32) -> ()
 // CHECK-NEXT:    llvm.return
 // CHECK-NEXT:  }
 // CHECK-NEXT:  llvm.func @_mlir_ciface_wrapped_function(i32, i32) attributes {llvm.emit_c_interface, sym_visibility = "private"}

--- a/tests/filecheck/dialects/llvm/global.mlir
+++ b/tests/filecheck/dialects/llvm/global.mlir
@@ -10,6 +10,8 @@ builtin.module {
     %0 = llvm.mlir.constant(42) : i64
     llvm.return %0 : i64
   }
+  llvm.mlir.global internal constant @str_inferred("test") {addr_space = 0 : i32}
+  llvm.mlir.global private @val_inferred(42 : i32) {addr_space = 0 : i32}
   %0 = llvm.mlir.addressof @str0 : !llvm.ptr
   %1 = llvm.getelementptr %0[0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.array<13 x i8>
 }
@@ -25,6 +27,8 @@ builtin.module {
 // CHECK-NEXT:     %0 = llvm.mlir.constant(42) : i64
 // CHECK-NEXT:     llvm.return %0 : i64
 // CHECK-NEXT:   }
+// CHECK-NEXT:   llvm.mlir.global internal constant @str_inferred("test") {addr_space = 0 : i32} : !llvm.array<4 x i8>
+// CHECK-NEXT:   llvm.mlir.global private @val_inferred(42 : i32) {addr_space = 0 : i32} : i32
 // CHECK-NEXT:   %1 = llvm.mlir.addressof @str0 : !llvm.ptr
 // CHECK-NEXT:   %2 = llvm.getelementptr %1[0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.array<13 x i8>
 // CHECK-NEXT: }

--- a/tests/filecheck/dialects/llvm/global.mlir
+++ b/tests/filecheck/dialects/llvm/global.mlir
@@ -1,14 +1,30 @@
 // RUN: XDSL_ROUNDTRIP
 builtin.module {
-  "llvm.mlir.global"() ({
-  }) {"global_type" = !llvm.array<13 x i8>, "sym_name" = "str0", "linkage" = #llvm.linkage<"internal">, "addr_space" = 0 : i32, "constant", "value" = "Hello world!\n", "unnamed_addr" = 0 : i64} : () -> ()
+  llvm.mlir.global internal constant @str0("Hello world!\n") {addr_space = 0 : i32} : !llvm.array<13 x i8>
+  llvm.mlir.global external @x() {addr_space = 0 : i32} : i32
+  llvm.mlir.global private @y(42 : i32) {addr_space = 0 : i32} : i32
+  llvm.mlir.global external thread_local @tl() {addr_space = 0 : i32} : i32
+  llvm.mlir.global external unnamed_addr @u() {addr_space = 0 : i32} : i32
+  llvm.mlir.global external local_unnamed_addr @l() {addr_space = 0 : i32} : i32
+  llvm.mlir.global external @g_with_init() {addr_space = 0 : i32} : i64 {
+    %0 = llvm.mlir.constant(42) : i64
+    llvm.return %0 : i64
+  }
   %0 = llvm.mlir.addressof @str0 : !llvm.ptr
   %1 = llvm.getelementptr %0[0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.array<13 x i8>
 }
 
 // CHECK: builtin.module {
-// CHECK-NEXT:   "llvm.mlir.global"() <{global_type = !llvm.array<13 x i8>, constant, sym_name = "str0", linkage = #llvm.linkage<"internal">, value = "Hello world!\n", addr_space = 0 : i32, unnamed_addr = 0 : i64}> ({
-// CHECK-NEXT:   }) : () -> ()
-// CHECK-NEXT:   %0 = llvm.mlir.addressof @str0 : !llvm.ptr
-// CHECK-NEXT:   %1 = llvm.getelementptr %0[0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.array<13 x i8>
+// CHECK-NEXT:   llvm.mlir.global internal constant @str0("Hello world!\n") {addr_space = 0 : i32} : !llvm.array<13 x i8>
+// CHECK-NEXT:   llvm.mlir.global external @x() {addr_space = 0 : i32} : i32
+// CHECK-NEXT:   llvm.mlir.global private @y(42 : i32) {addr_space = 0 : i32} : i32
+// CHECK-NEXT:   llvm.mlir.global external thread_local @tl() {addr_space = 0 : i32} : i32
+// CHECK-NEXT:   llvm.mlir.global external unnamed_addr @u() {addr_space = 0 : i32} : i32
+// CHECK-NEXT:   llvm.mlir.global external local_unnamed_addr @l() {addr_space = 0 : i32} : i32
+// CHECK-NEXT:   llvm.mlir.global external @g_with_init() {addr_space = 0 : i32} : i64 {
+// CHECK-NEXT:     %0 = llvm.mlir.constant(42) : i64
+// CHECK-NEXT:     llvm.return %0 : i64
+// CHECK-NEXT:   }
+// CHECK-NEXT:   %1 = llvm.mlir.addressof @str0 : !llvm.ptr
+// CHECK-NEXT:   %2 = llvm.getelementptr %1[0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.array<13 x i8>
 // CHECK-NEXT: }

--- a/tests/filecheck/dialects/llvm/inline_asm.mlir
+++ b/tests/filecheck/dialects/llvm/inline_asm.mlir
@@ -2,15 +2,18 @@
 
 %0 = "test.op"() : () -> i32
 %1 = "test.op"() : () -> i32
-"llvm.inline_asm"(%0, %1) <{asm_string = "csrw $0, $1", constraints = "i, r", has_side_effects, tail_call_kind = #llvm.tailcallkind<none>}> : (i32, i32) -> ()
+llvm.inline_asm has_side_effects "csrw $0, $1", "i, r" %0, %1 : (i32, i32) -> ()
 
 %2 = "test.op"() : () -> vector<8xf32>
 %3 = "test.op"() : () -> vector<8xf32>
-%4 = "llvm.inline_asm"(%2, %3) <{asm_dialect = 1 : i64, asm_string = "vaddps $0, $1, $2", constraints = "=x,x,x", tail_call_kind = #llvm.tailcallkind<none>}> : (vector<8xf32>, vector<8xf32>) -> vector<8xf32>
+%4 = llvm.inline_asm asm_dialect = intel "vaddps $0, $1, $2", "=x,x,x" %2, %3 : (vector<8xf32>, vector<8xf32>) -> vector<8xf32>
+
+%5 = llvm.inline_asm is_align_stack tail_call_kind = <tail> "foo", "=r,r" %0, %1 : (i32, i32) -> i32
 
 // CHECK: %0 = "test.op"() : () -> i32
-// CHECK-NEXT: 1 = "test.op"() : () -> i32
-// CHECK-NEXT: "llvm.inline_asm"(%0, %1) <{asm_string = "csrw $0, $1", constraints = "i, r", has_side_effects, tail_call_kind = #llvm.tailcallkind<none>}> : (i32, i32) -> ()
+// CHECK-NEXT: %1 = "test.op"() : () -> i32
+// CHECK-NEXT: llvm.inline_asm has_side_effects "csrw $0, $1", "i, r" %0, %1 : (i32, i32) -> ()
 // CHECK-NEXT: %2 = "test.op"() : () -> vector<8xf32>
 // CHECK-NEXT: %3 = "test.op"() : () -> vector<8xf32>
-// CHECK-NEXT: %4 = "llvm.inline_asm"(%2, %3) <{asm_dialect = 1 : i64, asm_string = "vaddps $0, $1, $2", constraints = "=x,x,x", tail_call_kind = #llvm.tailcallkind<none>}> : (vector<8xf32>, vector<8xf32>) -> vector<8xf32>
+// CHECK-NEXT: %4 = llvm.inline_asm asm_dialect = intel "vaddps $0, $1, $2", "=x,x,x" %2, %3 : (vector<8xf32>, vector<8xf32>) -> vector<8xf32>
+// CHECK-NEXT: %5 = llvm.inline_asm is_align_stack tail_call_kind = <tail> "foo", "=r,r" %0, %1 : (i32, i32) -> i32

--- a/tests/filecheck/dialects/llvm/invalid.mlir
+++ b/tests/filecheck/dialects/llvm/invalid.mlir
@@ -85,7 +85,7 @@ func.func @constant_op_rejects_invalid_prop() {
 // -----
 
 llvm.func @caller(%arg0: i32) -> i32 {
-  %0 = "llvm.call"(%arg0) <{callee = @unknown_fn, op_bundle_sizes = array<i32>, operandSegmentSizes = array<i32: 1, 0>}> : (i32) -> i32
+  %0 = llvm.call @unknown_fn(%arg0) : (i32) -> i32
   llvm.return %0 : i32
 }
 
@@ -98,7 +98,7 @@ func.func @not_llvm_func(%arg0: i32) -> i32 {
 }
 
 llvm.func @caller(%arg0: i32) -> i32 {
-  %0 = "llvm.call"(%arg0) <{callee = @not_llvm_func, op_bundle_sizes = array<i32>, operandSegmentSizes = array<i32: 1, 0>}> : (i32) -> i32
+  %0 = llvm.call @not_llvm_func(%arg0) : (i32) -> i32
   llvm.return %0 : i32
 }
 

--- a/tests/filecheck/dialects/llvm/invalid.mlir
+++ b/tests/filecheck/dialects/llvm/invalid.mlir
@@ -134,3 +134,13 @@ func.func @insertvalue_into_scalar() {
 }
 
 // CHECK: cannot index into i32
+
+// -----
+
+func.func @inline_asm_unknown_dialect() {
+  %v = "test.op"() : () -> i32
+  llvm.inline_asm asm_dialect = bogus "nop", "" %v : (i32) -> ()
+  func.return
+}
+
+// CHECK: unknown asm dialect 'bogus'

--- a/tests/filecheck/dialects/llvm/invalid.mlir
+++ b/tests/filecheck/dialects/llvm/invalid.mlir
@@ -144,3 +144,11 @@ func.func @inline_asm_unknown_dialect() {
 }
 
 // CHECK: unknown asm dialect 'bogus'
+
+// -----
+
+builtin.module {
+  llvm.mlir.global external @no_type_no_value() {addr_space = 0 : i32}
+}
+
+// CHECK: expected `:` followed by global type

--- a/tests/filecheck/dialects/printf/printf_to_llvm.mlir
+++ b/tests/filecheck/dialects/printf/printf_to_llvm.mlir
@@ -13,12 +13,11 @@ builtin.module {
 
 // CHECK:       %{{\d+}} = llvm.mlir.addressof @Hello_f_842f9d94ff2eba9703926bef3c2bc5f427db9871 : !llvm.ptr
 
-// CHECK:       "llvm.call"(%{{\d+}}, %{{\d+}}, %{{\d+}}) <{callee = @printf{{.*}}}> : (!llvm.ptr, f64, i32) -> ()
+// CHECK:       llvm.call @printf(%{{\d+}}, %{{\d+}}, %{{\d+}}){{.*}} : (!llvm.ptr, f64, i32) -> ()
 
 // CHECK:       llvm.func @printf(!llvm.ptr, ...)
 
-// CHECK:       "llvm.mlir.global"() <{global_type = !llvm.array<14 x i8>, sym_name = "Hello_f_842f9d94ff2eba9703926bef3c2bc5f427db9871", linkage = #llvm.linkage<"internal">, addr_space = 0 : i32, constant, value = dense<[72, 101, 108, 108, 111, 58, 32, 37, 102, 32, 37, 105, 10, 0]> : tensor<14xi8>}> ({
-// CHECK-NEXT:  }) : () -> ()
+// CHECK:       llvm.mlir.global internal constant @Hello_f_842f9d94ff2eba9703926bef3c2bc5f427db9871(dense<[72, 101, 108, 108, 111, 58, 32, 37, 102, 32, 37, 105, 10, 0]> : tensor<14xi8>) {addr_space = 0 : i32} : !llvm.array<14 x i8>
 
 // -----
 

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/func.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/func.mlir
@@ -89,14 +89,30 @@ llvm.func @func_with_attrs() attributes {hello = "world"} {
 // CHECK-NEXT: }
 
 llvm.func private @wrapped_function(%arg0: i32, %arg1: i32) attributes {llvm.emit_c_interface, sym_visibility = "private"} {
-   //"llvm.call"(%arg0, %arg1) <{CConv = #llvm.cconv<ccc>, TailCallKind = #llvm.tailcallkind<none>, callee = @_mlir_ciface_wrapped_function, fastmathFlags = #llvm.fastmath<none>, op_bundle_sizes = array<i32>, operandSegmentSizes = array<i32: 2, 0>}> : (i32, i32) -> ()
+   llvm.call @_mlir_ciface_wrapped_function(%arg0, %arg1) : (i32, i32) -> ()
    llvm.return
 }
 
 llvm.func @_mlir_ciface_wrapped_function(i32, i32) attributes {llvm.emit_c_interface, sym_visibility = "private"}
 
 // CHECK:  llvm.func private @wrapped_function(%{{.*}}: i32, %{{.*}}: i32) attributes {llvm.emit_c_interface, sym_visibility = "private"} {
-//     "llvm.call"(%{{.*}}, %{{.*}}) <{CConv = #llvm.cconv<ccc>, TailCallKind = #llvm.tailcallkind<none>, callee = @_mlir_ciface_wrapped_function, fastmathFlags = #llvm.fastmath<none>, op_bundle_sizes = array<i32>, operandSegmentSizes = array<i32: 2, 0>}> : (i32, i32) -> ()
+// CHECK-NEXT:    llvm.call @_mlir_ciface_wrapped_function(%{{.*}}, %{{.*}}) : (i32, i32) -> ()
 // CHECK-NEXT:    llvm.return
 // CHECK-NEXT:  }
 // CHECK-NEXT:  llvm.func @_mlir_ciface_wrapped_function(i32, i32) attributes {llvm.emit_c_interface, sym_visibility = "private"}
+
+llvm.func @test_calls(%arg0: i64, %fptr: !llvm.ptr) {
+  %0 = llvm.call %fptr(%arg0) : !llvm.ptr, (i64) -> i64
+  llvm.call tail @external_func(%arg0) : (i64) -> ()
+  llvm.call fastcc @external_func(%arg0) : (i64) -> ()
+  llvm.call_intrinsic "llvm.donothing"() : () -> ()
+  llvm.return
+}
+
+// CHECK: llvm.func @test_calls(%{{.*}}: i64, %{{.*}}: !llvm.ptr) {
+// CHECK-NEXT:   %{{.*}} = llvm.call %{{.*}}(%{{.*}}) : !llvm.ptr, (i64) -> i64
+// CHECK-NEXT:   llvm.call tail @external_func(%{{.*}}) : (i64) -> ()
+// CHECK-NEXT:   llvm.call fastcc @external_func(%{{.*}}) : (i64) -> ()
+// CHECK-NEXT:   llvm.call_intrinsic "llvm.donothing"() {{.*}}: () -> ()
+// CHECK-NEXT:   llvm.return
+// CHECK-NEXT: }

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/global.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/global.mlir
@@ -1,18 +1,15 @@
-// RUN: mlir-opt %s --mlir-print-op-generic | xdsl-opt --print-op-generic | filecheck %s
-"builtin.module"() ({
-  "llvm.mlir.global"() ({
-  }) {"global_type" = !llvm.array<12 x i8>, "sym_name" = "str0", "linkage" = #llvm.linkage<"internal">, "addr_space" = 0 : i32, "constant", "value" = "Hello world!", "unnamed_addr" = 0 : i64} : () -> ()
-  "llvm.mlir.global"() ({
-  }) {"global_type" = i32, "sym_name" = "data", "linkage" = #llvm.linkage<"internal">, "addr_space" = 0 : i32, "constant", "value" = 0 : i32, "unnamed_addr" = 0 : i64} : () -> ()
+// RUN: MLIR_ROUNDTRIP
+// RUN: MLIR_GENERIC_ROUNDTRIP
+builtin.module {
+  llvm.mlir.global internal constant @str0("Hello world!") {addr_space = 0 : i32} : !llvm.array<12 x i8>
+  llvm.mlir.global internal constant @data(0 : i32) {addr_space = 0 : i32} : i32
   %0 = llvm.mlir.addressof @data : !llvm.ptr
   %1 = llvm.mlir.zero : !llvm.struct<(i32, f32)>
-}) : () -> ()
+}
 
-// CHECK:      "builtin.module"() ({
-// CHECK-NEXT:   "llvm.mlir.global"() <{addr_space = 0 : i32, constant, global_type = !llvm.array<12 x i8>, linkage = #llvm.linkage<"internal">, sym_name = "str0", unnamed_addr = 0 : i64, value = "Hello world!", visibility_ = 0 : i64}> ({
-// CHECK-NEXT:   }) : () -> ()
-// CHECK-NEXT:   "llvm.mlir.global"() <{addr_space = 0 : i32, constant, global_type = i32, linkage = #llvm.linkage<"internal">, sym_name = "data", unnamed_addr = 0 : i64, value = 0 : i32, visibility_ = 0 : i64}> ({
-// CHECK-NEXT:   }) : () -> ()
-// CHECK-NEXT:   %0 = "llvm.mlir.addressof"() <{global_name = @data}> : () -> !llvm.ptr
-// CHECK-NEXT:   %1 = "llvm.mlir.zero"() : () -> !llvm.struct<(i32, f32)>
-// CHECK-NEXT: }) : () -> ()
+// CHECK:      builtin.module {
+// CHECK-NEXT:   llvm.mlir.global internal constant @str0("Hello world!") {{.*}}: !llvm.array<12 x i8>
+// CHECK-NEXT:   llvm.mlir.global internal constant @data(0 : i32) {{.*}}: i32
+// CHECK-NEXT:   %0 = llvm.mlir.addressof @data : !llvm.ptr
+// CHECK-NEXT:   %1 = llvm.mlir.zero : !llvm.struct<(i32, f32)>
+// CHECK-NEXT: }

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/inline_asm.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/inline_asm.mlir
@@ -1,16 +1,20 @@
+// RUN: MLIR_ROUNDTRIP
 // RUN: MLIR_GENERIC_ROUNDTRIP
 
 %0 = "test.op"() : () -> i32
 %1 = "test.op"() : () -> i32
-"llvm.inline_asm"(%0, %1) <{asm_string = "csrw $0, $1", constraints = "i, r", has_side_effects, tail_call_kind = #llvm.tailcallkind<none>}> : (i32, i32) -> ()
+llvm.inline_asm has_side_effects "csrw $0, $1", "i, r" %0, %1 : (i32, i32) -> ()
 
 %2 = "test.op"() : () -> vector<8xf32>
 %3 = "test.op"() : () -> vector<8xf32>
-%4 = "llvm.inline_asm"(%2, %3) <{asm_dialect = 1 : i64, asm_string = "vaddps $0, $1, $2", constraints = "=x,x,x", tail_call_kind = #llvm.tailcallkind<none>}> : (vector<8xf32>, vector<8xf32>) -> vector<8xf32>
+%4 = llvm.inline_asm asm_dialect = intel "vaddps $0, $1, $2", "=x,x,x" %2, %3 : (vector<8xf32>, vector<8xf32>) -> vector<8xf32>
+
+%5 = llvm.inline_asm is_align_stack tail_call_kind = <tail> "foo", "=r,r" %0, %1 : (i32, i32) -> i32
 
 // CHECK: %0 = "test.op"() : () -> i32
-// CHECK-NEXT: 1 = "test.op"() : () -> i32
-// CHECK-NEXT: "llvm.inline_asm"(%0, %1) <{asm_string = "csrw $0, $1", constraints = "i, r", has_side_effects, tail_call_kind = #llvm.tailcallkind<none>}> : (i32, i32) -> ()
+// CHECK-NEXT: %1 = "test.op"() : () -> i32
+// CHECK-NEXT: llvm.inline_asm has_side_effects "csrw $0, $1", "i, r" %0, %1 : (i32, i32) -> ()
 // CHECK-NEXT: %2 = "test.op"() : () -> vector<8xf32>
 // CHECK-NEXT: %3 = "test.op"() : () -> vector<8xf32>
-// CHECK-NEXT: %4 = "llvm.inline_asm"(%2, %3) <{asm_dialect = 1 : i64, asm_string = "vaddps $0, $1, $2", constraints = "=x,x,x", tail_call_kind = #llvm.tailcallkind<none>}> : (vector<8xf32>, vector<8xf32>) -> vector<8xf32>
+// CHECK-NEXT: %4 = llvm.inline_asm asm_dialect = intel "vaddps $0, $1, $2", "=x,x,x" %2, %3 : (vector<8xf32>, vector<8xf32>) -> vector<8xf32>
+// CHECK-NEXT: %5 = llvm.inline_asm is_align_stack tail_call_kind = <tail> "foo", "=r,r" %0, %1 : (i32, i32) -> i32

--- a/tests/filecheck/transforms/convert_riscv_to_llvm.mlir
+++ b/tests/filecheck/transforms/convert_riscv_to_llvm.mlir
@@ -7,61 +7,61 @@
 %x0 = rv32.get_register : !riscv.reg<zero>
 
 // CHECK: builtin.module {
-// CHECK-NEXT:  %reg = "llvm.inline_asm"() <{asm_string = "li $0, 0", constraints = "=r", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : () -> i32
+// CHECK-NEXT:  %reg = llvm.inline_asm "li $0, 0", "=r" : () -> i32
 // CHECK-NEXT:  %reg_1 = builtin.unrealized_conversion_cast %reg : i32 to !riscv.reg
-// CHECK-NEXT:  %a0 = "llvm.inline_asm"() <{asm_string = "li $0, 0", constraints = "=r", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : () -> i32
+// CHECK-NEXT:  %a0 = llvm.inline_asm "li $0, 0", "=r" : () -> i32
 // CHECK-NEXT:  %a0_1 = builtin.unrealized_conversion_cast %a0 : i32 to !riscv.reg<a0>
 // CHECK-NEXT:  %x0 = rv32.get_register : !riscv.reg<zero>
 
 // standard risc-v instructions
 
 %li = rv32.li 0 : !riscv.reg
-// CHECK-NEXT:  %li = "llvm.inline_asm"() <{asm_string = "li $0, 0", constraints = "=r", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : () -> i32
+// CHECK-NEXT:  %li = llvm.inline_asm "li $0, 0", "=r" : () -> i32
 // CHECK-NEXT:  %li_1 = builtin.unrealized_conversion_cast %li : i32 to !riscv.reg
 
 %sub = riscv.sub %reg, %reg : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:  %sub = builtin.unrealized_conversion_cast %reg_1 : !riscv.reg to i32
 // CHECK-NEXT:  %sub_1 = builtin.unrealized_conversion_cast %reg_1 : !riscv.reg to i32
-// CHECK-NEXT:  %sub_2 = "llvm.inline_asm"(%sub, %sub_1) <{asm_string = "sub $0, $1, $2", constraints = "=r,rI,rI", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : (i32, i32) -> i32
+// CHECK-NEXT:  %sub_2 = llvm.inline_asm "sub $0, $1, $2", "=r,rI,rI" %sub, %sub_1 : (i32, i32) -> i32
 // CHECK-NEXT:  %sub_3 = builtin.unrealized_conversion_cast %sub_2 : i32 to !riscv.reg
 
 %div = riscv.div %reg, %reg : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:  %div = builtin.unrealized_conversion_cast %reg_1 : !riscv.reg to i32
 // CHECK-NEXT:  %div_1 = builtin.unrealized_conversion_cast %reg_1 : !riscv.reg to i32
-// CHECK-NEXT:  %div_2 = "llvm.inline_asm"(%div, %div_1) <{asm_string = "div $0, $1, $2", constraints = "=r,rI,rI", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : (i32, i32) -> i32
+// CHECK-NEXT:  %div_2 = llvm.inline_asm "div $0, $1, $2", "=r,rI,rI" %div, %div_1 : (i32, i32) -> i32
 // CHECK-NEXT:  %div_3 = builtin.unrealized_conversion_cast %div_2 : i32 to !riscv.reg
 
 // named riscv registers:
 
 %li_named = rv32.li 0 : !riscv.reg<a0>
-// CHECK-NEXT:  %li_named = "llvm.inline_asm"() <{asm_string = "li $0, 0", constraints = "=r", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : () -> i32
+// CHECK-NEXT:  %li_named = llvm.inline_asm "li $0, 0", "=r" : () -> i32
 // CHECK-NEXT:  %li_named_1 = builtin.unrealized_conversion_cast %li_named : i32 to !riscv.reg<a0>
 
 %sub_named = riscv.sub %a0, %a0 : (!riscv.reg<a0>, !riscv.reg<a0>) -> !riscv.reg
 // CHECK-NEXT:  %sub_named = builtin.unrealized_conversion_cast %a0_1 : !riscv.reg<a0> to i32
 // CHECK-NEXT:  %sub_named_1 = builtin.unrealized_conversion_cast %a0_1 : !riscv.reg<a0> to i32
-// CHECK-NEXT:  %sub_named_2 = "llvm.inline_asm"(%sub_named, %sub_named_1) <{asm_string = "sub $0, $1, $2", constraints = "=r,rI,rI", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : (i32, i32) -> i32
+// CHECK-NEXT:  %sub_named_2 = llvm.inline_asm "sub $0, $1, $2", "=r,rI,rI" %sub_named, %sub_named_1 : (i32, i32) -> i32
 // CHECK-NEXT:  %sub_named_3 = builtin.unrealized_conversion_cast %sub_named_2 : i32 to !riscv.reg
 
 %div_named = riscv.div %a0, %a0 : (!riscv.reg<a0>, !riscv.reg<a0>) -> !riscv.reg
 // CHECK-NEXT:  %div_named = builtin.unrealized_conversion_cast %a0_1 : !riscv.reg<a0> to i32
 // CHECK-NEXT:  %div_named_1 = builtin.unrealized_conversion_cast %a0_1 : !riscv.reg<a0> to i32
-// CHECK-NEXT:  %div_named_2 = "llvm.inline_asm"(%div_named, %div_named_1) <{asm_string = "div $0, $1, $2", constraints = "=r,rI,rI", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : (i32, i32) -> i32
+// CHECK-NEXT:  %div_named_2 = llvm.inline_asm "div $0, $1, $2", "=r,rI,rI" %div_named, %div_named_1 : (i32, i32) -> i32
 // CHECK-NEXT:  %div_named_3 = builtin.unrealized_conversion_cast %div_named_2 : i32 to !riscv.reg
 
 
 // csr instructions
 
 %csrss = riscv.csrrs %x0, 3860, "r" : (!riscv.reg<zero>) -> !riscv.reg
-// CHECK-NEXT:  %csrss = "llvm.inline_asm"() <{asm_string = "csrrs $0, 3860, x0", constraints = "=r", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : () -> i32
+// CHECK-NEXT:  %csrss = llvm.inline_asm "csrrs $0, 3860, x0", "=r" : () -> i32
 // CHECK-NEXT:  %csrss_1 = builtin.unrealized_conversion_cast %csrss : i32 to !riscv.reg
 
 %csrrs = riscv.csrrs %x0, 1986 : (!riscv.reg<zero>) -> !riscv.reg<zero>
 // CHECK-NEXT:  %csrrs = rv32.get_register : !riscv.reg<zero>
-// CHECK-NEXT:  "llvm.inline_asm"() <{asm_string = "csrrs x0, 1986, x0", constraints = "", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : () -> ()
+// CHECK-NEXT:  llvm.inline_asm "csrrs x0, 1986, x0", "" : () -> ()
 
 %csrrci = riscv.csrrci 1984, 1 : () -> !riscv.reg
-// CHECK-NEXT:  %csrrci = "llvm.inline_asm"() <{asm_string = "csrrci $0, 1984, 1", constraints = "=r", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : () -> i32
+// CHECK-NEXT:  %csrrci = llvm.inline_asm "csrrci $0, 1984, 1", "=r" : () -> i32
 // CHECK-NEXT:  %csrrci_1 = builtin.unrealized_conversion_cast %csrrci : i32 to !riscv.reg
 
 
@@ -70,25 +70,25 @@
 riscv_snitch.dmsrc %reg, %reg : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:  %0 = builtin.unrealized_conversion_cast %reg_1 : !riscv.reg to i32
 // CHECK-NEXT:  %1 = builtin.unrealized_conversion_cast %reg_1 : !riscv.reg to i32
-// CHECK-NEXT:  "llvm.inline_asm"(%0, %1) <{asm_string = ".insn r 0x2b, 0, 0, x0, $0, $1", constraints = "rI,rI", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : (i32, i32) -> ()
+// CHECK-NEXT:  llvm.inline_asm ".insn r 0x2b, 0, 0, x0, $0, $1", "rI,rI" %0, %1 : (i32, i32) -> ()
 
 riscv_snitch.dmdst %reg, %reg : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:  %2 = builtin.unrealized_conversion_cast %reg_1 : !riscv.reg to i32
 // CHECK-NEXT:  %3 = builtin.unrealized_conversion_cast %reg_1 : !riscv.reg to i32
-// CHECK-NEXT:  "llvm.inline_asm"(%2, %3) <{asm_string = ".insn r 0x2b, 0, 1, x0, $0, $1", constraints = "rI,rI", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : (i32, i32) -> ()
+// CHECK-NEXT:  llvm.inline_asm ".insn r 0x2b, 0, 1, x0, $0, $1", "rI,rI" %2, %3 : (i32, i32) -> ()
 
 riscv_snitch.dmstr %reg, %reg : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:  %4 = builtin.unrealized_conversion_cast %reg_1 : !riscv.reg to i32
 // CHECK-NEXT:  %5 = builtin.unrealized_conversion_cast %reg_1 : !riscv.reg to i32
-// CHECK-NEXT:  "llvm.inline_asm"(%4, %5) <{asm_string = ".insn r 0x2b, 0, 6, x0, $0, $1", constraints = "rI,rI", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : (i32, i32) -> ()
+// CHECK-NEXT:  llvm.inline_asm ".insn r 0x2b, 0, 6, x0, $0, $1", "rI,rI" %4, %5 : (i32, i32) -> ()
 
 riscv_snitch.dmrep %reg : (!riscv.reg) -> ()
 // CHECK-NEXT:  %6 = builtin.unrealized_conversion_cast %reg_1 : !riscv.reg to i32
-// CHECK-NEXT:  "llvm.inline_asm"(%6) <{asm_string = ".insn r 0x2b, 0, 7, x0, $0, x0", constraints = "rI", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : (i32) -> ()
+// CHECK-NEXT:  llvm.inline_asm ".insn r 0x2b, 0, 7, x0, $0, x0", "rI" %6 : (i32) -> ()
 
 %dmcpyi = riscv_snitch.dmcpyi %reg, 2 : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:  %dmcpyi = builtin.unrealized_conversion_cast %reg_1 : !riscv.reg to i32
-// CHECK-NEXT:  %dmcpyi_1 = "llvm.inline_asm"(%dmcpyi) <{asm_string = ".insn r 0x2b, 0, 2, $0, $1, 2", constraints = "=r,rI", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : (i32) -> i32
+// CHECK-NEXT:  %dmcpyi_1 = llvm.inline_asm ".insn r 0x2b, 0, 2, $0, $1, 2", "=r,rI" %dmcpyi : (i32) -> i32
 // CHECK-NEXT:  %dmcpyi_2 = builtin.unrealized_conversion_cast %dmcpyi_1 : i32 to !riscv.reg
 
 
@@ -97,20 +97,20 @@ riscv_snitch.dmrep %reg : (!riscv.reg) -> ()
 // ------------------------------------------------------- //
 
 // COMPACT:      builtin.module {
-// COMPACT-NEXT:   %reg = "llvm.inline_asm"() <{asm_string = "li $0, 0", constraints = "=r", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : () -> i32
-// COMPACT-NEXT:   %a0 = "llvm.inline_asm"() <{asm_string = "li $0, 0", constraints = "=r", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : () -> i32
-// COMPACT-NEXT:   %li = "llvm.inline_asm"() <{asm_string = "li $0, 0", constraints = "=r", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : () -> i32
-// COMPACT-NEXT:   %sub = "llvm.inline_asm"(%reg, %reg) <{asm_string = "sub $0, $1, $2", constraints = "=r,rI,rI", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : (i32, i32) -> i32
-// COMPACT-NEXT:   %div = "llvm.inline_asm"(%reg, %reg) <{asm_string = "div $0, $1, $2", constraints = "=r,rI,rI", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : (i32, i32) -> i32
-// COMPACT-NEXT:   %li_named = "llvm.inline_asm"() <{asm_string = "li $0, 0", constraints = "=r", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : () -> i32
-// COMPACT-NEXT:   %sub_named = "llvm.inline_asm"(%a0, %a0) <{asm_string = "sub $0, $1, $2", constraints = "=r,rI,rI", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : (i32, i32) -> i32
-// COMPACT-NEXT:   %div_named = "llvm.inline_asm"(%a0, %a0) <{asm_string = "div $0, $1, $2", constraints = "=r,rI,rI", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : (i32, i32) -> i32
-// COMPACT-NEXT:   %csrss = "llvm.inline_asm"() <{asm_string = "csrrs $0, 3860, x0", constraints = "=r", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : () -> i32
-// COMPACT-NEXT:   "llvm.inline_asm"() <{asm_string = "csrrs x0, 1986, x0", constraints = "", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : () -> ()
-// COMPACT-NEXT:   %csrrci = "llvm.inline_asm"() <{asm_string = "csrrci $0, 1984, 1", constraints = "=r", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : () -> i32
-// COMPACT-NEXT:   "llvm.inline_asm"(%reg, %reg) <{asm_string = ".insn r 0x2b, 0, 0, x0, $0, $1", constraints = "rI,rI", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : (i32, i32) -> ()
-// COMPACT-NEXT:   "llvm.inline_asm"(%reg, %reg) <{asm_string = ".insn r 0x2b, 0, 1, x0, $0, $1", constraints = "rI,rI", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : (i32, i32) -> ()
-// COMPACT-NEXT:   "llvm.inline_asm"(%reg, %reg) <{asm_string = ".insn r 0x2b, 0, 6, x0, $0, $1", constraints = "rI,rI", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : (i32, i32) -> ()
-// COMPACT-NEXT:   "llvm.inline_asm"(%reg) <{asm_string = ".insn r 0x2b, 0, 7, x0, $0, x0", constraints = "rI", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : (i32) -> ()
-// COMPACT-NEXT:   %dmcpyi = "llvm.inline_asm"(%reg) <{asm_string = ".insn r 0x2b, 0, 2, $0, $1, 2", constraints = "=r,rI", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : (i32) -> i32
+// COMPACT-NEXT:   %reg = llvm.inline_asm "li $0, 0", "=r" : () -> i32
+// COMPACT-NEXT:   %a0 = llvm.inline_asm "li $0, 0", "=r" : () -> i32
+// COMPACT-NEXT:   %li = llvm.inline_asm "li $0, 0", "=r" : () -> i32
+// COMPACT-NEXT:   %sub = llvm.inline_asm "sub $0, $1, $2", "=r,rI,rI" %reg, %reg : (i32, i32) -> i32
+// COMPACT-NEXT:   %div = llvm.inline_asm "div $0, $1, $2", "=r,rI,rI" %reg, %reg : (i32, i32) -> i32
+// COMPACT-NEXT:   %li_named = llvm.inline_asm "li $0, 0", "=r" : () -> i32
+// COMPACT-NEXT:   %sub_named = llvm.inline_asm "sub $0, $1, $2", "=r,rI,rI" %a0, %a0 : (i32, i32) -> i32
+// COMPACT-NEXT:   %div_named = llvm.inline_asm "div $0, $1, $2", "=r,rI,rI" %a0, %a0 : (i32, i32) -> i32
+// COMPACT-NEXT:   %csrss = llvm.inline_asm "csrrs $0, 3860, x0", "=r" : () -> i32
+// COMPACT-NEXT:   llvm.inline_asm "csrrs x0, 1986, x0", "" : () -> ()
+// COMPACT-NEXT:   %csrrci = llvm.inline_asm "csrrci $0, 1984, 1", "=r" : () -> i32
+// COMPACT-NEXT:   llvm.inline_asm ".insn r 0x2b, 0, 0, x0, $0, $1", "rI,rI" %reg, %reg : (i32, i32) -> ()
+// COMPACT-NEXT:   llvm.inline_asm ".insn r 0x2b, 0, 1, x0, $0, $1", "rI,rI" %reg, %reg : (i32, i32) -> ()
+// COMPACT-NEXT:   llvm.inline_asm ".insn r 0x2b, 0, 6, x0, $0, $1", "rI,rI" %reg, %reg : (i32, i32) -> ()
+// COMPACT-NEXT:   llvm.inline_asm ".insn r 0x2b, 0, 7, x0, $0, x0", "rI" %reg : (i32) -> ()
+// COMPACT-NEXT:   %dmcpyi = llvm.inline_asm ".insn r 0x2b, 0, 2, $0, $1, 2", "=r,rI" %reg : (i32) -> i32
 // COMPACT-NEXT: }

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from types import EllipsisType
 from typing import ClassVar, cast
@@ -1317,11 +1317,6 @@ for the underlying semantics.
 """
 
 
-def _first_keyword(parser: Parser, keywords: Iterable[str]) -> str | None:
-    """Parse the first matching keyword from the given iterable, or `None`."""
-    return next((kw for kw in keywords if parser.parse_optional_keyword(kw)), None)
-
-
 @irdl_op_definition
 class InlineAsmOp(IRDLOperation):
     """
@@ -1920,9 +1915,11 @@ class GlobalOp(IRDLOperation):
 
     @classmethod
     def parse(cls, parser: Parser) -> GlobalOp:
-        linkage = _first_keyword(parser, _LINKAGE_OPTIONS) or "external"
+        linkage = parser.parse_optional_keyword_in(_LINKAGE_OPTIONS) or "external"
         thread_local_ = parser.parse_optional_keyword("thread_local") is not None
-        unnamed_addr_kw = _first_keyword(parser, UNNAMED_ADDR_KEYWORDS.values())
+        unnamed_addr_kw = parser.parse_optional_keyword_in(
+            UNNAMED_ADDR_KEYWORDS.values()
+        )
         unnamed_addr_val = next(
             (v for v, k in UNNAMED_ADDR_KEYWORDS.items() if k == unnamed_addr_kw),
             None,
@@ -2591,10 +2588,10 @@ class CallOp(IRDLOperation):
     @classmethod
     def parse(cls, parser: Parser) -> CallOp:
         cconv = CallingConventionAttr(
-            _first_keyword(parser, LLVM_CALLING_CONVS - {"ccc"}) or "ccc"
+            parser.parse_optional_keyword_in(LLVM_CALLING_CONVS - {"ccc"}) or "ccc"
         )
-        tck_kw = _first_keyword(
-            parser, (k.value for k in TailCallKind if k != TailCallKind.NONE)
+        tck_kw = parser.parse_optional_keyword_in(
+            {k.value for k in TailCallKind if k != TailCallKind.NONE}
         )
         tail_call_kind = TailCallKindAttr(
             TailCallKind(tck_kw) if tck_kw else TailCallKind.NONE

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -1418,12 +1418,13 @@ class InlineAsmOp(IRDLOperation):
         asm_string = parser.parse_str_literal()
         parser.parse_punctuation(",")
         constraints = parser.parse_str_literal()
-        operands: list[UnresolvedOperand] = []
-        first = parser.parse_optional_unresolved_operand()
-        if first is not None:
-            operands.append(first)
-            while parser.parse_optional_punctuation(",") is not None:
-                operands.append(parser.parse_unresolved_operand())
+        operands = (
+            parser.parse_optional_undelimited_comma_separated_list(
+                parser.parse_optional_unresolved_operand,
+                parser.parse_unresolved_operand,
+            )
+            or []
+        )
         attrs = parser.parse_optional_attr_dict()
         parser.parse_punctuation(":")
         ft = parser.parse_function_type()
@@ -1884,22 +1885,18 @@ class GlobalOp(IRDLOperation):
         if self.value is not None:
             printer.print_attribute(self.value)
         printer.print_string(")")
-        reserved = (
-            "global_type",
-            "sym_name",
-            "linkage",
-            "constant",
-            "thread_local_",
-            "unnamed_addr",
-            "value",
+        printer.print_op_attributes(
+            self.properties | self.attributes,
+            reserved_attr_names=(
+                "global_type",
+                "sym_name",
+                "linkage",
+                "constant",
+                "thread_local_",
+                "unnamed_addr",
+                "value",
+            ),
         )
-        attrs = {
-            **{k: v for k, v in self.properties.items() if k not in reserved},
-            **self.attributes,
-        }
-        if attrs:
-            printer.print_string(" ")
-            printer.print_attr_dict(attrs)
         printer.print_string(" : ")
         printer.print_attribute(self.global_type)
         if self.body.blocks:
@@ -2424,14 +2421,10 @@ class CallIntrinsicOp(IRDLOperation):
         printer.print_string("(")
         printer.print_list(self.args, printer.print_ssa_value)
         printer.print_string(")")
-        reserved = ("intrin", "op_bundle_sizes", "operandSegmentSizes")
-        attrs = {
-            **{k: v for k, v in self.properties.items() if k not in reserved},
-            **self.attributes,
-        }
-        if attrs:
-            printer.print_string(" ")
-            printer.print_attr_dict(attrs)
+        printer.print_op_attributes(
+            self.properties | self.attributes,
+            reserved_attr_names=("intrin", "op_bundle_sizes", "operandSegmentSizes"),
+        )
         printer.print_string(" : ")
         printer.print_function_type(
             [v.type for v in self.args],
@@ -2564,25 +2557,20 @@ class CallOp(IRDLOperation):
             printer.print_string(" vararg(")
             printer.print_attribute(self.var_callee_type)
             printer.print_string(")")
-        reserved = (
+        reserved = [
             "callee",
             "var_callee_type",
             "CConv",
             "TailCallKind",
-            "fastmathFlags",
             "op_bundle_sizes",
             "operandSegmentSizes",
+        ]
+        if self.fastmathFlags == FastMathAttr("none"):
+            reserved.append("fastmathFlags")
+        printer.print_op_attributes(
+            self.properties | self.attributes,
+            reserved_attr_names=reserved,
         )
-        attrs = {
-            **{k: v for k, v in self.properties.items() if k not in reserved},
-            **self.attributes,
-        }
-        reserved_fastmath = self.fastmathFlags == FastMathAttr("none")
-        if not reserved_fastmath:
-            attrs["fastmathFlags"] = self.fastmathFlags
-        if attrs:
-            printer.print_string(" ")
-            printer.print_attr_dict(attrs)
         printer.print_string(" : ")
         if self.callee is None:
             printer.print_attribute(self.args[0].type)

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -1306,6 +1306,7 @@ class TailCallKindAttr(EnumAttribute[TailCallKind]):
             super().print_parameter(printer)
 
 
+ASM_DIALECT_KEYWORDS: dict[int, str] = {0: "att", 1: "intel"}
 """
 Mapping from LLVM inline-assembly dialect integer values to their textual
 keyword form. See external
@@ -1314,7 +1315,6 @@ for the MLIR op, and
 [LLVM LangRef](https://llvm.org/docs/LangRef.html#inline-assembler-expressions)
 for the underlying semantics.
 """
-ASM_DIALECT_KEYWORDS: dict[int, str] = {0: "att", 1: "intel"}
 
 
 def _first_keyword(parser: Parser, keywords: Iterable[str]) -> str | None:
@@ -1477,9 +1477,9 @@ ATOMIC_ORDERING_KEYWORDS: dict[int, str] = {
 """
 Mapping from LLVM atomic ordering integer values to their textual keyword form.
 
-See [LLVM LangRef](https://llvm.org/docs/LangRef.html#ordering) for the
-semantics of each ordering, and [MLIR LLVM dialect](https://mlir.llvm.org/docs/Dialects/LLVM/#atomic-ordering)
-for the corresponding MLIR enum values.
+See https://llvm.org/docs/LangRef.html#ordering for the semantics of each
+ordering, and https://mlir.llvm.org/docs/Dialects/LLVM/#atomic-ordering for the
+corresponding MLIR enum values.
 """
 
 
@@ -1794,6 +1794,7 @@ class UndefOp(IRDLOperation):
         super().__init__(result_types=[result_type])
 
 
+UNNAMED_ADDR_KEYWORDS: dict[int, str] = {1: "local_unnamed_addr", 2: "unnamed_addr"}
 """
 Mapping from LLVM `unnamed_addr` integer values to their textual keyword form
 (0 = no keyword). See external
@@ -1802,7 +1803,6 @@ for the MLIR op, and
 [LLVM LangRef](https://llvm.org/docs/LangRef.html#global-variables) for the
 underlying semantics.
 """
-UNNAMED_ADDR_KEYWORDS: dict[int, str] = {1: "local_unnamed_addr", 2: "unnamed_addr"}
 
 
 @irdl_op_definition

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -1472,9 +1472,9 @@ ATOMIC_ORDERING_KEYWORDS: dict[int, str] = {
 """
 Mapping from LLVM atomic ordering integer values to their textual keyword form.
 
-See https://llvm.org/docs/LangRef.html#ordering for the semantics of each
-ordering, and https://mlir.llvm.org/docs/Dialects/LLVM/#atomic-ordering for the
-corresponding MLIR enum values.
+See [LLVM LangRef](https://llvm.org/docs/LangRef.html#ordering) for the
+semantics of each ordering, and [MLIR LLVM dialect](https://mlir.llvm.org/docs/Dialects/LLVM/#atomic-ordering)
+for the corresponding MLIR enum values.
 """
 
 

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from types import EllipsisType
 from typing import ClassVar, cast
@@ -75,7 +75,7 @@ from xdsl.irdl import (
     traits_def,
     var_operand_def,
 )
-from xdsl.parser import AttrParser, Parser, UnresolvedOperand
+from xdsl.parser import AttrParser, Parser
 from xdsl.printer import Printer
 from xdsl.traits import (
     IsTerminator,
@@ -1317,6 +1317,11 @@ for the underlying semantics.
 """
 
 
+def _first_keyword(parser: Parser, keywords: Iterable[str]) -> str | None:
+    """Parse the first matching keyword from the given iterable, or `None`."""
+    return next((kw for kw in keywords if parser.parse_optional_keyword(kw)), None)
+
+
 @irdl_op_definition
 class InlineAsmOp(IRDLOperation):
     """
@@ -1915,17 +1920,11 @@ class GlobalOp(IRDLOperation):
 
     @classmethod
     def parse(cls, parser: Parser) -> GlobalOp:
-        linkage = next(
-            (l for l in _LINKAGE_OPTIONS if parser.parse_optional_keyword(l)),
-            "external",
-        )
+        linkage = _first_keyword(parser, _LINKAGE_OPTIONS) or "external"
         thread_local_ = parser.parse_optional_keyword("thread_local") is not None
+        unnamed_addr_kw = _first_keyword(parser, UNNAMED_ADDR_KEYWORDS.values())
         unnamed_addr_val = next(
-            (
-                v
-                for v, k in UNNAMED_ADDR_KEYWORDS.items()
-                if parser.parse_optional_keyword(k)
-            ),
+            (v for v, k in UNNAMED_ADDR_KEYWORDS.items() if k == unnamed_addr_kw),
             None,
         )
         constant = parser.parse_optional_keyword("constant") is not None
@@ -2592,31 +2591,17 @@ class CallOp(IRDLOperation):
     @classmethod
     def parse(cls, parser: Parser) -> CallOp:
         cconv = CallingConventionAttr(
-            next(
-                (
-                    c
-                    for c in LLVM_CALLING_CONVS - {"ccc"}
-                    if parser.parse_optional_keyword(c)
-                ),
-                "ccc",
-            )
+            _first_keyword(parser, LLVM_CALLING_CONVS - {"ccc"}) or "ccc"
+        )
+        tck_kw = _first_keyword(
+            parser, (k.value for k in TailCallKind if k != TailCallKind.NONE)
         )
         tail_call_kind = TailCallKindAttr(
-            next(
-                (
-                    k
-                    for k in TailCallKind
-                    if k != TailCallKind.NONE and parser.parse_optional_keyword(k.value)
-                ),
-                TailCallKind.NONE,
-            )
+            TailCallKind(tck_kw) if tck_kw else TailCallKind.NONE
         )
-        callee: SymbolRefAttr | None = None
-        callee_ptr: UnresolvedOperand | None = None
-        if (sym_name := parser.parse_optional_symbol_name()) is not None:
-            callee = SymbolRefAttr(sym_name)
-        else:
-            callee_ptr = parser.parse_unresolved_operand()
+        sym_name = parser.parse_optional_symbol_name()
+        callee = SymbolRefAttr(sym_name) if sym_name else None
+        callee_ptr = None if callee else parser.parse_unresolved_operand()
         args_unresolved = parser.parse_comma_separated_list(
             parser.Delimiter.PAREN, parser.parse_unresolved_operand
         )

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -52,6 +52,7 @@ from xdsl.ir import (
     Region,
     SSAValue,
     TypeAttribute,
+    TypedAttribute,
 )
 from xdsl.irdl import (
     AnyAttr,
@@ -1306,6 +1307,14 @@ class TailCallKindAttr(EnumAttribute[TailCallKind]):
 
 
 ASM_DIALECT_KEYWORDS: dict[int, str] = {0: "att", 1: "intel"}
+"""
+Mapping from LLVM inline-assembly dialect integer values to their textual
+keyword form. See external
+[documentation](https://mlir.llvm.org/docs/Dialects/LLVM/#llvminline_asm-llvminlineasmop)
+for the MLIR op, and
+[LLVM LangRef](https://llvm.org/docs/LangRef.html#inline-assembler-expressions)
+for the underlying semantics.
+"""
 
 
 @irdl_op_definition
@@ -1787,7 +1796,15 @@ class UndefOp(IRDLOperation):
         super().__init__(result_types=[result_type])
 
 
-_UNNAMED_ADDR_KEYWORDS: dict[int, str] = {1: "local_unnamed_addr", 2: "unnamed_addr"}
+UNNAMED_ADDR_KEYWORDS: dict[int, str] = {1: "local_unnamed_addr", 2: "unnamed_addr"}
+"""
+Mapping from LLVM `unnamed_addr` integer values to their textual keyword form
+(0 = no keyword). See external
+[documentation](https://mlir.llvm.org/docs/Dialects/LLVM/#llvmmlirglobal-llvmglobalop)
+for the MLIR op, and
+[LLVM LangRef](https://llvm.org/docs/LangRef.html#global-variables) for the
+underlying semantics.
+"""
 
 
 @irdl_op_definition
@@ -1874,7 +1891,7 @@ class GlobalOp(IRDLOperation):
         if self.thread_local_ is not None:
             printer.print_string(" thread_local")
         if self.unnamed_addr is not None:
-            kw = _UNNAMED_ADDR_KEYWORDS.get(self.unnamed_addr.value.data)
+            kw = UNNAMED_ADDR_KEYWORDS.get(self.unnamed_addr.value.data)
             if kw is not None:
                 printer.print_string(f" {kw}")
         if self.constant is not None:
@@ -1926,8 +1943,15 @@ class GlobalOp(IRDLOperation):
             value = parser.parse_attribute()
             parser.parse_punctuation(")")
         attrs = parser.parse_optional_attr_dict()
-        parser.parse_punctuation(":")
-        global_type = parser.parse_type()
+        global_type: Attribute | None = None
+        if parser.parse_optional_punctuation(":") is not None:
+            global_type = parser.parse_type()
+        elif isinstance(value, StringAttr):
+            global_type = LLVMArrayType(len(value.data), IntegerType(8))
+        elif isinstance(value, TypedAttribute):
+            global_type = value.type
+        if global_type is None:
+            parser.raise_error("expected `:` followed by global type")
         body = parser.parse_optional_region()
         addr_space = 0
         if (a := attrs.pop("addr_space", None)) is not None:

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -74,7 +74,7 @@ from xdsl.irdl import (
     traits_def,
     var_operand_def,
 )
-from xdsl.parser import AttrParser, Parser
+from xdsl.parser import AttrParser, Parser, UnresolvedOperand
 from xdsl.printer import Printer
 from xdsl.traits import (
     IsTerminator,
@@ -1305,7 +1305,9 @@ class TailCallKindAttr(EnumAttribute[TailCallKind]):
             super().print_parameter(printer)
 
 
-# TODO: custom assembly format https://github.com/xdslproject/xdsl/issues/5897
+ASM_DIALECT_KEYWORDS: dict[int, str] = {0: "att", 1: "intel"}
+
+
 @irdl_op_definition
 class InlineAsmOp(IRDLOperation):
     """
@@ -1365,6 +1367,79 @@ class InlineAsmOp(IRDLOperation):
             properties=props,
             result_types=[res_types],
         )
+
+    def print(self, printer: Printer) -> None:
+        if self.has_side_effects is not None:
+            printer.print_string(" has_side_effects")
+        if self.is_align_stack is not None:
+            printer.print_string(" is_align_stack")
+        if self.asm_dialect is not None and self.asm_dialect.value.data != 0:
+            kw = ASM_DIALECT_KEYWORDS[self.asm_dialect.value.data]
+            printer.print_string(f" asm_dialect = {kw}")
+        if self.tail_call_kind.data != TailCallKind.NONE:
+            printer.print_string(
+                f" tail_call_kind = <{self.tail_call_kind.data.value}>"
+            )
+        printer.print_string(" ")
+        printer.print_string_literal(self.asm_string.data)
+        printer.print_string(", ")
+        printer.print_string_literal(self.constraints.data)
+        if self.operands_:
+            printer.print_string(" ")
+            printer.print_list(self.operands_, printer.print_ssa_value)
+        printer.print_op_attributes(self.attributes)
+        printer.print_string(" : ")
+        printer.print_function_type(
+            [v.type for v in self.operands_],
+            [self.res.type] if self.res is not None else [],
+        )
+
+    @classmethod
+    def parse(cls, parser: Parser) -> InlineAsmOp:
+        has_side_effects = parser.parse_optional_keyword("has_side_effects") is not None
+        is_align_stack = parser.parse_optional_keyword("is_align_stack") is not None
+        asm_dialect = 0
+        if parser.parse_optional_keyword("asm_dialect") is not None:
+            parser.parse_punctuation("=")
+            kw = parser.parse_identifier()
+            for v, k in ASM_DIALECT_KEYWORDS.items():
+                if k == kw:
+                    asm_dialect = v
+                    break
+            else:
+                parser.raise_error(f"unknown asm dialect '{kw}'")
+        tail_call_kind = TailCallKindAttr(TailCallKind.NONE)
+        if parser.parse_optional_keyword("tail_call_kind") is not None:
+            parser.parse_punctuation("=")
+            parser.parse_punctuation("<")
+            kind_kw = parser.parse_identifier()
+            parser.parse_punctuation(">")
+            tail_call_kind = TailCallKindAttr(TailCallKind(kind_kw))
+        asm_string = parser.parse_str_literal()
+        parser.parse_punctuation(",")
+        constraints = parser.parse_str_literal()
+        operands: list[UnresolvedOperand] = []
+        first = parser.parse_optional_unresolved_operand()
+        if first is not None:
+            operands.append(first)
+            while parser.parse_optional_punctuation(",") is not None:
+                operands.append(parser.parse_unresolved_operand())
+        attrs = parser.parse_optional_attr_dict()
+        parser.parse_punctuation(":")
+        ft = parser.parse_function_type()
+        resolved = parser.resolve_operands(operands, ft.inputs.data, parser.pos)
+        op = cls(
+            asm_string,
+            constraints,
+            resolved,
+            list(ft.outputs.data),
+            asm_dialect=asm_dialect,
+            has_side_effects=has_side_effects,
+            is_align_stack=is_align_stack,
+            tail_call_kind=tail_call_kind,
+        )
+        op.attributes |= attrs
+        return op
 
 
 @irdl_op_definition
@@ -1711,7 +1786,9 @@ class UndefOp(IRDLOperation):
         super().__init__(result_types=[result_type])
 
 
-# TODO: custom assembly format https://github.com/xdslproject/xdsl/issues/5897
+_UNNAMED_ADDR_KEYWORDS: dict[int, str] = {1: "local_unnamed_addr", 2: "unnamed_addr"}
+
+
 @irdl_op_definition
 class GlobalOp(IRDLOperation):
     name = "llvm.mlir.global"
@@ -1789,6 +1866,98 @@ class GlobalOp(IRDLOperation):
             body = Region()
 
         super().__init__(properties=props, regions=(body,))
+
+    def print(self, printer: Printer) -> None:
+        printer.print_string(" ")
+        printer.print_string(self.linkage.linkage.data)
+        if self.thread_local_ is not None:
+            printer.print_string(" thread_local")
+        if self.unnamed_addr is not None:
+            kw = _UNNAMED_ADDR_KEYWORDS.get(self.unnamed_addr.value.data)
+            if kw is not None:
+                printer.print_string(f" {kw}")
+        if self.constant is not None:
+            printer.print_string(" constant")
+        printer.print_string(" ")
+        printer.print_symbol_name(self.sym_name.data)
+        printer.print_string("(")
+        if self.value is not None:
+            printer.print_attribute(self.value)
+        printer.print_string(")")
+        reserved = (
+            "global_type",
+            "sym_name",
+            "linkage",
+            "constant",
+            "thread_local_",
+            "unnamed_addr",
+            "value",
+        )
+        attrs = {
+            **{k: v for k, v in self.properties.items() if k not in reserved},
+            **self.attributes,
+        }
+        if attrs:
+            printer.print_string(" ")
+            printer.print_attr_dict(attrs)
+        printer.print_string(" : ")
+        printer.print_attribute(self.global_type)
+        if self.body.blocks:
+            printer.print_string(" ")
+            printer.print_region(self.body)
+
+    @classmethod
+    def parse(cls, parser: Parser) -> GlobalOp:
+        linkage_str: str | None = None
+        for linkage_option in _LINKAGE_OPTIONS:
+            if parser.parse_optional_keyword(linkage_option) is not None:
+                linkage_str = linkage_option
+                break
+        if linkage_str is None:
+            linkage_str = "external"
+        thread_local_ = parser.parse_optional_keyword("thread_local") is not None
+        unnamed_addr_val: int | None = None
+        if parser.parse_optional_keyword("local_unnamed_addr") is not None:
+            unnamed_addr_val = 1
+        elif parser.parse_optional_keyword("unnamed_addr") is not None:
+            unnamed_addr_val = 2
+        constant = parser.parse_optional_keyword("constant") is not None
+        sym_name = parser.parse_symbol_name()
+        parser.parse_punctuation("(")
+        value = None
+        if parser.parse_optional_punctuation(")") is None:
+            value = parser.parse_attribute()
+            parser.parse_punctuation(")")
+        attrs = parser.parse_optional_attr_dict()
+        parser.parse_punctuation(":")
+        global_type = parser.parse_type()
+        body = parser.parse_optional_region()
+        addr_space = 0
+        if (a := attrs.pop("addr_space", None)) is not None:
+            assert isinstance(a, IntegerAttr)
+            addr_space = a.value.data
+        alignment: int | None = None
+        if (a := attrs.pop("alignment", None)) is not None:
+            assert isinstance(a, IntegerAttr)
+            alignment = a.value.data
+        section = attrs.pop("section", None)
+        dso_local = attrs.pop("dso_local", None) is not None
+        op = cls(
+            global_type=global_type,
+            sym_name=sym_name,
+            linkage=linkage_str,
+            addr_space=addr_space,
+            constant=constant,
+            dso_local=dso_local,
+            thread_local_=thread_local_,
+            value=value,
+            alignment=alignment,
+            unnamed_addr=unnamed_addr_val,
+            section=cast(StringAttr, section) if section is not None else None,
+            body=body,
+        )
+        op.attributes |= attrs
+        return op
 
 
 @irdl_op_definition
@@ -2212,7 +2381,6 @@ class FastMathAttr(FastMathAttrBase):
     name = "llvm.fastmath"
 
 
-# TODO: custom assembly format https://github.com/xdslproject/xdsl/issues/5897
 @irdl_op_definition
 class CallIntrinsicOp(IRDLOperation):
     """
@@ -2250,6 +2418,45 @@ class CallIntrinsicOp(IRDLOperation):
             },
         )
 
+    def print(self, printer: Printer) -> None:
+        printer.print_string(" ")
+        printer.print_string_literal(self.intrin.data)
+        printer.print_string("(")
+        printer.print_list(self.args, printer.print_ssa_value)
+        printer.print_string(")")
+        reserved = ("intrin", "op_bundle_sizes", "operandSegmentSizes")
+        attrs = {
+            **{k: v for k, v in self.properties.items() if k not in reserved},
+            **self.attributes,
+        }
+        if attrs:
+            printer.print_string(" ")
+            printer.print_attr_dict(attrs)
+        printer.print_string(" : ")
+        printer.print_function_type(
+            [v.type for v in self.args],
+            [self.ress.type] if self.ress is not None else [],
+        )
+
+    @classmethod
+    def parse(cls, parser: Parser) -> CallIntrinsicOp:
+        intrin = parser.parse_str_literal()
+        args_unresolved = parser.parse_comma_separated_list(
+            parser.Delimiter.PAREN, parser.parse_unresolved_operand
+        )
+        attrs = parser.parse_optional_attr_dict()
+        parser.parse_punctuation(":")
+        ft = parser.parse_function_type()
+        args = parser.resolve_operands(args_unresolved, ft.inputs.data, parser.pos)
+        op = cls(
+            intrin,
+            args,
+            list(ft.outputs.data),
+            op_bundle_sizes=DenseArrayBase.from_list(i32, ()),
+        )
+        op.attributes |= attrs
+        return op
+
 
 class CallOpSymbolUserOpInterface(SymbolUserOpInterface):
     """
@@ -2277,7 +2484,6 @@ class CallOpSymbolUserOpInterface(SymbolUserOpInterface):
             )
 
 
-# TODO: custom assembly format https://github.com/xdslproject/xdsl/issues/5897
 @irdl_op_definition
 class CallOp(IRDLOperation):
     name = "llvm.call"
@@ -2338,6 +2544,130 @@ class CallOp(IRDLOperation):
             },
             result_types=op_result_type,
         )
+
+    def print(self, printer: Printer) -> None:
+        if self.CConv.convention.data != "ccc":
+            printer.print_string(f" {self.CConv.convention.data}")
+        if self.TailCallKind.data != TailCallKind.NONE:
+            printer.print_string(f" {self.TailCallKind.data.value}")
+        printer.print_string(" ")
+        if self.callee is not None:
+            printer.print_attribute(self.callee)
+            call_args = self.args
+        else:
+            printer.print_ssa_value(self.args[0])
+            call_args = self.args[1:]
+        printer.print_string("(")
+        printer.print_list(call_args, printer.print_ssa_value)
+        printer.print_string(")")
+        if self.var_callee_type is not None:
+            printer.print_string(" vararg(")
+            printer.print_attribute(self.var_callee_type)
+            printer.print_string(")")
+        reserved = (
+            "callee",
+            "var_callee_type",
+            "CConv",
+            "TailCallKind",
+            "fastmathFlags",
+            "op_bundle_sizes",
+            "operandSegmentSizes",
+        )
+        attrs = {
+            **{k: v for k, v in self.properties.items() if k not in reserved},
+            **self.attributes,
+        }
+        reserved_fastmath = self.fastmathFlags == FastMathAttr("none")
+        if not reserved_fastmath:
+            attrs["fastmathFlags"] = self.fastmathFlags
+        if attrs:
+            printer.print_string(" ")
+            printer.print_attr_dict(attrs)
+        printer.print_string(" : ")
+        if self.callee is None:
+            printer.print_attribute(self.args[0].type)
+            printer.print_string(", ")
+        ret_types = [] if self.returned is None else [self.returned.type]
+        printer.print_function_type([v.type for v in call_args], ret_types)
+
+    @classmethod
+    def parse(cls, parser: Parser) -> CallOp:
+        cconv = CallingConventionAttr("ccc")
+        for c in LLVM_CALLING_CONVS:
+            if c == "ccc":
+                continue
+            if parser.parse_optional_keyword(c) is not None:
+                cconv = CallingConventionAttr(c)
+                break
+        tail_call_kind = TailCallKindAttr(TailCallKind.NONE)
+        for kind in TailCallKind:
+            if kind == TailCallKind.NONE:
+                continue
+            if parser.parse_optional_keyword(kind.value) is not None:
+                tail_call_kind = TailCallKindAttr(kind)
+                break
+        callee: SymbolRefAttr | None = None
+        callee_ptr: UnresolvedOperand | None = None
+        if (sym_name := parser.parse_optional_symbol_name()) is not None:
+            callee = SymbolRefAttr(sym_name)
+        else:
+            callee_ptr = parser.parse_unresolved_operand()
+        args_unresolved = parser.parse_comma_separated_list(
+            parser.Delimiter.PAREN, parser.parse_unresolved_operand
+        )
+        var_callee_type: Attribute | None = None
+        if parser.parse_optional_keyword("vararg") is not None:
+            parser.parse_punctuation("(")
+            var_callee_type = parser.parse_type()
+            parser.parse_punctuation(")")
+        attrs = parser.parse_optional_attr_dict()
+        parser.parse_punctuation(":")
+        ptr_type: Attribute | None = None
+        if callee is None:
+            ptr_type = parser.parse_type()
+            parser.parse_punctuation(",")
+        ft = parser.parse_function_type()
+        fastmath = FastMathAttr("none")
+        if (fm := attrs.pop("fastmathFlags", None)) is not None:
+            assert isinstance(fm, FastMathAttr)
+            fastmath = fm
+        ret_types = list(ft.outputs.data)
+        return_type = ret_types[0] if ret_types else None
+        if callee is not None:
+            args = parser.resolve_operands(args_unresolved, ft.inputs.data, parser.pos)
+            op = cls(
+                callee,
+                *args,
+                return_type=return_type,
+                calling_convention=cconv,
+                fastmath=fastmath,
+            )
+        else:
+            assert callee_ptr is not None
+            assert ptr_type is not None
+            resolved_ptr = parser.resolve_operand(callee_ptr, ptr_type)
+            arg_types = ft.inputs.data
+            resolved_args = parser.resolve_operands(
+                args_unresolved, arg_types, parser.pos
+            )
+            result_types = [return_type] if return_type is not None else []
+            op = cls.create(
+                operands=[resolved_ptr, *resolved_args],
+                properties={
+                    "fastmathFlags": fastmath,
+                    "CConv": cconv,
+                    "op_bundle_sizes": DenseArrayBase.from_list(i32, ()),
+                    "operandSegmentSizes": DenseArrayBase.from_list(
+                        i32, [1 + len(resolved_args), 0]
+                    ),
+                },
+                result_types=result_types,
+            )
+        if var_callee_type is not None:
+            op.properties["var_callee_type"] = var_callee_type
+        op.properties["TailCallKind"] = tail_call_kind
+        op.attributes |= attrs
+        return op
 
 
 LLVMType = (

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -1382,13 +1382,10 @@ class InlineAsmOp(IRDLOperation):
             printer.print_string(" has_side_effects")
         if self.is_align_stack is not None:
             printer.print_string(" is_align_stack")
-        if self.asm_dialect is not None and self.asm_dialect.value.data != 0:
-            kw = ASM_DIALECT_KEYWORDS[self.asm_dialect.value.data]
-            printer.print_string(f" asm_dialect = {kw}")
-        if self.tail_call_kind.data != TailCallKind.NONE:
-            printer.print_string(
-                f" tail_call_kind = <{self.tail_call_kind.data.value}>"
-            )
+        if self.asm_dialect is not None and (v := self.asm_dialect.value.data) != 0:
+            printer.print_string(f" asm_dialect = {ASM_DIALECT_KEYWORDS[v]}")
+        if (tck := self.tail_call_kind.data) != TailCallKind.NONE:
+            printer.print_string(f" tail_call_kind = <{tck.value}>")
         printer.print_string(" ")
         printer.print_string_literal(self.asm_string.data)
         printer.print_string(", ")
@@ -1411,19 +1408,16 @@ class InlineAsmOp(IRDLOperation):
         if parser.parse_optional_keyword("asm_dialect") is not None:
             parser.parse_punctuation("=")
             kw = parser.parse_identifier()
-            for v, k in ASM_DIALECT_KEYWORDS.items():
-                if k == kw:
-                    asm_dialect = v
-                    break
-            else:
+            inverse = {k: v for v, k in ASM_DIALECT_KEYWORDS.items()}
+            if kw not in inverse:
                 parser.raise_error(f"unknown asm dialect '{kw}'")
+            asm_dialect = inverse[kw]
         tail_call_kind = TailCallKindAttr(TailCallKind.NONE)
         if parser.parse_optional_keyword("tail_call_kind") is not None:
             parser.parse_punctuation("=")
             parser.parse_punctuation("<")
-            kind_kw = parser.parse_identifier()
+            tail_call_kind = TailCallKindAttr(TailCallKind(parser.parse_identifier()))
             parser.parse_punctuation(">")
-            tail_call_kind = TailCallKindAttr(TailCallKind(kind_kw))
         asm_string = parser.parse_str_literal()
         parser.parse_punctuation(",")
         constraints = parser.parse_str_literal()
@@ -1437,11 +1431,10 @@ class InlineAsmOp(IRDLOperation):
         attrs = parser.parse_optional_attr_dict()
         parser.parse_punctuation(":")
         ft = parser.parse_function_type()
-        resolved = parser.resolve_operands(operands, ft.inputs.data, parser.pos)
         op = cls(
             asm_string,
             constraints,
-            resolved,
+            parser.resolve_operands(operands, ft.inputs.data, parser.pos),
             list(ft.outputs.data),
             asm_dialect=asm_dialect,
             has_side_effects=has_side_effects,
@@ -1890,10 +1883,10 @@ class GlobalOp(IRDLOperation):
         printer.print_string(self.linkage.linkage.data)
         if self.thread_local_ is not None:
             printer.print_string(" thread_local")
-        if self.unnamed_addr is not None:
-            kw = UNNAMED_ADDR_KEYWORDS.get(self.unnamed_addr.value.data)
-            if kw is not None:
-                printer.print_string(f" {kw}")
+        if self.unnamed_addr is not None and (
+            kw := UNNAMED_ADDR_KEYWORDS.get(self.unnamed_addr.value.data)
+        ):
+            printer.print_string(f" {kw}")
         if self.constant is not None:
             printer.print_string(" constant")
         printer.print_string(" ")
@@ -1922,19 +1915,19 @@ class GlobalOp(IRDLOperation):
 
     @classmethod
     def parse(cls, parser: Parser) -> GlobalOp:
-        linkage_str: str | None = None
-        for linkage_option in _LINKAGE_OPTIONS:
-            if parser.parse_optional_keyword(linkage_option) is not None:
-                linkage_str = linkage_option
-                break
-        if linkage_str is None:
-            linkage_str = "external"
+        linkage = next(
+            (l for l in _LINKAGE_OPTIONS if parser.parse_optional_keyword(l)),
+            "external",
+        )
         thread_local_ = parser.parse_optional_keyword("thread_local") is not None
-        unnamed_addr_val: int | None = None
-        if parser.parse_optional_keyword("local_unnamed_addr") is not None:
-            unnamed_addr_val = 1
-        elif parser.parse_optional_keyword("unnamed_addr") is not None:
-            unnamed_addr_val = 2
+        unnamed_addr_val = next(
+            (
+                v
+                for v, k in UNNAMED_ADDR_KEYWORDS.items()
+                if parser.parse_optional_keyword(k)
+            ),
+            None,
+        )
         constant = parser.parse_optional_keyword("constant") is not None
         sym_name = parser.parse_symbol_name()
         parser.parse_punctuation("(")
@@ -1943,39 +1936,33 @@ class GlobalOp(IRDLOperation):
             value = parser.parse_attribute()
             parser.parse_punctuation(")")
         attrs = parser.parse_optional_attr_dict()
-        global_type: Attribute | None = None
         if parser.parse_optional_punctuation(":") is not None:
             global_type = parser.parse_type()
         elif isinstance(value, StringAttr):
             global_type = LLVMArrayType(len(value.data), IntegerType(8))
         elif isinstance(value, TypedAttribute):
             global_type = value.get_type()
-        if global_type is None:
+        else:
             parser.raise_error("expected `:` followed by global type")
-        body = parser.parse_optional_region()
-        addr_space = 0
-        if (a := attrs.pop("addr_space", None)) is not None:
-            assert isinstance(a, IntegerAttr)
-            addr_space = a.value.data
-        alignment: int | None = None
-        if (a := attrs.pop("alignment", None)) is not None:
-            assert isinstance(a, IntegerAttr)
-            alignment = a.value.data
+        addr_space = attrs.pop("addr_space", IntegerAttr(0, 32))
+        alignment = attrs.pop("alignment", None)
         section = attrs.pop("section", None)
-        dso_local = attrs.pop("dso_local", None) is not None
+        assert isinstance(addr_space, IntegerAttr)
+        assert alignment is None or isinstance(alignment, IntegerAttr)
+        assert section is None or isinstance(section, StringAttr)
         op = cls(
             global_type=global_type,
             sym_name=sym_name,
-            linkage=linkage_str,
-            addr_space=addr_space,
+            linkage=linkage,
+            addr_space=addr_space.value.data,
             constant=constant,
-            dso_local=dso_local,
+            dso_local=attrs.pop("dso_local", None) is not None,
             thread_local_=thread_local_,
             value=value,
-            alignment=alignment,
+            alignment=alignment.value.data if alignment is not None else None,
             unnamed_addr=unnamed_addr_val,
-            section=cast(StringAttr, section) if section is not None else None,
-            body=body,
+            section=section,
+            body=parser.parse_optional_region(),
         )
         op.attributes |= attrs
         return op
@@ -2604,20 +2591,26 @@ class CallOp(IRDLOperation):
 
     @classmethod
     def parse(cls, parser: Parser) -> CallOp:
-        cconv = CallingConventionAttr("ccc")
-        for c in LLVM_CALLING_CONVS:
-            if c == "ccc":
-                continue
-            if parser.parse_optional_keyword(c) is not None:
-                cconv = CallingConventionAttr(c)
-                break
-        tail_call_kind = TailCallKindAttr(TailCallKind.NONE)
-        for kind in TailCallKind:
-            if kind == TailCallKind.NONE:
-                continue
-            if parser.parse_optional_keyword(kind.value) is not None:
-                tail_call_kind = TailCallKindAttr(kind)
-                break
+        cconv = CallingConventionAttr(
+            next(
+                (
+                    c
+                    for c in LLVM_CALLING_CONVS - {"ccc"}
+                    if parser.parse_optional_keyword(c)
+                ),
+                "ccc",
+            )
+        )
+        tail_call_kind = TailCallKindAttr(
+            next(
+                (
+                    k
+                    for k in TailCallKind
+                    if k != TailCallKind.NONE and parser.parse_optional_keyword(k.value)
+                ),
+                TailCallKind.NONE,
+            )
+        )
         callee: SymbolRefAttr | None = None
         callee_ptr: UnresolvedOperand | None = None
         if (sym_name := parser.parse_optional_symbol_name()) is not None:
@@ -2634,50 +2627,33 @@ class CallOp(IRDLOperation):
             parser.parse_punctuation(")")
         attrs = parser.parse_optional_attr_dict()
         parser.parse_punctuation(":")
-        ptr_type: Attribute | None = None
-        if callee is None:
-            ptr_type = parser.parse_type()
+        ptr_operands: list[SSAValue] = []
+        if callee_ptr is not None:
+            ptr_operands.append(parser.resolve_operand(callee_ptr, parser.parse_type()))
             parser.parse_punctuation(",")
         ft = parser.parse_function_type()
-        fastmath = FastMathAttr("none")
-        if (fm := attrs.pop("fastmathFlags", None)) is not None:
-            assert isinstance(fm, FastMathAttr)
-            fastmath = fm
-        ret_types = list(ft.outputs.data)
-        return_type = ret_types[0] if ret_types else None
+        fastmath = attrs.pop("fastmathFlags", FastMathAttr("none"))
+        assert isinstance(fastmath, FastMathAttr)
+        all_args = [
+            *ptr_operands,
+            *parser.resolve_operands(args_unresolved, ft.inputs.data, parser.pos),
+        ]
+        props: dict[str, Attribute] = {
+            "fastmathFlags": fastmath,
+            "CConv": cconv,
+            "TailCallKind": tail_call_kind,
+            "op_bundle_sizes": DenseArrayBase.from_list(i32, ()),
+            "operandSegmentSizes": DenseArrayBase.from_list(i32, [len(all_args), 0]),
+        }
         if callee is not None:
-            args = parser.resolve_operands(args_unresolved, ft.inputs.data, parser.pos)
-            op = cls(
-                callee,
-                *args,
-                return_type=return_type,
-                calling_convention=cconv,
-                fastmath=fastmath,
-            )
-        else:
-            assert callee_ptr is not None
-            assert ptr_type is not None
-            resolved_ptr = parser.resolve_operand(callee_ptr, ptr_type)
-            arg_types = ft.inputs.data
-            resolved_args = parser.resolve_operands(
-                args_unresolved, arg_types, parser.pos
-            )
-            result_types = [return_type] if return_type is not None else []
-            op = cls.create(
-                operands=[resolved_ptr, *resolved_args],
-                properties={
-                    "fastmathFlags": fastmath,
-                    "CConv": cconv,
-                    "op_bundle_sizes": DenseArrayBase.from_list(i32, ()),
-                    "operandSegmentSizes": DenseArrayBase.from_list(
-                        i32, [1 + len(resolved_args), 0]
-                    ),
-                },
-                result_types=result_types,
-            )
+            props["callee"] = callee
         if var_callee_type is not None:
-            op.properties["var_callee_type"] = var_callee_type
-        op.properties["TailCallKind"] = tail_call_kind
+            props["var_callee_type"] = var_callee_type
+        op = cls.create(
+            operands=all_args,
+            properties=props,
+            result_types=list(ft.outputs.data),
+        )
         op.attributes |= attrs
         return op
 

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -1306,7 +1306,6 @@ class TailCallKindAttr(EnumAttribute[TailCallKind]):
             super().print_parameter(printer)
 
 
-ASM_DIALECT_KEYWORDS: dict[int, str] = {0: "att", 1: "intel"}
 """
 Mapping from LLVM inline-assembly dialect integer values to their textual
 keyword form. See external
@@ -1315,6 +1314,7 @@ for the MLIR op, and
 [LLVM LangRef](https://llvm.org/docs/LangRef.html#inline-assembler-expressions)
 for the underlying semantics.
 """
+ASM_DIALECT_KEYWORDS: dict[int, str] = {0: "att", 1: "intel"}
 
 
 def _first_keyword(parser: Parser, keywords: Iterable[str]) -> str | None:
@@ -1794,7 +1794,6 @@ class UndefOp(IRDLOperation):
         super().__init__(result_types=[result_type])
 
 
-UNNAMED_ADDR_KEYWORDS: dict[int, str] = {1: "local_unnamed_addr", 2: "unnamed_addr"}
 """
 Mapping from LLVM `unnamed_addr` integer values to their textual keyword form
 (0 = no keyword). See external
@@ -1803,6 +1802,7 @@ for the MLIR op, and
 [LLVM LangRef](https://llvm.org/docs/LangRef.html#global-variables) for the
 underlying semantics.
 """
+UNNAMED_ADDR_KEYWORDS: dict[int, str] = {1: "local_unnamed_addr", 2: "unnamed_addr"}
 
 
 @irdl_op_definition

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -1949,7 +1949,7 @@ class GlobalOp(IRDLOperation):
         elif isinstance(value, StringAttr):
             global_type = LLVMArrayType(len(value.data), IntegerType(8))
         elif isinstance(value, TypedAttribute):
-            global_type = value.type
+            global_type = value.get_type()
         if global_type is None:
             parser.raise_error("expected `:` followed by global type")
         body = parser.parse_optional_region()

--- a/xdsl/parser/base_parser.py
+++ b/xdsl/parser/base_parser.py
@@ -3,6 +3,7 @@ This file contains the definition of `BaseParser`, a recursive descent parser
 that is inherited from the different parsers used in xDSL.
 """
 
+from collections.abc import Collection
 from dataclasses import dataclass
 from typing import NoReturn
 
@@ -257,6 +258,17 @@ class BaseParser(GenericParser[MLIRTokenKind]):
         ):
             self._consume_token(MLIRTokenKind.BARE_IDENT)
             return keyword
+        return None
+
+    def parse_optional_keyword_in(self, keywords: Collection[str]) -> str | None:
+        """Parse a keyword if it matches any in the given collection, or `None`."""
+        if (
+            self._current_token.kind == MLIRTokenKind.BARE_IDENT
+            and self._current_token.text in keywords
+        ):
+            text = self._current_token.text
+            self._consume_token(MLIRTokenKind.BARE_IDENT)
+            return text
         return None
 
     def parse_keyword(self, keyword: str, context_msg: str = "") -> str:


### PR DESCRIPTION
Resolves the remaining 4 ops in #5897 (`llvm.inline_asm`, `llvm.mlir.global`, `llvm.call_intrinsic`, `llvm.call`). Stacked on top of #5908.