### PR TITLE
CI: enable ruff RUF015 rule

### DIFF
--- a/benchmarks/rewriting.py
+++ b/benchmarks/rewriting.py
@@ -122,7 +122,7 @@ class RewritingMicrobenchmarks:
         self.add_op_def = AddiOp.get_irdl_definition()
         self.add_op_construct = VarIRConstruct.OPERAND
         self.add_op_result = self.add_op.result
-        self.add_op_result_use = list(self.add_op_result.uses)[0]
+        self.add_op_result_use = next(iter(self.add_op_result.uses))
         self.sub_op = SubiOp(self.const_1, self.const_0)
         self.sub_op_result = self.sub_op.result
         self.insert_point = InsertPoint.before(self.add_op)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,7 +123,7 @@ extend-include = ["*.ipynb", "*.pyi"]
 exclude = [".venv", "docs/marimo"]
 
 [tool.ruff.lint]
-select = ["E", "F", "W", "I", "UP", "PT", "TID251", "INP", "PYI"]
+select = ["E", "F", "W", "I", "UP", "PT", "TID251", "INP", "PYI", "RUF015"]
 ignore = [
     "E741",   # https://beta.ruff.rs/docs/rules/ambiguous-variable-name/
     "PT006",  # https://beta.ruff.rs/docs/rules/pytest-parametrize-names-wrong-type/

--- a/xdsl/interactive/add_arguments_screen.py
+++ b/xdsl/interactive/add_arguments_screen.py
@@ -57,11 +57,13 @@ class AddArguments(Screen[ModulePass | None]):
         concatenated_arg_val = self.argument_text_area.text
 
         try:
-            parsed_spec = list(
-                parse_pipeline(
-                    f"{self.selected_pass_type.name}{{{concatenated_arg_val}}}"
+            parsed_spec = next(
+                iter(
+                    parse_pipeline(
+                        f"{self.selected_pass_type.name}{{{concatenated_arg_val}}}"
+                    )
                 )
-            )[0]
+            )
         except ArgSpecParseError:
             self.selected_pass_value = None
             return


### PR DESCRIPTION
Towards #5927 — picks one rule per the issue's "ideally one PR per rule" request.

Enables [RUF015](https://docs.astral.sh/ruff/rules/unnecessary-iterable-allocation-for-first-element/) (\`unnecessary-iterable-allocation-for-first-element\`). The rule flags \`list(it)[0]\` patterns where \`next(iter(it))\` is correct - avoids materialising a list just to grab one element.

## Existing call sites rewritten

| Site | Before | After |
| --- | --- | --- |
| \`benchmarks/rewriting.py:125\` | \`list(self.add_op_result.uses)[0]\` | \`next(iter(self.add_op_result.uses))\` |
| \`xdsl/interactive/add_arguments_screen.py:60-64\` | \`list(parse_pipeline(...))[0]\` | \`next(iter(parse_pipeline(...)))\` |

## Verification

\`ruff check benchmarks/rewriting.py xdsl/interactive/add_arguments_screen.py\` passes. \`ruff check .\` on the full repo shows the only remaining finding is a pre-existing I001 in a \`tests/filecheck\` fixture unrelated to this change (it shows up identically on \`upstream/main\` without this PR's diff).

Happy to also pick up RUF001 / 002 / 003 / 005 / 007 / 012 / 018 / 033 / 043 in follow-up PRs if this lands well.