### PR TITLE
dialects: (llvm) custom print/parse for global

### DIFF
--- a/tests/filecheck/dialects/llvm/global.mlir
+++ b/tests/filecheck/dialects/llvm/global.mlir
@@ -1,14 +1,34 @@
 // RUN: XDSL_ROUNDTRIP
 builtin.module {
-  "llvm.mlir.global"() ({
-  }) {"global_type" = !llvm.array<13 x i8>, "sym_name" = "str0", "linkage" = #llvm.linkage<"internal">, "addr_space" = 0 : i32, "constant", "value" = "Hello world!\n", "unnamed_addr" = 0 : i64} : () -> ()
-  %0 = llvm.mlir.addressof @str0 : !llvm.ptr
-  %1 = llvm.getelementptr %0[0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.array<13 x i8>
+  llvm.mlir.global internal constant @str0("Hello world!\n") {addr_space = 0 : i32} : !llvm.array<13 x i8>
+  llvm.mlir.global external @x() {addr_space = 0 : i32} : i32
+  llvm.mlir.global private @y(42 : i32) {addr_space = 0 : i32} : i32
+  llvm.mlir.global external thread_local @tl() {addr_space = 0 : i32} : i32
+  llvm.mlir.global external unnamed_addr @u() {addr_space = 0 : i32} : i32
+  llvm.mlir.global external local_unnamed_addr @l() {addr_space = 0 : i32} : i32
+  llvm.mlir.global external @g_with_init() {addr_space = 0 : i32} : i64 {
+    %0 = "llvm.mlir.constant"() <{value = 42 : i64}> : () -> i64
+    "llvm.return"(%0) : (i64) -> ()
+  }
+  llvm.mlir.global internal constant @str_inferred("test") {addr_space = 0 : i32}
+  llvm.mlir.global private @val_inferred(42 : i32) {addr_space = 0 : i32}
+  %0 = "llvm.mlir.addressof"() <{global_name = @str0}> : () -> !llvm.ptr
+  %1 = "llvm.getelementptr"(%0) <{elem_type = !llvm.array<13 x i8>, noWrapFlags = 0 : i32, rawConstantIndices = array<i32: 0, 0>}> : (!llvm.ptr) -> !llvm.ptr
 }
 
 // CHECK: builtin.module {
-// CHECK-NEXT:   "llvm.mlir.global"() <{global_type = !llvm.array<13 x i8>, constant, sym_name = "str0", linkage = #llvm.linkage<"internal">, value = "Hello world!\n", addr_space = 0 : i32, unnamed_addr = 0 : i64}> ({
-// CHECK-NEXT:   }) : () -> ()
-// CHECK-NEXT:   %0 = llvm.mlir.addressof @str0 : !llvm.ptr
-// CHECK-NEXT:   %1 = llvm.getelementptr %0[0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.array<13 x i8>
+// CHECK-NEXT:   llvm.mlir.global internal constant @str0("Hello world!\n") {addr_space = 0 : i32} : !llvm.array<13 x i8>
+// CHECK-NEXT:   llvm.mlir.global external @x() {addr_space = 0 : i32} : i32
+// CHECK-NEXT:   llvm.mlir.global private @y(42 : i32) {addr_space = 0 : i32} : i32
+// CHECK-NEXT:   llvm.mlir.global external thread_local @tl() {addr_space = 0 : i32} : i32
+// CHECK-NEXT:   llvm.mlir.global external unnamed_addr @u() {addr_space = 0 : i32} : i32
+// CHECK-NEXT:   llvm.mlir.global external local_unnamed_addr @l() {addr_space = 0 : i32} : i32
+// CHECK-NEXT:   llvm.mlir.global external @g_with_init() {addr_space = 0 : i32} : i64 {
+// CHECK-NEXT:     %0 = llvm.mlir.constant(42) : i64
+// CHECK-NEXT:     llvm.return %0 : i64
+// CHECK-NEXT:   }
+// CHECK-NEXT:   llvm.mlir.global internal constant @str_inferred("test") {addr_space = 0 : i32} : !llvm.array<4 x i8>
+// CHECK-NEXT:   llvm.mlir.global private @val_inferred(42 : i32) {addr_space = 0 : i32} : i32
+// CHECK-NEXT:   %1 = "llvm.mlir.addressof"() <{global_name = @str0}> : () -> !llvm.ptr
+// CHECK-NEXT:   %2 = "llvm.getelementptr"(%1) <{elem_type = !llvm.array<13 x i8>, noWrapFlags = 0 : i32, rawConstantIndices = array<i32: 0, 0>}> : (!llvm.ptr) -> !llvm.ptr
 // CHECK-NEXT: }

--- a/tests/filecheck/dialects/llvm/global.mlir
+++ b/tests/filecheck/dialects/llvm/global.mlir
@@ -29,6 +29,6 @@ builtin.module {
 // CHECK-NEXT:   }
 // CHECK-NEXT:   llvm.mlir.global internal constant @str_inferred("test") {addr_space = 0 : i32} : !llvm.array<4 x i8>
 // CHECK-NEXT:   llvm.mlir.global private @val_inferred(42 : i32) {addr_space = 0 : i32} : i32
-// CHECK-NEXT:   %1 = "llvm.mlir.addressof"() <{global_name = @str0}> : () -> !llvm.ptr
-// CHECK-NEXT:   %2 = "llvm.getelementptr"(%1) <{elem_type = !llvm.array<13 x i8>, noWrapFlags = 0 : i32, rawConstantIndices = array<i32: 0, 0>}> : (!llvm.ptr) -> !llvm.ptr
+// CHECK-NEXT:   %1 = llvm.mlir.addressof @str0 : !llvm.ptr
+// CHECK-NEXT:   %2 = llvm.getelementptr %1[0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.array<13 x i8>
 // CHECK-NEXT: }

--- a/tests/filecheck/dialects/llvm/global.mlir
+++ b/tests/filecheck/dialects/llvm/global.mlir
@@ -7,13 +7,13 @@ builtin.module {
   llvm.mlir.global external unnamed_addr @u() {addr_space = 0 : i32} : i32
   llvm.mlir.global external local_unnamed_addr @l() {addr_space = 0 : i32} : i32
   llvm.mlir.global external @g_with_init() {addr_space = 0 : i32} : i64 {
-    %0 = "llvm.mlir.constant"() <{value = 42 : i64}> : () -> i64
-    "llvm.return"(%0) : (i64) -> ()
+    %0 = llvm.mlir.constant(42 : i64) : i64
+    llvm.return %0 : i64
   }
   llvm.mlir.global internal constant @str_inferred("test") {addr_space = 0 : i32}
   llvm.mlir.global private @val_inferred(42 : i32) {addr_space = 0 : i32}
-  %0 = "llvm.mlir.addressof"() <{global_name = @str0}> : () -> !llvm.ptr
-  %1 = "llvm.getelementptr"(%0) <{elem_type = !llvm.array<13 x i8>, noWrapFlags = 0 : i32, rawConstantIndices = array<i32: 0, 0>}> : (!llvm.ptr) -> !llvm.ptr
+  %0 = llvm.mlir.addressof @str0 : !llvm.ptr
+  %1 = llvm.getelementptr %0[0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.array<13 x i8>
 }
 
 // CHECK: builtin.module {

--- a/tests/filecheck/dialects/llvm/invalid.mlir
+++ b/tests/filecheck/dialects/llvm/invalid.mlir
@@ -144,3 +144,11 @@ func.func @inline_asm_unknown_dialect() {
 }
 
 // CHECK: Expected one of 'att', 'intel' after 'asm_dialect ='
+
+// -----
+
+builtin.module {
+  llvm.mlir.global external @no_type_no_value() {addr_space = 0 : i32}
+}
+
+// CHECK: expected `:` followed by global type

--- a/tests/filecheck/dialects/printf/printf_to_llvm.mlir
+++ b/tests/filecheck/dialects/printf/printf_to_llvm.mlir
@@ -17,8 +17,7 @@ builtin.module {
 
 // CHECK:       llvm.func @printf(!llvm.ptr, ...)
 
-// CHECK:       "llvm.mlir.global"() <{global_type = !llvm.array<14 x i8>, sym_name = "Hello_f_842f9d94ff2eba9703926bef3c2bc5f427db9871", linkage = #llvm.linkage<"internal">, addr_space = 0 : i32, constant, value = dense<[72, 101, 108, 108, 111, 58, 32, 37, 102, 32, 37, 105, 10, 0]> : tensor<14xi8>}> ({
-// CHECK-NEXT:  }) : () -> ()
+// CHECK:       llvm.mlir.global internal constant @Hello_f_842f9d94ff2eba9703926bef3c2bc5f427db9871(dense<[72, 101, 108, 108, 111, 58, 32, 37, 102, 32, 37, 105, 10, 0]> : tensor<14xi8>) {addr_space = 0 : i32} : !llvm.array<14 x i8>
 
 // -----
 

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/global.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/global.mlir
@@ -1,18 +1,11 @@
-// RUN: mlir-opt %s --mlir-print-op-generic | xdsl-opt --print-op-generic | filecheck %s
-"builtin.module"() ({
-  "llvm.mlir.global"() ({
-  }) {"global_type" = !llvm.array<12 x i8>, "sym_name" = "str0", "linkage" = #llvm.linkage<"internal">, "addr_space" = 0 : i32, "constant", "value" = "Hello world!", "unnamed_addr" = 0 : i64} : () -> ()
-  "llvm.mlir.global"() ({
-  }) {"global_type" = i32, "sym_name" = "data", "linkage" = #llvm.linkage<"internal">, "addr_space" = 0 : i32, "constant", "value" = 0 : i32, "unnamed_addr" = 0 : i64} : () -> ()
-  %0 = llvm.mlir.addressof @data : !llvm.ptr
-  %1 = llvm.mlir.zero : !llvm.struct<(i32, f32)>
-}) : () -> ()
+// RUN: MLIR_ROUNDTRIP
+// RUN: MLIR_GENERIC_ROUNDTRIP
+builtin.module {
+  llvm.mlir.global internal constant @str0("Hello world!") {addr_space = 0 : i32} : !llvm.array<12 x i8>
+  llvm.mlir.global internal constant @data(0 : i32) {addr_space = 0 : i32} : i32
+}
 
-// CHECK:      "builtin.module"() ({
-// CHECK-NEXT:   "llvm.mlir.global"() <{addr_space = 0 : i32, constant, global_type = !llvm.array<12 x i8>, linkage = #llvm.linkage<"internal">, sym_name = "str0", unnamed_addr = 0 : i64, value = "Hello world!", visibility_ = 0 : i64}> ({
-// CHECK-NEXT:   }) : () -> ()
-// CHECK-NEXT:   "llvm.mlir.global"() <{addr_space = 0 : i32, constant, global_type = i32, linkage = #llvm.linkage<"internal">, sym_name = "data", unnamed_addr = 0 : i64, value = 0 : i32, visibility_ = 0 : i64}> ({
-// CHECK-NEXT:   }) : () -> ()
-// CHECK-NEXT:   %0 = "llvm.mlir.addressof"() <{global_name = @data}> : () -> !llvm.ptr
-// CHECK-NEXT:   %1 = "llvm.mlir.zero"() : () -> !llvm.struct<(i32, f32)>
-// CHECK-NEXT: }) : () -> ()
+// CHECK:      builtin.module {
+// CHECK-NEXT:   llvm.mlir.global internal constant @str0("Hello world!") {{.*}}: !llvm.array<12 x i8>
+// CHECK-NEXT:   llvm.mlir.global internal constant @data(0 : i32) {{.*}}: i32
+// CHECK-NEXT: }

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/global.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/global.mlir
@@ -3,9 +3,31 @@
 builtin.module {
   llvm.mlir.global internal constant @str0("Hello world!") {addr_space = 0 : i32} : !llvm.array<12 x i8>
   llvm.mlir.global internal constant @data(0 : i32) {addr_space = 0 : i32} : i32
+  llvm.mlir.global external @x() {addr_space = 0 : i32} : i32
+  llvm.mlir.global private @y(42 : i32) {addr_space = 0 : i32} : i32
+  llvm.mlir.global external thread_local @tl() {addr_space = 0 : i32} : i32
+  llvm.mlir.global external unnamed_addr @u() {addr_space = 0 : i32} : i32
+  llvm.mlir.global external local_unnamed_addr @l() {addr_space = 0 : i32} : i32
+  llvm.mlir.global external @g_with_init() {addr_space = 0 : i32} : i64 {
+    %0 = llvm.mlir.constant(42 : i64) : i64
+    llvm.return %0 : i64
+  }
+  llvm.mlir.global internal constant @str_inferred("test") {addr_space = 0 : i32}
+  llvm.mlir.global private @val_inferred(42 : i32) {addr_space = 0 : i32}
 }
 
 // CHECK:      builtin.module {
 // CHECK-NEXT:   llvm.mlir.global internal constant @str0("Hello world!") {{.*}}: !llvm.array<12 x i8>
 // CHECK-NEXT:   llvm.mlir.global internal constant @data(0 : i32) {{.*}}: i32
+// CHECK-NEXT:   llvm.mlir.global external @x() {{.*}}: i32
+// CHECK-NEXT:   llvm.mlir.global private @y(42 : i32) {{.*}}: i32
+// CHECK-NEXT:   llvm.mlir.global external thread_local @tl() {{.*}}: i32
+// CHECK-NEXT:   llvm.mlir.global external unnamed_addr @u() {{.*}}: i32
+// CHECK-NEXT:   llvm.mlir.global external local_unnamed_addr @l() {{.*}}: i32
+// CHECK-NEXT:   llvm.mlir.global external @g_with_init() {{.*}}: i64 {
+// CHECK-NEXT:     %{{.*}} = llvm.mlir.constant(42{{.*}}) : i64
+// CHECK-NEXT:     llvm.return %{{.*}} : i64
+// CHECK-NEXT:   }
+// CHECK-NEXT:   llvm.mlir.global internal constant @str_inferred("test") {{.*}}
+// CHECK-NEXT:   llvm.mlir.global private @val_inferred(42 : i32) {{.*}}
 // CHECK-NEXT: }

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -1802,7 +1802,7 @@ class UndefOp(IRDLOperation):
         super().__init__(result_types=[result_type])
 
 
-UNNAMED_ADDR_KEYWORDS: dict[int, str] = {1: "local_unnamed_addr", 2: "unnamed_addr"}
+UNNAMED_ADDR_KEYWORD_BY_KEY: dict[int, str] = {1: "local_unnamed_addr", 2: "unnamed_addr"}
 """
 Mapping from LLVM `unnamed_addr` integer values to their textual keyword form
 (0 = no keyword). See external

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -1802,7 +1802,10 @@ class UndefOp(IRDLOperation):
         super().__init__(result_types=[result_type])
 
 
-UNNAMED_ADDR_KEYWORD_BY_KEY: dict[int, str] = {1: "local_unnamed_addr", 2: "unnamed_addr"}
+UNNAMED_ADDR_KEYWORD_BY_KEY: dict[int, str] = {
+    1: "local_unnamed_addr",
+    2: "unnamed_addr",
+}
 """
 Mapping from LLVM `unnamed_addr` integer values to their textual keyword form
 (0 = no keyword). See external
@@ -1811,6 +1814,9 @@ for the MLIR op, and
 [LLVM LangRef](https://llvm.org/docs/LangRef.html#global-variables) for the
 underlying semantics.
 """
+UNNAMED_ADDR_KEY_BY_KEYWORD: dict[str, int] = {
+    v: k for k, v in UNNAMED_ADDR_KEYWORD_BY_KEY.items()
+}
 
 
 @irdl_op_definition
@@ -1897,7 +1903,7 @@ class GlobalOp(IRDLOperation):
         if self.thread_local_ is not None:
             printer.print_string(" thread_local")
         if self.unnamed_addr is not None and (
-            kw := UNNAMED_ADDR_KEYWORDS.get(self.unnamed_addr.value.data)
+            kw := UNNAMED_ADDR_KEYWORD_BY_KEY.get(self.unnamed_addr.value.data)
         ):
             printer.print_string(f" {kw}")
         if self.constant is not None:
@@ -1931,9 +1937,13 @@ class GlobalOp(IRDLOperation):
         linkage = parser.parse_optional_keyword_in(_LINKAGE_OPTIONS) or "external"
         thread_local_ = parser.parse_optional_keyword("thread_local") is not None
         unnamed_addr_kw = parser.parse_optional_keyword_in(
-            UNNAMED_ADDR_KEYWORDS.values()
+            UNNAMED_ADDR_KEYWORD_BY_KEY.values()
         )
-        unnamed_addr_val = UNNAMED_ADDR_KEY_BY_KEYWORD.get(unnamed_addr_kw)
+        unnamed_addr_val = (
+            UNNAMED_ADDR_KEY_BY_KEYWORD.get(unnamed_addr_kw)
+            if unnamed_addr_kw is not None
+            else None
+        )
         constant = parser.parse_optional_keyword("constant") is not None
         sym_name = parser.parse_symbol_name()
         parser.parse_punctuation("(")

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -52,6 +52,7 @@ from xdsl.ir import (
     Region,
     SSAValue,
     TypeAttribute,
+    TypedAttribute,
 )
 from xdsl.irdl import (
     AnyAttr,
@@ -1801,7 +1802,17 @@ class UndefOp(IRDLOperation):
         super().__init__(result_types=[result_type])
 
 
-# TODO: custom assembly format https://github.com/xdslproject/xdsl/issues/5897
+UNNAMED_ADDR_KEYWORDS: dict[int, str] = {1: "local_unnamed_addr", 2: "unnamed_addr"}
+"""
+Mapping from LLVM `unnamed_addr` integer values to their textual keyword form
+(0 = no keyword). See external
+[documentation](https://mlir.llvm.org/docs/Dialects/LLVM/#llvmmlirglobal-llvmglobalop)
+for the MLIR op, and
+[LLVM LangRef](https://llvm.org/docs/LangRef.html#global-variables) for the
+underlying semantics.
+"""
+
+
 @irdl_op_definition
 class GlobalOp(IRDLOperation):
     name = "llvm.mlir.global"
@@ -1879,6 +1890,91 @@ class GlobalOp(IRDLOperation):
             body = Region()
 
         super().__init__(properties=props, regions=(body,))
+
+    def print(self, printer: Printer) -> None:
+        printer.print_string(" ")
+        printer.print_string(self.linkage.linkage.data)
+        if self.thread_local_ is not None:
+            printer.print_string(" thread_local")
+        if self.unnamed_addr is not None and (
+            kw := UNNAMED_ADDR_KEYWORDS.get(self.unnamed_addr.value.data)
+        ):
+            printer.print_string(f" {kw}")
+        if self.constant is not None:
+            printer.print_string(" constant")
+        printer.print_string(" ")
+        printer.print_symbol_name(self.sym_name.data)
+        printer.print_string("(")
+        if self.value is not None:
+            printer.print_attribute(self.value)
+        printer.print_string(")")
+        printer.print_op_attributes(
+            self.properties | self.attributes,
+            reserved_attr_names=(
+                "global_type",
+                "sym_name",
+                "linkage",
+                "constant",
+                "thread_local_",
+                "unnamed_addr",
+                "value",
+            ),
+        )
+        printer.print_string(" : ")
+        printer.print_attribute(self.global_type)
+        if self.body.blocks:
+            printer.print_string(" ")
+            printer.print_region(self.body)
+
+    @classmethod
+    def parse(cls, parser: Parser) -> GlobalOp:
+        linkage = parser.parse_optional_keyword_in(_LINKAGE_OPTIONS) or "external"
+        thread_local_ = parser.parse_optional_keyword("thread_local") is not None
+        unnamed_addr_kw = parser.parse_optional_keyword_in(
+            UNNAMED_ADDR_KEYWORDS.values()
+        )
+        unnamed_addr_val = next(
+            (v for v, k in UNNAMED_ADDR_KEYWORDS.items() if k == unnamed_addr_kw),
+            None,
+        )
+        constant = parser.parse_optional_keyword("constant") is not None
+        sym_name = parser.parse_symbol_name()
+        parser.parse_punctuation("(")
+        value = None
+        if parser.parse_optional_punctuation(")") is None:
+            value = parser.parse_attribute()
+            parser.parse_punctuation(")")
+        attrs = parser.parse_optional_attr_dict()
+        if parser.parse_optional_punctuation(":") is not None:
+            global_type = parser.parse_type()
+        elif isinstance(value, StringAttr):
+            global_type = LLVMArrayType(len(value.data), IntegerType(8))
+        elif isinstance(value, TypedAttribute):
+            global_type = value.get_type()
+        else:
+            parser.raise_error("expected `:` followed by global type")
+        addr_space = attrs.pop("addr_space", IntegerAttr(0, 32))
+        alignment = attrs.pop("alignment", None)
+        section = attrs.pop("section", None)
+        assert isinstance(addr_space, IntegerAttr)
+        assert alignment is None or isinstance(alignment, IntegerAttr)
+        assert section is None or isinstance(section, StringAttr)
+        op = cls(
+            global_type=global_type,
+            sym_name=sym_name,
+            linkage=linkage,
+            addr_space=addr_space.value.data,
+            constant=constant,
+            dso_local=attrs.pop("dso_local", None) is not None,
+            thread_local_=thread_local_,
+            value=value,
+            alignment=alignment.value.data if alignment is not None else None,
+            unnamed_addr=unnamed_addr_val,
+            section=section,
+            body=parser.parse_optional_region(),
+        )
+        op.attributes |= attrs
+        return op
 
 
 @irdl_op_definition

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -1814,9 +1814,11 @@ for the MLIR op, and
 [LLVM LangRef](https://llvm.org/docs/LangRef.html#global-variables) for the
 underlying semantics.
 """
+
 UNNAMED_ADDR_KEY_BY_KEYWORD: dict[str, int] = {
     v: k for k, v in UNNAMED_ADDR_KEYWORD_BY_KEY.items()
 }
+"""Reverse mapping from keyword string to integer key."""
 
 
 @irdl_op_definition

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -1933,10 +1933,7 @@ class GlobalOp(IRDLOperation):
         unnamed_addr_kw = parser.parse_optional_keyword_in(
             UNNAMED_ADDR_KEYWORDS.values()
         )
-        unnamed_addr_val = next(
-            (v for v, k in UNNAMED_ADDR_KEYWORDS.items() if k == unnamed_addr_kw),
-            None,
-        )
+        unnamed_addr_val = UNNAMED_ADDR_KEY_BY_KEYWORD.get(unnamed_addr_kw)
         constant = parser.parse_optional_keyword("constant") is not None
         sym_name = parser.parse_symbol_name()
         parser.parse_punctuation("(")


### PR DESCRIPTION
Split out from #5912 per reviewer request. Adds custom `print`/`parse` methods to `GlobalOp` so it uses `llvm.mlir.global linkage [thread_local] [unnamed_addr] [constant] @name(value) {attrs} : type` syntax instead of the generic format. Also adds `parse_optional_keyword_in` utility to the base parser.