### PR TITLE
bench: add LLVM backend conversion benchmark

### DIFF
--- a/benchmarks/llvm_backend.py
+++ b/benchmarks/llvm_backend.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+from bench_utils import Benchmark, profile
+
+from xdsl.backend.llvm.convert import convert_module
+from xdsl.context import Context
+from xdsl.dialects.builtin import Builtin, ModuleOp
+from xdsl.dialects.llvm import LLVM
+from xdsl.dialects.vector import Vector
+from xdsl.parser import Parser
+
+FILECHECK_TEST = (
+    Path(__file__).parents[1]
+    / "tests"
+    / "filecheck"
+    / "backend"
+    / "llvm"
+    / "convert_op.mlir"
+)
+
+
+def _parse_module() -> ModuleOp:
+    ctx = Context(allow_unregistered=True)
+    ctx.load_dialect(Builtin)
+    ctx.load_dialect(LLVM)
+    ctx.load_dialect(Vector)
+    module = Parser(ctx, FILECHECK_TEST.read_text()).parse_module()
+    assert isinstance(module, ModuleOp)
+    return module
+
+
+class LLVMBackend:
+    MODULE = _parse_module()
+
+    def time_convert_module(self) -> None:
+        convert_module(LLVMBackend.MODULE)
+
+
+if __name__ == "__main__":
+    BACKEND = LLVMBackend()
+    profile(
+        {
+            "LLVMBackend.convert_module": Benchmark(BACKEND.time_convert_module),
+        }
+    )


### PR DESCRIPTION
- Adds a benchmark that measures `convert_module` on the LLVM backend filecheck test (`tests/filecheck/backend/llvm/convert_op.mlir`).
- Enables catching performance regressions in the LLVM backend conversion path.

```bash
uv run benchmarks/llvm_backend.py LLVMBackend.convert_module run
uv run benchmarks/llvm_backend.py LLVMBackend.convert_module timeit
```