### PR TITLE
dialects: (arith) Added bf16 as floating-point-like

### DIFF
--- a/tests/dialects/test_arith.py
+++ b/tests/dialects/test_arith.py
@@ -68,6 +68,8 @@ from xdsl.dialects.builtin import (
     f16,
     f32,
     f64,
+    f80,
+    f128,
     i1,
     i32,
     i64,
@@ -291,6 +293,14 @@ def test_select_op():
         (IntegerType(16), bf16),
         (VectorType(bf16, [4]), VectorType(IntegerType(16), [4])),
         (MemRefType(bf16, [5]), MemRefType(IntegerType(16), [5])),
+        (f80, IntegerType(80)),
+        (IntegerType(80), f80),
+        (VectorType(f80, [4]), VectorType(IntegerType(80), [4])),
+        (MemRefType(f80, [5]), MemRefType(IntegerType(80), [5])),
+        (f128, IntegerType(128)),
+        (IntegerType(128), f128),
+        (VectorType(f128, [4]), VectorType(IntegerType(128), [4])),
+        (MemRefType(f128, [5]), MemRefType(IntegerType(128), [5])),
     ],
 )
 def test_bitcast_op(in_type: Attribute, out_type: Attribute):
@@ -320,6 +330,8 @@ BITWIDTH_MISMATCH = "operand and result types must have equal bitwidths or be In
         (MemRefType(i32, [5]), MemRefType(f32, [6]), SHAPE_MISMATCH),
         (MemRefType(i32, [5]), f32, SHAPE_MISMATCH),
         (bf16, f32, BITWIDTH_MISMATCH),
+        (f80, f128, BITWIDTH_MISMATCH),
+        (f128, f64, BITWIDTH_MISMATCH),
     ],
 )
 def test_bitcast_incorrect(in_type: Attribute, out_type: Attribute, err_msg: str):

--- a/tests/dialects/test_arith.py
+++ b/tests/dialects/test_arith.py
@@ -64,6 +64,8 @@ from xdsl.dialects.builtin import (
     Signedness,
     TensorType,
     VectorType,
+    bf16,
+    f16,
     f32,
     f64,
     i1,
@@ -283,6 +285,12 @@ def test_select_op():
         (VectorType(i64, [3]), VectorType(f64, [3])),
         (VectorType(f32, [3]), VectorType(i32, [3])),
         (MemRefType(i32, [5]), MemRefType(f32, [5])),
+        (bf16, f16),
+        (f16, bf16),
+        (bf16, IntegerType(16)),
+        (IntegerType(16), bf16),
+        (VectorType(bf16, [4]), VectorType(IntegerType(16), [4])),
+        (MemRefType(bf16, [5]), MemRefType(IntegerType(16), [5])),
     ],
 )
 def test_bitcast_op(in_type: Attribute, out_type: Attribute):
@@ -311,6 +319,7 @@ BITWIDTH_MISMATCH = "operand and result types must have equal bitwidths or be In
         (VectorType(i32, [5]), VectorType(f64, [5]), BITWIDTH_MISMATCH),
         (MemRefType(i32, [5]), MemRefType(f32, [6]), SHAPE_MISMATCH),
         (MemRefType(i32, [5]), f32, SHAPE_MISMATCH),
+        (bf16, f32, BITWIDTH_MISMATCH),
     ],
 )
 def test_bitcast_incorrect(in_type: Attribute, out_type: Attribute, err_msg: str):

--- a/tests/filecheck/dialects/arith/arith_ops.mlir
+++ b/tests/filecheck/dialects/arith/arith_ops.mlir
@@ -10,6 +10,12 @@
 %lhsbf16, %rhsbf16 = "test.op"() : () -> (bf16, bf16)
 %lhsbf16vec, %rhsbf16vec = "test.op"() : () -> (vector<4xbf16>, vector<4xbf16>)
 %lhsi16 = "test.op"() : () -> i16
+%lhsf80, %rhsf80 = "test.op"() : () -> (f80, f80)
+%lhsf80vec, %rhsf80vec = "test.op"() : () -> (vector<4xf80>, vector<4xf80>)
+%lhsi80 = "test.op"() : () -> i80
+%lhsf128, %rhsf128 = "test.op"() : () -> (f128, f128)
+%lhsf128vec, %rhsf128vec = "test.op"() : () -> (vector<4xf128>, vector<4xf128>)
+%lhsi128 = "test.op"() : () -> i128
 
 
 %divsi = arith.divsi %lhsi32, %rhsi32 : i32
@@ -170,6 +176,38 @@
 // CHECK-NEXT: %bitcast_bf16_to_f16 = arith.bitcast %lhsbf16 : bf16 to f16
 // CHECK-NEXT: %bitcast_i16_to_bf16 = arith.bitcast %lhsi16 : i16 to bf16
 // CHECK-NEXT: %bitcast_bf16_vec = arith.bitcast %lhsbf16vec : vector<4xbf16> to vector<4xi16>
