### PR TITLE
dialects: (llvm) custom print/parse for call

### DIFF
--- a/tests/filecheck/backend/llvm/convert_op.mlir
+++ b/tests/filecheck/backend/llvm/convert_op.mlir
@@ -811,13 +811,7 @@ builtin.module {
   // CHECK-NEXT: }
 
   llvm.func @call_op(%arg0: i32) -> i32 {
-    %0 = "llvm.call"(%arg0) <{
-      callee = @helper,
-      fastmathFlags = #llvm.fastmath<nnan, ninf>,
-      CConv = #llvm.cconv<fastcc>,
-      TailCallKind = #llvm.tailcallkind<tail>,
-      operandSegmentSizes = array<i32: 1, 0>
-    }> : (i32) -> i32
+    %0 = llvm.call fastcc tail @helper(%arg0) {fastmathFlags = #llvm.fastmath<nnan, ninf>} : (i32) -> i32
     llvm.return %0 : i32
   }
 

--- a/tests/filecheck/dialects/llvm/func.mlir
+++ b/tests/filecheck/dialects/llvm/func.mlir
@@ -85,14 +85,39 @@ llvm.func @func_with_attrs() attributes {hello = "world"} {
 // CHECK-NEXT: }
 
 llvm.func private @wrapped_function(%arg0: i32, %arg1: i32) attributes {llvm.emit_c_interface, sym_visibility = "private"} {
-   "llvm.call"(%arg0, %arg1) <{CConv = #llvm.cconv<ccc>, TailCallKind = #llvm.tailcallkind<none>, callee = @_mlir_ciface_wrapped_function, fastmathFlags = #llvm.fastmath<none>, op_bundle_sizes = array<i32>, operandSegmentSizes = array<i32: 2, 0>}> : (i32, i32) -> ()
+   llvm.call @_mlir_ciface_wrapped_function(%arg0, %arg1) : (i32, i32) -> ()
    llvm.return
 }
 
 llvm.func @_mlir_ciface_wrapped_function(i32, i32) attributes {llvm.emit_c_interface, sym_visibility = "private"}
 
 // CHECK:  llvm.func private @wrapped_function(%{{.*}}: i32, %{{.*}}: i32) attributes {llvm.emit_c_interface, sym_visibility = "private"} {
-// CHECK-NEXT:    "llvm.call"(%{{.*}}, %{{.*}}) <{CConv = #llvm.cconv<ccc>, TailCallKind = #llvm.tailcallkind<none>, callee = @_mlir_ciface_wrapped_function, fastmathFlags = #llvm.fastmath<none>, op_bundle_sizes = array<i32>, operandSegmentSizes = array<i32: 2, 0>}> : (i32, i32) -> ()
+// CHECK-NEXT:    llvm.call @_mlir_ciface_wrapped_function(%{{.*}}, %{{.*}}) : (i32, i32) -> ()
 // CHECK-NEXT:    llvm.return
 // CHECK-NEXT:  }
 // CHECK-NEXT:  llvm.func @_mlir_ciface_wrapped_function(i32, i32) attributes {llvm.emit_c_interface, sym_visibility = "private"}
+
+llvm.func @float_callee(f32) -> f32
+llvm.func @variadic_callee(i32, ...) -> i32
+
+llvm.func @test_calls(%arg0: i32, %fptr: !llvm.ptr, %farg: f32) {
+  llvm.call @_mlir_ciface_wrapped_function(%arg0, %arg0) : (i32, i32) -> ()
+  %0 = llvm.call %fptr(%arg0) : !llvm.ptr, (i32) -> i32
+  llvm.call tail @external_func(%arg0) : (i32) -> ()
+  llvm.call fastcc @external_func(%arg0) : (i32) -> ()
+  %1 = llvm.call @variadic_callee(%arg0) vararg(!llvm.func<i32 (i32, ...)>) : (i32) -> i32
+  %2 = llvm.call @float_callee(%farg) {fastmathFlags = #llvm.fastmath<fast>} : (f32) -> f32
+  llvm.return
+}
+
+// CHECK: llvm.func @float_callee(f32) -> f32
+// CHECK-NEXT: llvm.func @variadic_callee(i32, ...) -> i32
+// CHECK-NEXT: llvm.func @test_calls(%{{.*}}: i32, %{{.*}}: !llvm.ptr, %{{.*}}: f32) {
+// CHECK-NEXT:   llvm.call @_mlir_ciface_wrapped_function(%{{.*}}, %{{.*}}) : (i32, i32) -> ()
+// CHECK-NEXT:   %{{.*}} = llvm.call %{{.*}}(%{{.*}}) : !llvm.ptr, (i32) -> i32
+// CHECK-NEXT:   llvm.call tail @external_func(%{{.*}}) : (i32) -> ()
+// CHECK-NEXT:   llvm.call fastcc @external_func(%{{.*}}) : (i32) -> ()
+// CHECK-NEXT:   %{{.*}} = llvm.call @variadic_callee(%{{.*}}) vararg(!llvm.func<i32 (i32, ...)>) : (i32) -> i32
+// CHECK-NEXT:   %{{.*}} = llvm.call @float_callee(%{{.*}}) {fastmathFlags = #llvm.fastmath<fast>} : (f32) -> f32
+// CHECK-NEXT:   llvm.return
+// CHECK-NEXT: }

--- a/tests/filecheck/dialects/printf/printf_to_llvm.mlir
+++ b/tests/filecheck/dialects/printf/printf_to_llvm.mlir
@@ -13,7 +13,7 @@ builtin.module {
 
 // CHECK:       %{{\d+}} = llvm.mlir.addressof @Hello_f_842f9d94ff2eba9703926bef3c2bc5f427db9871 : !llvm.ptr
 
-// CHECK:       "llvm.call"(%{{\d+}}, %{{\d+}}, %{{\d+}}) <{callee = @printf{{.*}}}> : (!llvm.ptr, f64, i32) -> ()
+// CHECK:       llvm.call @printf(%{{\d+}}, %{{\d+}}, %{{\d+}}){{.*}} : (!llvm.ptr, f64, i32) -> ()
 
 // CHECK:       llvm.func @printf(!llvm.ptr, ...)
 

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/func.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/func.mlir
@@ -108,9 +108,9 @@ llvm.func @test_calls(%arg0: i64, %fptr: !llvm.ptr) {
   llvm.return
 }
 
-// CHECK: llvm.func @test_calls(%{{.*}}: i64, %{{.*}}: !llvm.ptr) {
-// CHECK-NEXT:   %{{.*}} = llvm.call %{{.*}}(%{{.*}}) : !llvm.ptr, (i64) -> i64
-// CHECK-NEXT:   llvm.call tail @external_func(%{{.*}}) : (i64) -> ()
-// CHECK-NEXT:   llvm.call fastcc @external_func(%{{.*}}) : (i64) -> ()
+// CHECK: llvm.func @test_calls(%[[ARG0:.*]]: i64, %[[FPTR:.*]]: !llvm.ptr) {
+// CHECK-NEXT:   %[[V0:.*]] = llvm.call %[[FPTR]](%[[ARG0]]) : !llvm.ptr, (i64) -> i64
+// CHECK-NEXT:   llvm.call tail @external_func(%[[ARG0]]) : (i64) -> ()
+// CHECK-NEXT:   llvm.call fastcc @external_func(%[[ARG0]]) : (i64) -> ()
 // CHECK-NEXT:   llvm.return
 // CHECK-NEXT: }

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/func.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/func.mlir
@@ -89,14 +89,28 @@ llvm.func @func_with_attrs() attributes {hello = "world"} {
 // CHECK-NEXT: }
 
 llvm.func private @wrapped_function(%arg0: i32, %arg1: i32) attributes {llvm.emit_c_interface, sym_visibility = "private"} {
-   //"llvm.call"(%arg0, %arg1) <{CConv = #llvm.cconv<ccc>, TailCallKind = #llvm.tailcallkind<none>, callee = @_mlir_ciface_wrapped_function, fastmathFlags = #llvm.fastmath<none>, op_bundle_sizes = array<i32>, operandSegmentSizes = array<i32: 2, 0>}> : (i32, i32) -> ()
+   llvm.call @_mlir_ciface_wrapped_function(%arg0, %arg1) : (i32, i32) -> ()
    llvm.return
 }
 
 llvm.func @_mlir_ciface_wrapped_function(i32, i32) attributes {llvm.emit_c_interface, sym_visibility = "private"}
 
 // CHECK:  llvm.func private @wrapped_function(%{{.*}}: i32, %{{.*}}: i32) attributes {llvm.emit_c_interface, sym_visibility = "private"} {
-//     "llvm.call"(%{{.*}}, %{{.*}}) <{CConv = #llvm.cconv<ccc>, TailCallKind = #llvm.tailcallkind<none>, callee = @_mlir_ciface_wrapped_function, fastmathFlags = #llvm.fastmath<none>, op_bundle_sizes = array<i32>, operandSegmentSizes = array<i32: 2, 0>}> : (i32, i32) -> ()
+// CHECK-NEXT:    llvm.call @_mlir_ciface_wrapped_function(%{{.*}}, %{{.*}}) : (i32, i32) -> ()
 // CHECK-NEXT:    llvm.return
 // CHECK-NEXT:  }
 // CHECK-NEXT:  llvm.func @_mlir_ciface_wrapped_function(i32, i32) attributes {llvm.emit_c_interface, sym_visibility = "private"}
+
+llvm.func @test_calls(%arg0: i64, %fptr: !llvm.ptr) {
+  %0 = llvm.call %fptr(%arg0) : !llvm.ptr, (i64) -> i64
+  llvm.call tail @external_func(%arg0) : (i64) -> ()
+  llvm.call fastcc @external_func(%arg0) : (i64) -> ()
+  llvm.return
+}
+
+// CHECK: llvm.func @test_calls(%{{.*}}: i64, %{{.*}}: !llvm.ptr) {
+// CHECK-NEXT:   %{{.*}} = llvm.call %{{.*}}(%{{.*}}) : !llvm.ptr, (i64) -> i64
+// CHECK-NEXT:   llvm.call tail @external_func(%{{.*}}) : (i64) -> ()
+// CHECK-NEXT:   llvm.call fastcc @external_func(%{{.*}}) : (i64) -> ()
+// CHECK-NEXT:   llvm.return
+// CHECK-NEXT: }

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -2339,6 +2339,100 @@ class CallOp(IRDLOperation):
             result_types=op_result_type,
         )
 
+    def print(self, printer: Printer) -> None:
+        if self.CConv.convention.data != "ccc":
+            printer.print_string(f" {self.CConv.convention.data}")
+        if self.TailCallKind.data != TailCallKind.NONE:
+            printer.print_string(f" {self.TailCallKind.data.value}")
+        printer.print_string(" ")
+        if self.callee is not None:
+            printer.print_attribute(self.callee)
+            call_args = self.args
+        else:
+            printer.print_ssa_value(self.args[0])
+            call_args = self.args[1:]
+        printer.print_string("(")
+        printer.print_list(call_args, printer.print_ssa_value)
+        printer.print_string(")")
+        if self.var_callee_type is not None:
+            printer.print_string(" vararg(")
+            printer.print_attribute(self.var_callee_type)
+            printer.print_string(")")
+        reserved = [
+            "callee",
+            "var_callee_type",
+            "CConv",
+            "TailCallKind",
+            "op_bundle_sizes",
+            "operandSegmentSizes",
+        ]
+        if self.fastmathFlags == FastMathAttr("none"):
+            reserved.append("fastmathFlags")
+        printer.print_op_attributes(
+            self.properties | self.attributes,
+            reserved_attr_names=reserved,
+        )
+        printer.print_string(" : ")
+        if self.callee is None:
+            printer.print_attribute(self.args[0].type)
+            printer.print_string(", ")
+        ret_types = [] if self.returned is None else [self.returned.type]
+        printer.print_function_type([v.type for v in call_args], ret_types)
+
+    @classmethod
+    def parse(cls, parser: Parser) -> CallOp:
+        cconv = CallingConventionAttr(
+            parser.parse_optional_keyword_in(LLVM_CALLING_CONVS - {"ccc"}) or "ccc"
+        )
+        tck_kw = parser.parse_optional_keyword_in(
+            {k.value for k in TailCallKind if k != TailCallKind.NONE}
+        )
+        tail_call_kind = TailCallKindAttr(
+            TailCallKind(tck_kw) if tck_kw else TailCallKind.NONE
+        )
+        sym_name = parser.parse_optional_symbol_name()
+        callee = SymbolRefAttr(sym_name) if sym_name else None
+        callee_ptr = None if callee else parser.parse_unresolved_operand()
+        args_unresolved = parser.parse_comma_separated_list(
+            parser.Delimiter.PAREN, parser.parse_unresolved_operand
+        )
+        var_callee_type: Attribute | None = None
+        if parser.parse_optional_keyword("vararg") is not None:
+            parser.parse_punctuation("(")
+            var_callee_type = parser.parse_type()
+            parser.parse_punctuation(")")
+        attrs = parser.parse_optional_attr_dict()
+        parser.parse_punctuation(":")
+        ptr_operands: list[SSAValue] = []
+        if callee_ptr is not None:
+            ptr_operands.append(parser.resolve_operand(callee_ptr, parser.parse_type()))
+            parser.parse_punctuation(",")
+        ft = parser.parse_function_type()
+        fastmath = attrs.pop("fastmathFlags", FastMathAttr("none"))
+        assert isinstance(fastmath, FastMathAttr)
+        all_args = [
+            *ptr_operands,
+            *parser.resolve_operands(args_unresolved, ft.inputs.data, parser.pos),
+        ]
+        props: dict[str, Attribute] = {
+            "fastmathFlags": fastmath,
+            "CConv": cconv,
+            "TailCallKind": tail_call_kind,
+            "op_bundle_sizes": DenseArrayBase.from_list(i32, ()),
+            "operandSegmentSizes": DenseArrayBase.from_list(i32, [len(all_args), 0]),
+        }
+        if callee is not None:
+            props["callee"] = callee
+        if var_callee_type is not None:
+            props["var_callee_type"] = var_callee_type
+        op = cls.create(
+            operands=all_args,
+            properties=props,
+            result_types=list(ft.outputs.data),
+        )
+        op.attributes |= attrs
+        return op
+
 
 LLVMType = (
     LLVMStructType | LLVMPointerType | LLVMArrayType | LLVMVoidType | LLVMFunctionType

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -2428,7 +2428,7 @@ class CallOp(IRDLOperation):
         op = cls.create(
             operands=all_args,
             properties=props,
-            result_types=list(ft.outputs.data),
+            result_types=ft.outputs.data,
         )
         op.attributes |= attrs
         return op


### PR DESCRIPTION
- Split out from #5912 per reviewer request.
- Adds custom `print`/`parse` methods to `CallOp` so it uses `llvm.call [cconv] [tail] @callee(args) [vararg(type)] {attrs} : (types) -> ret` syntax instead of the generic format.
- Adds `parse_optional_keyword_in` utility to the base parser.
