### PR TITLE
dialects: (llvm) add parse_optional_keyword_in helper

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1474,3 +1474,16 @@ def test_parse_optional_keyword_in_non_identifier():
     parser = Parser(Context(), "42 remaining")
     result = parser.parse_optional_keyword_in({"fastcc"})
     assert result is None
+
+
+def test_parse_keyword_in_matching():
+    parser = Parser(Context(), "fastcc remaining")
+    result = parser.parse_keyword_in({"fastcc", "ccc", "tailcc"})
+    assert result == "fastcc"
+    assert parser.parse_optional_identifier() == "remaining"
+
+
+def test_parse_keyword_in_non_matching():
+    parser = Parser(Context(), "other remaining")
+    with pytest.raises(ParseError, match="Expected one of"):
+        parser.parse_keyword_in({"fastcc", "ccc"})

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1454,3 +1454,23 @@ def test_slash_punctuation_in_registered_attr():
     with StringIO() as io:
         Printer(io).print_attribute(attr)
         assert io.getvalue() == "#test_slash.attr</>"
+
+
+def test_parse_optional_keyword_in_matching():
+    parser = Parser(Context(), "fastcc remaining")
+    result = parser.parse_optional_keyword_in({"fastcc", "ccc", "tailcc"})
+    assert result == "fastcc"
+    assert parser.parse_optional_identifier() == "remaining"
+
+
+def test_parse_optional_keyword_in_non_matching():
+    parser = Parser(Context(), "other remaining")
+    result = parser.parse_optional_keyword_in({"fastcc", "ccc"})
+    assert result is None
+    assert parser.parse_optional_identifier() == "other"
+
+
+def test_parse_optional_keyword_in_non_identifier():
+    parser = Parser(Context(), "42 remaining")
+    result = parser.parse_optional_keyword_in({"fastcc"})
+    assert result is None

--- a/xdsl/parser/base_parser.py
+++ b/xdsl/parser/base_parser.py
@@ -3,6 +3,7 @@ This file contains the definition of `BaseParser`, a recursive descent parser
 that is inherited from the different parsers used in xDSL.
 """
 
+from collections.abc import Collection
 from dataclasses import dataclass
 from typing import NoReturn
 
@@ -258,6 +259,16 @@ class BaseParser(GenericParser[MLIRTokenKind]):
             self._consume_token(MLIRTokenKind.BARE_IDENT)
             return keyword
         return None
+
+    def parse_optional_keyword_in(self, keywords: Collection[str]) -> str | None:
+        """Parse an identifier if it matches any in the given collection."""
+        if (
+            self._current_token.kind == MLIRTokenKind.BARE_IDENT
+            and self._current_token.text in keywords
+        ):
+            keyword = self._current_token.text
+            self._consume_token(MLIRTokenKind.BARE_IDENT)
+            return keyword
 
     def parse_keyword(self, keyword: str, context_msg: str = "") -> str:
         """Parse a specific identifier."""

--- a/xdsl/parser/base_parser.py
+++ b/xdsl/parser/base_parser.py
@@ -267,16 +267,16 @@ class BaseParser(GenericParser[MLIRTokenKind]):
             and self._current_token.text in keywords
         ):
             keyword = self._current_token.text
-            self._consume_token(MLIRTokenKind.BARE_IDENT)
+            self._consume_token()
             return keyword
 
     def parse_keyword_in(self, keywords: Collection[str], context_msg: str = "") -> str:
         """Parse an identifier that must match one of the given keywords."""
-        result = self.parse_optional_keyword_in(keywords)
-        if result is not None:
-            return result
         expected = ", ".join(f"'{k}'" for k in sorted(keywords))
-        self.raise_error(f"Expected one of {expected}" + context_msg)
+        return self.expect(
+            lambda: self.parse_optional_keyword_in(keywords),
+            f"Expected one of {expected}" + context_msg,
+        )
 
     def parse_keyword(self, keyword: str, context_msg: str = "") -> str:
         """Parse a specific identifier."""

--- a/xdsl/parser/base_parser.py
+++ b/xdsl/parser/base_parser.py
@@ -270,6 +270,14 @@ class BaseParser(GenericParser[MLIRTokenKind]):
             self._consume_token(MLIRTokenKind.BARE_IDENT)
             return keyword
 
+    def parse_keyword_in(self, keywords: Collection[str], context_msg: str = "") -> str:
+        """Parse an identifier that must match one of the given keywords."""
+        result = self.parse_optional_keyword_in(keywords)
+        if result is not None:
+            return result
+        expected = ", ".join(f"'{k}'" for k in sorted(keywords))
+        self.raise_error(f"Expected one of {expected}" + context_msg)
+
     def parse_keyword(self, keyword: str, context_msg: str = "") -> str:
         """Parse a specific identifier."""
 


### PR DESCRIPTION
Split out from #5946 per reviewer request.

Adds `parse_optional_keyword_in` in `xdsl/dialects/llvm.py` that parses an identifier, checks membership in a keyword collection, and rolls back the parser position on mismatch.