+
+%addf_f80 = arith.addf %lhsf80, %rhsf80 : f80
+%addf_f80_vector = arith.addf %lhsf80vec, %rhsf80vec : vector<4xf80>
+%negf_f80 = arith.negf %lhsf80 : f80
+%cmpf_f80 = arith.cmpf ogt, %lhsf80, %rhsf80 : f80
+%bitcast_f80_to_i80 = arith.bitcast %lhsf80 : f80 to i80
+%bitcast_i80_to_f80 = arith.bitcast %lhsi80 : i80 to f80
+%bitcast_f80_vec = arith.bitcast %lhsf80vec : vector<4xf80> to vector<4xi80>
+
+// CHECK-NEXT: %addf_f80 = arith.addf %lhsf80, %rhsf80 : f80
+// CHECK-NEXT: %addf_f80_vector = arith.addf %lhsf80vec, %rhsf80vec : vector<4xf80>
+// CHECK-NEXT: %negf_f80 = arith.negf %lhsf80 : f80
+// CHECK-NEXT: %cmpf_f80 = arith.cmpf ogt, %lhsf80, %rhsf80 : f80
+// CHECK-NEXT: %bitcast_f80_to_i80 = arith.bitcast %lhsf80 : f80 to i80
+// CHECK-NEXT: %bitcast_i80_to_f80 = arith.bitcast %lhsi80 : i80 to f80
+// CHECK-NEXT: %bitcast_f80_vec = arith.bitcast %lhsf80vec : vector<4xf80> to vector<4xi80>
+
+%addf_f128 = arith.addf %lhsf128, %rhsf128 : f128
+%addf_f128_vector = arith.addf %lhsf128vec, %rhsf128vec : vector<4xf128>
+%negf_f128 = arith.negf %lhsf128 : f128
+%cmpf_f128 = arith.cmpf ogt, %lhsf128, %rhsf128 : f128
+%bitcast_f128_to_i128 = arith.bitcast %lhsf128 : f128 to i128
+%bitcast_i128_to_f128 = arith.bitcast %lhsi128 : i128 to f128
+%bitcast_f128_vec = arith.bitcast %lhsf128vec : vector<4xf128> to vector<4xi128>
+
+// CHECK-NEXT: %addf_f128 = arith.addf %lhsf128, %rhsf128 : f128
+// CHECK-NEXT: %addf_f128_vector = arith.addf %lhsf128vec, %rhsf128vec : vector<4xf128>
+// CHECK-NEXT: %negf_f128 = arith.negf %lhsf128 : f128
+// CHECK-NEXT: %cmpf_f128 = arith.cmpf ogt, %lhsf128, %rhsf128 : f128
+// CHECK-NEXT: %bitcast_f128_to_i128 = arith.bitcast %lhsf128 : f128 to i128
+// CHECK-NEXT: %bitcast_i128_to_f128 = arith.bitcast %lhsi128 : i128 to f128
+// CHECK-NEXT: %bitcast_f128_vec = arith.bitcast %lhsf128vec : vector<4xf128> to vector<4xi128>
 
 %extf = "arith.extf"(%lhsf32) : (f32) -> f64
 

--- a/tests/filecheck/dialects/arith/arith_ops.mlir
+++ b/tests/filecheck/dialects/arith/arith_ops.mlir
@@ -7,6 +7,9 @@
 %lhsf32, %rhsf32 = "test.op"() : () -> (f32, f32)
 %lhsf64, %rhsf64 = "test.op"() : () -> (f64, f64)
 %lhsvec, %rhsvec = "test.op"() : () -> (vector<4xf32>, vector<4xf32>)
+%lhsbf16, %rhsbf16 = "test.op"() : () -> (bf16, bf16)
+%lhsbf16vec, %rhsbf16vec = "test.op"() : () -> (vector<4xbf16>, vector<4xbf16>)
+%lhsi16 = "test.op"() : () -> i16
 
 
 %divsi = arith.divsi %lhsi32, %rhsi32 : i32
@@ -149,6 +152,24 @@
 %negf = "arith.negf"(%lhsf32) : (f32) -> f32
 
 // CHECK-NEXT: %negf = arith.negf %lhsf32 : f32
+
+%addf_bf16 = arith.addf %lhsbf16, %rhsbf16 : bf16
+%addf_bf16_vector = arith.addf %lhsbf16vec, %rhsbf16vec : vector<4xbf16>
+%negf_bf16 = arith.negf %lhsbf16 : bf16
+%cmpf_bf16 = arith.cmpf ogt, %lhsbf16, %rhsbf16 : bf16
+%bitcast_bf16_to_i16 = arith.bitcast %lhsbf16 : bf16 to i16
+%bitcast_bf16_to_f16 = arith.bitcast %lhsbf16 : bf16 to f16
+%bitcast_i16_to_bf16 = arith.bitcast %lhsi16 : i16 to bf16
+%bitcast_bf16_vec = arith.bitcast %lhsbf16vec : vector<4xbf16> to vector<4xi16>
+
+// CHECK-NEXT: %addf_bf16 = arith.addf %lhsbf16, %rhsbf16 : bf16
+// CHECK-NEXT: %addf_bf16_vector = arith.addf %lhsbf16vec, %rhsbf16vec : vector<4xbf16>
+// CHECK-NEXT: %negf_bf16 = arith.negf %lhsbf16 : bf16
+// CHECK-NEXT: %cmpf_bf16 = arith.cmpf ogt, %lhsbf16, %rhsbf16 : bf16
+// CHECK-NEXT: %bitcast_bf16_to_i16 = arith.bitcast %lhsbf16 : bf16 to i16
+// CHECK-NEXT: %bitcast_bf16_to_f16 = arith.bitcast %lhsbf16 : bf16 to f16
+// CHECK-NEXT: %bitcast_i16_to_bf16 = arith.bitcast %lhsi16 : i16 to bf16
+// CHECK-NEXT: %bitcast_bf16_vec = arith.bitcast %lhsbf16vec : vector<4xbf16> to vector<4xi16>
 
 %extf = "arith.extf"(%lhsf32) : (f32) -> f64
 

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/arith/arith_bcast.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/arith/arith_bcast.mlir
@@ -9,6 +9,20 @@
 // CHECK-NEXT:   %5 = arith.bitcast %4 : i64 to f64
 // CHECK-NEXT:   %6 = arith.bitcast %5 : f64 to i64
 
+// CHECK-NEXT:   %7 = "test.op"() : () -> i16
+// CHECK-NEXT:   %8 = arith.bitcast %7 : i16 to bf16
+// CHECK-NEXT:   %9 = arith.bitcast %8 : bf16 to i16
+// CHECK-NEXT:   %10 = arith.bitcast %8 : bf16 to f16
+// CHECK-NEXT:   %11 = arith.bitcast %10 : f16 to bf16
+
+// CHECK-NEXT:   %12 = "test.op"() : () -> i80
+// CHECK-NEXT:   %13 = arith.bitcast %12 : i80 to f80
+// CHECK-NEXT:   %14 = arith.bitcast %13 : f80 to i80
+
+// CHECK-NEXT:   %15 = "test.op"() : () -> i128
+// CHECK-NEXT:   %16 = arith.bitcast %15 : i128 to f128
+// CHECK-NEXT:   %17 = arith.bitcast %16 : f128 to i128
+
 %0 = "test.op"() : () -> i32
 %1 = "arith.bitcast"(%0) : (i32) -> i32
 %2 = "arith.bitcast"(%0) : (i32) -> f32
