### PR TITLE
dialects: (acc) Extend parallel op to include properties

### DIFF
--- a/tests/dialects/test_acc.py
+++ b/tests/dialects/test_acc.py
@@ -4,7 +4,17 @@ Test the usage of the acc (OpenACC) dialect.
 
 from xdsl.dialects import acc
 from xdsl.dialects.arith import ConstantOp
-from xdsl.dialects.builtin import MemRefType, f32, i1, i32
+from xdsl.dialects.builtin import (
+    ArrayAttr,
+    BoolAttr,
+    DenseArrayBase,
+    IntegerType,
+    MemRefType,
+    UnitAttr,
+    f32,
+    i1,
+    i32,
+)
 from xdsl.dialects.test import TestOp
 from xdsl.ir import Block, Region
 
@@ -31,6 +41,19 @@ def test_parallel_empty_verifies():
     assert len(op.private_operands) == 0
     assert len(op.firstprivate_operands) == 0
     assert len(op.data_clause_operands) == 0
+    assert op.async_operands_device_type is None
+    assert op.async_only is None
+    assert op.wait_operands_segments is None
+    assert op.wait_operands_device_type is None
+    assert op.has_wait_devnum is None
+    assert op.wait_only is None
+    assert op.num_gangs_segments is None
+    assert op.num_gangs_device_type is None
+    assert op.num_workers_device_type is None
+    assert op.vector_length_device_type is None
+    assert op.self_attr is None
+    assert op.default_attr is None
+    assert op.combined is None
     assert isinstance(op.region.block.last_op, acc.YieldOp)
 
 
@@ -58,6 +81,76 @@ def test_parallel_with_operands_verifies():
     assert op.if_cond is if_cond_val.result
     assert op.self_cond is None
     assert op.data_clause_operands[0] is data_val.res[0]
+
+
+def test_parallel_accepts_device_type_attrs():
+    """Per-device-type array attributes land on the op as properties."""
+    nvidia = acc.DeviceTypeAttr(acc.DeviceType.NVIDIA)
+    host = acc.DeviceTypeAttr(acc.DeviceType.HOST)
+    op = acc.ParallelOp(
+        region=Region(Block([acc.YieldOp()])),
+        async_operands_device_type=ArrayAttr([nvidia]),
+        async_only=ArrayAttr([host]),
+        wait_operands_device_type=ArrayAttr([nvidia, host]),
+        wait_operands_segments=DenseArrayBase.from_list(IntegerType(32), [1, 1]),
+        has_wait_devnum=ArrayAttr(
+            [BoolAttr.from_bool(False), BoolAttr.from_bool(True)]
+        ),
+        wait_only=ArrayAttr([host]),
+        num_gangs_device_type=ArrayAttr([nvidia]),
+        num_gangs_segments=DenseArrayBase.from_list(IntegerType(32), [1]),
+        num_workers_device_type=ArrayAttr([nvidia]),
+        vector_length_device_type=ArrayAttr([nvidia]),
+    )
+    op.verify()
+
+    assert op.async_operands_device_type == ArrayAttr([nvidia])
+    assert op.async_only == ArrayAttr([host])
+    assert op.wait_operands_device_type == ArrayAttr([nvidia, host])
+    assert op.wait_operands_segments == DenseArrayBase.from_list(
+        IntegerType(32), [1, 1]
+    )
+    assert op.has_wait_devnum == ArrayAttr(
+        [BoolAttr.from_bool(False), BoolAttr.from_bool(True)]
+    )
+    assert op.wait_only == ArrayAttr([host])
+    assert op.num_gangs_device_type == ArrayAttr([nvidia])
+    assert op.num_gangs_segments == DenseArrayBase.from_list(IntegerType(32), [1])
+    assert op.num_workers_device_type == ArrayAttr([nvidia])
+    assert op.vector_length_device_type == ArrayAttr([nvidia])
+
+
+def test_parallel_unit_and_default_attrs():
+    """self_attr / combined accept bool shortcuts; default_attr accepts enum."""
+    op = acc.ParallelOp(
+        region=Region(Block([acc.YieldOp()])),
+        self_attr=True,
+        default_attr=acc.ClauseDefaultValue.PRESENT,
+        combined=True,
+    )
+    op.verify()
+
+    assert isinstance(op.self_attr, UnitAttr)
+    assert isinstance(op.combined, UnitAttr)
+    assert op.default_attr == acc.ClauseDefaultValueAttr(acc.ClauseDefaultValue.PRESENT)
+
+    # The shortcut `False` leaves the properties unset.
+    op_off = acc.ParallelOp(region=Region(Block([acc.YieldOp()])))
+    assert op_off.self_attr is None
+    assert op_off.combined is None
+
+    # Explicitly passing the attribute instance is also supported.
+    op_explicit = acc.ParallelOp(
+        region=Region(Block([acc.YieldOp()])),
+        self_attr=UnitAttr(),
+        default_attr=acc.ClauseDefaultValueAttr(acc.ClauseDefaultValue.NONE),
+        combined=UnitAttr(),
+    )
+    assert isinstance(op_explicit.self_attr, UnitAttr)
+    assert isinstance(op_explicit.combined, UnitAttr)
+    assert op_explicit.default_attr == acc.ClauseDefaultValueAttr(
+        acc.ClauseDefaultValue.NONE
+    )
 
 
 def test_yield_construction_and_operands():

