### PR TITLE
dialects: (llvm) custom print/parse for call_intrinsic

### DIFF
--- a/tests/dialects/test_llvm.py
+++ b/tests/dialects/test_llvm.py
@@ -558,12 +558,15 @@ def test_call_op_variadic():
 
 
 def test_call_intrinsic_op_converts_str_to_stringattr():
-    # verify string intrinsic name is auto-converted to StringAttr
-    op = llvm.CallIntrinsicOp(
-        "llvm.intr", [], [], op_bundle_sizes=llvm.DenseArrayBase.from_list(i32, [])
-    )
+    op = llvm.CallIntrinsicOp("llvm.intr", [], [])
     assert isinstance(op.intrin, builtin.StringAttr)
     assert op.intrin.data == "llvm.intr"
+
+
+def test_call_intrinsic_op_accepts_stringattr():
+    intrin = builtin.StringAttr("llvm.smax")
+    op = llvm.CallIntrinsicOp(intrin, [], [])
+    assert op.intrin is intrin
 
 
 def test_func_op_visibility_default():

--- a/tests/filecheck/dialects/llvm/func.mlir
+++ b/tests/filecheck/dialects/llvm/func.mlir
@@ -121,3 +121,18 @@ llvm.func @test_calls(%arg0: i32, %fptr: !llvm.ptr, %farg: f32) {
 // CHECK-NEXT:   %{{.*}} = llvm.call @float_callee(%{{.*}}) {fastmathFlags = #llvm.fastmath<fast>} : (f32) -> f32
 // CHECK-NEXT:   llvm.return
 // CHECK-NEXT: }
+
+%ci0, %ci1 = "test.op"() : () -> (i64, i64)
+%ci2 = llvm.call_intrinsic "llvm.smax"(%ci0, %ci1) : (i64, i64) -> i64
+llvm.call_intrinsic "llvm.donothing"() : () -> ()
+%ci3 = llvm.call_intrinsic "llvm.smax"(%ci0, %ci1) {fastmathFlags = #llvm.fastmath<reassoc,nnan>} : (i64, i64) -> i64
+%ci4 = llvm.call_intrinsic "llvm.smax"(%ci0, %ci1) {fastmathFlags = #llvm.fastmath<fast>} : (i64, i64) -> i64
+
+%ci5 = llvm.call_intrinsic "llvm.smax"(%ci0, %ci1) [%ci0, %ci1 : i64, i64] {op_bundle_sizes = array<i32: 2>} : (i64, i64) -> i64
+
+// CHECK: %ci0, %ci1 = "test.op"() : () -> (i64, i64)
+// CHECK-NEXT: %ci2 = llvm.call_intrinsic "llvm.smax"(%ci0, %ci1) : (i64, i64) -> i64
+// CHECK-NEXT: llvm.call_intrinsic "llvm.donothing"() : () -> ()
+// CHECK-NEXT: %ci3 = llvm.call_intrinsic "llvm.smax"(%ci0, %ci1) {fastmathFlags = #llvm.fastmath<reassoc,nnan>} : (i64, i64) -> i64
+// CHECK-NEXT: %ci4 = llvm.call_intrinsic "llvm.smax"(%ci0, %ci1) {fastmathFlags = #llvm.fastmath<fast>} : (i64, i64) -> i64
+// CHECK-NEXT: %ci5 = llvm.call_intrinsic "llvm.smax"(%ci0, %ci1) [%ci0, %ci1 : i64, i64] {op_bundle_sizes = array<i32: 2>} : (i64, i64) -> i64

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/func.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/func.mlir
@@ -114,3 +114,19 @@ llvm.func @test_calls(%arg0: i64, %fptr: !llvm.ptr) {
 // CHECK-NEXT:   llvm.call fastcc @external_func(%[[ARG0]]) : (i64) -> ()
 // CHECK-NEXT:   llvm.return
 // CHECK-NEXT: }
+
+llvm.func @test_call_intrinsic(%arg0: i64, %arg1: i64) {
+  %0 = llvm.call_intrinsic "llvm.smax"(%arg0, %arg1) : (i64, i64) -> i64
+  llvm.call_intrinsic "llvm.donothing"() : () -> ()
+  %1 = llvm.call_intrinsic "llvm.smax"(%arg0, %arg1) {fastmathFlags = #llvm.fastmath<reassoc,nnan>} : (i64, i64) -> i64
+  %2 = llvm.call_intrinsic "llvm.smax"(%arg0, %arg1) {fastmathFlags = #llvm.fastmath<fast>} : (i64, i64) -> i64
+  llvm.return
+}
+
+// CHECK: llvm.func @test_call_intrinsic(%{{.*}}: i64, %{{.*}}: i64) {
+// CHECK-NEXT:   %{{.*}} = llvm.call_intrinsic "llvm.smax"(%{{.*}}, %{{.*}}) : (i64, i64) -> i64
+// CHECK-NEXT:   llvm.call_intrinsic "llvm.donothing"() : () -> ()
+// CHECK-NEXT:   %{{.*}} = llvm.call_intrinsic "llvm.smax"(%{{.*}}, %{{.*}}) {fastmathFlags = #llvm.fastmath<reassoc,nnan>} : (i64, i64) -> i64
+// CHECK-NEXT:   %{{.*}} = llvm.call_intrinsic "llvm.smax"(%{{.*}}, %{{.*}}) {fastmathFlags = #llvm.fastmath<fast>} : (i64, i64) -> i64
+// CHECK-NEXT:   llvm.return
+// CHECK-NEXT: }

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -2221,14 +2221,26 @@ class CallIntrinsicOp(IRDLOperation):
 
     name = "llvm.call_intrinsic"
 
-    fastmathFlags = opt_prop_def(FastMathAttr)
+    fastmathFlags = prop_def(FastMathAttr, default_value=FastMathAttr(None))
     intrin = prop_def(StringAttr)
-    op_bundle_sizes = prop_def(DenseArrayBase.constr(i32))
+    op_bundle_sizes = prop_def(
+        DenseArrayBase.constr(i32),
+        default_value=DenseArrayBase.from_list(i32, ()),
+    )
     args = var_operand_def()
     op_bundle_operands = var_operand_def()
     ress = opt_result_def()
 
-    irdl_options = (AttrSizedOperandSegments(as_property=True),)
+    assembly_format = (
+        "$intrin `(` $args `)` (`[` $op_bundle_operands^ `:`"
+        " type($op_bundle_operands) `]`)?"
+        " attr-dict `:` functional-type($args, results)"
+    )
+
+    irdl_options = (
+        AttrSizedOperandSegments(as_property=True),
+        ParsePropInAttrDict(),
+    )
 
     def __init__(
         self,
@@ -2236,7 +2248,7 @@ class CallIntrinsicOp(IRDLOperation):
         args: Sequence[SSAValue],
         result_types: Sequence[Attribute],
         *,
-        op_bundle_sizes: DenseArrayBase,
+        op_bundle_sizes: DenseArrayBase = DenseArrayBase.from_list(i32, ()),
         op_bundle_operands: Sequence[SSAValue] = (),
     ):
         if isinstance(intrin, str):


### PR DESCRIPTION
- Add custom `print`/`parse` methods to `CallIntrinsicOp` so it uses `llvm.call_intrinsic "name"(args) : (types) -> ret` syntax instead of the generic format.
- Add roundtrip filecheck tests for both xdsl and mlir-conversion paths.

Split out from #5912 per reviewer request.