@@ -17,3 +31,17 @@
 %4 = "test.op"() : () -> i64
 %5 = "arith.bitcast"(%4) : (i64) -> f64
 %6 = "arith.bitcast"(%5) : (f64) -> i64
+
+%7 = "test.op"() : () -> i16
+%8 = "arith.bitcast"(%7) : (i16) -> bf16
+%9 = "arith.bitcast"(%8) : (bf16) -> i16
+%10 = "arith.bitcast"(%8) : (bf16) -> f16
+%11 = "arith.bitcast"(%10) : (f16) -> bf16
+
+%12 = "test.op"() : () -> i80
+%13 = "arith.bitcast"(%12) : (i80) -> f80
+%14 = "arith.bitcast"(%13) : (f80) -> i80
+
+%15 = "test.op"() : () -> i128
+%16 = "arith.bitcast"(%15) : (i128) -> f128
+%17 = "arith.bitcast"(%16) : (f128) -> i128

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/arith/arith_bcast.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/arith/arith_bcast.mlir
@@ -1,47 +1,40 @@
-// RUN: mlir-opt %s --allow-unregistered-dialect | xdsl-opt | filecheck %s
+// RUN: MLIR_ROUNDTRIP
 
-// CHECK:        %0 = "test.op"() : () -> i32
-// CHECK-NEXT:   %1 = arith.bitcast %0 : i32 to i32
-// CHECK-NEXT:   %2 = arith.bitcast %0 : i32 to f32
-// CHECK-NEXT:   %3 = arith.bitcast %2 : f32 to i32
+module {
+  %0, %4, %7, %12, %15 = "test.op"() : () -> (i32, i64, i16, i80, i128)
+  %1 = arith.bitcast %0 : i32 to i32
+  %2 = arith.bitcast %0 : i32 to f32
+  %3 = arith.bitcast %2 : f32 to i32
 
-// CHECK-NEXT:   %4 = "test.op"() : () -> i64
-// CHECK-NEXT:   %5 = arith.bitcast %4 : i64 to f64
-// CHECK-NEXT:   %6 = arith.bitcast %5 : f64 to i64
+  %5 = arith.bitcast %4 : i64 to f64
+  %6 = arith.bitcast %5 : f64 to i64
 
-// CHECK-NEXT:   %7 = "test.op"() : () -> i16
-// CHECK-NEXT:   %8 = arith.bitcast %7 : i16 to bf16
-// CHECK-NEXT:   %9 = arith.bitcast %8 : bf16 to i16
-// CHECK-NEXT:   %10 = arith.bitcast %8 : bf16 to f16
-// CHECK-NEXT:   %11 = arith.bitcast %10 : f16 to bf16
+  %8 = arith.bitcast %7 : i16 to bf16
+  %9 = arith.bitcast %8 : bf16 to i16
+  %10 = arith.bitcast %8 : bf16 to f16
+  %11 = arith.bitcast %10 : f16 to bf16
 
-// CHECK-NEXT:   %12 = "test.op"() : () -> i80
-// CHECK-NEXT:   %13 = arith.bitcast %12 : i80 to f80
-// CHECK-NEXT:   %14 = arith.bitcast %13 : f80 to i80
+  %13 = arith.bitcast %12 : i80 to f80
+  %14 = arith.bitcast %13 : f80 to i80
 
-// CHECK-NEXT:   %15 = "test.op"() : () -> i128
-// CHECK-NEXT:   %16 = arith.bitcast %15 : i128 to f128
-// CHECK-NEXT:   %17 = arith.bitcast %16 : f128 to i128
+  %16 = arith.bitcast %15 : i128 to f128
+  %17 = arith.bitcast %16 : f128 to i128
+}
 
-%0 = "test.op"() : () -> i32
-%1 = "arith.bitcast"(%0) : (i32) -> i32
-%2 = "arith.bitcast"(%0) : (i32) -> f32
-%3 = "arith.bitcast"(%2) : (f32) -> i32
+// CHECK:        %{{.*}} = arith.bitcast %{{.*}} : i32 to i32
+// CHECK-NEXT:   %{{.*}} = arith.bitcast %{{.*}} : i32 to f32
+// CHECK-NEXT:   %{{.*}} = arith.bitcast %{{.*}} : f32 to i32
 
-%4 = "test.op"() : () -> i64
-%5 = "arith.bitcast"(%4) : (i64) -> f64
-%6 = "arith.bitcast"(%5) : (f64) -> i64
+// CHECK:        %{{.*}} = arith.bitcast %{{.*}} : i64 to f64
+// CHECK-NEXT:   %{{.*}} = arith.bitcast %{{.*}} : f64 to i64
 
-%7 = "test.op"() : () -> i16
-%8 = "arith.bitcast"(%7) : (i16) -> bf16
-%9 = "arith.bitcast"(%8) : (bf16) -> i16
-%10 = "arith.bitcast"(%8) : (bf16) -> f16
-%11 = "arith.bitcast"(%10) : (f16) -> bf16
+// CHECK:        %{{.*}} = arith.bitcast %{{.*}} : i16 to bf16
+// CHECK-NEXT:   %{{.*}} = arith.bitcast %{{.*}} : bf16 to i16
+// CHECK-NEXT:   %{{.*}} = arith.bitcast %{{.*}} : bf16 to f16
+// CHECK-NEXT:   %{{.*}} = arith.bitcast %{{.*}} : f16 to bf16
 
-%12 = "test.op"() : () -> i80
-%13 = "arith.bitcast"(%12) : (i80) -> f80
-%14 = "arith.bitcast"(%13) : (f80) -> i80
+// CHECK:        %{{.*}} = arith.bitcast %{{.*}} : i80 to f80
+// CHECK-NEXT:   %{{.*}} = arith.bitcast %{{.*}} : f80 to i80
 