--- a/tests/filecheck/dialects/acc/ops.mlir
+++ b/tests/filecheck/dialects/acc/ops.mlir
@@ -20,4 +20,40 @@ builtin.module {
   // CHECK:      "acc.parallel"() <{operandSegmentSizes = array<i32: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>}> ({
   // CHECK-NEXT:   acc.yield %{{.*}} : memref<10xf32>
   // CHECK-NEXT: }) : () -> ()
+
+  func.func @acc_parallel_default_and_unit_attrs() {
+    "acc.parallel"() <{defaultAttr = #acc<defaultvalue present>, selfAttr, combined, operandSegmentSizes = array<i32: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>}> ({
+      "acc.yield"() : () -> ()
+    }) : () -> ()
+    func.return
+  }
+  // CHECK:      "acc.parallel"() <{defaultAttr = #acc<defaultvalue present>, selfAttr, combined, operandSegmentSizes = array<i32: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>}> ({
+  // CHECK-NEXT:   acc.yield
+  // CHECK-NEXT: }) : () -> ()
+
+  func.func @acc_parallel_default_none() {
+    "acc.parallel"() <{defaultAttr = #acc<defaultvalue none>, operandSegmentSizes = array<i32: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>}> ({
+      "acc.yield"() : () -> ()
+    }) : () -> ()
+    func.return
+  }
+  // CHECK: "acc.parallel"() <{defaultAttr = #acc<defaultvalue none>
+
+  func.func @acc_parallel_device_type_arrays() {
+    "acc.parallel"() <{asyncOnly = [#acc.device_type<nvidia>, #acc.device_type<host>], asyncOperandsDeviceType = [#acc.device_type<nvidia>], waitOnly = [#acc.device_type<multicore>], waitOperandsDeviceType = [#acc.device_type<default>], waitOperandsSegments = array<i32: 1>, hasWaitDevnum = [false], numGangsDeviceType = [#acc.device_type<star>], numGangsSegments = array<i32: 0>, numWorkersDeviceType = [#acc.device_type<radeon>], vectorLengthDeviceType = [#acc.device_type<none>], operandSegmentSizes = array<i32: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>}> ({
+      "acc.yield"() : () -> ()
+    }) : () -> ()
+    func.return
+  }
+  // CHECK:      "acc.parallel"() <{
+  // CHECK-SAME: asyncOnly = [#acc.device_type<nvidia>, #acc.device_type<host>]
+  // CHECK-SAME: asyncOperandsDeviceType = [#acc.device_type<nvidia>]
+  // CHECK-SAME: waitOnly = [#acc.device_type<multicore>]
+  // CHECK-SAME: waitOperandsDeviceType = [#acc.device_type<default>]
+  // CHECK-SAME: waitOperandsSegments = array<i32: 1>
+  // CHECK-SAME: hasWaitDevnum = [false]
+  // CHECK-SAME: numGangsDeviceType = [#acc.device_type<star>]
+  // CHECK-SAME: numGangsSegments = array<i32: 0>
+  // CHECK-SAME: numWorkersDeviceType = [#acc.device_type<radeon>]
+  // CHECK-SAME: vectorLengthDeviceType = [#acc.device_type<none>]
 }

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/ops.mlir
@@ -7,11 +7,35 @@ builtin.module {
     }) : () -> ()
     func.return
   }
