### PR TITLE
dialects: (acc) Initial OpenACC dialect with parallel and yield

### DIFF
--- a/tests/dialects/test_acc.py
+++ b/tests/dialects/test_acc.py
@@ -181,10 +181,3 @@ def test_yield_inside_parallel_ok():
     last = op.region.block.last_op
     assert isinstance(last, acc.YieldOp)
     last.verify()
-
-
-def test_dialect_registration():
-    """The dialect exposes exactly the two bootstrap ops."""
-    op_names = {op.name for op in acc.ACC.operations}
-    assert op_names == {"acc.parallel", "acc.yield"}
-    assert acc.ACC.name == "acc"

--- a/tests/dialects/test_acc.py
+++ b/tests/dialects/test_acc.py
@@ -2,14 +2,11 @@
 Test the usage of the acc (OpenACC) dialect.
 """
 
-import pytest
-
 from xdsl.dialects import acc
 from xdsl.dialects.arith import ConstantOp
-from xdsl.dialects.builtin import IntegerType, MemRefType, ModuleOp, f32, i1, i32
+from xdsl.dialects.builtin import MemRefType, f32, i1, i32
 from xdsl.dialects.test import TestOp
 from xdsl.ir import Block, Region
-from xdsl.utils.exceptions import VerifyException
 
 
 def _empty_parallel() -> acc.ParallelOp:
@@ -63,51 +60,6 @@ def test_parallel_with_operands_verifies():
     assert op.data_clause_operands[0] is data_val.res[0]
 
 
-def test_parallel_empty_block_fails():
-    op = acc.ParallelOp(region=Region(Block([])))
-    with pytest.raises(
-        VerifyException,
-        match="acc.parallel contains empty block in single-block region",
-    ):
-        op.verify()
-
-
-def test_parallel_wrong_terminator_fails():
-    """
-    A non-terminator op as the last op in the single-block region triggers the
-    core-region check before SingleBlockImplicitTerminator.
-    """
-    body_op = TestOp(result_types=[i32])
-    op = acc.ParallelOp(region=Region(Block([body_op])))
-    with pytest.raises(
-        VerifyException,
-        match="terminates block in single-block region but is not a terminator",
-    ):
-        op.verify()
-
-
-def test_parallel_non_integer_async_operand_fails():
-    """async_operands must be integer or index typed."""
-    bad = TestOp(result_types=[MemRefType(f32, [1])])
-    op = acc.ParallelOp(
-        region=Region(Block([acc.YieldOp()])),
-        async_operands=[bad.res[0]],
-    )
-    with pytest.raises(VerifyException):
-        op.verify()
-
-
-def test_parallel_if_cond_non_i1_fails():
-    """if_cond must be i1."""
-    not_i1 = ConstantOp.from_int_and_width(1, IntegerType(32))
-    op = acc.ParallelOp(
-        region=Region(Block([acc.YieldOp()])),
-        if_cond=not_i1.result,
-    )
-    with pytest.raises(VerifyException):
-        op.verify()
-
-
 def test_yield_construction_and_operands():
     """YieldOp inherits AbstractYieldOperation: variadic operands of any type."""
     v = TestOp(result_types=[MemRefType(f32, [10])])
@@ -119,18 +71,6 @@ def test_yield_construction_and_operands():
 
     empty_yield = acc.YieldOp()
     assert len(empty_yield.arguments) == 0
-
-
-def test_yield_outside_parallel_fails():
-    """HasParent(ParallelOp) on acc.yield. The yield needs a real parent op
-    (not acc.parallel) to exercise the check — HasParent skips detached ops."""
-    yield_op = acc.YieldOp()
-    module = ModuleOp([yield_op])
-    with pytest.raises(
-        VerifyException,
-        match="'acc.yield' expects parent op 'acc.parallel'",
-    ):
-        module.verify()
 
 
 def test_yield_inside_parallel_ok():

--- a/tests/dialects/test_acc.py
+++ b/tests/dialects/test_acc.py
@@ -1,0 +1,190 @@
+"""
+Test the usage of the acc (OpenACC) dialect.
+"""
+
+import pytest
+
+from xdsl.dialects import acc
+from xdsl.dialects.arith import ConstantOp
+from xdsl.dialects.builtin import IntegerType, MemRefType, ModuleOp, f32, i1, i32
+from xdsl.dialects.test import TestOp
+from xdsl.ir import Block, Region
+from xdsl.utils.exceptions import VerifyException
+
+
+def _empty_parallel() -> acc.ParallelOp:
+    """acc.parallel with an empty body (just the required yield)."""
+    return acc.ParallelOp(
+        operands=[[], [], [], [], [], [], [], [], [], [], []],
+        regions=[Region(Block([acc.YieldOp()]))],
+    )
+
+
+def test_parallel_empty_verifies():
+    op = _empty_parallel()
+    op.verify()
+
+    assert len(op.regions) == 1
+    assert len(op.region.blocks) == 1
+    assert len(op.async_operands) == 0
+    assert len(op.wait_operands) == 0
+    assert len(op.num_gangs) == 0
+    assert len(op.num_workers) == 0
+    assert len(op.vector_length) == 0
+    assert op.if_cond is None
+    assert op.self_cond is None
+    assert len(op.reduction_operands) == 0
+    assert len(op.private_operands) == 0
+    assert len(op.firstprivate_operands) == 0
+    assert len(op.data_clause_operands) == 0
+    assert isinstance(op.region.block.last_op, acc.YieldOp)
+
+
+def test_parallel_with_operands_verifies():
+    """Populate several operand groups and verify segment bookkeeping."""
+    async_val = ConstantOp.from_int_and_width(1, i32)
+    num_gangs_val = ConstantOp.from_int_and_width(4, i32)
+    num_workers_val = ConstantOp.from_int_and_width(8, i32)
+    if_cond_val = ConstantOp.from_int_and_width(1, i1)
+    data_val = TestOp(result_types=[MemRefType(f32, [10])])
+
+    op = acc.ParallelOp(
+        operands=[
+            [async_val.result],
+            [],
+            [num_gangs_val.result],
+            [num_workers_val.result],
+            [],
+            [if_cond_val.result],
+            [],
+            [],
+            [],
+            [],
+            [data_val.res[0]],
+        ],
+        regions=[Region(Block([acc.YieldOp()]))],
+    )
+    op.verify()
+
+    assert op.async_operands[0] is async_val.result
+    assert op.num_gangs[0] is num_gangs_val.result
+    assert op.num_workers[0] is num_workers_val.result
+    assert op.if_cond is if_cond_val.result
+    assert op.self_cond is None
+    assert op.data_clause_operands[0] is data_val.res[0]
+
+
+def test_parallel_empty_block_fails():
+    op = acc.ParallelOp(
+        operands=[[], [], [], [], [], [], [], [], [], [], []],
+        regions=[Region(Block([]))],
+    )
+    with pytest.raises(
+        VerifyException,
+        match="acc.parallel contains empty block in single-block region",
+    ):
+        op.verify()
+
+
+def test_parallel_wrong_terminator_fails():
+    """
+    A non-terminator op as the last op in the single-block region triggers the
+    core-region check before SingleBlockImplicitTerminator.
+    """
+    body_op = TestOp(result_types=[i32])
+    op = acc.ParallelOp(
+        operands=[[], [], [], [], [], [], [], [], [], [], []],
+        regions=[Region(Block([body_op]))],
+    )
+    with pytest.raises(
+        VerifyException,
+        match="terminates block in single-block region but is not a terminator",
+    ):
+        op.verify()
+
+
+def test_parallel_non_integer_async_operand_fails():
+    """async_operands must be integer or index typed."""
+    bad = TestOp(result_types=[MemRefType(f32, [1])])
+    op = acc.ParallelOp(
+        operands=[
+            [bad.res[0]],
+            [],
+            [],
+            [],
+            [],
+            [],
+            [],
+            [],
+            [],
+            [],
+            [],
+        ],
+        regions=[Region(Block([acc.YieldOp()]))],
+    )
+    with pytest.raises(VerifyException):
+        op.verify()
+
+
+def test_parallel_if_cond_non_i1_fails():
+    """if_cond must be i1."""
+    not_i1 = ConstantOp.from_int_and_width(1, IntegerType(32))
+    op = acc.ParallelOp(
+        operands=[
+            [],
+            [],
+            [],
+            [],
+            [],
+            [not_i1.result],
+            [],
+            [],
+            [],
+            [],
+            [],
+        ],
+        regions=[Region(Block([acc.YieldOp()]))],
+    )
+    with pytest.raises(VerifyException):
+        op.verify()
+
+
+def test_yield_construction_and_operands():
+    """YieldOp inherits AbstractYieldOperation: variadic operands of any type."""
+    v = TestOp(result_types=[MemRefType(f32, [10])])
+    yield_op = acc.YieldOp(v.res[0])
+
+    assert yield_op.name == "acc.yield"
+    assert len(yield_op.arguments) == 1
+    assert yield_op.arguments[0] is v.res[0]
+
+    empty_yield = acc.YieldOp()
+    assert len(empty_yield.arguments) == 0
+
+
+def test_yield_outside_parallel_fails():
+    """HasParent(ParallelOp) on acc.yield. The yield needs a real parent op
+    (not acc.parallel) to exercise the check — HasParent skips detached ops."""
+    yield_op = acc.YieldOp()
+    module = ModuleOp([yield_op])
+    with pytest.raises(
+        VerifyException,
+        match="'acc.yield' expects parent op 'acc.parallel'",
+    ):
+        module.verify()
+
+
+def test_yield_inside_parallel_ok():
+    """Building a yield inside acc.parallel's region should verify."""
+    op = _empty_parallel()
+    op.verify()
+    last = op.region.block.last_op
+    assert isinstance(last, acc.YieldOp)
+    last.verify()
+
+
+def test_dialect_registration():
+    """The dialect exposes exactly the two bootstrap ops."""
+    op_names = {op.name for op in acc.ACC.operations}
+    assert op_names == {"acc.parallel", "acc.yield"}
+    assert acc.ACC.name == "acc"

