### PR TITLE
backend: (llvm) build typed pointer once from xdsl type attrs

### DIFF
--- a/xdsl/backend/llvm/convert.py
+++ b/xdsl/backend/llvm/convert.py
@@ -7,7 +7,7 @@ from xdsl.backend.llvm.convert_op import convert_op
 from xdsl.backend.llvm.convert_type import convert_type
 from xdsl.context import Context
 from xdsl.dialects import llvm
-from xdsl.dialects.builtin import IntegerAttr, ModuleOp
+from xdsl.dialects.builtin import IntAttr, IntegerAttr, ModuleOp
 from xdsl.ir import Block, SSAValue
 from xdsl.utils.target import Target
 
@@ -104,15 +104,22 @@ def convert_module(
         ret_type = convert_type(op.function_type.output)
         arg_types: list[ir.Type] = []
         for idx, mlir_type in enumerate(op.function_type.inputs):
-            base = convert_type(mlir_type)
-            # Typed pointer lets llvmlite emit the pointee for byval/sret/etc.
-            if isinstance(base, ir.PointerType) and op.arg_attrs is not None:
-                attrs = op.arg_attrs.data[idx].data
-                if elem := next(
-                    (attrs[n] for n in _ARG_ATTR_TYPES if n in attrs), None
-                ):
-                    base = ir.PointerType(convert_type(elem), addrspace=base.addrspace)
-            arg_types.append(base)
+            if not (
+                isinstance(mlir_type, llvm.LLVMPointerType) and op.arg_attrs is not None
+            ):
+                arg_types.append(convert_type(mlir_type))
+                continue
+            attrs = op.arg_attrs.data[idx].data
+            elem = next((attrs[n] for n in _ARG_ATTR_TYPES if n in attrs), None)
+            if elem is None:
+                arg_types.append(convert_type(mlir_type))
+                continue
+            addrspace = (
+                mlir_type.addr_space.data
+                if isinstance(mlir_type.addr_space, IntAttr)
+                else 0
+            )
+            arg_types.append(ir.PointerType(convert_type(elem), addrspace=addrspace))
         func_type = ir.FunctionType(ret_type, arg_types)
         fn = ir.Function(llvm_module, func_type, name=op.sym_name.data)
 


### PR DESCRIPTION
- Addresses reviewer TODO from #5850: determine the pointee and addrspace before constructing the PointerType so we never mutate a cached instance or create a throwaway intermediate.
- Checks `mlir_type` directly (via `isinstance(mlir_type, llvm.LLVMPointerType)`) instead of converting first and inspecting the result, then extracts `addr_space` from the xdsl type attribute rather than from the converted llvmlite object.

Split from #5909.