### PR TITLE
dialects: (acc) OpenACC kernels operation support

### DIFF
--- a/tests/dialects/test_acc.py
+++ b/tests/dialects/test_acc.py
@@ -331,3 +331,24 @@ def test_serial_unit_and_default_attrs():
     assert op_explicit.default_attr == acc.ClauseDefaultValueAttr(
         acc.ClauseDefaultValue.NONE
     )
+
+
+def test_kernels_init_bool_shortcuts():
+    """The bool-shortcut branch in KernelsOp.__init__ (self_attr=True / combined=True
+    / default_attr=enum) cannot be reached via the parser — filecheck would have to
+    pass already-constructed attributes — so this Python-only branch lives here."""
+    op = acc.KernelsOp(
+        region=Region(Block()),
+        self_attr=True,
+        default_attr=acc.ClauseDefaultValue.PRESENT,
+        combined=True,
+    )
+    op.verify()
+
+    assert isinstance(op.self_attr, UnitAttr)
+    assert isinstance(op.combined, UnitAttr)
+    assert op.default_attr == acc.ClauseDefaultValueAttr(acc.ClauseDefaultValue.PRESENT)
+
+    op_off = acc.KernelsOp(region=Region(Block()))
+    assert op_off.self_attr is None
+    assert op_off.combined is None