--- a/tests/dialects/test_acc.py
+++ b/tests/dialects/test_acc.py
@@ -14,10 +14,7 @@ from xdsl.utils.exceptions import VerifyException
 
 def _empty_parallel() -> acc.ParallelOp:
     """acc.parallel with an empty body (just the required yield)."""
-    return acc.ParallelOp(
-        operands=[[], [], [], [], [], [], [], [], [], [], []],
-        regions=[Region(Block([acc.YieldOp()]))],
-    )
+    return acc.ParallelOp(region=Region(Block([acc.YieldOp()])))
 
 
 def test_parallel_empty_verifies():
@@ -49,20 +46,12 @@ def test_parallel_with_operands_verifies():
     data_val = TestOp(result_types=[MemRefType(f32, [10])])
 
     op = acc.ParallelOp(
-        operands=[
-            [async_val.result],
-            [],
-            [num_gangs_val.result],
-            [num_workers_val.result],
-            [],
-            [if_cond_val.result],
-            [],
-            [],
-            [],
-            [],
-            [data_val.res[0]],
-        ],
-        regions=[Region(Block([acc.YieldOp()]))],
+        region=Region(Block([acc.YieldOp()])),
+        async_operands=[async_val.result],
+        num_gangs=[num_gangs_val.result],
+        num_workers=[num_workers_val.result],
+        if_cond=if_cond_val.result,
+        data_clause_operands=[data_val.res[0]],
     )
     op.verify()
 