-%15 = "test.op"() : () -> i128
-%16 = "arith.bitcast"(%15) : (i128) -> f128
-%17 = "arith.bitcast"(%16) : (f128) -> i128
+// CHECK:        %{{.*}} = arith.bitcast %{{.*}} : i128 to f128
+// CHECK-NEXT:   %{{.*}} = arith.bitcast %{{.*}} : f128 to i128

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/arith/arith_cmp.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/arith/arith_cmp.mlir
@@ -24,12 +24,12 @@
   %17 = "arith.select"(%16, %f128_lhs, %f128_rhs) : (i1, f128, f128) -> f128
 }) : ()->()
 
-// CHECK:        "arith.cmpf"(%0, %1) <{fastmath = #arith.fastmath<none>, predicate = 2 : i64}> : (f64, f64) -> i1
-// CHECK:        "arith.select"(%6, %0, %1) : (i1, f64, f64) -> f64
-// CHECK:        "arith.cmpi"(%2, %3) <{predicate = 1 : i64}> : (i32, i32) -> i1
-// CHECK:        "arith.select"(%8, %2, %3) : (i1, i32, i32) -> i32
-// CHECK:        "arith.cmpi"(%4, %5) <{predicate = 1 : i64}> : (index, index) -> i1
-// CHECK:        "arith.select"(%10, %4, %5) : (i1, index, index) -> index
+// CHECK:        "arith.cmpf"(%{{.*}}, %{{.*}}) <{fastmath = #arith.fastmath<none>, predicate = 2 : i64}> : (f64, f64) -> i1
+// CHECK:        "arith.select"(%{{.*}}, %{{.*}}, %{{.*}}) : (i1, f64, f64) -> f64
+// CHECK:        "arith.cmpi"(%{{.*}}, %{{.*}}) <{predicate = 1 : i64}> : (i32, i32) -> i1
+// CHECK:        "arith.select"(%{{.*}}, %{{.*}}, %{{.*}}) : (i1, i32, i32) -> i32
+// CHECK:        "arith.cmpi"(%{{.*}}, %{{.*}}) <{predicate = 1 : i64}> : (index, index) -> i1
+// CHECK:        "arith.select"(%{{.*}}, %{{.*}}, %{{.*}}) : (i1, index, index) -> index
 // CHECK:        "arith.cmpf"(%{{.*}}, %{{.*}}) <{fastmath = #arith.fastmath<none>, predicate = 2 : i64}> : (bf16, bf16) -> i1
 // CHECK:        "arith.select"(%{{.*}}, %{{.*}}, %{{.*}}) : (i1, bf16, bf16) -> bf16
 // CHECK:        "arith.cmpf"(%{{.*}}, %{{.*}}) <{fastmath = #arith.fastmath<none>, predicate = 2 : i64}> : (f80, f80) -> i1

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/arith/arith_cmp.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/arith/arith_cmp.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt %s --mlir-print-op-generic | xdsl-opt --print-op-generic | filecheck %s
+// RUN: mlir-opt %s --mlir-print-op-generic --allow-unregistered-dialect | xdsl-opt --print-op-generic --allow-unregistered-dialect | filecheck %s
 
 "builtin.module"() ({
   %0 = "arith.constant"() {"value" = 1.0 : f64} : () -> f64
@@ -7,12 +7,21 @@
   %3 = "arith.constant"() {"value" = 2 : i32} : () -> i32
   %4 = "arith.constant"() {"value" = 1 : index} : () -> index
   %5 = "arith.constant"() {"value" = 2 : index} : () -> index
+  %bf_lhs, %bf_rhs = "test.op"() : () -> (bf16, bf16)
+  %f80_lhs, %f80_rhs = "test.op"() : () -> (f80, f80)
+  %f128_lhs, %f128_rhs = "test.op"() : () -> (f128, f128)
   %6 = "arith.cmpf"(%0, %1) {"predicate" = 2 : i64} : (f64, f64) -> i1
   %7 = "arith.select"(%6, %0, %1) : (i1, f64, f64) -> f64
   %8 = "arith.cmpi"(%2, %3) {"predicate" = 1 : i64} : (i32, i32) -> i1
   %9 = "arith.select"(%8, %2, %3) : (i1, i32, i32) -> i32
   %10 = "arith.cmpi"(%4, %5) {"predicate" = 1 : i64} : (index, index) -> i1
   %11 = "arith.select"(%10, %4, %5) : (i1, index, index) -> index
+  %12 = "arith.cmpf"(%bf_lhs, %bf_rhs) {"predicate" = 2 : i64} : (bf16, bf16) -> i1
+  %13 = "arith.select"(%12, %bf_lhs, %bf_rhs) : (i1, bf16, bf16) -> bf16
+  %14 = "arith.cmpf"(%f80_lhs, %f80_rhs) {"predicate" = 2 : i64} : (f80, f80) -> i1
+  %15 = "arith.select"(%14, %f80_lhs, %f80_rhs) : (i1, f80, f80) -> f80
+  %16 = "arith.cmpf"(%f128_lhs, %f128_rhs) {"predicate" = 2 : i64} : (f128, f128) -> i1
+  %17 = "arith.select"(%16, %f128_lhs, %f128_rhs) : (i1, f128, f128) -> f128
 }) : ()->()
 
 // CHECK:        "arith.cmpf"(%0, %1) <{fastmath = #arith.fastmath<none>, predicate = 2 : i64}> : (f64, f64) -> i1
@@ -21,3 +30,9 @@
 // CHECK:        "arith.select"(%8, %2, %3) : (i1, i32, i32) -> i32
 // CHECK:        "arith.cmpi"(%4, %5) <{predicate = 1 : i64}> : (index, index) -> i1
 // CHECK:        "arith.select"(%10, %4, %5) : (i1, index, index) -> index
