### PR TITLE
core: ban direct imports of utils implementations.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,6 +138,10 @@ ignore = [
 max-line-length = 130
 
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
+"typing.TypeVar".msg = "Use typing_extensions.TypeVar instead."
+"xdsl.dialects.utils.bit_enum_attribute".msg = "Use xdsl.dialects.utils instead"
+"xdsl.dialects.utils.dimension_list".msg = "Use xdsl.dialects.utils instead"
+"xdsl.dialects.utils.dynamic_index_list".msg = "Use xdsl.dialects.utils instead"
 "xdsl.dialects.utils.fast_math".msg = "Use xdsl.dialects.utils instead"
 "xdsl.dialects.utils.format".msg = "Use xdsl.dialects.utils instead"
 "xdsl.ir.affine.affine_expr".msg = "Use xdsl.ir.affine instead"
@@ -153,7 +157,6 @@ max-line-length = 130
 "xdsl.parser.base_parser".msg = "Use xdsl.parser instead."
 "xdsl.parser.core".msg = "Use xdsl.parser instead."
 "xdsl.parser.generic_parser".msg = "Use xdsl.parser instead."
-"typing.TypeVar".msg = "Use typing_extensions.TypeVar instead."
 
 
 [tool.ruff.lint.per-file-ignores]

--- a/tests/test_dialect_utils.py
+++ b/tests/test_dialect_utils.py
@@ -15,8 +15,8 @@ from xdsl.dialects.utils import (
     print_dynamic_index_list,
     print_empty_dimension_list_directive,
     split_dynamic_index_list,
+    verify_dynamic_index_list,
 )
-from xdsl.dialects.utils.dynamic_index_list import verify_dynamic_index_list
 from xdsl.ir import Dialect, SSAValue
 from xdsl.parser import Parser, UnresolvedOperand
 from xdsl.printer import Printer

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -37,12 +37,10 @@ from xdsl.dialects.utils import (
     BitEnumAttribute,
     FastMathAttrBase,
     FastMathFlag,
-    parse_func_op_like,
-    print_func_op_like,
-)
-from xdsl.dialects.utils.dynamic_index_list import (
     parse_dynamic_index_list_without_types,
+    parse_func_op_like,
     print_dynamic_index_list,
+    print_func_op_like,
 )
 from xdsl.ir import (
     Attribute,

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -33,10 +33,8 @@ from xdsl.dialects.builtin import (
     i64,
 )
 from xdsl.dialects.utils import (
-    split_dynamic_index_list,
-)
-from xdsl.dialects.utils.dynamic_index_list import (
     DynamicIndexList,
+    split_dynamic_index_list,
     verify_dynamic_index_list,
 )
 from xdsl.dialects.utils.reshape_ops_utils import (

--- a/xdsl/dialects/tensor.py
+++ b/xdsl/dialects/tensor.py
@@ -24,8 +24,6 @@ from xdsl.dialects.builtin import (
 )
 from xdsl.dialects.utils import (
     AbstractYieldOperation,
-)
-from xdsl.dialects.utils.dynamic_index_list import (
     DynamicIndexList,
     parse_dynamic_index_list_without_types,
     print_dynamic_index_list,

--- a/xdsl/dialects/utils/__init__.py
+++ b/xdsl/dialects/utils/__init__.py
@@ -1,5 +1,6 @@
 # TID 251 enforces to not import from those
 # We need to skip it here to allow importing from here instead.
+# If adding banned imports, add them also to pyproject.toml.
 from .bit_enum_attribute import *  # noqa: TID251
 from .dimension_list import *  # noqa: TID251
 from .dynamic_index_list import *  # noqa: TID251

--- a/xdsl/dialects/vector.py
+++ b/xdsl/dialects/vector.py
@@ -35,11 +35,11 @@ from xdsl.dialects.builtin import (
     i64,
 )
 from xdsl.dialects.utils import (
+    DynamicIndexList,
     get_dynamic_index_list,
     split_dynamic_index_list,
     verify_dynamic_index_list,
 )
-from xdsl.dialects.utils.dynamic_index_list import DynamicIndexList
 from xdsl.ir import (
     Attribute,
     Dialect,

--- a/xdsl/ir/__init__.py
+++ b/xdsl/ir/__init__.py
@@ -1,3 +1,4 @@
 # TID 251 enforces to not import from core
 # We need to skip it here to allow importing from here instead.
+# If adding banned imports, add them also to pyproject.toml.
 from .core import *  # noqa: TID251

--- a/xdsl/ir/affine/__init__.py
+++ b/xdsl/ir/affine/__init__.py
@@ -1,5 +1,6 @@
 # TID 251 enforces to not import from those
 # We need to skip it here to allow importing from here instead.
+# If adding banned imports, add them also to pyproject.toml.
 from .affine_expr import *  # noqa: TID251
 from .affine_map import *  # noqa: TID251
 from .affine_set import *  # noqa: TID251

--- a/xdsl/irdl/__init__.py
+++ b/xdsl/irdl/__init__.py
@@ -1,5 +1,6 @@
 # TID 251 enforces to not import from nested irdl
 # We need to skip it here to allow importing from here instead.
+# If adding banned imports, add them also to pyproject.toml.
 from .attributes import *  # noqa: TID251
 from .constraints import *  # noqa: TID251
 from .operations import *  # noqa: TID251

--- a/xdsl/parser/__init__.py
+++ b/xdsl/parser/__init__.py
@@ -1,5 +1,6 @@
 # TID 251 enforces to not import from nested modules
 # We need to skip it here to allow importing from here instead.
+# If adding banned imports, add them also to pyproject.toml.
 # To avoid circular imports, affine_parser needs to be imported first
 from .affine_parser import *  # noqa: TID251
 from .attribute_parser import *  # noqa: TID251


### PR DESCRIPTION
`bit_enum_attribute`, `dimension_list`, and `dynamic_index_list` were never actually banned from being imported directly, leading to inconsistent usage. This PR bans them and adds a comment to help avoid this in the future.

This is a breaking change.