--- a/tests/filecheck/dialects/acc/ops.mlir
+++ b/tests/filecheck/dialects/acc/ops.mlir
@@ -433,4 +433,189 @@ builtin.module {
   // CHECK:         acc.serial wait({%{{.*}} : i32, %{{.*}} : i32}) {
   // CHECK-NEXT:      acc.yield
   // CHECK-NEXT:    }
+
+  // acc.kernels uses the upstream `NoTerminator` body shape: the body can
+  // be empty or contain ops that lower to a kernels region. acc.yield is
+  // *not* a valid terminator inside acc.kernels (upstream's acc.yield
+  // ParentOneOf list excludes KernelsOp); the dedicated acc.terminator op
+  // lands later in the roadmap.
+  func.func @kernels_empty() {
+    acc.kernels {
+    }
+    func.return
+  }
+  // CHECK-LABEL: func.func @kernels_empty() {
+  // CHECK-NEXT:    acc.kernels {
+  // CHECK-NEXT:    }
+
+  func.func @kernels_if_self(%c1 : i1) {
+    acc.kernels self(%c1) if(%c1) {
+    }
+    func.return
+  }
+  // CHECK-LABEL: func.func @kernels_if_self(
+  // CHECK:         acc.kernels self(%{{.*}}) if(%{{.*}}) {
+  // CHECK-NEXT:    }
+
+  func.func @kernels_data_ops(%m : memref<10xf32>) {
+    acc.kernels dataOperands(%m : memref<10xf32>) {
+    }
+    func.return
+  }
+  // CHECK-LABEL: func.func @kernels_data_ops(
+  // CHECK:         acc.kernels dataOperands(%{{.*}} : memref<10xf32>) {
+  // CHECK-NEXT:    }
+
+  func.func @kernels_private_firstprivate_reduction(%m : memref<10xf32>) {
+    acc.kernels firstprivate(%m : memref<10xf32>) private(%m : memref<10xf32>) reduction(%m : memref<10xf32>) {
+    }
+    func.return
+  }
+  // CHECK-LABEL: func.func @kernels_private_firstprivate_reduction(
+  // CHECK:         acc.kernels firstprivate(%{{.*}} : memref<10xf32>) private(%{{.*}} : memref<10xf32>) reduction(%{{.*}} : memref<10xf32>) {
+  // CHECK-NEXT:    }
+
+  func.func @kernels_async_bare() {
+    acc.kernels async {
+    }
+    func.return
+  }
+  // CHECK-LABEL: func.func @kernels_async_bare() {
+  // CHECK-NEXT:    acc.kernels async {
+  // CHECK-NEXT:    }
+
+  func.func @kernels_async_keyword_only_with_dt() {
+    acc.kernels async([#acc.device_type<nvidia>]) {
+    }
+    func.return
+  }
+  // CHECK-LABEL: func.func @kernels_async_keyword_only_with_dt() {
+  // CHECK-NEXT:    acc.kernels async([#acc.device_type<nvidia>]) {
+  // CHECK-NEXT:    }
+
+  func.func @kernels_async_one_operand(%a : i64) {
+    acc.kernels async(%a : i64) {
+    }
+    func.return
+  }
+  // CHECK-LABEL: func.func @kernels_async_one_operand(
+  // CHECK:         acc.kernels async(%{{.*}} : i64) {
+  // CHECK-NEXT:    }
+
+  func.func @kernels_async_operand_with_dt(%a : i64) {
+    acc.kernels async(%a : i64 [#acc.device_type<nvidia>]) {
+    }
+    func.return
+  }
+  // CHECK-LABEL: func.func @kernels_async_operand_with_dt(
+  // CHECK:         acc.kernels async(%{{.*}} : i64 [#acc.device_type<nvidia>]) {
+  // CHECK-NEXT:    }
+
+  func.func @kernels_async_mixed(%a : i64) {
+    acc.kernels async([#acc.device_type<nvidia>], %a : i64 [#acc.device_type<default>]) {
+    }
+    func.return
+  }
+  // CHECK-LABEL: func.func @kernels_async_mixed(
+  // CHECK:         acc.kernels async([#acc.device_type<nvidia>], %{{.*}} : i64 [#acc.device_type<default>]) {
+  // CHECK-NEXT:    }
+
+  func.func @kernels_num_gangs_single(%a : i32) {
+    acc.kernels num_gangs({%a : i32}) {
+    }
+    func.return
+  }
+  // CHECK-LABEL: func.func @kernels_num_gangs_single(
+  // CHECK:         acc.kernels num_gangs({%{{.*}} : i32}) {
+  // CHECK-NEXT:    }
+
+  func.func @kernels_num_gangs_multi(%a : i32, %b : i32, %c : index) {
+    acc.kernels num_gangs({%a : i32, %b : i32, %c : index}) {
+    }
+    func.return
+  }
+  // CHECK-LABEL: func.func @kernels_num_gangs_multi(
+  // CHECK:         acc.kernels num_gangs({%{{.*}} : i32, %{{.*}} : i32, %{{.*}} : index}) {
+  // CHECK-NEXT:    }
+
+  func.func @kernels_num_gangs_multi_dt(%a : i32, %b : i32, %c : i32) {
+    acc.kernels num_gangs({%a : i32} [#acc.device_type<default>], {%b : i32, %c : i32} [#acc.device_type<nvidia>]) {
+    }
+    func.return
+  }
+  // CHECK-LABEL: func.func @kernels_num_gangs_multi_dt(
+  // CHECK:         acc.kernels num_gangs({%{{.*}} : i32} [#acc.device_type<default>], {%{{.*}} : i32, %{{.*}} : i32} [#acc.device_type<nvidia>]) {
+  // CHECK-NEXT:    }
+
+  func.func @kernels_num_workers_vector_length(%a : i64, %b : i32) {
+    acc.kernels num_workers(%a : i64 [#acc.device_type<nvidia>]) vector_length(%b : i32) {
+    }
+    func.return
+  }
+  // CHECK-LABEL: func.func @kernels_num_workers_vector_length(
+  // CHECK:         acc.kernels num_workers(%{{.*}} : i64 [#acc.device_type<nvidia>]) vector_length(%{{.*}} : i32) {
+  // CHECK-NEXT:    }
+
+  func.func @kernels_wait_bare() {
+    acc.kernels wait {
+    }
+    func.return
+  }
+  // CHECK-LABEL: func.func @kernels_wait_bare() {
+  // CHECK-NEXT:    acc.kernels wait {
+  // CHECK-NEXT:    }
+
+  func.func @kernels_wait_group(%a : i64, %b : i32) {
+    acc.kernels wait({%a : i64, %b : i32}) {
+    }
+    func.return
+  }
+  // CHECK-LABEL: func.func @kernels_wait_group(
+  // CHECK:         acc.kernels wait({%{{.*}} : i64, %{{.*}} : i32}) {
+  // CHECK-NEXT:    }
+
+  func.func @kernels_wait_devnum(%a : i64, %b : i32) {
+    acc.kernels wait({devnum: %a : i64, %b : i32}) {
+    }
+    func.return
+  }
+  // CHECK-LABEL: func.func @kernels_wait_devnum(
+  // CHECK:         acc.kernels wait({devnum: %{{.*}} : i64, %{{.*}} : i32}) {
+  // CHECK-NEXT:    }
+
+  func.func @kernels_wait_mixed(%a : i64, %b : i32) {
+    acc.kernels wait([#acc.device_type<nvidia>], {devnum: %a : i64, %b : i32} [#acc.device_type<default>]) {
+    }
+    func.return
+  }
+  // CHECK-LABEL: func.func @kernels_wait_mixed(
+  // CHECK:         acc.kernels wait([#acc.device_type<nvidia>], {devnum: %{{.*}} : i64, %{{.*}} : i32} [#acc.device_type<default>]) {
+  // CHECK-NEXT:    }
+
+  func.func @kernels_combined_prefix() {
+    acc.kernels combined(loop) {
+    }
+    func.return
+  }
+  // CHECK-LABEL: func.func @kernels_combined_prefix() {
+  // CHECK-NEXT:    acc.kernels combined(loop) {
+  // CHECK-NEXT:    }
+
+  func.func @kernels_default_self_attrs_via_attr_dict() {
+    acc.kernels {
+    } attributes {defaultAttr = #acc<defaultvalue present>, selfAttr}
+    func.return
+  }
+  // CHECK-LABEL: func.func @kernels_default_self_attrs_via_attr_dict() {
+  // CHECK-NEXT:    acc.kernels {
+  // CHECK-NEXT:    } attributes {defaultAttr = #acc<defaultvalue present>, selfAttr}
+
+  func.func @kernels_generic_roundtrip_retained() {
+    "acc.kernels"() <{operandSegmentSizes = array<i32: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>}> ({
+    }) : () -> ()
+    func.return
+  }
+  // CHECK-LABEL: func.func @kernels_generic_roundtrip_retained() {
+  // CHECK-NEXT:    acc.kernels {
+  // CHECK-NEXT:    }
 }

--- a/tests/filecheck/dialects/acc/ops_invalid.mlir
+++ b/tests/filecheck/dialects/acc/ops_invalid.mlir
@@ -44,3 +44,19 @@ func.func @serial_wrong_terminator(%arg0: i32) {
   func.return
 }
 // CHECK: Operation builtin.unrealized_conversion_cast terminates block in single-block region but is not a terminator
+
+// -----
+
+// acc.kernels uses upstream's NoTerminator body modeling (AnyRegion with no
+// implicit terminator), so empty blocks and non-terminator final ops are
+// accepted; the only verifier failure unique to that trait is a multi-block
+// region.
+func.func @kernels_multi_block() {
+  "acc.kernels"() <{operandSegmentSizes = array<i32: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>}> ({
+  ^bb0:
+    "cf.br"()[^bb1] : () -> ()
+  ^bb1:
+  }) : () -> ()
+  func.return
+}
+// CHECK: 'acc.kernels' does not contain single-block regions

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/ops.mlir
@@ -287,4 +287,134 @@ builtin.module {
   // CHECK:         acc.serial combined(loop) async(%{{.*}} : i64) wait({%{{.*}} : i64}) self(%{{.*}}) if(%{{.*}}) {
   // CHECK-NEXT:      acc.yield
   // CHECK-NEXT:    } attributes {defaultAttr = #acc<defaultvalue present>, selfAttr}
+
+  // acc.kernels models upstream's `AnyRegion` body (NoTerminator); upstream
+  // mlir-opt rejects acc.yield inside acc.kernels (yield's ParentOneOf list
+  // excludes KernelsOp), so all bodies here are empty until acc.terminator
+  // is introduced later in the roadmap.
+  func.func @kernels_empty() {
+    acc.kernels {
+    }
+    func.return
+  }
+  // CHECK:       func.func @kernels_empty() {
+  // CHECK-NEXT:    acc.kernels {
+  // CHECK-NEXT:    }
+
+  func.func @kernels_self_if(%c : i1) {
+    acc.kernels self(%c) if(%c) {
+    }
+    func.return
+  }
+  // CHECK:       func.func @kernels_self_if(
+  // CHECK:         acc.kernels self(%{{.*}}) if(%{{.*}}) {
+  // CHECK-NEXT:    }
+
+  func.func @kernels_combined_default_self() {
+    acc.kernels combined(loop) {
+    } attributes {defaultAttr = #acc<defaultvalue present>, selfAttr}
+    func.return
+  }
+  // CHECK:       func.func @kernels_combined_default_self() {
+  // CHECK-NEXT:    acc.kernels combined(loop) {
+  // CHECK-NEXT:    } attributes {defaultAttr = #acc<defaultvalue present>, selfAttr}
+
+  func.func @kernels_async_bare() {
+    acc.kernels async {
+    }
+    func.return
+  }
+  // CHECK:       func.func @kernels_async_bare() {
+  // CHECK-NEXT:    acc.kernels async {
+  // CHECK-NEXT:    }
+
+  func.func @kernels_async_one_operand(%a : i64) {
+    acc.kernels async(%a : i64) {
+    }
+    func.return
+  }
+  // CHECK:       func.func @kernels_async_one_operand(
+  // CHECK:         acc.kernels async(%{{.*}} : i64) {
+  // CHECK-NEXT:    }
+
+  func.func @kernels_async_operand_with_dt(%a : i64) {
+    acc.kernels async(%a : i64 [#acc.device_type<default>]) {
+    }
+    func.return
+  }
+  // CHECK:       func.func @kernels_async_operand_with_dt(
+  // CHECK:         acc.kernels async(%{{.*}} : i64 [#acc.device_type<default>]) {
+  // CHECK-NEXT:    }
+
+  func.func @kernels_num_gangs_single(%a : i32) {
+    acc.kernels num_gangs({%a : i32}) {
+    }
+    func.return
+  }
+  // CHECK:       func.func @kernels_num_gangs_single(
+  // CHECK:         acc.kernels num_gangs({%{{.*}} : i32}) {
+  // CHECK-NEXT:    }
+
+  func.func @kernels_num_gangs_multi_dt(%a : i32, %b : i32, %c : i32) {
+    acc.kernels num_gangs({%a : i32} [#acc.device_type<default>], {%b : i32, %c : i32} [#acc.device_type<nvidia>]) {
+    }
+    func.return
+  }
+  // CHECK:       func.func @kernels_num_gangs_multi_dt(
+  // CHECK:         acc.kernels num_gangs({%{{.*}} : i32} [#acc.device_type<default>], {%{{.*}} : i32, %{{.*}} : i32} [#acc.device_type<nvidia>]) {
+  // CHECK-NEXT:    }
+
+  func.func @kernels_num_workers_vector_length(%a : i64, %b : i32, %c : i32) {
+    acc.kernels num_workers(%a : i64 [#acc.device_type<default>], %b : i32 [#acc.device_type<nvidia>]) vector_length(%c : i32) {
+    }
+    func.return
+  }
+  // CHECK:       func.func @kernels_num_workers_vector_length(
+  // CHECK:         acc.kernels num_workers(%{{.*}} : i64 [#acc.device_type<default>], %{{.*}} : i32 [#acc.device_type<nvidia>]) vector_length(%{{.*}} : i32) {
+  // CHECK-NEXT:    }
+
+  func.func @kernels_wait_bare() {
+    acc.kernels wait {
+    }
+    func.return
+  }
+  // CHECK:       func.func @kernels_wait_bare() {
+  // CHECK-NEXT:    acc.kernels wait {
+  // CHECK-NEXT:    }
+
+  func.func @kernels_wait_group(%a : i64, %b : i32) {
+    acc.kernels wait({%a : i64, %b : i32}) {
+    }
+    func.return
+  }
+  // CHECK:       func.func @kernels_wait_group(
+  // CHECK:         acc.kernels wait({%{{.*}} : i64, %{{.*}} : i32}) {
+  // CHECK-NEXT:    }
+
+  func.func @kernels_wait_devnum(%a : i64, %b : i32) {
+    acc.kernels wait({devnum: %a : i64, %b : i32}) {
+    }
+    func.return
+  }
+  // CHECK:       func.func @kernels_wait_devnum(
+  // CHECK:         acc.kernels wait({devnum: %{{.*}} : i64, %{{.*}} : i32}) {
+  // CHECK-NEXT:    }
+
+  func.func @kernels_wait_mixed(%a : i64, %b : i32) {
+    acc.kernels wait([#acc.device_type<nvidia>], {devnum: %a : i64, %b : i32} [#acc.device_type<default>]) {
+    }
+    func.return
+  }
+  // CHECK:       func.func @kernels_wait_mixed(
+  // CHECK:         acc.kernels wait([#acc.device_type<nvidia>], {devnum: %{{.*}} : i64, %{{.*}} : i32} [#acc.device_type<default>]) {
+  // CHECK-NEXT:    }
+
+  func.func @kernels_test_entire(%c : i1, %a : i32, %b : i64) {
+    acc.kernels combined(loop) async(%b : i64) num_workers(%b : i64) vector_length(%a : i32) wait({%b : i64}) self(%c) if(%c) {
+    } attributes {defaultAttr = #acc<defaultvalue present>, selfAttr}
+    func.return
+  }
+  // CHECK:       func.func @kernels_test_entire(
+  // CHECK:         acc.kernels combined(loop) async(%{{.*}} : i64) num_workers(%{{.*}} : i64) vector_length(%{{.*}} : i32) wait({%{{.*}} : i64}) self(%{{.*}}) if(%{{.*}}) {
+  // CHECK-NEXT:    } attributes {defaultAttr = #acc<defaultvalue present>, selfAttr}
 }

--- a/xdsl/dialects/acc.py
+++ b/xdsl/dialects/acc.py
@@ -952,8 +952,8 @@ class KernelsOp(IRDLOperation):
         WaitClause,
     )
 
-    # Upstream `acc.kernels` body uses `acc.terminator` (which lands in PR 9)
-    # rather than `acc.yield`; until that op exists we accept any (or empty)
+    # Upstream `acc.kernels` body uses `acc.terminator` rather than `acc.yield`
+    # That will be supported later, until that op exists we accept any (or empty)
     # body via NoTerminator, mirroring upstream's `AnyRegion` modeling.
     assembly_format = (
         "(`combined` `(` `loop` `)` $combined^)?"

--- a/xdsl/dialects/acc.py
+++ b/xdsl/dialects/acc.py
@@ -60,6 +60,7 @@ from xdsl.traits import (
     HasParent,
     IsTerminator,
     NoMemoryEffect,
+    NoTerminator,
     RecursiveMemoryEffect,
     SingleBlockImplicitTerminator,
 )
@@ -889,6 +890,182 @@ class SerialOp(IRDLOperation):
 
 
 @irdl_op_definition
+class KernelsOp(IRDLOperation):
+    """
+    Implementation of upstream acc.kernels.
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/OpenACCDialect/#acckernels-acckernelsop).
+    """
+
+    name = "acc.kernels"
+
+    async_operands = var_operand_def(IntegerType | IndexType)
+    wait_operands = var_operand_def(IntegerType | IndexType)
+    num_gangs = var_operand_def(IntegerType | IndexType)
+    num_workers = var_operand_def(IntegerType | IndexType)
+    vector_length = var_operand_def(IntegerType | IndexType)
+    if_cond = opt_operand_def(I1)
+    self_cond = opt_operand_def(I1)
+    reduction_operands = var_operand_def()
+    private_operands = var_operand_def()
+    firstprivate_operands = var_operand_def()
+    data_clause_operands = var_operand_def()
+
+    async_operands_device_type = opt_prop_def(
+        ArrayAttr[DeviceTypeAttr], prop_name="asyncOperandsDeviceType"
+    )
+    async_only = opt_prop_def(ArrayAttr[DeviceTypeAttr], prop_name="asyncOnly")
+    wait_operands_device_type = opt_prop_def(
+        ArrayAttr[DeviceTypeAttr], prop_name="waitOperandsDeviceType"
+    )
+    wait_operands_segments = opt_prop_def(
+        DenseArrayBase.constr(IntegerType(32)), prop_name="waitOperandsSegments"
+    )
+    has_wait_devnum = opt_prop_def(ArrayAttr[BoolAttr], prop_name="hasWaitDevnum")
+    wait_only = opt_prop_def(ArrayAttr[DeviceTypeAttr], prop_name="waitOnly")
+    num_gangs_segments = opt_prop_def(
+        DenseArrayBase.constr(IntegerType(32)), prop_name="numGangsSegments"
+    )
+    num_gangs_device_type = opt_prop_def(
+        ArrayAttr[DeviceTypeAttr], prop_name="numGangsDeviceType"
+    )
+    num_workers_device_type = opt_prop_def(
+        ArrayAttr[DeviceTypeAttr], prop_name="numWorkersDeviceType"
+    )
+    vector_length_device_type = opt_prop_def(
+        ArrayAttr[DeviceTypeAttr], prop_name="vectorLengthDeviceType"
+    )
+    self_attr = opt_prop_def(UnitAttr, prop_name="selfAttr")
+    default_attr = opt_prop_def(ClauseDefaultValueAttr, prop_name="defaultAttr")
+    combined = opt_prop_def(UnitAttr)
+
+    region = region_def()
+
+    irdl_options = (
+        AttrSizedOperandSegments(as_property=True),
+        ParsePropInAttrDict(),
+    )
+
+    custom_directives = (
+        DeviceTypeOperands,
+        NumGangs,
+        DeviceTypeOperandsWithKeywordOnly,
+        WaitClause,
+    )
+
+    # Upstream `acc.kernels` body uses `acc.terminator` (which lands in PR 9)
+    # rather than `acc.yield`; until that op exists we accept any (or empty)
+    # body via NoTerminator, mirroring upstream's `AnyRegion` modeling.
+    assembly_format = (
+        "(`combined` `(` `loop` `)` $combined^)?"
+        " (`dataOperands` `(` $data_clause_operands^ `:`"
+        " type($data_clause_operands) `)`)?"
+        " (`async` custom<DeviceTypeOperandsWithKeywordOnly>($async_operands,"
+        " type($async_operands), $asyncOperandsDeviceType, $asyncOnly)^)?"
+        " (`firstprivate` `(` $firstprivate_operands^ `:`"
+        " type($firstprivate_operands) `)`)?"
+        " (`num_gangs` `(` custom<NumGangs>($num_gangs, type($num_gangs),"
+        " $numGangsDeviceType, $numGangsSegments)^ `)`)?"
+        " (`num_workers` `(` custom<DeviceTypeOperands>($num_workers,"
+        " type($num_workers), $numWorkersDeviceType)^ `)`)?"
+        " (`private` `(` $private_operands^ `:`"
+        " type($private_operands) `)`)?"
+        " (`vector_length` `(` custom<DeviceTypeOperands>($vector_length,"
+        " type($vector_length), $vectorLengthDeviceType)^ `)`)?"
+        " (`wait` custom<WaitClause>($wait_operands, type($wait_operands),"
+        " $waitOperandsDeviceType, $waitOperandsSegments, $hasWaitDevnum,"
+        " $waitOnly)^)?"
+        " (`self` `(` $self_cond^ `)`)?"
+        " (`if` `(` $if_cond^ `)`)?"
+        " (`reduction` `(` $reduction_operands^ `:`"
+        " type($reduction_operands) `)`)?"
+        " $region attr-dict-with-keyword"
+    )
+
+    traits = lazy_traits_def(
+        lambda: (
+            NoTerminator(),
+            RecursiveMemoryEffect(),
+        )
+    )
+
+    def __init__(
+        self,
+        *,
+        region: Region,
+        async_operands: Sequence[SSAValue | Operation] = (),
+        wait_operands: Sequence[SSAValue | Operation] = (),
+        num_gangs: Sequence[SSAValue | Operation] = (),
+        num_workers: Sequence[SSAValue | Operation] = (),
+        vector_length: Sequence[SSAValue | Operation] = (),
+        if_cond: SSAValue | Operation | None = None,
+        self_cond: SSAValue | Operation | None = None,
+        reduction_operands: Sequence[SSAValue | Operation] = (),
+        private_operands: Sequence[SSAValue | Operation] = (),
+        firstprivate_operands: Sequence[SSAValue | Operation] = (),
+        data_clause_operands: Sequence[SSAValue | Operation] = (),
+        async_operands_device_type: ArrayAttr[DeviceTypeAttr] | None = None,
+        async_only: ArrayAttr[DeviceTypeAttr] | None = None,
+        wait_operands_device_type: ArrayAttr[DeviceTypeAttr] | None = None,
+        wait_operands_segments: DenseArrayBase | None = None,
+        has_wait_devnum: ArrayAttr[BoolAttr] | None = None,
+        wait_only: ArrayAttr[DeviceTypeAttr] | None = None,
+        num_gangs_segments: DenseArrayBase | None = None,
+        num_gangs_device_type: ArrayAttr[DeviceTypeAttr] | None = None,
+        num_workers_device_type: ArrayAttr[DeviceTypeAttr] | None = None,
+        vector_length_device_type: ArrayAttr[DeviceTypeAttr] | None = None,
+        self_attr: UnitAttr | bool = False,
+        default_attr: ClauseDefaultValueAttr | ClauseDefaultValue | None = None,
+        combined: UnitAttr | bool = False,
+    ) -> None:
+        self_attr_prop: UnitAttr | None = (
+            (UnitAttr() if self_attr else None)
+            if isinstance(self_attr, bool)
+            else self_attr
+        )
+        combined_prop: UnitAttr | None = (
+            (UnitAttr() if combined else None)
+            if isinstance(combined, bool)
+            else combined
+        )
+        default_prop: ClauseDefaultValueAttr | None = (
+            ClauseDefaultValueAttr(default_attr)
+            if isinstance(default_attr, ClauseDefaultValue)
+            else default_attr
+        )
+        super().__init__(
+            operands=[
+                async_operands,
+                wait_operands,
+                num_gangs,
+                num_workers,
+                vector_length,
+                [if_cond] if if_cond is not None else [],
+                [self_cond] if self_cond is not None else [],
+                reduction_operands,
+                private_operands,
+                firstprivate_operands,
+                data_clause_operands,
+            ],
+            properties={
+                "asyncOperandsDeviceType": async_operands_device_type,
+                "asyncOnly": async_only,
+                "waitOperandsDeviceType": wait_operands_device_type,
+                "waitOperandsSegments": wait_operands_segments,
+                "hasWaitDevnum": has_wait_devnum,
+                "waitOnly": wait_only,
+                "numGangsSegments": num_gangs_segments,
+                "numGangsDeviceType": num_gangs_device_type,
+                "numWorkersDeviceType": num_workers_device_type,
+                "vectorLengthDeviceType": vector_length_device_type,
+                "selfAttr": self_attr_prop,
+                "defaultAttr": default_prop,
+                "combined": combined_prop,
+            },
+            regions=[region],
+        )
+
+
+@irdl_op_definition
 class YieldOp(AbstractYieldOperation[Attribute]):
     """
     Implementation of upstream acc.yield.
@@ -911,6 +1088,7 @@ ACC = Dialect(
     [
         ParallelOp,
         SerialOp,
+        KernelsOp,
         YieldOp,
     ],
     [


### PR DESCRIPTION
Support for the acc.kernels operation in the OpenACC dialect, builds on custom syntax parsers/printers already present in the dialect
