### PR TITLE
dialects: (llvm) custom print/parse for inline_asm

### DIFF
--- a/tests/filecheck/backend/llvm/convert_op.mlir
+++ b/tests/filecheck/backend/llvm/convert_op.mlir
@@ -361,11 +361,10 @@ builtin.module {
   }
 
   llvm.func @inline_asm(%arg0: i32) {
-    "llvm.inline_asm"(%arg0) <{
-      asm_string = "add $0, 1",
-      constraints = "r",
-      has_side_effects
-    }> : (i32) -> ()
+    llvm.inline_asm has_side_effects "add $0, 1", "r" %arg0 : (i32) -> ()
+    llvm.inline_asm "add $0, 1", "r" %arg0 : (i32) -> ()
+    llvm.inline_asm asm_dialect = att "add $0, 1", "r" %arg0 : (i32) -> ()
+    llvm.inline_asm asm_dialect = intel "add $0, 1", "r" %arg0 : (i32) -> ()
     llvm.return
   }
 
@@ -373,7 +372,22 @@ builtin.module {
   // CHECK-NEXT: {
   // CHECK-NEXT: {{.[0-9]+}}:
   // CHECK-NEXT:   call void asm sideeffect "add $0, 1", "r"(i32 %".1")
+  // CHECK-NEXT:   call void asm  "add $0, 1", "r"(i32 %".1")
+  // CHECK-NEXT:   call void asm  "add $0, 1", "r"(i32 %".1")
+  // CHECK-NEXT:   call void asm  "add $0, 1", "r"(i32 %".1")
   // CHECK-NEXT:   ret void
+  // CHECK-NEXT: }
+
+  llvm.func @inline_asm_with_result(%arg0: i32) -> i32 {
+    %0 = llvm.inline_asm "mov $0, $1", "=r,r" %arg0 : (i32) -> i32
+    llvm.return %0 : i32
+  }
+
+  // CHECK: define i32 @"inline_asm_with_result"(i32 %".1")
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {{.[0-9]+}}:
+  // CHECK-NEXT:   {{%.+}} = call i32 asm  "mov $0, $1", "=r,r"(i32 %".1")
+  // CHECK-NEXT:   ret i32 {{%.+}}
   // CHECK-NEXT: }
 
   llvm.func @alloca_op(%arg0: i32) {

--- a/tests/filecheck/dialects/llvm/inline_asm.mlir
+++ b/tests/filecheck/dialects/llvm/inline_asm.mlir
@@ -2,15 +2,23 @@
 
 %0 = "test.op"() : () -> i32
 %1 = "test.op"() : () -> i32
-"llvm.inline_asm"(%0, %1) <{asm_string = "csrw $0, $1", constraints = "i, r", has_side_effects, tail_call_kind = #llvm.tailcallkind<none>}> : (i32, i32) -> ()
+llvm.inline_asm has_side_effects "csrw $0, $1", "i, r" %0, %1 : (i32, i32) -> ()
+
+llvm.inline_asm "add $0, 1", "r" %0 : (i32) -> ()
 
 %2 = "test.op"() : () -> vector<8xf32>
 %3 = "test.op"() : () -> vector<8xf32>
-%4 = "llvm.inline_asm"(%2, %3) <{asm_dialect = 1 : i64, asm_string = "vaddps $0, $1, $2", constraints = "=x,x,x", tail_call_kind = #llvm.tailcallkind<none>}> : (vector<8xf32>, vector<8xf32>) -> vector<8xf32>
+%4 = llvm.inline_asm asm_dialect = att "vaddps $0, $1, $2", "=x,x,x" %2, %3 : (vector<8xf32>, vector<8xf32>) -> vector<8xf32>
+%5 = llvm.inline_asm asm_dialect = intel "vaddps $0, $1, $2", "=x,x,x" %2, %3 : (vector<8xf32>, vector<8xf32>) -> vector<8xf32>
+
+%6 = llvm.inline_asm is_align_stack tail_call_kind = <tail> "foo", "=r,r" %0, %1 : (i32, i32) -> i32
 
 // CHECK: %0 = "test.op"() : () -> i32
-// CHECK-NEXT: 1 = "test.op"() : () -> i32
-// CHECK-NEXT: "llvm.inline_asm"(%0, %1) <{asm_string = "csrw $0, $1", constraints = "i, r", has_side_effects, tail_call_kind = #llvm.tailcallkind<none>}> : (i32, i32) -> ()
+// CHECK-NEXT: %1 = "test.op"() : () -> i32
+// CHECK-NEXT: llvm.inline_asm has_side_effects "csrw $0, $1", "i, r" %0, %1 : (i32, i32) -> ()
+// CHECK-NEXT: llvm.inline_asm "add $0, 1", "r" %0 : (i32) -> ()
 // CHECK-NEXT: %2 = "test.op"() : () -> vector<8xf32>
 // CHECK-NEXT: %3 = "test.op"() : () -> vector<8xf32>
-// CHECK-NEXT: %4 = "llvm.inline_asm"(%2, %3) <{asm_dialect = 1 : i64, asm_string = "vaddps $0, $1, $2", constraints = "=x,x,x", tail_call_kind = #llvm.tailcallkind<none>}> : (vector<8xf32>, vector<8xf32>) -> vector<8xf32>
+// CHECK-NEXT: %4 = llvm.inline_asm asm_dialect = att "vaddps $0, $1, $2", "=x,x,x" %2, %3 : (vector<8xf32>, vector<8xf32>) -> vector<8xf32>
+// CHECK-NEXT: %5 = llvm.inline_asm asm_dialect = intel "vaddps $0, $1, $2", "=x,x,x" %2, %3 : (vector<8xf32>, vector<8xf32>) -> vector<8xf32>
+// CHECK-NEXT: %6 = llvm.inline_asm is_align_stack tail_call_kind = <tail> "foo", "=r,r" %0, %1 : (i32, i32) -> i32

--- a/tests/filecheck/dialects/llvm/invalid.mlir
+++ b/tests/filecheck/dialects/llvm/invalid.mlir
@@ -134,3 +134,13 @@ func.func @insertvalue_into_scalar() {
 }
 
 // CHECK: cannot index into i32
+
+// -----
+
+func.func @inline_asm_unknown_dialect() {
+  %v = "test.op"() : () -> i32
+  llvm.inline_asm asm_dialect = bogus "nop", "" %v : (i32) -> ()
+  func.return
+}
+
+// CHECK: Expected one of 'att', 'intel' after 'asm_dialect ='

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/inline_asm.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/inline_asm.mlir
@@ -1,16 +1,25 @@
+// RUN: MLIR_ROUNDTRIP
 // RUN: MLIR_GENERIC_ROUNDTRIP
 
 %0 = "test.op"() : () -> i32
 %1 = "test.op"() : () -> i32
-"llvm.inline_asm"(%0, %1) <{asm_string = "csrw $0, $1", constraints = "i, r", has_side_effects, tail_call_kind = #llvm.tailcallkind<none>}> : (i32, i32) -> ()
+llvm.inline_asm has_side_effects "csrw $0, $1", "i, r" %0, %1 : (i32, i32) -> ()
+
+llvm.inline_asm "add $0, 1", "r" %0 : (i32) -> ()
 
 %2 = "test.op"() : () -> vector<8xf32>
 %3 = "test.op"() : () -> vector<8xf32>
-%4 = "llvm.inline_asm"(%2, %3) <{asm_dialect = 1 : i64, asm_string = "vaddps $0, $1, $2", constraints = "=x,x,x", tail_call_kind = #llvm.tailcallkind<none>}> : (vector<8xf32>, vector<8xf32>) -> vector<8xf32>
+%4 = llvm.inline_asm asm_dialect = att "vaddps $0, $1, $2", "=x,x,x" %2, %3 : (vector<8xf32>, vector<8xf32>) -> vector<8xf32>
+%5 = llvm.inline_asm asm_dialect = intel "vaddps $0, $1, $2", "=x,x,x" %2, %3 : (vector<8xf32>, vector<8xf32>) -> vector<8xf32>
+
+%6 = llvm.inline_asm is_align_stack tail_call_kind = <tail> "foo", "=r,r" %0, %1 : (i32, i32) -> i32
 
 // CHECK: %0 = "test.op"() : () -> i32
-// CHECK-NEXT: 1 = "test.op"() : () -> i32
-// CHECK-NEXT: "llvm.inline_asm"(%0, %1) <{asm_string = "csrw $0, $1", constraints = "i, r", has_side_effects, tail_call_kind = #llvm.tailcallkind<none>}> : (i32, i32) -> ()
+// CHECK-NEXT: %1 = "test.op"() : () -> i32
+// CHECK-NEXT: llvm.inline_asm has_side_effects "csrw $0, $1", "i, r" %0, %1 : (i32, i32) -> ()
+// CHECK-NEXT: llvm.inline_asm "add $0, 1", "r" %0 : (i32) -> ()
 // CHECK-NEXT: %2 = "test.op"() : () -> vector<8xf32>
 // CHECK-NEXT: %3 = "test.op"() : () -> vector<8xf32>
-// CHECK-NEXT: %4 = "llvm.inline_asm"(%2, %3) <{asm_dialect = 1 : i64, asm_string = "vaddps $0, $1, $2", constraints = "=x,x,x", tail_call_kind = #llvm.tailcallkind<none>}> : (vector<8xf32>, vector<8xf32>) -> vector<8xf32>
+// CHECK-NEXT: %4 = llvm.inline_asm asm_dialect = att "vaddps $0, $1, $2", "=x,x,x" %2, %3 : (vector<8xf32>, vector<8xf32>) -> vector<8xf32>
+// CHECK-NEXT: %5 = llvm.inline_asm asm_dialect = intel "vaddps $0, $1, $2", "=x,x,x" %2, %3 : (vector<8xf32>, vector<8xf32>) -> vector<8xf32>
+// CHECK-NEXT: %6 = llvm.inline_asm is_align_stack tail_call_kind = <tail> "foo", "=r,r" %0, %1 : (i32, i32) -> i32

--- a/tests/filecheck/transforms/convert_riscv_to_llvm.mlir
+++ b/tests/filecheck/transforms/convert_riscv_to_llvm.mlir
@@ -7,61 +7,61 @@
 %x0 = rv32.get_register : !riscv.reg<zero>
 
 // CHECK: builtin.module {
-// CHECK-NEXT:  %reg = "llvm.inline_asm"() <{asm_string = "li $0, 0", constraints = "=r", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : () -> i32
+// CHECK-NEXT:  %reg = llvm.inline_asm "li $0, 0", "=r" : () -> i32
 // CHECK-NEXT:  %reg_1 = builtin.unrealized_conversion_cast %reg : i32 to !riscv.reg
-// CHECK-NEXT:  %a0 = "llvm.inline_asm"() <{asm_string = "li $0, 0", constraints = "=r", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : () -> i32
+// CHECK-NEXT:  %a0 = llvm.inline_asm "li $0, 0", "=r" : () -> i32
 // CHECK-NEXT:  %a0_1 = builtin.unrealized_conversion_cast %a0 : i32 to !riscv.reg<a0>
 // CHECK-NEXT:  %x0 = rv32.get_register : !riscv.reg<zero>
 
 // standard risc-v instructions
 
 %li = rv32.li 0 : !riscv.reg
-// CHECK-NEXT:  %li = "llvm.inline_asm"() <{asm_string = "li $0, 0", constraints = "=r", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : () -> i32
+// CHECK-NEXT:  %li = llvm.inline_asm "li $0, 0", "=r" : () -> i32
 // CHECK-NEXT:  %li_1 = builtin.unrealized_conversion_cast %li : i32 to !riscv.reg
 
 %sub = riscv.sub %reg, %reg : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:  %sub = builtin.unrealized_conversion_cast %reg_1 : !riscv.reg to i32
 // CHECK-NEXT:  %sub_1 = builtin.unrealized_conversion_cast %reg_1 : !riscv.reg to i32
-// CHECK-NEXT:  %sub_2 = "llvm.inline_asm"(%sub, %sub_1) <{asm_string = "sub $0, $1, $2", constraints = "=r,rI,rI", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : (i32, i32) -> i32
+// CHECK-NEXT:  %sub_2 = llvm.inline_asm "sub $0, $1, $2", "=r,rI,rI" %sub, %sub_1 : (i32, i32) -> i32
 // CHECK-NEXT:  %sub_3 = builtin.unrealized_conversion_cast %sub_2 : i32 to !riscv.reg
 
 %div = riscv.div %reg, %reg : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:  %div = builtin.unrealized_conversion_cast %reg_1 : !riscv.reg to i32
 // CHECK-NEXT:  %div_1 = builtin.unrealized_conversion_cast %reg_1 : !riscv.reg to i32
-// CHECK-NEXT:  %div_2 = "llvm.inline_asm"(%div, %div_1) <{asm_string = "div $0, $1, $2", constraints = "=r,rI,rI", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : (i32, i32) -> i32
+// CHECK-NEXT:  %div_2 = llvm.inline_asm "div $0, $1, $2", "=r,rI,rI" %div, %div_1 : (i32, i32) -> i32
 // CHECK-NEXT:  %div_3 = builtin.unrealized_conversion_cast %div_2 : i32 to !riscv.reg
 
 // named riscv registers:
 
 %li_named = rv32.li 0 : !riscv.reg<a0>
-// CHECK-NEXT:  %li_named = "llvm.inline_asm"() <{asm_string = "li $0, 0", constraints = "=r", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : () -> i32
+// CHECK-NEXT:  %li_named = llvm.inline_asm "li $0, 0", "=r" : () -> i32
 // CHECK-NEXT:  %li_named_1 = builtin.unrealized_conversion_cast %li_named : i32 to !riscv.reg<a0>
 
 %sub_named = riscv.sub %a0, %a0 : (!riscv.reg<a0>, !riscv.reg<a0>) -> !riscv.reg
 // CHECK-NEXT:  %sub_named = builtin.unrealized_conversion_cast %a0_1 : !riscv.reg<a0> to i32
 // CHECK-NEXT:  %sub_named_1 = builtin.unrealized_conversion_cast %a0_1 : !riscv.reg<a0> to i32
-// CHECK-NEXT:  %sub_named_2 = "llvm.inline_asm"(%sub_named, %sub_named_1) <{asm_string = "sub $0, $1, $2", constraints = "=r,rI,rI", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : (i32, i32) -> i32
+// CHECK-NEXT:  %sub_named_2 = llvm.inline_asm "sub $0, $1, $2", "=r,rI,rI" %sub_named, %sub_named_1 : (i32, i32) -> i32
 // CHECK-NEXT:  %sub_named_3 = builtin.unrealized_conversion_cast %sub_named_2 : i32 to !riscv.reg
 
 %div_named = riscv.div %a0, %a0 : (!riscv.reg<a0>, !riscv.reg<a0>) -> !riscv.reg
 // CHECK-NEXT:  %div_named = builtin.unrealized_conversion_cast %a0_1 : !riscv.reg<a0> to i32
 // CHECK-NEXT:  %div_named_1 = builtin.unrealized_conversion_cast %a0_1 : !riscv.reg<a0> to i32
-// CHECK-NEXT:  %div_named_2 = "llvm.inline_asm"(%div_named, %div_named_1) <{asm_string = "div $0, $1, $2", constraints = "=r,rI,rI", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : (i32, i32) -> i32
+// CHECK-NEXT:  %div_named_2 = llvm.inline_asm "div $0, $1, $2", "=r,rI,rI" %div_named, %div_named_1 : (i32, i32) -> i32
 // CHECK-NEXT:  %div_named_3 = builtin.unrealized_conversion_cast %div_named_2 : i32 to !riscv.reg
 
 
 // csr instructions
 
 %csrss = riscv.csrrs %x0, 3860, "r" : (!riscv.reg<zero>) -> !riscv.reg
-// CHECK-NEXT:  %csrss = "llvm.inline_asm"() <{asm_string = "csrrs $0, 3860, x0", constraints = "=r", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : () -> i32
+// CHECK-NEXT:  %csrss = llvm.inline_asm "csrrs $0, 3860, x0", "=r" : () -> i32
 // CHECK-NEXT:  %csrss_1 = builtin.unrealized_conversion_cast %csrss : i32 to !riscv.reg
 
 %csrrs = riscv.csrrs %x0, 1986 : (!riscv.reg<zero>) -> !riscv.reg<zero>
 // CHECK-NEXT:  %csrrs = rv32.get_register : !riscv.reg<zero>
-// CHECK-NEXT:  "llvm.inline_asm"() <{asm_string = "csrrs x0, 1986, x0", constraints = "", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : () -> ()
+// CHECK-NEXT:  llvm.inline_asm "csrrs x0, 1986, x0", "" : () -> ()
 
 %csrrci = riscv.csrrci 1984, 1 : () -> !riscv.reg
-// CHECK-NEXT:  %csrrci = "llvm.inline_asm"() <{asm_string = "csrrci $0, 1984, 1", constraints = "=r", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : () -> i32
+// CHECK-NEXT:  %csrrci = llvm.inline_asm "csrrci $0, 1984, 1", "=r" : () -> i32
 // CHECK-NEXT:  %csrrci_1 = builtin.unrealized_conversion_cast %csrrci : i32 to !riscv.reg
 
 
@@ -70,25 +70,25 @@
 riscv_snitch.dmsrc %reg, %reg : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:  %0 = builtin.unrealized_conversion_cast %reg_1 : !riscv.reg to i32
 // CHECK-NEXT:  %1 = builtin.unrealized_conversion_cast %reg_1 : !riscv.reg to i32
-// CHECK-NEXT:  "llvm.inline_asm"(%0, %1) <{asm_string = ".insn r 0x2b, 0, 0, x0, $0, $1", constraints = "rI,rI", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : (i32, i32) -> ()
+// CHECK-NEXT:  llvm.inline_asm ".insn r 0x2b, 0, 0, x0, $0, $1", "rI,rI" %0, %1 : (i32, i32) -> ()
 
 riscv_snitch.dmdst %reg, %reg : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:  %2 = builtin.unrealized_conversion_cast %reg_1 : !riscv.reg to i32
 // CHECK-NEXT:  %3 = builtin.unrealized_conversion_cast %reg_1 : !riscv.reg to i32
-// CHECK-NEXT:  "llvm.inline_asm"(%2, %3) <{asm_string = ".insn r 0x2b, 0, 1, x0, $0, $1", constraints = "rI,rI", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : (i32, i32) -> ()
+// CHECK-NEXT:  llvm.inline_asm ".insn r 0x2b, 0, 1, x0, $0, $1", "rI,rI" %2, %3 : (i32, i32) -> ()
 
 riscv_snitch.dmstr %reg, %reg : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:  %4 = builtin.unrealized_conversion_cast %reg_1 : !riscv.reg to i32
 // CHECK-NEXT:  %5 = builtin.unrealized_conversion_cast %reg_1 : !riscv.reg to i32
-// CHECK-NEXT:  "llvm.inline_asm"(%4, %5) <{asm_string = ".insn r 0x2b, 0, 6, x0, $0, $1", constraints = "rI,rI", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : (i32, i32) -> ()
+// CHECK-NEXT:  llvm.inline_asm ".insn r 0x2b, 0, 6, x0, $0, $1", "rI,rI" %4, %5 : (i32, i32) -> ()
 
 riscv_snitch.dmrep %reg : (!riscv.reg) -> ()
 // CHECK-NEXT:  %6 = builtin.unrealized_conversion_cast %reg_1 : !riscv.reg to i32
-// CHECK-NEXT:  "llvm.inline_asm"(%6) <{asm_string = ".insn r 0x2b, 0, 7, x0, $0, x0", constraints = "rI", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : (i32) -> ()
+// CHECK-NEXT:  llvm.inline_asm ".insn r 0x2b, 0, 7, x0, $0, x0", "rI" %6 : (i32) -> ()
 
 %dmcpyi = riscv_snitch.dmcpyi %reg, 2 : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:  %dmcpyi = builtin.unrealized_conversion_cast %reg_1 : !riscv.reg to i32
-// CHECK-NEXT:  %dmcpyi_1 = "llvm.inline_asm"(%dmcpyi) <{asm_string = ".insn r 0x2b, 0, 2, $0, $1, 2", constraints = "=r,rI", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : (i32) -> i32
+// CHECK-NEXT:  %dmcpyi_1 = llvm.inline_asm ".insn r 0x2b, 0, 2, $0, $1, 2", "=r,rI" %dmcpyi : (i32) -> i32
 // CHECK-NEXT:  %dmcpyi_2 = builtin.unrealized_conversion_cast %dmcpyi_1 : i32 to !riscv.reg
 
 
@@ -97,20 +97,20 @@ riscv_snitch.dmrep %reg : (!riscv.reg) -> ()
 // ------------------------------------------------------- //
 
 // COMPACT:      builtin.module {
-// COMPACT-NEXT:   %reg = "llvm.inline_asm"() <{asm_string = "li $0, 0", constraints = "=r", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : () -> i32
-// COMPACT-NEXT:   %a0 = "llvm.inline_asm"() <{asm_string = "li $0, 0", constraints = "=r", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : () -> i32
-// COMPACT-NEXT:   %li = "llvm.inline_asm"() <{asm_string = "li $0, 0", constraints = "=r", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : () -> i32
-// COMPACT-NEXT:   %sub = "llvm.inline_asm"(%reg, %reg) <{asm_string = "sub $0, $1, $2", constraints = "=r,rI,rI", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : (i32, i32) -> i32
-// COMPACT-NEXT:   %div = "llvm.inline_asm"(%reg, %reg) <{asm_string = "div $0, $1, $2", constraints = "=r,rI,rI", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : (i32, i32) -> i32
-// COMPACT-NEXT:   %li_named = "llvm.inline_asm"() <{asm_string = "li $0, 0", constraints = "=r", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : () -> i32
-// COMPACT-NEXT:   %sub_named = "llvm.inline_asm"(%a0, %a0) <{asm_string = "sub $0, $1, $2", constraints = "=r,rI,rI", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : (i32, i32) -> i32
-// COMPACT-NEXT:   %div_named = "llvm.inline_asm"(%a0, %a0) <{asm_string = "div $0, $1, $2", constraints = "=r,rI,rI", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : (i32, i32) -> i32
-// COMPACT-NEXT:   %csrss = "llvm.inline_asm"() <{asm_string = "csrrs $0, 3860, x0", constraints = "=r", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : () -> i32
-// COMPACT-NEXT:   "llvm.inline_asm"() <{asm_string = "csrrs x0, 1986, x0", constraints = "", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : () -> ()
-// COMPACT-NEXT:   %csrrci = "llvm.inline_asm"() <{asm_string = "csrrci $0, 1984, 1", constraints = "=r", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : () -> i32
-// COMPACT-NEXT:   "llvm.inline_asm"(%reg, %reg) <{asm_string = ".insn r 0x2b, 0, 0, x0, $0, $1", constraints = "rI,rI", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : (i32, i32) -> ()
-// COMPACT-NEXT:   "llvm.inline_asm"(%reg, %reg) <{asm_string = ".insn r 0x2b, 0, 1, x0, $0, $1", constraints = "rI,rI", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : (i32, i32) -> ()
-// COMPACT-NEXT:   "llvm.inline_asm"(%reg, %reg) <{asm_string = ".insn r 0x2b, 0, 6, x0, $0, $1", constraints = "rI,rI", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : (i32, i32) -> ()
-// COMPACT-NEXT:   "llvm.inline_asm"(%reg) <{asm_string = ".insn r 0x2b, 0, 7, x0, $0, x0", constraints = "rI", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : (i32) -> ()
-// COMPACT-NEXT:   %dmcpyi = "llvm.inline_asm"(%reg) <{asm_string = ".insn r 0x2b, 0, 2, $0, $1, 2", constraints = "=r,rI", asm_dialect = 0 : i64, tail_call_kind = #llvm.tailcallkind<none>}> : (i32) -> i32
+// COMPACT-NEXT:   %reg = llvm.inline_asm "li $0, 0", "=r" : () -> i32
+// COMPACT-NEXT:   %a0 = llvm.inline_asm "li $0, 0", "=r" : () -> i32
+// COMPACT-NEXT:   %li = llvm.inline_asm "li $0, 0", "=r" : () -> i32
+// COMPACT-NEXT:   %sub = llvm.inline_asm "sub $0, $1, $2", "=r,rI,rI" %reg, %reg : (i32, i32) -> i32
+// COMPACT-NEXT:   %div = llvm.inline_asm "div $0, $1, $2", "=r,rI,rI" %reg, %reg : (i32, i32) -> i32
+// COMPACT-NEXT:   %li_named = llvm.inline_asm "li $0, 0", "=r" : () -> i32
+// COMPACT-NEXT:   %sub_named = llvm.inline_asm "sub $0, $1, $2", "=r,rI,rI" %a0, %a0 : (i32, i32) -> i32
+// COMPACT-NEXT:   %div_named = llvm.inline_asm "div $0, $1, $2", "=r,rI,rI" %a0, %a0 : (i32, i32) -> i32
+// COMPACT-NEXT:   %csrss = llvm.inline_asm "csrrs $0, 3860, x0", "=r" : () -> i32
+// COMPACT-NEXT:   llvm.inline_asm "csrrs x0, 1986, x0", "" : () -> ()
+// COMPACT-NEXT:   %csrrci = llvm.inline_asm "csrrci $0, 1984, 1", "=r" : () -> i32
+// COMPACT-NEXT:   llvm.inline_asm ".insn r 0x2b, 0, 0, x0, $0, $1", "rI,rI" %reg, %reg : (i32, i32) -> ()
+// COMPACT-NEXT:   llvm.inline_asm ".insn r 0x2b, 0, 1, x0, $0, $1", "rI,rI" %reg, %reg : (i32, i32) -> ()
+// COMPACT-NEXT:   llvm.inline_asm ".insn r 0x2b, 0, 6, x0, $0, $1", "rI,rI" %reg, %reg : (i32, i32) -> ()
+// COMPACT-NEXT:   llvm.inline_asm ".insn r 0x2b, 0, 7, x0, $0, x0", "rI" %reg : (i32) -> ()
+// COMPACT-NEXT:   %dmcpyi = llvm.inline_asm ".insn r 0x2b, 0, 2, $0, $1, 2", "=r,rI" %reg : (i32) -> i32
 // COMPACT-NEXT: }

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -1305,7 +1305,22 @@ class TailCallKindAttr(EnumAttribute[TailCallKind]):
             super().print_parameter(printer)
 
 
-# TODO: custom assembly format https://github.com/xdslproject/xdsl/issues/5897
+ASM_DIALECT_NAME_BY_KEY: dict[int, str] = {0: "att", 1: "intel"}
+"""
+Mapping from LLVM inline-assembly dialect integer values to their textual
+keyword form. See external
+[documentation](https://mlir.llvm.org/docs/Dialects/LLVM/#llvminline_asm-llvminlineasmop)
+for the MLIR op, and
+[LLVM LangRef](https://llvm.org/docs/LangRef.html#inline-assembler-expressions)
+for the underlying semantics.
+"""
+
+ASM_DIALECT_KEY_BY_NAME: dict[str, int] = {
+    v: k for k, v in ASM_DIALECT_NAME_BY_KEY.items()
+}
+"""Inverse of ASM_DIALECT_NAME_BY_KEY: maps keyword strings to integer keys."""
+
+
 @irdl_op_definition
 class InlineAsmOp(IRDLOperation):
     """
@@ -1343,7 +1358,7 @@ class InlineAsmOp(IRDLOperation):
         constraints: str,
         operands: Sequence[SSAValue | Operation],
         res_types: Sequence[Attribute] | None = None,
-        asm_dialect: int = 0,
+        asm_dialect: int | None = None,
         has_side_effects: bool = False,
         is_align_stack: bool = False,
         tail_call_kind: TailCallKindAttr | None = None,
@@ -1351,7 +1366,9 @@ class InlineAsmOp(IRDLOperation):
         props: dict[str, Attribute | None] = {
             "asm_string": StringAttr(asm_string),
             "constraints": StringAttr(constraints),
-            "asm_dialect": IntegerAttr(asm_dialect, 64),
+            "asm_dialect": IntegerAttr(asm_dialect, 64)
+            if asm_dialect is not None
+            else None,
             "has_side_effects": UnitAttr() if has_side_effects else None,
             "is_align_stack": UnitAttr() if is_align_stack else None,
             "tail_call_kind": tail_call_kind,
@@ -1365,6 +1382,79 @@ class InlineAsmOp(IRDLOperation):
             properties=props,
             result_types=[res_types],
         )
+
+    def print(self, printer: Printer) -> None:
+        if self.has_side_effects is not None:
+            printer.print_string(" has_side_effects")
+        if self.is_align_stack is not None:
+            printer.print_string(" is_align_stack")
+        if self.asm_dialect is not None:
+            printer.print_string(
+                f" asm_dialect = {ASM_DIALECT_NAME_BY_KEY[self.asm_dialect.value.data]}"
+            )
+        if (tck := self.tail_call_kind.data) != TailCallKind.NONE:
+            printer.print_string(f" tail_call_kind = <{tck.value}>")
+        printer.print_string(" ")
+        printer.print_string_literal(self.asm_string.data)
+        printer.print_string(", ")
+        printer.print_string_literal(self.constraints.data)
+        if self.operands_:
+            printer.print_string(" ")
+            printer.print_list(self.operands_, printer.print_ssa_value)
+        printer.print_op_attributes(self.attributes)
+        printer.print_string(" : ")
+        printer.print_function_type(
+            [v.type for v in self.operands_],
+            [self.res.type] if self.res is not None else [],
+        )
+
+    @classmethod
+    def parse(cls, parser: Parser) -> InlineAsmOp:
+        has_side_effects = parser.parse_optional_keyword("has_side_effects") is not None
+        is_align_stack = parser.parse_optional_keyword("is_align_stack") is not None
+        asm_dialect: int | None = None
+        if parser.parse_optional_keyword("asm_dialect") is not None:
+            parser.parse_punctuation("=")
+            if parser.parse_optional_keyword("att") is not None:
+                asm_dialect = ASM_DIALECT_KEY_BY_NAME["att"]
+            elif parser.parse_optional_keyword("intel") is not None:
+                asm_dialect = ASM_DIALECT_KEY_BY_NAME["intel"]
+            else:
+                parser.raise_error(
+                    "Expected one of 'att', 'intel' after 'asm_dialect ='"
+                )
+        tail_call_kind = TailCallKindAttr(TailCallKind.NONE)
+        if parser.parse_optional_keyword("tail_call_kind") is not None:
+            parser.parse_punctuation("=")
+            parser.parse_punctuation("<")
+            tail_call_kind = TailCallKindAttr(parser.parse_str_enum(TailCallKind))
+            parser.parse_punctuation(">")
+        asm_string = parser.parse_str_literal()
+        parser.parse_punctuation(",")
+        constraints = parser.parse_str_literal()
+        operands_pos = parser.pos
+        operands = (
+            parser.parse_optional_undelimited_comma_separated_list(
+                parser.parse_optional_unresolved_operand,
+                parser.parse_unresolved_operand,
+            )
+            or []
+        )
+        attrs = parser.parse_optional_attr_dict()
+        parser.parse_punctuation(":")
+        ft = parser.parse_function_type()
+        op = cls(
+            asm_string,
+            constraints,
+            parser.resolve_operands(operands, ft.inputs.data, operands_pos),
+            ft.outputs.data,
+            asm_dialect=asm_dialect,
+            has_side_effects=has_side_effects,
+            is_align_stack=is_align_stack,
+            tail_call_kind=tail_call_kind,
+        )
+        op.attributes |= attrs
+        return op
 
 
 @irdl_op_definition


### PR DESCRIPTION
- Split out from #5912 per reviewer request.
- Adds custom `print`/`parse` methods to `InlineAsmOp` so it uses `llvm.inline_asm [flags] "asm_string", "constraints" operands : (types) -> ret` syntax instead of the generic format.
- Updates all filecheck tests to use the new custom format.
