### PR TITLE
backend: (llvm) drop @cache from convert_type

### DIFF
--- a/xdsl/backend/llvm/convert_op.py
+++ b/xdsl/backend/llvm/convert_op.py
@@ -240,6 +240,7 @@ def _convert_call(
 def _convert_alloca(
     op: llvm.AllocaOp, builder: ir.IRBuilder, val_map: dict[SSAValue, ir.Value]
 ):
+    assert op.elem_type is not None
     alloca_instr = builder.alloca(convert_type(op.elem_type), size=val_map[op.size])
     if op.alignment:
         alloca_instr.align = op.alignment.value.data

--- a/xdsl/backend/llvm/convert_type.py
+++ b/xdsl/backend/llvm/convert_type.py
@@ -1,5 +1,4 @@
 from collections.abc import Callable
-from functools import cache
 from typing import Any
 
 import llvmlite.ir as ir
@@ -100,7 +99,6 @@ _TYPE_CONVERTERS: dict[type[Attribute], Callable[[Any], ir.Type]] = {
 }
 
 
-@cache
 def convert_type(type_attr: Attribute) -> ir.Type:
     """
     Convert an xDSL type attribute to an LLVM IR type.


### PR DESCRIPTION
- Removes `@cache` from `convert_type` because it returns mutable llvmlite objects. Caching lets one caller's mutation silently corrupt every other user of that type.
- Adds `assert op.elem_type is not None` before alloca conversion, since removing `@cache` exposed a pre-existing type mismatch where `AllocaOp.elem_type` is optional but `convert_type` requires a non-None `Attribute`.

Split from #5909.