@@ -75,10 +64,7 @@ def test_parallel_with_operands_verifies():
 
 
 def test_parallel_empty_block_fails():
-    op = acc.ParallelOp(
-        operands=[[], [], [], [], [], [], [], [], [], [], []],
-        regions=[Region(Block([]))],
-    )
+    op = acc.ParallelOp(region=Region(Block([])))
     with pytest.raises(
         VerifyException,
         match="acc.parallel contains empty block in single-block region",
@@ -92,10 +78,7 @@ def test_parallel_wrong_terminator_fails():
     core-region check before SingleBlockImplicitTerminator.
     """
     body_op = TestOp(result_types=[i32])
-    op = acc.ParallelOp(
-        operands=[[], [], [], [], [], [], [], [], [], [], []],
-        regions=[Region(Block([body_op]))],
-    )
+    op = acc.ParallelOp(region=Region(Block([body_op])))
     with pytest.raises(
         VerifyException,
         match="terminates block in single-block region but is not a terminator",
@@ -107,20 +90,8 @@ def test_parallel_non_integer_async_operand_fails():
     """async_operands must be integer or index typed."""
     bad = TestOp(result_types=[MemRefType(f32, [1])])
     op = acc.ParallelOp(
-        operands=[
-            [bad.res[0]],
-            [],
-            [],
-            [],
-            [],
-            [],
-            [],
-            [],
-            [],
-            [],
-            [],
-        ],
-        regions=[Region(Block([acc.YieldOp()]))],
+        region=Region(Block([acc.YieldOp()])),
+        async_operands=[bad.res[0]],
     )
     with pytest.raises(VerifyException):
         op.verify()
@@ -130,20 +101,8 @@ def test_parallel_if_cond_non_i1_fails():
     """if_cond must be i1."""
     not_i1 = ConstantOp.from_int_and_width(1, IntegerType(32))
     op = acc.ParallelOp(
-        operands=[
-            [],
-            [],
-            [],
-            [],
-            [],
-            [not_i1.result],
-            [],
-            [],
-            [],
-            [],
-            [],
-        ],
-        regions=[Region(Block([acc.YieldOp()]))],
+        region=Region(Block([acc.YieldOp()])),
+        if_cond=not_i1.result,
     )
     with pytest.raises(VerifyException):
         op.verify()

--- a/tests/filecheck/dialects/acc/ops.mlir
+++ b/tests/filecheck/dialects/acc/ops.mlir
@@ -1,0 +1,23 @@
+// RUN: XDSL_ROUNDTRIP
+
+builtin.module {
+  func.func @acc_parallel_empty() {
+    "acc.parallel"() <{operandSegmentSizes = array<i32: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>}> ({
+      "acc.yield"() : () -> ()
+    }) : () -> ()
+    func.return
+  }
+  // CHECK:      "acc.parallel"() <{operandSegmentSizes = array<i32: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>}> ({
+  // CHECK-NEXT:   acc.yield
+  // CHECK-NEXT: }) : () -> ()
+
+  func.func @acc_parallel_yield_operands(%arg0: memref<10xf32>) {
+    "acc.parallel"() <{operandSegmentSizes = array<i32: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>}> ({
+      "acc.yield"(%arg0) : (memref<10xf32>) -> ()
+    }) : () -> ()
+    func.return
+  }
+  // CHECK:      "acc.parallel"() <{operandSegmentSizes = array<i32: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>}> ({
+  // CHECK-NEXT:   acc.yield %{{.*}} : memref<10xf32>
+  // CHECK-NEXT: }) : () -> ()
+}

--- a/tests/filecheck/dialects/acc/ops_invalid.mlir
+++ b/tests/filecheck/dialects/acc/ops_invalid.mlir
@@ -1,0 +1,26 @@
+// RUN: xdsl-opt %s --verify-diagnostics --split-input-file | filecheck %s
+
+func.func @empty_block() {
+  "acc.parallel"() <{operandSegmentSizes = array<i32: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>}> ({
+  ^bb0:
+  }) : () -> ()
+  func.return
+}
+// CHECK: acc.parallel
+
+// -----
+
+func.func @wrong_terminator(%arg0: i32) {
+  "acc.parallel"() <{operandSegmentSizes = array<i32: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>}> ({
+    %0 = "builtin.unrealized_conversion_cast"(%arg0) : (i32) -> i32
+  }) : () -> ()
+  func.return
+}
+// CHECK: builtin.unrealized_conversion_cast
+
+// -----
+
+builtin.module {
+  "acc.yield"() : () -> ()
+}
+// CHECK: 'acc.yield' expects parent op 'acc.parallel'

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/ops.mlir
@@ -1,0 +1,19 @@
+// RUN: xdsl-opt %s --print-op-generic | mlir-opt --mlir-print-op-generic | xdsl-opt | filecheck %s
+
+builtin.module {
+  func.func @acc_parallel_empty() {
+    "acc.parallel"() <{operandSegmentSizes = array<i32: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>}> ({
+      "acc.yield"() : () -> ()
+    }) : () -> ()
+    func.return
+  }
+}
+
+// CHECK:       builtin.module {
+// CHECK-NEXT:    func.func @acc_parallel_empty() {
+// CHECK-NEXT:      "acc.parallel"() <{operandSegmentSizes = array<i32: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>}> ({
+// CHECK-NEXT:        acc.yield
+// CHECK-NEXT:      }) : () -> ()
+// CHECK-NEXT:      func.return
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/ops.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --print-op-generic | mlir-opt --mlir-print-op-generic | xdsl-opt | filecheck %s
+// RUN: MLIR_GENERIC_ROUNDTRIP
 
 builtin.module {
   func.func @acc_parallel_empty() {

--- a/xdsl/dialects/__init__.py
+++ b/xdsl/dialects/__init__.py
@@ -8,6 +8,11 @@ from xdsl.utils.dialect_loader import IRDLDialectFinder
 def get_all_dialects() -> dict[str, Callable[[], Dialect]]:
     """Returns all available dialects."""
 
+    def get_acc():
+        from xdsl.dialects.acc import ACC
+
+        return ACC
+
     def get_accfg():
         from xdsl.dialects.accfg import ACCFG
 
@@ -384,6 +389,7 @@ def get_all_dialects() -> dict[str, Callable[[], Dialect]]:
         return X86_Scf
 
     return {
+        "acc": get_acc,
         "accfg": get_accfg,
         "affine": get_affine,
         "air": get_air,

--- a/xdsl/dialects/acc.py
+++ b/xdsl/dialects/acc.py
@@ -1,0 +1,86 @@
+"""
+The OpenACC (acc) dialect that models the OpenACC programming model in MLIR.
+
+OpenACC is a directive-based programming model for accelerating applications
+on heterogeneous systems. This dialect exposes compute constructs, data
+constructs, loops, and the associated clauses so that host and accelerator
+code can be represented, analysed, and lowered to target-specific runtimes.
+
+See external [documentation](https://mlir.llvm.org/docs/Dialects/OpenACCDialect/).
+"""
+
+from xdsl.dialects.builtin import I1, IndexType, IntegerType
+from xdsl.dialects.utils import AbstractYieldOperation
+from xdsl.ir import Attribute, Dialect
+from xdsl.irdl import (
+    AttrSizedOperandSegments,
+    IRDLOperation,
+    base,
+    irdl_op_definition,
+    lazy_traits_def,
+    opt_operand_def,
+    region_def,
+    traits_def,
+    var_operand_def,
+)
+from xdsl.traits import (
+    HasParent,
+    IsTerminator,
+    NoMemoryEffect,
+    RecursiveMemoryEffect,
+    SingleBlockImplicitTerminator,
+)
+
+_IntOrIndex = base(IntegerType) | base(IndexType)
+
+
+@irdl_op_definition
+class ParallelOp(IRDLOperation):
+    """
+    Implementation of upstream acc.parallel.
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/OpenACCDialect/#accparallel-accparallelop).
+    """
+
+    name = "acc.parallel"
+
+    async_operands = var_operand_def(_IntOrIndex)
+    wait_operands = var_operand_def(_IntOrIndex)
+    num_gangs = var_operand_def(_IntOrIndex)
+    num_workers = var_operand_def(_IntOrIndex)
+    vector_length = var_operand_def(_IntOrIndex)
+    if_cond = opt_operand_def(I1)
+    self_cond = opt_operand_def(I1)
+    reduction_operands = var_operand_def()
+    private_operands = var_operand_def()
+    firstprivate_operands = var_operand_def()
+    data_clause_operands = var_operand_def()
+
+    region = region_def("single_block")
+
+    irdl_options = (AttrSizedOperandSegments(as_property=True),)
+
+    traits = lazy_traits_def(
+        lambda: (
+            SingleBlockImplicitTerminator(YieldOp),
+            RecursiveMemoryEffect(),
+        )
+    )
+
+
+@irdl_op_definition
+class YieldOp(AbstractYieldOperation[Attribute]):
+    """
+    Implementation of upstream acc.yield.
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/OpenACCDialect/#accyield-accyieldop).
+    """
+
+    name = "acc.yield"
+
+    traits = traits_def(
+        IsTerminator(),
+        NoMemoryEffect(),
+        HasParent(ParallelOp),
+    )
+
+
+ACC = Dialect("acc", [ParallelOp, YieldOp], [])

--- a/xdsl/dialects/acc.py
+++ b/xdsl/dialects/acc.py
@@ -17,7 +17,6 @@ from xdsl.ir import Attribute, Dialect, Operation, Region, SSAValue
 from xdsl.irdl import (
     AttrSizedOperandSegments,
     IRDLOperation,
-    base,
     irdl_op_definition,
     lazy_traits_def,
     opt_operand_def,
@@ -33,8 +32,6 @@ from xdsl.traits import (
     SingleBlockImplicitTerminator,
 )
 
-_IntOrIndex = base(IntegerType) | base(IndexType)
-
 
 @irdl_op_definition
 class ParallelOp(IRDLOperation):
@@ -45,11 +42,11 @@ class ParallelOp(IRDLOperation):
 
     name = "acc.parallel"
 
-    async_operands = var_operand_def(_IntOrIndex)
-    wait_operands = var_operand_def(_IntOrIndex)
-    num_gangs = var_operand_def(_IntOrIndex)
-    num_workers = var_operand_def(_IntOrIndex)
-    vector_length = var_operand_def(_IntOrIndex)
+    async_operands = var_operand_def(IntegerType | IndexType)
+    wait_operands = var_operand_def(IntegerType | IndexType)
+    num_gangs = var_operand_def(IntegerType | IndexType)
+    num_workers = var_operand_def(IntegerType | IndexType)
+    vector_length = var_operand_def(IntegerType | IndexType)
     if_cond = opt_operand_def(I1)
     self_cond = opt_operand_def(I1)
     reduction_operands = var_operand_def()

--- a/xdsl/dialects/acc.py
+++ b/xdsl/dialects/acc.py
@@ -9,9 +9,11 @@ code can be represented, analysed, and lowered to target-specific runtimes.
 See external [documentation](https://mlir.llvm.org/docs/Dialects/OpenACCDialect/).
 """
 
+from collections.abc import Sequence
+
 from xdsl.dialects.builtin import I1, IndexType, IntegerType
 from xdsl.dialects.utils import AbstractYieldOperation
-from xdsl.ir import Attribute, Dialect
+from xdsl.ir import Attribute, Dialect, Operation, Region, SSAValue
 from xdsl.irdl import (
     AttrSizedOperandSegments,
     IRDLOperation,
@@ -66,6 +68,39 @@ class ParallelOp(IRDLOperation):
         )
     )
 
+    def __init__(
+        self,
+        *,
+        region: Region,
+        async_operands: Sequence[SSAValue | Operation] = (),
+        wait_operands: Sequence[SSAValue | Operation] = (),
+        num_gangs: Sequence[SSAValue | Operation] = (),
+        num_workers: Sequence[SSAValue | Operation] = (),
+        vector_length: Sequence[SSAValue | Operation] = (),
+        if_cond: SSAValue | Operation | None = None,
+        self_cond: SSAValue | Operation | None = None,
+        reduction_operands: Sequence[SSAValue | Operation] = (),
+        private_operands: Sequence[SSAValue | Operation] = (),
+        firstprivate_operands: Sequence[SSAValue | Operation] = (),
+        data_clause_operands: Sequence[SSAValue | Operation] = (),
+    ) -> None:
+        super().__init__(
+            operands=[
+                async_operands,
+                wait_operands,
+                num_gangs,
+                num_workers,
+                vector_length,
+                [if_cond] if if_cond is not None else [],
+                [self_cond] if self_cond is not None else [],
+                reduction_operands,
+                private_operands,
+                firstprivate_operands,
+                data_clause_operands,
+            ],
+            regions=[region],
+        )
+
 
 @irdl_op_definition
 class YieldOp(AbstractYieldOperation[Attribute]):
@@ -83,4 +118,11 @@ class YieldOp(AbstractYieldOperation[Attribute]):
     )
 
 
-ACC = Dialect("acc", [ParallelOp, YieldOp,], [])
+ACC = Dialect(
+    "acc",
+    [
+        ParallelOp,
+        YieldOp,
+    ],
+    [],
+)

--- a/xdsl/dialects/acc.py
+++ b/xdsl/dialects/acc.py
@@ -83,4 +83,4 @@ class YieldOp(AbstractYieldOperation[Attribute]):
     )
 
 
-ACC = Dialect("acc", [ParallelOp, YieldOp], [])
+ACC = Dialect("acc", [ParallelOp, YieldOp,], [])


### PR DESCRIPTION
Initial OpenACC, acc, dialect with acc.parallel and acc.yield along with tests for these operations. This technology is popular in HPC for directive programming of accelerators.