+  func.func @acc_parallel_default_and_unit_attrs() {
+    "acc.parallel"() <{defaultAttr = #acc<defaultvalue present>, selfAttr, combined, operandSegmentSizes = array<i32: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>}> ({
+      "acc.yield"() : () -> ()
+    }) : () -> ()
+    func.return
+  }
+  func.func @acc_parallel_device_type_arrays() {
+    "acc.parallel"() <{asyncOnly = [#acc.device_type<nvidia>], waitOnly = [#acc.device_type<host>], operandSegmentSizes = array<i32: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>}> ({
+      "acc.yield"() : () -> ()
+    }) : () -> ()
+    func.return
+  }
 }
 
 // CHECK:       builtin.module {
 // CHECK-NEXT:    func.func @acc_parallel_empty() {
 // CHECK-NEXT:      "acc.parallel"() <{operandSegmentSizes = array<i32: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>}> ({
+// CHECK-NEXT:        acc.yield
+// CHECK-NEXT:      }) : () -> ()
+// CHECK-NEXT:      func.return
+// CHECK-NEXT:    }
+// CHECK-NEXT:    func.func @acc_parallel_default_and_unit_attrs() {
+// CHECK-NEXT:      "acc.parallel"() <{combined, defaultAttr = #acc<defaultvalue present>, operandSegmentSizes = array<i32: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>, selfAttr}> ({
+// CHECK-NEXT:        acc.yield
+// CHECK-NEXT:      }) : () -> ()
+// CHECK-NEXT:      func.return
+// CHECK-NEXT:    }
+// CHECK-NEXT:    func.func @acc_parallel_device_type_arrays() {
+// CHECK-NEXT:      "acc.parallel"() <{asyncOnly = [#acc.device_type<nvidia>], operandSegmentSizes = array<i32: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>, waitOnly = [#acc.device_type<host>]}> ({
 // CHECK-NEXT:        acc.yield
 // CHECK-NEXT:      }) : () -> ()
 // CHECK-NEXT:      func.return

--- a/xdsl/dialects/acc.py
+++ b/xdsl/dialects/acc.py
@@ -40,7 +40,6 @@ from xdsl.irdl import (
     opt_operand_def,
     opt_prop_def,
     region_def,
-    traits_def,
     var_operand_def,
 )
 from xdsl.parser import AttrParser
@@ -247,10 +246,12 @@ class YieldOp(AbstractYieldOperation[Attribute]):
 
     name = "acc.yield"
 