+// CHECK:        "arith.cmpf"(%{{.*}}, %{{.*}}) <{fastmath = #arith.fastmath<none>, predicate = 2 : i64}> : (bf16, bf16) -> i1
+// CHECK:        "arith.select"(%{{.*}}, %{{.*}}, %{{.*}}) : (i1, bf16, bf16) -> bf16
+// CHECK:        "arith.cmpf"(%{{.*}}, %{{.*}}) <{fastmath = #arith.fastmath<none>, predicate = 2 : i64}> : (f80, f80) -> i1
+// CHECK:        "arith.select"(%{{.*}}, %{{.*}}, %{{.*}}) : (i1, f80, f80) -> f80
+// CHECK:        "arith.cmpf"(%{{.*}}, %{{.*}}) <{fastmath = #arith.fastmath<none>, predicate = 2 : i64}> : (f128, f128) -> i1
+// CHECK:        "arith.select"(%{{.*}}, %{{.*}}, %{{.*}}) : (i1, f128, f128) -> f128

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/arith/arith_cmp.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/arith/arith_cmp.mlir
@@ -1,38 +1,36 @@
-// RUN: mlir-opt %s --mlir-print-op-generic --allow-unregistered-dialect | xdsl-opt --print-op-generic --allow-unregistered-dialect | filecheck %s
+// RUN: MLIR_ROUNDTRIP
 
-"builtin.module"() ({
-  %0 = "arith.constant"() {"value" = 1.0 : f64} : () -> f64
-  %1 = "arith.constant"() {"value" = 1.0 : f64} : () -> f64
-  %2 = "arith.constant"() {"value" = 1 : i32} : () -> i32
-  %3 = "arith.constant"() {"value" = 2 : i32} : () -> i32
-  %4 = "arith.constant"() {"value" = 1 : index} : () -> index
-  %5 = "arith.constant"() {"value" = 2 : index} : () -> index
-  %bf_lhs, %bf_rhs = "test.op"() : () -> (bf16, bf16)
-  %f80_lhs, %f80_rhs = "test.op"() : () -> (f80, f80)
-  %f128_lhs, %f128_rhs = "test.op"() : () -> (f128, f128)
-  %6 = "arith.cmpf"(%0, %1) {"predicate" = 2 : i64} : (f64, f64) -> i1
-  %7 = "arith.select"(%6, %0, %1) : (i1, f64, f64) -> f64
-  %8 = "arith.cmpi"(%2, %3) {"predicate" = 1 : i64} : (i32, i32) -> i1
-  %9 = "arith.select"(%8, %2, %3) : (i1, i32, i32) -> i32
-  %10 = "arith.cmpi"(%4, %5) {"predicate" = 1 : i64} : (index, index) -> i1
-  %11 = "arith.select"(%10, %4, %5) : (i1, index, index) -> index
-  %12 = "arith.cmpf"(%bf_lhs, %bf_rhs) {"predicate" = 2 : i64} : (bf16, bf16) -> i1
-  %13 = "arith.select"(%12, %bf_lhs, %bf_rhs) : (i1, bf16, bf16) -> bf16
-  %14 = "arith.cmpf"(%f80_lhs, %f80_rhs) {"predicate" = 2 : i64} : (f80, f80) -> i1
-  %15 = "arith.select"(%14, %f80_lhs, %f80_rhs) : (i1, f80, f80) -> f80
-  %16 = "arith.cmpf"(%f128_lhs, %f128_rhs) {"predicate" = 2 : i64} : (f128, f128) -> i1
-  %17 = "arith.select"(%16, %f128_lhs, %f128_rhs) : (i1, f128, f128) -> f128
-}) : ()->()
+module {
+  %0 = arith.constant 1.0 : f64
+  %1 = arith.constant 1.0 : f64
+  %2 = arith.constant 1 : i32
+  %3 = arith.constant 2 : i32
+  %4 = arith.constant 1 : index
+  %5 = arith.constant 2 : index
+  %bf_lhs, %bf_rhs, %f80_lhs, %f80_rhs, %f128_lhs, %f128_rhs = "test.op"() : () -> (bf16, bf16, f80, f80, f128, f128)
+  %6 = arith.cmpf ogt, %0, %1 : f64
+  %7 = arith.select %6, %0, %1 : f64
+  %8 = arith.cmpi ne, %2, %3 : i32
+  %9 = arith.select %8, %2, %3 : i32
+  %10 = arith.cmpi ne, %4, %5 : index
+  %11 = arith.select %10, %4, %5 : index
+  %12 = arith.cmpf ogt, %bf_lhs, %bf_rhs : bf16
+  %13 = arith.select %12, %bf_lhs, %bf_rhs : bf16
+  %14 = arith.cmpf ogt, %f80_lhs, %f80_rhs : f80
+  %15 = arith.select %14, %f80_lhs, %f80_rhs : f80
+  %16 = arith.cmpf ogt, %f128_lhs, %f128_rhs : f128
+  %17 = arith.select %16, %f128_lhs, %f128_rhs : f128
+}
 
