### PR TITLE
dialects: (acc) Support for OpenACC serial operation

### DIFF
--- a/tests/dialects/test_acc.py
+++ b/tests/dialects/test_acc.py
@@ -361,12 +361,3 @@ def test_serial_unit_and_default_attrs():
     assert op_explicit.default_attr == acc.ClauseDefaultValueAttr(
         acc.ClauseDefaultValue.NONE
     )
-
-
-def test_yield_inside_serial_ok():
-    """Building a yield inside acc.serial's region should verify."""
-    op = _empty_serial()
-    op.verify()
-    last = op.region.block.last_op
-    assert isinstance(last, acc.YieldOp)
-    last.verify()

--- a/tests/dialects/test_acc.py
+++ b/tests/dialects/test_acc.py
@@ -307,31 +307,6 @@ def test_serial_accepts_device_type_attrs():
     assert op.wait_only == ArrayAttr([host])
 
 
-def test_serial_wait_print_without_metadata():
-    """WaitClause.print falls back when device_types / segments / has_devnum are unset.
-
-    None of these branches are reachable via filecheck round-trip — the parser
-    always sets all three properties — so they need a Python-constructed op.
-    """
-    a = ConstantOp.from_int_and_width(1, i32)
-    b = ConstantOp.from_int_and_width(2, i32)
-
-    op = acc.SerialOp(
-        region=Region(Block([acc.YieldOp()])),
-        wait_operands=[a.result, b.result],
-    )
-    op.verify()
-    assert op.wait_operands_device_type is None
-    assert op.wait_operands_segments is None
-    assert op.has_wait_devnum is None
-
-    out = io.StringIO()
-    Printer(stream=out).print_op(op)
-    text = out.getvalue()
-    assert "wait({%0 : i32, %1 : i32})" in text
-    assert "devnum:" not in text
-
-
 def test_serial_unit_and_default_attrs():
     """self_attr / combined accept bool shortcuts; default_attr accepts enum."""
     op = acc.SerialOp(

--- a/tests/dialects/test_acc.py
+++ b/tests/dialects/test_acc.py
@@ -232,3 +232,141 @@ def test_yield_inside_parallel_ok():
     last = op.region.block.last_op
     assert isinstance(last, acc.YieldOp)
     last.verify()
+
+
+def _empty_serial() -> acc.SerialOp:
+    """acc.serial with an empty body (just the required yield)."""
+    return acc.SerialOp(region=Region(Block([acc.YieldOp()])))
+
+
+def test_serial_empty_verifies():
+    op = _empty_serial()
+    op.verify()
+
+    assert len(op.regions) == 1
+    assert len(op.region.blocks) == 1
+    assert len(op.async_operands) == 0
+    assert len(op.wait_operands) == 0
+    assert op.if_cond is None
+    assert op.self_cond is None
+    assert len(op.reduction_operands) == 0
+    assert len(op.private_operands) == 0
+    assert len(op.firstprivate_operands) == 0
+    assert len(op.data_clause_operands) == 0
+    assert op.async_operands_device_type is None
+    assert op.async_only is None
+    assert op.wait_operands_device_type is None
+    assert op.wait_operands_segments is None
+    assert op.has_wait_devnum is None
+    assert op.wait_only is None
+    assert op.self_attr is None
+    assert op.default_attr is None
+    assert op.combined is None
+    assert isinstance(op.region.block.last_op, acc.YieldOp)
+
+
+def test_serial_with_operands_verifies():
+    """Populate several operand groups and verify segment bookkeeping."""
+    async_val = ConstantOp.from_int_and_width(1, i32)
+    if_cond_val = ConstantOp.from_int_and_width(1, i1)
+    data_val = TestOp(result_types=[MemRefType(f32, [10])])
+    private_val = TestOp(result_types=[MemRefType(f32, [10])])
+
+    op = acc.SerialOp(
+        region=Region(Block([acc.YieldOp()])),
+        async_operands=[async_val.result],
+        if_cond=if_cond_val.result,
+        data_clause_operands=[data_val.res[0]],
+        private_operands=[private_val.res[0]],
+    )
+    op.verify()
+
+    assert op.async_operands[0] is async_val.result
+    assert op.if_cond is if_cond_val.result
+    assert op.self_cond is None
+    assert op.data_clause_operands[0] is data_val.res[0]
+    assert op.private_operands[0] is private_val.res[0]
+
+
+def test_serial_accepts_device_type_attrs():
+    """Per-device-type array attributes land on the op as properties."""
+    nvidia = acc.DeviceTypeAttr(acc.DeviceType.NVIDIA)
+    host = acc.DeviceTypeAttr(acc.DeviceType.HOST)
+    op = acc.SerialOp(
+        region=Region(Block([acc.YieldOp()])),
+        async_operands_device_type=ArrayAttr([nvidia]),
+        async_only=ArrayAttr([host]),
+        wait_operands_device_type=ArrayAttr([nvidia, host]),
+        wait_only=ArrayAttr([host]),
+    )
+    op.verify()
+
+    assert op.async_operands_device_type == ArrayAttr([nvidia])
+    assert op.async_only == ArrayAttr([host])
+    assert op.wait_operands_device_type == ArrayAttr([nvidia, host])
+    assert op.wait_only == ArrayAttr([host])
+
+
+def test_serial_wait_print_without_metadata():
+    """WaitClause.print falls back when device_types / segments / has_devnum are unset.
+
+    None of these branches are reachable via filecheck round-trip — the parser
+    always sets all three properties — so they need a Python-constructed op.
+    """
+    a = ConstantOp.from_int_and_width(1, i32)
+    b = ConstantOp.from_int_and_width(2, i32)
+
+    op = acc.SerialOp(
+        region=Region(Block([acc.YieldOp()])),
+        wait_operands=[a.result, b.result],
+    )
+    op.verify()
+    assert op.wait_operands_device_type is None
+    assert op.wait_operands_segments is None
+    assert op.has_wait_devnum is None
+
+    out = io.StringIO()
+    Printer(stream=out).print_op(op)
+    text = out.getvalue()
+    assert "wait({%0 : i32, %1 : i32})" in text
+    assert "devnum:" not in text
+
+
+def test_serial_unit_and_default_attrs():
+    """self_attr / combined accept bool shortcuts; default_attr accepts enum."""
+    op = acc.SerialOp(
+        region=Region(Block([acc.YieldOp()])),
+        self_attr=True,
+        default_attr=acc.ClauseDefaultValue.PRESENT,
+        combined=True,
+    )
+    op.verify()
+
+    assert isinstance(op.self_attr, UnitAttr)
+    assert isinstance(op.combined, UnitAttr)
+    assert op.default_attr == acc.ClauseDefaultValueAttr(acc.ClauseDefaultValue.PRESENT)
+
+    op_off = acc.SerialOp(region=Region(Block([acc.YieldOp()])))
+    assert op_off.self_attr is None
+    assert op_off.combined is None
+
+    op_explicit = acc.SerialOp(
+        region=Region(Block([acc.YieldOp()])),
+        self_attr=UnitAttr(),
+        default_attr=acc.ClauseDefaultValueAttr(acc.ClauseDefaultValue.NONE),
+        combined=UnitAttr(),
+    )
+    assert isinstance(op_explicit.self_attr, UnitAttr)
+    assert isinstance(op_explicit.combined, UnitAttr)
+    assert op_explicit.default_attr == acc.ClauseDefaultValueAttr(
+        acc.ClauseDefaultValue.NONE
+    )
+
+
+def test_yield_inside_serial_ok():
+    """Building a yield inside acc.serial's region should verify."""
+    op = _empty_serial()
+    op.verify()
+    last = op.region.block.last_op
+    assert isinstance(last, acc.YieldOp)
+    last.verify()

--- a/tests/dialects/test_acc.py
+++ b/tests/dialects/test_acc.py
@@ -234,13 +234,8 @@ def test_yield_inside_parallel_ok():
     last.verify()
 
 
-def _empty_serial() -> acc.SerialOp:
-    """acc.serial with an empty body (just the required yield)."""
-    return acc.SerialOp(region=Region(Block([acc.YieldOp()])))
-
-
 def test_serial_empty_verifies():
-    op = _empty_serial()
+    op = acc.SerialOp(region=Region(Block([acc.YieldOp()])))
     op.verify()
 
     assert len(op.regions) == 1

--- a/tests/filecheck/dialects/acc/ops.mlir
+++ b/tests/filecheck/dialects/acc/ops.mlir
@@ -242,4 +242,180 @@ builtin.module {
   // CHECK-NEXT:    acc.parallel {
   // CHECK-NEXT:      acc.yield
   // CHECK-NEXT:    }
+
+  func.func @serial_empty() {
+    acc.serial {
+      acc.yield
+    }
+    func.return
+  }
+  // CHECK-LABEL: func.func @serial_empty() {
+  // CHECK-NEXT:    acc.serial {
+  // CHECK-NEXT:      acc.yield
+  // CHECK-NEXT:    }
+
+  func.func @serial_if_self(%c1 : i1) {
+    acc.serial self(%c1) if(%c1) {
+      acc.yield
+    }
+    func.return
+  }
+  // CHECK-LABEL: func.func @serial_if_self(
+  // CHECK:         acc.serial self(%{{.*}}) if(%{{.*}}) {
+  // CHECK-NEXT:      acc.yield
+  // CHECK-NEXT:    }
+
+  func.func @serial_data_ops(%m : memref<10xf32>) {
+    acc.serial dataOperands(%m : memref<10xf32>) {
+      acc.yield
+    }
+    func.return
+  }
+  // CHECK-LABEL: func.func @serial_data_ops(
+  // CHECK:         acc.serial dataOperands(%{{.*}} : memref<10xf32>) {
+  // CHECK-NEXT:      acc.yield
+  // CHECK-NEXT:    }
+
+  func.func @serial_private_firstprivate_reduction(%m : memref<10xf32>) {
+    acc.serial firstprivate(%m : memref<10xf32>) private(%m : memref<10xf32>) reduction(%m : memref<10xf32>) {
+      acc.yield
+    }
+    func.return
+  }
+  // CHECK-LABEL: func.func @serial_private_firstprivate_reduction(
+  // CHECK:         acc.serial firstprivate(%{{.*}} : memref<10xf32>) private(%{{.*}} : memref<10xf32>) reduction(%{{.*}} : memref<10xf32>) {
+  // CHECK-NEXT:      acc.yield
+  // CHECK-NEXT:    }
+
+  func.func @serial_async_bare() {
+    acc.serial async {
+      acc.yield
+    }
+    func.return
+  }
+  // CHECK-LABEL: func.func @serial_async_bare() {
+  // CHECK-NEXT:    acc.serial async {
+  // CHECK-NEXT:      acc.yield
+  // CHECK-NEXT:    }
+
+  func.func @serial_async_keyword_only_with_dt() {
+    acc.serial async([#acc.device_type<nvidia>]) {
+      acc.yield
+    }
+    func.return
+  }
+  // CHECK-LABEL: func.func @serial_async_keyword_only_with_dt() {
+  // CHECK-NEXT:    acc.serial async([#acc.device_type<nvidia>]) {
+  // CHECK-NEXT:      acc.yield
+  // CHECK-NEXT:    }
+
+  func.func @serial_async_one_operand(%a : i64) {
+    acc.serial async(%a : i64) {
+      acc.yield
+    }
+    func.return
+  }
+  // CHECK-LABEL: func.func @serial_async_one_operand(
+  // CHECK:         acc.serial async(%{{.*}} : i64) {
+  // CHECK-NEXT:      acc.yield
+  // CHECK-NEXT:    }
+
+  func.func @serial_async_operand_with_dt(%a : i64) {
+    acc.serial async(%a : i64 [#acc.device_type<nvidia>]) {
+      acc.yield
+    }
+    func.return
+  }
+  // CHECK-LABEL: func.func @serial_async_operand_with_dt(
+  // CHECK:         acc.serial async(%{{.*}} : i64 [#acc.device_type<nvidia>]) {
+  // CHECK-NEXT:      acc.yield
+  // CHECK-NEXT:    }
+
+  func.func @serial_async_mixed(%a : i64) {
+    acc.serial async([#acc.device_type<nvidia>], %a : i64 [#acc.device_type<default>]) {
+      acc.yield
+    }
+    func.return
+  }
+  // CHECK-LABEL: func.func @serial_async_mixed(
+  // CHECK:         acc.serial async([#acc.device_type<nvidia>], %{{.*}} : i64 [#acc.device_type<default>]) {
+  // CHECK-NEXT:      acc.yield
+  // CHECK-NEXT:    }
+
+  func.func @serial_wait_bare() {
+    acc.serial wait {
+      acc.yield
+    }
+    func.return
+  }
+  // CHECK-LABEL: func.func @serial_wait_bare() {
+  // CHECK-NEXT:    acc.serial wait {
+  // CHECK-NEXT:      acc.yield
+  // CHECK-NEXT:    }
+
+  func.func @serial_wait_group(%a : i64, %b : i32) {
+    acc.serial wait({%a : i64, %b : i32}) {
+      acc.yield
+    }
+    func.return
+  }
+  // CHECK-LABEL: func.func @serial_wait_group(
+  // CHECK:         acc.serial wait({%{{.*}} : i64, %{{.*}} : i32}) {
+  // CHECK-NEXT:      acc.yield
+  // CHECK-NEXT:    }
+
+  func.func @serial_wait_devnum(%a : i64, %b : i32) {
+    acc.serial wait({devnum: %a : i64, %b : i32}) {
+      acc.yield
+    }
+    func.return
+  }
+  // CHECK-LABEL: func.func @serial_wait_devnum(
+  // CHECK:         acc.serial wait({devnum: %{{.*}} : i64, %{{.*}} : i32}) {
+  // CHECK-NEXT:      acc.yield
+  // CHECK-NEXT:    }
+
+  func.func @serial_wait_mixed(%a : i64, %b : i32) {
+    acc.serial wait([#acc.device_type<nvidia>], {devnum: %a : i64, %b : i32} [#acc.device_type<default>]) {
+      acc.yield
+    }
+    func.return
+  }
+  // CHECK-LABEL: func.func @serial_wait_mixed(
+  // CHECK:         acc.serial wait([#acc.device_type<nvidia>], {devnum: %{{.*}} : i64, %{{.*}} : i32} [#acc.device_type<default>]) {
+  // CHECK-NEXT:      acc.yield
+  // CHECK-NEXT:    }
+
+  func.func @serial_combined_prefix() {
+    acc.serial combined(loop) {
+      acc.yield
+    }
+    func.return
+  }
+  // CHECK-LABEL: func.func @serial_combined_prefix() {
+  // CHECK-NEXT:    acc.serial combined(loop) {
+  // CHECK-NEXT:      acc.yield
+  // CHECK-NEXT:    }
+
+  func.func @serial_default_self_attrs_via_attr_dict() {
+    acc.serial {
+      acc.yield
+    } attributes {defaultAttr = #acc<defaultvalue present>, selfAttr}
+    func.return
+  }
+  // CHECK-LABEL: func.func @serial_default_self_attrs_via_attr_dict() {
+  // CHECK-NEXT:    acc.serial {
+  // CHECK-NEXT:      acc.yield
+  // CHECK-NEXT:    } attributes {defaultAttr = #acc<defaultvalue present>, selfAttr}
+
+  func.func @serial_generic_roundtrip_retained() {
+    "acc.serial"() <{operandSegmentSizes = array<i32: 0, 0, 0, 0, 0, 0, 0, 0>}> ({
+      "acc.yield"() : () -> ()
+    }) : () -> ()
+    func.return
+  }
+  // CHECK-LABEL: func.func @serial_generic_roundtrip_retained() {
+  // CHECK-NEXT:    acc.serial {
+  // CHECK-NEXT:      acc.yield
+  // CHECK-NEXT:    }
 }

--- a/tests/filecheck/dialects/acc/ops.mlir
+++ b/tests/filecheck/dialects/acc/ops.mlir
@@ -418,4 +418,19 @@ builtin.module {
   // CHECK-NEXT:    acc.serial {
   // CHECK-NEXT:      acc.yield
   // CHECK-NEXT:    }
+
+  // Generic-form input with wait operands but none of the wait property
+  // attributes (waitOperandsDeviceType / waitOperandsSegments / hasWaitDevnum)
+  // exercises the WaitClause printer's fallback path; the pretty parser would
+  // never produce this combination because it always populates all three.
+  func.func @serial_wait_printer_fallback(%a : i32, %b : i32) {
+    "acc.serial"(%a, %b) <{operandSegmentSizes = array<i32: 0, 2, 0, 0, 0, 0, 0, 0>}> ({
+      "acc.yield"() : () -> ()
+    }) : (i32, i32) -> ()
+    func.return
+  }
+  // CHECK-LABEL: func.func @serial_wait_printer_fallback(
+  // CHECK:         acc.serial wait({%{{.*}} : i32, %{{.*}} : i32}) {
+  // CHECK-NEXT:      acc.yield
+  // CHECK-NEXT:    }
 }

--- a/tests/filecheck/dialects/acc/ops_invalid.mlir
+++ b/tests/filecheck/dialects/acc/ops_invalid.mlir
@@ -33,7 +33,7 @@ func.func @serial_empty_block() {
   }) : () -> ()
   func.return
 }
-// CHECK: acc.serial
+// CHECK: Operation acc.serial contains empty block in single-block region that expects at least a terminator
 
 // -----
 
@@ -43,4 +43,4 @@ func.func @serial_wrong_terminator(%arg0: i32) {
   }) : () -> ()
   func.return
 }
-// CHECK: builtin.unrealized_conversion_cast
+// CHECK: Operation builtin.unrealized_conversion_cast terminates block in single-block region but is not a terminator

--- a/tests/filecheck/dialects/acc/ops_invalid.mlir
+++ b/tests/filecheck/dialects/acc/ops_invalid.mlir
@@ -23,4 +23,24 @@ func.func @wrong_terminator(%arg0: i32) {
 builtin.module {
   "acc.yield"() : () -> ()
 }
-// CHECK: 'acc.yield' expects parent op 'acc.parallel'
+// CHECK: 'acc.yield' expects parent op
+
+// -----
+
+func.func @serial_empty_block() {
+  "acc.serial"() <{operandSegmentSizes = array<i32: 0, 0, 0, 0, 0, 0, 0, 0>}> ({
+  ^bb0:
+  }) : () -> ()
+  func.return
+}
+// CHECK: acc.serial
+
+// -----
+
+func.func @serial_wrong_terminator(%arg0: i32) {
+  "acc.serial"() <{operandSegmentSizes = array<i32: 0, 0, 0, 0, 0, 0, 0, 0>}> ({
+    %0 = "builtin.unrealized_conversion_cast"(%arg0) : (i32) -> i32
+  }) : () -> ()
+  func.return
+}
+// CHECK: builtin.unrealized_conversion_cast

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/ops.mlir
@@ -166,4 +166,125 @@ builtin.module {
   // CHECK:         acc.parallel combined(loop) async(%{{.*}} : i64) num_workers(%{{.*}} : i64) vector_length(%{{.*}} : i32) wait({%{{.*}} : i64}) self(%{{.*}}) if(%{{.*}}) {
   // CHECK-NEXT:      acc.yield
   // CHECK-NEXT:    } attributes {defaultAttr = #acc<defaultvalue present>, selfAttr}
+
+  func.func @serial_empty() {
+    acc.serial {
+      acc.yield
+    }
+    func.return
+  }
+  // CHECK:       func.func @serial_empty() {
+  // CHECK-NEXT:    acc.serial {
+  // CHECK-NEXT:      acc.yield
+  // CHECK-NEXT:    }
+
+  func.func @serial_self_if(%c : i1) {
+    acc.serial self(%c) if(%c) {
+      acc.yield
+    }
+    func.return
+  }
+  // CHECK:       func.func @serial_self_if(
+  // CHECK:         acc.serial self(%{{.*}}) if(%{{.*}}) {
+  // CHECK-NEXT:      acc.yield
+  // CHECK-NEXT:    }
+
+  func.func @serial_combined_default_self() {
+    acc.serial combined(loop) {
+      acc.yield
+    } attributes {defaultAttr = #acc<defaultvalue present>, selfAttr}
+    func.return
+  }
+  // CHECK:       func.func @serial_combined_default_self() {
+  // CHECK-NEXT:    acc.serial combined(loop) {
+  // CHECK-NEXT:      acc.yield
+  // CHECK-NEXT:    } attributes {defaultAttr = #acc<defaultvalue present>, selfAttr}
+
+  func.func @serial_async_bare() {
+    acc.serial async {
+      acc.yield
+    }
+    func.return
+  }
+  // CHECK:       func.func @serial_async_bare() {
+  // CHECK-NEXT:    acc.serial async {
+  // CHECK-NEXT:      acc.yield
+  // CHECK-NEXT:    }
+
+  func.func @serial_async_one_operand(%a : i64) {
+    acc.serial async(%a : i64) {
+      acc.yield
+    }
+    func.return
+  }
+  // CHECK:       func.func @serial_async_one_operand(
+  // CHECK:         acc.serial async(%{{.*}} : i64) {
+  // CHECK-NEXT:      acc.yield
+  // CHECK-NEXT:    }
+
+  func.func @serial_async_operand_with_dt(%a : i64) {
+    acc.serial async(%a : i64 [#acc.device_type<default>]) {
+      acc.yield
+    }
+    func.return
+  }
+  // CHECK:       func.func @serial_async_operand_with_dt(
+  // CHECK:         acc.serial async(%{{.*}} : i64 [#acc.device_type<default>]) {
+  // CHECK-NEXT:      acc.yield
+  // CHECK-NEXT:    }
+
+  func.func @serial_wait_bare() {
+    acc.serial wait {
+      acc.yield
+    }
+    func.return
+  }
+  // CHECK:       func.func @serial_wait_bare() {
+  // CHECK-NEXT:    acc.serial wait {
+  // CHECK-NEXT:      acc.yield
+  // CHECK-NEXT:    }
+
+  func.func @serial_wait_group(%a : i64, %b : i32) {
+    acc.serial wait({%a : i64, %b : i32}) {
+      acc.yield
+    }
+    func.return
+  }
+  // CHECK:       func.func @serial_wait_group(
+  // CHECK:         acc.serial wait({%{{.*}} : i64, %{{.*}} : i32}) {
+  // CHECK-NEXT:      acc.yield
+  // CHECK-NEXT:    }
+
+  func.func @serial_wait_devnum(%a : i64, %b : i32) {
+    acc.serial wait({devnum: %a : i64, %b : i32}) {
+      acc.yield
+    }
+    func.return
+  }
+  // CHECK:       func.func @serial_wait_devnum(
+  // CHECK:         acc.serial wait({devnum: %{{.*}} : i64, %{{.*}} : i32}) {
+  // CHECK-NEXT:      acc.yield
+  // CHECK-NEXT:    }
+
+  func.func @serial_wait_mixed(%a : i64, %b : i32) {
+    acc.serial wait([#acc.device_type<nvidia>], {devnum: %a : i64, %b : i32} [#acc.device_type<default>]) {
+      acc.yield
+    }
+    func.return
+  }
+  // CHECK:       func.func @serial_wait_mixed(
+  // CHECK:         acc.serial wait([#acc.device_type<nvidia>], {devnum: %{{.*}} : i64, %{{.*}} : i32} [#acc.device_type<default>]) {
+  // CHECK-NEXT:      acc.yield
+  // CHECK-NEXT:    }
+
+  func.func @serial_test_entire(%c : i1, %b : i64) {
+    acc.serial combined(loop) async(%b : i64) wait({%b : i64}) self(%c) if(%c) {
+      acc.yield
+    } attributes {defaultAttr = #acc<defaultvalue present>, selfAttr}
+    func.return
+  }
+  // CHECK:       func.func @serial_test_entire(
+  // CHECK:         acc.serial combined(loop) async(%{{.*}} : i64) wait({%{{.*}} : i64}) self(%{{.*}}) if(%{{.*}}) {
+  // CHECK-NEXT:      acc.yield
+  // CHECK-NEXT:    } attributes {defaultAttr = #acc<defaultvalue present>, selfAttr}
 }

--- a/xdsl/dialects/acc.py
+++ b/xdsl/dialects/acc.py
@@ -753,6 +753,142 @@ class ParallelOp(IRDLOperation):
 
 
 @irdl_op_definition
+class SerialOp(IRDLOperation):
+    """
+    Implementation of upstream acc.serial.
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/OpenACCDialect/#accserial-accserialop).
+    """
+
+    name = "acc.serial"
+
+    async_operands = var_operand_def(IntegerType | IndexType)
+    wait_operands = var_operand_def(IntegerType | IndexType)
+    if_cond = opt_operand_def(I1)
+    self_cond = opt_operand_def(I1)
+    reduction_operands = var_operand_def()
+    private_operands = var_operand_def()
+    firstprivate_operands = var_operand_def()
+    data_clause_operands = var_operand_def()
+
+    async_operands_device_type = opt_prop_def(
+        ArrayAttr[DeviceTypeAttr], prop_name="asyncOperandsDeviceType"
+    )
+    async_only = opt_prop_def(ArrayAttr[DeviceTypeAttr], prop_name="asyncOnly")
+    wait_operands_device_type = opt_prop_def(
+        ArrayAttr[DeviceTypeAttr], prop_name="waitOperandsDeviceType"
+    )
+    wait_operands_segments = opt_prop_def(
+        DenseArrayBase.constr(IntegerType(32)), prop_name="waitOperandsSegments"
+    )
+    has_wait_devnum = opt_prop_def(ArrayAttr[BoolAttr], prop_name="hasWaitDevnum")
+    wait_only = opt_prop_def(ArrayAttr[DeviceTypeAttr], prop_name="waitOnly")
+    self_attr = opt_prop_def(UnitAttr, prop_name="selfAttr")
+    default_attr = opt_prop_def(ClauseDefaultValueAttr, prop_name="defaultAttr")
+    combined = opt_prop_def(UnitAttr)
+
+    region = region_def("single_block")
+
+    irdl_options = (
+        AttrSizedOperandSegments(as_property=True),
+        ParsePropInAttrDict(),
+    )
+
+    custom_directives = (
+        DeviceTypeOperandsWithKeywordOnly,
+        WaitClause,
+    )
+
+    assembly_format = (
+        "(`combined` `(` `loop` `)` $combined^)?"
+        " (`dataOperands` `(` $data_clause_operands^ `:`"
+        " type($data_clause_operands) `)`)?"
+        " (`async` custom<DeviceTypeOperandsWithKeywordOnly>($async_operands,"
+        " type($async_operands), $asyncOperandsDeviceType, $asyncOnly)^)?"
+        " (`firstprivate` `(` $firstprivate_operands^ `:`"
+        " type($firstprivate_operands) `)`)?"
+        " (`private` `(` $private_operands^ `:`"
+        " type($private_operands) `)`)?"
+        " (`wait` custom<WaitClause>($wait_operands, type($wait_operands),"
+        " $waitOperandsDeviceType, $waitOperandsSegments, $hasWaitDevnum,"
+        " $waitOnly)^)?"
+        " (`self` `(` $self_cond^ `)`)?"
+        " (`if` `(` $if_cond^ `)`)?"
+        " (`reduction` `(` $reduction_operands^ `:`"
+        " type($reduction_operands) `)`)?"
+        " $region attr-dict-with-keyword"
+    )
+
+    traits = lazy_traits_def(
+        lambda: (
+            SingleBlockImplicitTerminator(YieldOp),
+            RecursiveMemoryEffect(),
+        )
+    )
+
+    def __init__(
+        self,
+        *,
+        region: Region,
+        async_operands: Sequence[SSAValue | Operation] = (),
+        wait_operands: Sequence[SSAValue | Operation] = (),
+        if_cond: SSAValue | Operation | None = None,
+        self_cond: SSAValue | Operation | None = None,
+        reduction_operands: Sequence[SSAValue | Operation] = (),
+        private_operands: Sequence[SSAValue | Operation] = (),
+        firstprivate_operands: Sequence[SSAValue | Operation] = (),
+        data_clause_operands: Sequence[SSAValue | Operation] = (),
+        async_operands_device_type: ArrayAttr[DeviceTypeAttr] | None = None,
+        async_only: ArrayAttr[DeviceTypeAttr] | None = None,
+        wait_operands_device_type: ArrayAttr[DeviceTypeAttr] | None = None,
+        wait_operands_segments: DenseArrayBase | None = None,
+        has_wait_devnum: ArrayAttr[BoolAttr] | None = None,
+        wait_only: ArrayAttr[DeviceTypeAttr] | None = None,
+        self_attr: UnitAttr | bool = False,
+        default_attr: ClauseDefaultValueAttr | ClauseDefaultValue | None = None,
+        combined: UnitAttr | bool = False,
+    ) -> None:
+        self_attr_prop: UnitAttr | None = (
+            (UnitAttr() if self_attr else None)
+            if isinstance(self_attr, bool)
+            else self_attr
+        )
+        combined_prop: UnitAttr | None = (
+            (UnitAttr() if combined else None)
+            if isinstance(combined, bool)
+            else combined
+        )
+        default_prop: ClauseDefaultValueAttr | None = (
+            ClauseDefaultValueAttr(default_attr)
+            if isinstance(default_attr, ClauseDefaultValue)
+            else default_attr
+        )
+        super().__init__(
+            operands=[
+                async_operands,
+                wait_operands,
+                [if_cond] if if_cond is not None else [],
+                [self_cond] if self_cond is not None else [],
+                reduction_operands,
+                private_operands,
+                firstprivate_operands,
+                data_clause_operands,
+            ],
+            properties={
+                "asyncOperandsDeviceType": async_operands_device_type,
+                "asyncOnly": async_only,
+                "waitOperandsDeviceType": wait_operands_device_type,
+                "waitOperandsSegments": wait_operands_segments,
+                "hasWaitDevnum": has_wait_devnum,
+                "waitOnly": wait_only,
+                "selfAttr": self_attr_prop,
+                "defaultAttr": default_prop,
+                "combined": combined_prop,
+            },
+            regions=[region],
+        )
+
+
+@irdl_op_definition
 class YieldOp(AbstractYieldOperation[Attribute]):
     """
     Implementation of upstream acc.yield.
@@ -765,7 +901,7 @@ class YieldOp(AbstractYieldOperation[Attribute]):
         lambda: (
             IsTerminator(),
             NoMemoryEffect(),
-            HasParent(ParallelOp),
+            HasParent(ParallelOp, SerialOp),
         )
     )
 
@@ -774,6 +910,7 @@ ACC = Dialect(
     "acc",
     [
         ParallelOp,
+        SerialOp,
         YieldOp,
     ],
     [


### PR DESCRIPTION
Support for the OpenACC serial operation, much of the custom assembly format is able to reuse what we added for parallel op (which is why I went back and did that fully first). Added filecheck and Python API tests for the operation.