-    traits = traits_def(
-        IsTerminator(),
-        NoMemoryEffect(),
-        HasParent(ParallelOp),
+    traits = lazy_traits_def(
+        lambda: (
+            IsTerminator(),
+            NoMemoryEffect(),
+            HasParent(ParallelOp),
+        )
     )
 
 

--- a/xdsl/dialects/acc.py
+++ b/xdsl/dialects/acc.py
@@ -11,19 +11,40 @@ See external [documentation](https://mlir.llvm.org/docs/Dialects/OpenACCDialect/
 
 from collections.abc import Sequence
 
-from xdsl.dialects.builtin import I1, IndexType, IntegerType
+from xdsl.dialects.builtin import (
+    I1,
+    ArrayAttr,
+    BoolAttr,
+    DenseArrayBase,
+    IndexType,
+    IntegerType,
+    UnitAttr,
+)
 from xdsl.dialects.utils import AbstractYieldOperation
-from xdsl.ir import Attribute, Dialect, Operation, Region, SSAValue
+from xdsl.ir import (
+    Attribute,
+    Dialect,
+    EnumAttribute,
+    Operation,
+    Region,
+    SpacedOpaqueSyntaxAttribute,
+    SSAValue,
+    StrEnum,
+)
 from xdsl.irdl import (
     AttrSizedOperandSegments,
     IRDLOperation,
+    irdl_attr_definition,
     irdl_op_definition,
     lazy_traits_def,
     opt_operand_def,
+    opt_prop_def,
     region_def,
     traits_def,
     var_operand_def,
 )
+from xdsl.parser import AttrParser
+from xdsl.printer import Printer
 from xdsl.traits import (
     HasParent,
     IsTerminator,
@@ -31,6 +52,53 @@ from xdsl.traits import (
     RecursiveMemoryEffect,
     SingleBlockImplicitTerminator,
 )
+
+
+class DeviceType(StrEnum):
+    NONE = "none"
+    STAR = "star"
+    DEFAULT = "default"
+    HOST = "host"
+    MULTICORE = "multicore"
+    NVIDIA = "nvidia"
+    RADEON = "radeon"
+
+
+class ClauseDefaultValue(StrEnum):
+    PRESENT = "present"
+    NONE = "none"
+
+
+@irdl_attr_definition
+class DeviceTypeAttr(EnumAttribute[DeviceType]):
+    """
+    Device type attribute used to associate values of clauses with a specific
+    device_type. Prints using the pretty form `#acc.device_type<value>` to
+    match upstream MLIR (which defines `assemblyFormat = "`<` $value `>`"`).
+    """
+
+    name = "acc.device_type"
+
+    def print_parameter(self, printer: Printer) -> None:
+        with printer.in_angle_brackets():
+            printer.print_string(self.data.value)
+
+    @classmethod
+    def parse_parameter(cls, parser: AttrParser) -> DeviceType:
+        with parser.in_angle_brackets():
+            return parser.parse_str_enum(DeviceType)
+
+
+@irdl_attr_definition
+class ClauseDefaultValueAttr(
+    EnumAttribute[ClauseDefaultValue], SpacedOpaqueSyntaxAttribute
+):
+    """
+    Default clause value attribute, selecting either `none` or `present`.
+    See upstream `acc.defaultvalue`.
+    """
+
+    name = "acc.defaultvalue"
 
 
 @irdl_op_definition
@@ -53,6 +121,34 @@ class ParallelOp(IRDLOperation):
     private_operands = var_operand_def()
     firstprivate_operands = var_operand_def()
     data_clause_operands = var_operand_def()
+
+    async_operands_device_type = opt_prop_def(
+        ArrayAttr[DeviceTypeAttr], prop_name="asyncOperandsDeviceType"
+    )
+    async_only = opt_prop_def(ArrayAttr[DeviceTypeAttr], prop_name="asyncOnly")
+    wait_operands_segments = opt_prop_def(
+        DenseArrayBase.constr(IntegerType(32)), prop_name="waitOperandsSegments"
+    )
+    wait_operands_device_type = opt_prop_def(
+        ArrayAttr[DeviceTypeAttr], prop_name="waitOperandsDeviceType"
+    )
+    has_wait_devnum = opt_prop_def(ArrayAttr[BoolAttr], prop_name="hasWaitDevnum")
+    wait_only = opt_prop_def(ArrayAttr[DeviceTypeAttr], prop_name="waitOnly")
+    num_gangs_segments = opt_prop_def(
+        DenseArrayBase.constr(IntegerType(32)), prop_name="numGangsSegments"
+    )
+    num_gangs_device_type = opt_prop_def(
+        ArrayAttr[DeviceTypeAttr], prop_name="numGangsDeviceType"
+    )
+    num_workers_device_type = opt_prop_def(
+        ArrayAttr[DeviceTypeAttr], prop_name="numWorkersDeviceType"
+    )
+    vector_length_device_type = opt_prop_def(
+        ArrayAttr[DeviceTypeAttr], prop_name="vectorLengthDeviceType"
+    )
+    self_attr = opt_prop_def(UnitAttr, prop_name="selfAttr")
+    default_attr = opt_prop_def(ClauseDefaultValueAttr, prop_name="defaultAttr")
+    combined = opt_prop_def(UnitAttr)
 
     region = region_def("single_block")
 
@@ -80,7 +176,35 @@ class ParallelOp(IRDLOperation):
         private_operands: Sequence[SSAValue | Operation] = (),
         firstprivate_operands: Sequence[SSAValue | Operation] = (),
         data_clause_operands: Sequence[SSAValue | Operation] = (),
+        async_operands_device_type: ArrayAttr[DeviceTypeAttr] | None = None,
+        async_only: ArrayAttr[DeviceTypeAttr] | None = None,
+        wait_operands_segments: DenseArrayBase | None = None,
+        wait_operands_device_type: ArrayAttr[DeviceTypeAttr] | None = None,
+        has_wait_devnum: ArrayAttr[BoolAttr] | None = None,
+        wait_only: ArrayAttr[DeviceTypeAttr] | None = None,
+        num_gangs_segments: DenseArrayBase | None = None,
+        num_gangs_device_type: ArrayAttr[DeviceTypeAttr] | None = None,
+        num_workers_device_type: ArrayAttr[DeviceTypeAttr] | None = None,
+        vector_length_device_type: ArrayAttr[DeviceTypeAttr] | None = None,
+        self_attr: UnitAttr | bool = False,
+        default_attr: ClauseDefaultValueAttr | ClauseDefaultValue | None = None,
+        combined: UnitAttr | bool = False,
     ) -> None:
+        self_attr_prop: UnitAttr | None = (
+            (UnitAttr() if self_attr else None)
+            if isinstance(self_attr, bool)
+            else self_attr
+        )
+        combined_prop: UnitAttr | None = (
+            (UnitAttr() if combined else None)
+            if isinstance(combined, bool)
+            else combined
+        )
+        default_prop: ClauseDefaultValueAttr | None = (
+            ClauseDefaultValueAttr(default_attr)
+            if isinstance(default_attr, ClauseDefaultValue)
+            else default_attr
+        )
         super().__init__(
             operands=[
                 async_operands,
@@ -95,6 +219,21 @@ class ParallelOp(IRDLOperation):
                 firstprivate_operands,
                 data_clause_operands,
             ],
+            properties={
+                "asyncOperandsDeviceType": async_operands_device_type,
+                "asyncOnly": async_only,
+                "waitOperandsSegments": wait_operands_segments,
+                "waitOperandsDeviceType": wait_operands_device_type,
+                "hasWaitDevnum": has_wait_devnum,
+                "waitOnly": wait_only,
+                "numGangsSegments": num_gangs_segments,
+                "numGangsDeviceType": num_gangs_device_type,
+                "numWorkersDeviceType": num_workers_device_type,
+                "vectorLengthDeviceType": vector_length_device_type,
+                "selfAttr": self_attr_prop,
+                "defaultAttr": default_prop,
+                "combined": combined_prop,
+            },
             regions=[region],
         )
 
@@ -121,5 +260,8 @@ ACC = Dialect(
         ParallelOp,
         YieldOp,
     ],
-    [],
+    [
+        DeviceTypeAttr,
+        ClauseDefaultValueAttr,
+    ],
 )


### PR DESCRIPTION
The previous acc.parallel op was a skeleton of the operation to keep PRs small. That only included the operands, this extends that operation with the properties and this includes bespoke dialect attributes, representing the full parallel operation as per the MLIR OpenACC dialect.