-// CHECK:        "arith.cmpf"(%{{.*}}, %{{.*}}) <{fastmath = #arith.fastmath<none>, predicate = 2 : i64}> : (f64, f64) -> i1
-// CHECK:        "arith.select"(%{{.*}}, %{{.*}}, %{{.*}}) : (i1, f64, f64) -> f64
-// CHECK:        "arith.cmpi"(%{{.*}}, %{{.*}}) <{predicate = 1 : i64}> : (i32, i32) -> i1
-// CHECK:        "arith.select"(%{{.*}}, %{{.*}}, %{{.*}}) : (i1, i32, i32) -> i32
-// CHECK:        "arith.cmpi"(%{{.*}}, %{{.*}}) <{predicate = 1 : i64}> : (index, index) -> i1
-// CHECK:        "arith.select"(%{{.*}}, %{{.*}}, %{{.*}}) : (i1, index, index) -> index
-// CHECK:        "arith.cmpf"(%{{.*}}, %{{.*}}) <{fastmath = #arith.fastmath<none>, predicate = 2 : i64}> : (bf16, bf16) -> i1
-// CHECK:        "arith.select"(%{{.*}}, %{{.*}}, %{{.*}}) : (i1, bf16, bf16) -> bf16
-// CHECK:        "arith.cmpf"(%{{.*}}, %{{.*}}) <{fastmath = #arith.fastmath<none>, predicate = 2 : i64}> : (f80, f80) -> i1
-// CHECK:        "arith.select"(%{{.*}}, %{{.*}}, %{{.*}}) : (i1, f80, f80) -> f80
-// CHECK:        "arith.cmpf"(%{{.*}}, %{{.*}}) <{fastmath = #arith.fastmath<none>, predicate = 2 : i64}> : (f128, f128) -> i1
-// CHECK:        "arith.select"(%{{.*}}, %{{.*}}, %{{.*}}) : (i1, f128, f128) -> f128
+// CHECK:        %{{.*}} = arith.cmpf ogt, %{{.*}}, %{{.*}} : f64
+// CHECK:        %{{.*}} = arith.select %{{.*}}, %{{.*}}, %{{.*}} : f64
+// CHECK:        %{{.*}} = arith.cmpi ne, %{{.*}}, %{{.*}} : i32
+// CHECK:        %{{.*}} = arith.select %{{.*}}, %{{.*}}, %{{.*}} : i32
+// CHECK:        %{{.*}} = arith.cmpi ne, %{{.*}}, %{{.*}} : index
+// CHECK:        %{{.*}} = arith.select %{{.*}}, %{{.*}}, %{{.*}} : index
+// CHECK:        %{{.*}} = arith.cmpf ogt, %{{.*}}, %{{.*}} : bf16
+// CHECK:        %{{.*}} = arith.select %{{.*}}, %{{.*}}, %{{.*}} : bf16
+// CHECK:        %{{.*}} = arith.cmpf ogt, %{{.*}}, %{{.*}} : f80
+// CHECK:        %{{.*}} = arith.select %{{.*}}, %{{.*}}, %{{.*}} : f80
+// CHECK:        %{{.*}} = arith.cmpf ogt, %{{.*}}, %{{.*}} : f128
+// CHECK:        %{{.*}} = arith.select %{{.*}}, %{{.*}}, %{{.*}} : f128

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/arith/arith_fp_conv.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/arith/arith_fp_conv.mlir
@@ -1,39 +1,37 @@
-// RUN: mlir-opt %s --mlir-print-op-generic --allow-unregistered-dialect | xdsl-opt --print-op-generic --allow-unregistered-dialect | filecheck %s
+// RUN: MLIR_ROUNDTRIP
 
-"builtin.module"() ({
-  %0 = "arith.constant"() {"value" = 1.0 : f16} : () -> f16
-  %1 = "arith.constant"() {"value" = 1.0 : f32} : () -> f32
-  %2 = "arith.constant"() {"value" = 1.0 : f64} : () -> f64
-  %bf = "test.op"() : () -> bf16
-  %f80v = "test.op"() : () -> f80
-  %f128v = "test.op"() : () -> f128
-  %3 = "arith.extf"(%0) : (f16) -> f32
-  %4 = "arith.extf"(%0) : (f16) -> f64
-  %5 = "arith.extf"(%1) : (f32) -> f64
-  %6 = "arith.truncf"(%1) : (f32) -> f16
-  %7 = "arith.truncf"(%2) : (f64) -> f32
-  %8 = "arith.truncf"(%2) : (f64) -> f16
-  %9 = "arith.extf"(%bf) : (bf16) -> f32
-  %10 = "arith.extf"(%bf) : (bf16) -> f64
-  %11 = "arith.extf"(%1) : (f32) -> f80
-  %12 = "arith.extf"(%2) : (f64) -> f128
-  %13 = "arith.truncf"(%1) : (f32) -> bf16
-  %14 = "arith.truncf"(%2) : (f64) -> bf16
-  %15 = "arith.truncf"(%f80v) : (f80) -> f32
-  %16 = "arith.truncf"(%f128v) : (f128) -> f64
-}) : ()->()
+module {
+  %0 = arith.constant 1.0 : f16
+  %1 = arith.constant 1.0 : f32
+  %2 = arith.constant 1.0 : f64
+  %bf, %f80v, %f128v = "test.op"() : () -> (bf16, f80, f128)
+  %3 = arith.extf %0 : f16 to f32
+  %4 = arith.extf %0 : f16 to f64
+  %5 = arith.extf %1 : f32 to f64
+  %6 = arith.truncf %1 : f32 to f16
+  %7 = arith.truncf %2 : f64 to f32
+  %8 = arith.truncf %2 : f64 to f16
+  %9 = arith.extf %bf : bf16 to f32
+  %10 = arith.extf %bf : bf16 to f64
+  %11 = arith.extf %1 : f32 to f80
+  %12 = arith.extf %2 : f64 to f128
+  %13 = arith.truncf %1 : f32 to bf16
+  %14 = arith.truncf %2 : f64 to bf16
+  %15 = arith.truncf %f80v : f80 to f32
+  %16 = arith.truncf %f128v : f128 to f64
+}
 
-// CHECK:        "arith.extf"(%0) : (f16) -> f32
-// CHECK:        "arith.extf"(%0) : (f16) -> f64
-// CHECK:        "arith.extf"(%1) : (f32) -> f64
-// CHECK:        "arith.truncf"(%1) : (f32) -> f16
-// CHECK:        "arith.truncf"(%2) : (f64) -> f32
-// CHECK:        "arith.truncf"(%2) : (f64) -> f16
-// CHECK:        "arith.extf"(%{{.*}}) : (bf16) -> f32
-// CHECK:        "arith.extf"(%{{.*}}) : (bf16) -> f64
-// CHECK:        "arith.extf"(%1) : (f32) -> f80
-// CHECK:        "arith.extf"(%2) : (f64) -> f128
-// CHECK:        "arith.truncf"(%1) : (f32) -> bf16
-// CHECK:        "arith.truncf"(%2) : (f64) -> bf16
-// CHECK:        "arith.truncf"(%{{.*}}) : (f80) -> f32
-// CHECK:        "arith.truncf"(%{{.*}}) : (f128) -> f64
+// CHECK:        %{{.*}} = arith.extf %{{.*}} : f16 to f32
+// CHECK:        %{{.*}} = arith.extf %{{.*}} : f16 to f64
+// CHECK:        %{{.*}} = arith.extf %{{.*}} : f32 to f64
+// CHECK:        %{{.*}} = arith.truncf %{{.*}} : f32 to f16
+// CHECK:        %{{.*}} = arith.truncf %{{.*}} : f64 to f32
+// CHECK:        %{{.*}} = arith.truncf %{{.*}} : f64 to f16
+// CHECK:        %{{.*}} = arith.extf %{{.*}} : bf16 to f32
+// CHECK:        %{{.*}} = arith.extf %{{.*}} : bf16 to f64
+// CHECK:        %{{.*}} = arith.extf %{{.*}} : f32 to f80
+// CHECK:        %{{.*}} = arith.extf %{{.*}} : f64 to f128
+// CHECK:        %{{.*}} = arith.truncf %{{.*}} : f32 to bf16
+// CHECK:        %{{.*}} = arith.truncf %{{.*}} : f64 to bf16
+// CHECK:        %{{.*}} = arith.truncf %{{.*}} : f80 to f32
+// CHECK:        %{{.*}} = arith.truncf %{{.*}} : f128 to f64

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/arith/arith_fp_conv.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/arith/arith_fp_conv.mlir
@@ -1,15 +1,26 @@
-// RUN: mlir-opt %s --mlir-print-op-generic | xdsl-opt --print-op-generic | filecheck %s
+// RUN: mlir-opt %s --mlir-print-op-generic --allow-unregistered-dialect | xdsl-opt --print-op-generic --allow-unregistered-dialect | filecheck %s
 
 "builtin.module"() ({
   %0 = "arith.constant"() {"value" = 1.0 : f16} : () -> f16
   %1 = "arith.constant"() {"value" = 1.0 : f32} : () -> f32
   %2 = "arith.constant"() {"value" = 1.0 : f64} : () -> f64
+  %bf = "test.op"() : () -> bf16
+  %f80v = "test.op"() : () -> f80
+  %f128v = "test.op"() : () -> f128
   %3 = "arith.extf"(%0) : (f16) -> f32
   %4 = "arith.extf"(%0) : (f16) -> f64
   %5 = "arith.extf"(%1) : (f32) -> f64
   %6 = "arith.truncf"(%1) : (f32) -> f16
   %7 = "arith.truncf"(%2) : (f64) -> f32
   %8 = "arith.truncf"(%2) : (f64) -> f16
+  %9 = "arith.extf"(%bf) : (bf16) -> f32
+  %10 = "arith.extf"(%bf) : (bf16) -> f64
+  %11 = "arith.extf"(%1) : (f32) -> f80
+  %12 = "arith.extf"(%2) : (f64) -> f128
+  %13 = "arith.truncf"(%1) : (f32) -> bf16
+  %14 = "arith.truncf"(%2) : (f64) -> bf16
+  %15 = "arith.truncf"(%f80v) : (f80) -> f32
+  %16 = "arith.truncf"(%f128v) : (f128) -> f64
 }) : ()->()
 
 // CHECK:        "arith.extf"(%0) : (f16) -> f32
@@ -18,3 +29,11 @@
 // CHECK:        "arith.truncf"(%1) : (f32) -> f16
 // CHECK:        "arith.truncf"(%2) : (f64) -> f32
 // CHECK:        "arith.truncf"(%2) : (f64) -> f16
+// CHECK:        "arith.extf"(%{{.*}}) : (bf16) -> f32
+// CHECK:        "arith.extf"(%{{.*}}) : (bf16) -> f64
+// CHECK:        "arith.extf"(%1) : (f32) -> f80
+// CHECK:        "arith.extf"(%2) : (f64) -> f128
+// CHECK:        "arith.truncf"(%1) : (f32) -> bf16
+// CHECK:        "arith.truncf"(%2) : (f64) -> bf16
+// CHECK:        "arith.truncf"(%{{.*}}) : (f80) -> f32
+// CHECK:        "arith.truncf"(%{{.*}}) : (f128) -> f64

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/arith/arith_fp_ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/arith/arith_fp_ops.mlir
@@ -1,11 +1,20 @@
-// RUN: mlir-opt %s --mlir-print-op-generic | xdsl-opt --print-op-generic | filecheck %s
+// RUN: mlir-opt %s --mlir-print-op-generic --allow-unregistered-dialect | xdsl-opt --print-op-generic --allow-unregistered-dialect | filecheck %s
 
 "builtin.module"() ({
   %0 = "arith.constant"() {"value" = 1.0 : f32} : () -> f32
   %1 = "arith.constant"() {"value" = 1.0 : f64} : () -> f64
-  %3 = "arith.negf"(%0) : (f32) -> f32
-  %4 = "arith.negf"(%1) : (f64) -> f64
+  %2 = "test.op"() : () -> bf16
+  %3 = "test.op"() : () -> f80
+  %4 = "test.op"() : () -> f128
+  %5 = "arith.negf"(%0) : (f32) -> f32
+  %6 = "arith.negf"(%1) : (f64) -> f64
+  %7 = "arith.negf"(%2) : (bf16) -> bf16
+  %8 = "arith.negf"(%3) : (f80) -> f80
+  %9 = "arith.negf"(%4) : (f128) -> f128
 }) : ()->()
 
 // CHECK:        "arith.negf"(%0) <{fastmath = #arith.fastmath<none>}> : (f32) -> f32
 // CHECK:        "arith.negf"(%1) <{fastmath = #arith.fastmath<none>}> : (f64) -> f64
+// CHECK:        "arith.negf"(%2) <{fastmath = #arith.fastmath<none>}> : (bf16) -> bf16
+// CHECK:        "arith.negf"(%3) <{fastmath = #arith.fastmath<none>}> : (f80) -> f80
+// CHECK:        "arith.negf"(%4) <{fastmath = #arith.fastmath<none>}> : (f128) -> f128

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/arith/arith_fp_ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/arith/arith_fp_ops.mlir
@@ -1,20 +1,18 @@
-// RUN: mlir-opt %s --mlir-print-op-generic --allow-unregistered-dialect | xdsl-opt --print-op-generic --allow-unregistered-dialect | filecheck %s
+// RUN: MLIR_ROUNDTRIP
 
-"builtin.module"() ({
-  %0 = "arith.constant"() {"value" = 1.0 : f32} : () -> f32
-  %1 = "arith.constant"() {"value" = 1.0 : f64} : () -> f64
-  %2 = "test.op"() : () -> bf16
-  %3 = "test.op"() : () -> f80
-  %4 = "test.op"() : () -> f128
-  %5 = "arith.negf"(%0) : (f32) -> f32
-  %6 = "arith.negf"(%1) : (f64) -> f64
-  %7 = "arith.negf"(%2) : (bf16) -> bf16
-  %8 = "arith.negf"(%3) : (f80) -> f80
-  %9 = "arith.negf"(%4) : (f128) -> f128
-}) : ()->()
+module {
+  %0 = arith.constant 1.0 : f32
+  %1 = arith.constant 1.0 : f64
+  %2, %3, %4 = "test.op"() : () -> (bf16, f80, f128)
+  %5 = arith.negf %0 : f32
+  %6 = arith.negf %1 : f64
+  %7 = arith.negf %2 : bf16
+  %8 = arith.negf %3 : f80
+  %9 = arith.negf %4 : f128
+}
 
-// CHECK:        "arith.negf"(%0) <{fastmath = #arith.fastmath<none>}> : (f32) -> f32
-// CHECK:        "arith.negf"(%1) <{fastmath = #arith.fastmath<none>}> : (f64) -> f64
-// CHECK:        "arith.negf"(%2) <{fastmath = #arith.fastmath<none>}> : (bf16) -> bf16
-// CHECK:        "arith.negf"(%3) <{fastmath = #arith.fastmath<none>}> : (f80) -> f80
-// CHECK:        "arith.negf"(%4) <{fastmath = #arith.fastmath<none>}> : (f128) -> f128
+// CHECK:        %{{.*}} = arith.negf %{{.*}} : f32
+// CHECK:        %{{.*}} = arith.negf %{{.*}} : f64
+// CHECK:        %{{.*}} = arith.negf %{{.*}} : bf16
+// CHECK:        %{{.*}} = arith.negf %{{.*}} : f80
+// CHECK:        %{{.*}} = arith.negf %{{.*}} : f128

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -10,14 +10,10 @@ from xdsl.dialect_interfaces.constant_materialization import (
 from xdsl.dialects.builtin import (
     AnyFloat,
     AnyFloatConstr,
-    BFloat16Type,
     ContainerOf,
     DenseIntOrFPElementsAttr,
     DenseResourceAttr,
     FixedBitwidthType,
-    Float16Type,
-    Float32Type,
-    Float64Type,
     FloatAttr,
     IndexType,
     IndexTypeConstr,
@@ -69,9 +65,7 @@ from xdsl.utils.type import get_element_type_or_self, have_compatible_shape
 
 boolLike = ContainerOf(IntegerType(1))
 signlessIntegerLike = ContainerOf(AnyOf([IntegerType, IndexType]))
-floatingPointLike = ContainerOf(
-    AnyOf([BFloat16Type, Float16Type, Float32Type, Float64Type])
-)
+floatingPointLike = ContainerOf(AnyFloatConstr)
 
 
 CMPI_COMPARISON_OPERATIONS = [
@@ -1197,33 +1191,11 @@ class BitcastOp(IRDLOperation):
     name = "arith.bitcast"
 
     input = operand_def(
-        ContainerOf(
-            AnyOf(
-                (
-                    IntegerType,
-                    IndexType,
-                    BFloat16Type,
-                    Float16Type,
-                    Float32Type,
-                    Float64Type,
-                )
-            )
-        )
+        ContainerOf(AnyOf((IntegerType, IndexType)) | AnyFloatConstr)
         | MemRefType.constr(element_type=AnyFloatConstr | SignlessIntegerConstraint)
     )
     result = result_def(
-        ContainerOf(
-            AnyOf(
-                (
-                    IntegerType,
-                    IndexType,
-                    BFloat16Type,
-                    Float16Type,
-                    Float32Type,
-                    Float64Type,
-                )
-            )
-        )
+        ContainerOf(AnyOf((IntegerType, IndexType)) | AnyFloatConstr)
         | MemRefType.constr(element_type=AnyFloatConstr | SignlessIntegerConstraint)
     )
 

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -10,6 +10,7 @@ from xdsl.dialect_interfaces.constant_materialization import (
 from xdsl.dialects.builtin import (
     AnyFloat,
     AnyFloatConstr,
+    BFloat16Type,
     ContainerOf,
     DenseIntOrFPElementsAttr,
     DenseResourceAttr,
@@ -68,7 +69,9 @@ from xdsl.utils.type import get_element_type_or_self, have_compatible_shape
 
 boolLike = ContainerOf(IntegerType(1))
 signlessIntegerLike = ContainerOf(AnyOf([IntegerType, IndexType]))
-floatingPointLike = ContainerOf(AnyOf([Float16Type, Float32Type, Float64Type]))
+floatingPointLike = ContainerOf(
+    AnyOf([BFloat16Type, Float16Type, Float32Type, Float64Type])
+)
 
 
 CMPI_COMPARISON_OPERATIONS = [
@@ -1195,13 +1198,31 @@ class BitcastOp(IRDLOperation):
 
     input = operand_def(
         ContainerOf(
-            AnyOf((IntegerType, IndexType, Float16Type, Float32Type, Float64Type))
+            AnyOf(
+                (
+                    IntegerType,
+                    IndexType,
+                    BFloat16Type,
+                    Float16Type,
+                    Float32Type,
+                    Float64Type,
+                )
+            )
         )
         | MemRefType.constr(element_type=AnyFloatConstr | SignlessIntegerConstraint)
     )
     result = result_def(
         ContainerOf(
-            AnyOf((IntegerType, IndexType, Float16Type, Float32Type, Float64Type))
+            AnyOf(
+                (
+                    IntegerType,
+                    IndexType,
+                    BFloat16Type,
+                    Float16Type,
+                    Float32Type,
+                    Float64Type,
+                )
+            )
         )
         | MemRefType.constr(element_type=AnyFloatConstr | SignlessIntegerConstraint)
     )


### PR DESCRIPTION
Currently floatingPointLike in the arith dialect is limited to FP16, FP32 and FP64. However, in MLIR this uses the AnyFloatConstr and indeed the xDSL math dialect does the same too. Have therefore moved to this same approach, which means that bf16, fp80 and fp128 are also supported by arith conversion and floating point operations which is inline with MLIR. Have added filecheck tests for these.