### PR TITLE
dialects: (riscv_scf) infer constant step in linalg-snitch backend

### DIFF
--- a/tests/filecheck/projects/riscv-backend-paper/add.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/add.mlir
@@ -1,7 +1,7 @@
 // RUN: xdsl-run %s | filecheck %s
 // RUN: xdsl-opt -p convert-linalg-to-loops %s | xdsl-run | filecheck %s
 // RUN: xdsl-opt %s -p convert-linalg-to-memref-stream | xdsl-run | filecheck %s
-// RUN: xdsl-opt %s -p convert-linalg-to-memref-stream,memref-streamify,convert-memref-stream-to-loops,convert-memref-stream-to-snitch-stream,convert-arith-to-riscv,convert-func-to-riscv-func,convert-memref-to-riscv,convert-scf-to-riscv-scf,riscv-lower-parallel-mov,convert-print-format-to-riscv-debug,reconcile-unrealized-casts,snitch-allocate-registers | xdsl-run | filecheck %s
+// RUN: xdsl-opt %s -p convert-linalg-to-memref-stream,memref-streamify,convert-memref-stream-to-loops,convert-memref-stream-to-snitch-stream,convert-arith-to-riscv,convert-func-to-riscv-func,convert-memref-to-riscv,convert-scf-to-riscv-scf,riscv-lower-parallel-mov,convert-print-format-to-riscv-debug,reconcile-unrealized-casts,riscv-scf-for-infer-constant-step,snitch-allocate-registers | xdsl-run | filecheck %s
 
 builtin.module {
     "memref.global"() {"sym_name" = "a", "type" = memref<2x3xf64>, "initial_value" = dense<[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]> : tensor<2x3xf64>, "sym_visibility" = "public"} : () -> ()

--- a/tests/filecheck/projects/riscv-backend-paper/bottom_up_f32.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/bottom_up_f32.mlir
@@ -79,65 +79,65 @@ func.func public @pooling_nchw_max_d1_s2_3x3(
     func.return
   }
 
-// CHECK-NEXT:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1", "ft2"], "preallocated_int": ["a0", "a1", "zero"], "allocated_float": ["ft0", "ft1", "ft3", "ft4", "ft5", "ft6", "ft7"], "allocated_int": ["a0", "a1", "a2", "a3", "t0", "t1", "t2", "t3", "t4", "t5", "t6", "zero"]}
+// CHECK-NEXT:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1", "ft2"], "preallocated_int": ["a0", "a1", "zero"], "allocated_float": ["ft0", "ft1", "ft3", "ft4", "ft5", "ft6", "ft7"], "allocated_int": ["a0", "a1", "t0", "t1", "t2", "t3", "t4", "t5", "t6", "zero"]}
 // CHECK-NEXT:  .globl pooling_nchw_max_d1_s2_3x3
 // CHECK-NEXT:  .p2align 2
 // CHECK-NEXT:  pooling_nchw_max_d1_s2_3x3:
 // CHECK-NEXT:      mv t1, a0
 // CHECK-NEXT:      mv t0, a1
-// CHECK-NEXT:      li t4, -10000
-// CHECK-NEXT:      fcvt.d.w ft3, t4
+// CHECK-NEXT:      li t3, -10000
+// CHECK-NEXT:      fcvt.d.w ft3, t3
 // CHECK-NEXT:      li t3, 8
 // CHECK-NEXT:      mv t2, zero
 // CHECK-NEXT:      # Constant folded riscv_cf.bge
 // CHECK-NEXT:  scf_body_{{\d}}_for:
-// CHECK-NEXT:      li a2, 2
-// CHECK-NEXT:      mul a2, t2, a2
-// CHECK-NEXT:      li t6, 18
-// CHECK-NEXT:      mul a2, a2, t6
-// CHECK-NEXT:      li t6, 8
-// CHECK-NEXT:      mul a2, a2, t6                               # multiply by element size
-// CHECK-NEXT:      add a2, t1, a2
-// CHECK-NEXT:      li t6, 8
-// CHECK-NEXT:      mul t6, t2, t6
+// CHECK-NEXT:      li t4, 2
+// CHECK-NEXT:      mul t4, t2, t4
+// CHECK-NEXT:      li t5, 18
+// CHECK-NEXT:      mul t4, t4, t5
 // CHECK-NEXT:      li t5, 8
-// CHECK-NEXT:      mul t6, t6, t5                               # multiply by element size
-// CHECK-NEXT:      add t6, t0, t6
-// CHECK-NEXT:      li t5, 3
-// CHECK-NEXT:      scfgwi t5, 64                                # dm 0 dim 0 bound
-// CHECK-NEXT:      li t5, 2
-// CHECK-NEXT:      scfgwi t5, 96                                # dm 0 dim 1 bound
-// CHECK-NEXT:      li t5, 2
-// CHECK-NEXT:      scfgwi t5, 128                               # dm 0 dim 2 bound
-// CHECK-NEXT:      li t5, 1
-// CHECK-NEXT:      scfgwi t5, 160                               # dm 0 dim 3 bound
-// CHECK-NEXT:      li t5, 16
-// CHECK-NEXT:      scfgwi t5, 192                               # dm 0 dim 0 stride
-// CHECK-NEXT:      li t5, -40
-// CHECK-NEXT:      scfgwi t5, 224                               # dm 0 dim 1 stride
-// CHECK-NEXT:      li t5, 80
-// CHECK-NEXT:      scfgwi t5, 256                               # dm 0 dim 2 stride
-// CHECK-NEXT:      li t5, -288
-// CHECK-NEXT:      scfgwi t5, 288                               # dm 0 dim 3 stride
-// CHECK-NEXT:      scfgwi zero, 32                              # dm 0 repeat
-// CHECK-NEXT:      li t5, 7
-// CHECK-NEXT:      scfgwi t5, 65                                # dm 1 dim 0 bound
+// CHECK-NEXT:      mul t4, t4, t5                               # multiply by element size
+// CHECK-NEXT:      add t4, t1, t4
 // CHECK-NEXT:      li t5, 8
-// CHECK-NEXT:      scfgwi t5, 193                               # dm 1 dim 0 stride
-// CHECK-NEXT:      scfgwi zero, 33                              # dm 1 repeat
-// CHECK-NEXT:      scfgwi a2, 864                               # dm 0 dim 3 source
-// CHECK-NEXT:      scfgwi t6, 897                               # dm 1 dim 0 destination
-// CHECK-NEXT:      csrrsi zero, 1984, 1                         # SSR enable
+// CHECK-NEXT:      mul t5, t2, t5
+// CHECK-NEXT:      li t6, 8
+// CHECK-NEXT:      mul t5, t5, t6                               # multiply by element size
+// CHECK-NEXT:      add t5, t0, t5
+// CHECK-NEXT:      li t6, 3
+// CHECK-NEXT:      scfgwi t6, 64                                # dm 0 dim 0 bound
 // CHECK-NEXT:      li t6, 2
-// CHECK-NEXT:      mv t5, zero
+// CHECK-NEXT:      scfgwi t6, 96                                # dm 0 dim 1 bound
+// CHECK-NEXT:      li t6, 2
+// CHECK-NEXT:      scfgwi t6, 128                               # dm 0 dim 2 bound
+// CHECK-NEXT:      li t6, 1
+// CHECK-NEXT:      scfgwi t6, 160                               # dm 0 dim 3 bound
+// CHECK-NEXT:      li t6, 16
+// CHECK-NEXT:      scfgwi t6, 192                               # dm 0 dim 0 stride
+// CHECK-NEXT:      li t6, -40
+// CHECK-NEXT:      scfgwi t6, 224                               # dm 0 dim 1 stride
+// CHECK-NEXT:      li t6, 80
+// CHECK-NEXT:      scfgwi t6, 256                               # dm 0 dim 2 stride
+// CHECK-NEXT:      li t6, -288
+// CHECK-NEXT:      scfgwi t6, 288                               # dm 0 dim 3 stride
+// CHECK-NEXT:      scfgwi zero, 32                              # dm 0 repeat
+// CHECK-NEXT:      li t6, 7
+// CHECK-NEXT:      scfgwi t6, 65                                # dm 1 dim 0 bound
+// CHECK-NEXT:      li t6, 8
+// CHECK-NEXT:      scfgwi t6, 193                               # dm 1 dim 0 stride
+// CHECK-NEXT:      scfgwi zero, 33                              # dm 1 repeat
+// CHECK-NEXT:      scfgwi t4, 864                               # dm 0 dim 3 source
+// CHECK-NEXT:      scfgwi t5, 897                               # dm 1 dim 0 destination
+// CHECK-NEXT:      csrrsi zero, 1984, 1                         # SSR enable
+// CHECK-NEXT:      li t5, 2
+// CHECK-NEXT:      mv t4, zero
 // CHECK-NEXT:      # Constant folded riscv_cf.bge
 // CHECK-NEXT:  scf_body_{{\d}}_for:
 // CHECK-NEXT:      fmv.d ft7, ft3
 // CHECK-NEXT:      fmv.d ft6, ft3
 // CHECK-NEXT:      fmv.d ft5, ft3
 // CHECK-NEXT:      fmv.d ft4, ft3
-// CHECK-NEXT:      li a3, 8
-// CHECK-NEXT:      frep.o a3, 4, 0, 0
+// CHECK-NEXT:      li t6, 8
+// CHECK-NEXT:      frep.o t6, 4, 0, 0
 // CHECK-NEXT:      fmax.d ft7, ft0, ft7
 // CHECK-NEXT:      fmax.d ft6, ft0, ft6
 // CHECK-NEXT:      fmax.d ft5, ft0, ft5
@@ -146,8 +146,8 @@ func.func public @pooling_nchw_max_d1_s2_3x3(
 // CHECK-NEXT:      fmv.d ft1, ft6
 // CHECK-NEXT:      fmv.d ft1, ft5
 // CHECK-NEXT:      fmv.d ft1, ft4
-// CHECK-NEXT:      addi t5, t5, 1
-// CHECK-NEXT:      blt t5, t6, scf_body_{{\d}}_for
+// CHECK-NEXT:      addi t4, t4, 1
+// CHECK-NEXT:      blt t4, t5, scf_body_{{\d}}_for
 // CHECK-NEXT:  scf_body_end_{{\d}}_for:
 // CHECK-NEXT:      csrrci zero, 1984, 1                         # SSR disable
 // CHECK-NEXT:      addi t2, t2, 1

--- a/tests/filecheck/projects/riscv-backend-paper/bottom_up_f64.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/bottom_up_f64.mlir
@@ -34,7 +34,7 @@ func.func public @conv_2d_nchw_fchw_d1_s1_3x3(
   }
 
 
-// CHECK-NEXT:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1", "ft2"], "preallocated_int": ["a0", "a1", "a2", "zero"], "allocated_float": ["ft0", "ft1", "ft2", "ft3", "ft4", "ft5", "ft6", "ft7"], "allocated_int": ["a0", "a1", "a2", "a3", "a4", "a5", "t0", "t1", "t2", "t3", "t4", "t5", "t6", "zero"]}
+// CHECK-NEXT:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1", "ft2"], "preallocated_int": ["a0", "a1", "a2", "zero"], "allocated_float": ["ft0", "ft1", "ft2", "ft3", "ft4", "ft5", "ft6", "ft7"], "allocated_int": ["a0", "a1", "a2", "a3", "a4", "t0", "t1", "t2", "t3", "t4", "t5", "t6", "zero"]}
 // CHECK:       .text
 // CHECK-NEXT:  .globl conv_2d_nchw_fchw_d1_s1_3x3
 // CHECK-NEXT:  .p2align 2
@@ -47,68 +47,68 @@ func.func public @conv_2d_nchw_fchw_d1_s1_3x3(
 // CHECK-NEXT:      mv t3, zero
 // CHECK-NEXT:      # Constant folded riscv_cf.bge
 // CHECK-NEXT:  scf_body_{{\d}}_for:
-// CHECK-NEXT:      mv t6, t3
-// CHECK-NEXT:      li a4, 10
-// CHECK-NEXT:      mul t6, t6, a4
+// CHECK-NEXT:      mv a3, t3
+// CHECK-NEXT:      li t5, 10
+// CHECK-NEXT:      mul a3, a3, t5
+// CHECK-NEXT:      li t5, 8
+// CHECK-NEXT:      mul a3, a3, t5                               # multiply by element size
+// CHECK-NEXT:      add a3, t2, a3
+// CHECK-NEXT:      mv t5, t1
+// CHECK-NEXT:      li t6, 8
+// CHECK-NEXT:      mul t6, t3, t6
 // CHECK-NEXT:      li a4, 8
 // CHECK-NEXT:      mul t6, t6, a4                               # multiply by element size
-// CHECK-NEXT:      add t6, t2, t6
-// CHECK-NEXT:      mv a4, t1
-// CHECK-NEXT:      li a3, 8
-// CHECK-NEXT:      mul a3, t3, a3
-// CHECK-NEXT:      li a5, 8
-// CHECK-NEXT:      mul a3, a3, a5                               # multiply by element size
-// CHECK-NEXT:      add a3, t0, a3
-// CHECK-NEXT:      li a5, 3
-// CHECK-NEXT:      scfgwi a5, 64                                # dm 0 dim 0 bound
-// CHECK-NEXT:      li a5, 2
-// CHECK-NEXT:      scfgwi a5, 96                                # dm 0 dim 1 bound
-// CHECK-NEXT:      li a5, 2
-// CHECK-NEXT:      scfgwi a5, 128                               # dm 0 dim 2 bound
-// CHECK-NEXT:      li a5, 1
-// CHECK-NEXT:      scfgwi a5, 160                               # dm 0 dim 3 bound
-// CHECK-NEXT:      li a5, 8
-// CHECK-NEXT:      scfgwi a5, 192                               # dm 0 dim 0 stride
-// CHECK-NEXT:      li a5, -16
-// CHECK-NEXT:      scfgwi a5, 224                               # dm 0 dim 1 stride
-// CHECK-NEXT:      li a5, 40
-// CHECK-NEXT:      scfgwi a5, 256                               # dm 0 dim 2 stride
-// CHECK-NEXT:      li a5, -168
-// CHECK-NEXT:      scfgwi a5, 288                               # dm 0 dim 3 stride
+// CHECK-NEXT:      add t6, t0, t6
+// CHECK-NEXT:      li a4, 3
+// CHECK-NEXT:      scfgwi a4, 64                                # dm 0 dim 0 bound
+// CHECK-NEXT:      li a4, 2
+// CHECK-NEXT:      scfgwi a4, 96                                # dm 0 dim 1 bound
+// CHECK-NEXT:      li a4, 2
+// CHECK-NEXT:      scfgwi a4, 128                               # dm 0 dim 2 bound
+// CHECK-NEXT:      li a4, 1
+// CHECK-NEXT:      scfgwi a4, 160                               # dm 0 dim 3 bound
+// CHECK-NEXT:      li a4, 8
+// CHECK-NEXT:      scfgwi a4, 192                               # dm 0 dim 0 stride
+// CHECK-NEXT:      li a4, -16
+// CHECK-NEXT:      scfgwi a4, 224                               # dm 0 dim 1 stride
+// CHECK-NEXT:      li a4, 40
+// CHECK-NEXT:      scfgwi a4, 256                               # dm 0 dim 2 stride
+// CHECK-NEXT:      li a4, -168
+// CHECK-NEXT:      scfgwi a4, 288                               # dm 0 dim 3 stride
 // CHECK-NEXT:      scfgwi zero, 32                              # dm 0 repeat
-// CHECK-NEXT:      li a5, 2
-// CHECK-NEXT:      scfgwi a5, 65                                # dm 1 dim 0 bound
-// CHECK-NEXT:      li a5, 2
-// CHECK-NEXT:      scfgwi a5, 97                                # dm 1 dim 1 bound
-// CHECK-NEXT:      li a5, 1
-// CHECK-NEXT:      scfgwi a5, 129                               # dm 1 dim 2 bound
-// CHECK-NEXT:      li a5, 8
-// CHECK-NEXT:      scfgwi a5, 193                               # dm 1 dim 0 stride
-// CHECK-NEXT:      li a5, 8
-// CHECK-NEXT:      scfgwi a5, 225                               # dm 1 dim 1 stride
-// CHECK-NEXT:      li a5, -64
-// CHECK-NEXT:      scfgwi a5, 257                               # dm 1 dim 2 stride
-// CHECK-NEXT:      li a5, 3
-// CHECK-NEXT:      scfgwi a5, 33                                # dm 1 repeat
-// CHECK-NEXT:      li a5, 7
-// CHECK-NEXT:      scfgwi a5, 66                                # dm 2 dim 0 bound
-// CHECK-NEXT:      li a5, 8
-// CHECK-NEXT:      scfgwi a5, 194                               # dm 2 dim 0 stride
+// CHECK-NEXT:      li a4, 2
+// CHECK-NEXT:      scfgwi a4, 65                                # dm 1 dim 0 bound
+// CHECK-NEXT:      li a4, 2
+// CHECK-NEXT:      scfgwi a4, 97                                # dm 1 dim 1 bound
+// CHECK-NEXT:      li a4, 1
+// CHECK-NEXT:      scfgwi a4, 129                               # dm 1 dim 2 bound
+// CHECK-NEXT:      li a4, 8
+// CHECK-NEXT:      scfgwi a4, 193                               # dm 1 dim 0 stride
+// CHECK-NEXT:      li a4, 8
+// CHECK-NEXT:      scfgwi a4, 225                               # dm 1 dim 1 stride
+// CHECK-NEXT:      li a4, -64
+// CHECK-NEXT:      scfgwi a4, 257                               # dm 1 dim 2 stride
+// CHECK-NEXT:      li a4, 3
+// CHECK-NEXT:      scfgwi a4, 33                                # dm 1 repeat
+// CHECK-NEXT:      li a4, 7
+// CHECK-NEXT:      scfgwi a4, 66                                # dm 2 dim 0 bound
+// CHECK-NEXT:      li a4, 8
+// CHECK-NEXT:      scfgwi a4, 194                               # dm 2 dim 0 stride
 // CHECK-NEXT:      scfgwi zero, 34                              # dm 2 repeat
-// CHECK-NEXT:      scfgwi t6, 864                               # dm 0 dim 3 source
-// CHECK-NEXT:      scfgwi a4, 833                               # dm 1 dim 2 source
-// CHECK-NEXT:      scfgwi a3, 898                               # dm 2 dim 0 destination
+// CHECK-NEXT:      scfgwi a3, 864                               # dm 0 dim 3 source
+// CHECK-NEXT:      scfgwi t5, 833                               # dm 1 dim 2 source
+// CHECK-NEXT:      scfgwi t6, 898                               # dm 2 dim 0 destination
 // CHECK-NEXT:      csrrsi zero, 1984, 1                         # SSR enable
-// CHECK-NEXT:      li a3, 2
-// CHECK-NEXT:      mv t6, zero
+// CHECK-NEXT:      li t6, 2
+// CHECK-NEXT:      mv t5, zero
 // CHECK-NEXT:      # Constant folded riscv_cf.bge
 // CHECK-NEXT:  scf_body_{{\d}}_for:
 // CHECK-NEXT:      fmv.d ft7, ft3
 // CHECK-NEXT:      fmv.d ft6, ft3
 // CHECK-NEXT:      fmv.d ft5, ft3
 // CHECK-NEXT:      fmv.d ft4, ft3
-// CHECK-NEXT:      li a5, 8
-// CHECK-NEXT:      frep.o a5, 4, 0, 0
+// CHECK-NEXT:      li a3, 8
+// CHECK-NEXT:      frep.o a3, 4, 0, 0
 // CHECK-NEXT:      fmadd.d ft7, ft0, ft1, ft7
 // CHECK-NEXT:      fmadd.d ft6, ft0, ft1, ft6
 // CHECK-NEXT:      fmadd.d ft5, ft0, ft1, ft5
@@ -117,8 +117,8 @@ func.func public @conv_2d_nchw_fchw_d1_s1_3x3(
 // CHECK-NEXT:      fmv.d ft2, ft6
 // CHECK-NEXT:      fmv.d ft2, ft5
 // CHECK-NEXT:      fmv.d ft2, ft4
-// CHECK-NEXT:      addi t6, t6, 1
-// CHECK-NEXT:      blt t6, a3, scf_body_{{\d}}_for
+// CHECK-NEXT:      addi t5, t5, 1
+// CHECK-NEXT:      blt t5, t6, scf_body_{{\d}}_for
 // CHECK-NEXT:  scf_body_end_{{\d}}_for:
 // CHECK-NEXT:      csrrci zero, 1984, 1                         # SSR disable
 // CHECK-NEXT:      addi t3, t3, 1
@@ -308,9 +308,9 @@ func.func public @conv_2d_nchw_fchw_d1_s1_3x3(
 // CHECK-NEXT:  .globl matmul
 // CHECK-NEXT:  .p2align 2
 // CHECK-NEXT:  matmul:
-// CHECK-NEXT:      mv t0, a0
-// CHECK-NEXT:      mv t1, a1
-// CHECK-NEXT:      mv t2, a2
+// CHECK-NEXT:      mv t2, a0
+// CHECK-NEXT:      mv t0, a1
+// CHECK-NEXT:      mv t1, a2
 // CHECK-NEXT:      fcvt.d.w ft3, zero
 // CHECK-NEXT:      li t3, 7
 // CHECK-NEXT:      scfgwi t3, 64                                # dm 0 dim 0 bound
@@ -348,9 +348,9 @@ func.func public @conv_2d_nchw_fchw_d1_s1_3x3(
 // CHECK-NEXT:      li t3, 8
 // CHECK-NEXT:      scfgwi t3, 194                               # dm 2 dim 0 stride
 // CHECK-NEXT:      scfgwi zero, 34                              # dm 2 repeat
-// CHECK-NEXT:      scfgwi t0, 832                               # dm 0 dim 2 source
-// CHECK-NEXT:      scfgwi t1, 865                               # dm 1 dim 3 source
-// CHECK-NEXT:      scfgwi t2, 898                               # dm 2 dim 0 destination
+// CHECK-NEXT:      scfgwi t2, 832                               # dm 0 dim 2 source
+// CHECK-NEXT:      scfgwi t0, 865                               # dm 1 dim 3 source
+// CHECK-NEXT:      scfgwi t1, 898                               # dm 2 dim 0 destination
 // CHECK-NEXT:      csrrsi zero, 1984, 1                         # SSR enable
 // CHECK-NEXT:      li t1, 16
 // CHECK-NEXT:      mv t0, zero
@@ -360,8 +360,8 @@ func.func public @conv_2d_nchw_fchw_d1_s1_3x3(
 // CHECK-NEXT:      fmv.d ft6, ft3
 // CHECK-NEXT:      fmv.d ft5, ft3
 // CHECK-NEXT:      fmv.d ft4, ft3
-// CHECK-NEXT:      li t3, 7
-// CHECK-NEXT:      frep.o t3, 4, 0, 0
+// CHECK-NEXT:      li t2, 7
+// CHECK-NEXT:      frep.o t2, 4, 0, 0
 // CHECK-NEXT:      fmadd.d ft7, ft0, ft1, ft7
 // CHECK-NEXT:      fmadd.d ft6, ft0, ft1, ft6
 // CHECK-NEXT:      fmadd.d ft5, ft0, ft1, ft5
@@ -413,65 +413,65 @@ func.func public @pooling_nchw_max_d1_s2_3x3(
   }
 
 
-// CHECK-NEXT:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1", "ft2"], "preallocated_int": ["a0", "a1", "zero"], "allocated_float": ["ft0", "ft1", "ft3", "ft4", "ft5", "ft6", "ft7"], "allocated_int": ["a0", "a1", "a2", "a3", "t0", "t1", "t2", "t3", "t4", "t5", "t6", "zero"]}
+// CHECK-NEXT:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1", "ft2"], "preallocated_int": ["a0", "a1", "zero"], "allocated_float": ["ft0", "ft1", "ft3", "ft4", "ft5", "ft6", "ft7"], "allocated_int": ["a0", "a1", "t0", "t1", "t2", "t3", "t4", "t5", "t6", "zero"]}
 // CHECK-NEXT:  .globl pooling_nchw_max_d1_s2_3x3
 // CHECK-NEXT:  .p2align 2
 // CHECK-NEXT:  pooling_nchw_max_d1_s2_3x3:
 // CHECK-NEXT:      mv t1, a0
 // CHECK-NEXT:      mv t0, a1
-// CHECK-NEXT:      li t4, -10000
-// CHECK-NEXT:      fcvt.d.w ft3, t4
+// CHECK-NEXT:      li t3, -10000
+// CHECK-NEXT:      fcvt.d.w ft3, t3
 // CHECK-NEXT:      li t3, 8
 // CHECK-NEXT:      mv t2, zero
 // CHECK-NEXT:      # Constant folded riscv_cf.bge
 // CHECK-NEXT:  scf_body_{{\d}}_for:
-// CHECK-NEXT:      li a2, 2
-// CHECK-NEXT:      mul a2, t2, a2
-// CHECK-NEXT:      li t6, 18
-// CHECK-NEXT:      mul a2, a2, t6
-// CHECK-NEXT:      li t6, 8
-// CHECK-NEXT:      mul a2, a2, t6                               # multiply by element size
-// CHECK-NEXT:      add a2, t1, a2
-// CHECK-NEXT:      li t6, 8
-// CHECK-NEXT:      mul t6, t2, t6
+// CHECK-NEXT:      li t4, 2
+// CHECK-NEXT:      mul t4, t2, t4
+// CHECK-NEXT:      li t5, 18
+// CHECK-NEXT:      mul t4, t4, t5
 // CHECK-NEXT:      li t5, 8
-// CHECK-NEXT:      mul t6, t6, t5                               # multiply by element size
-// CHECK-NEXT:      add t6, t0, t6
-// CHECK-NEXT:      li t5, 3
-// CHECK-NEXT:      scfgwi t5, 64                                # dm 0 dim 0 bound
-// CHECK-NEXT:      li t5, 2
-// CHECK-NEXT:      scfgwi t5, 96                                # dm 0 dim 1 bound
-// CHECK-NEXT:      li t5, 2
-// CHECK-NEXT:      scfgwi t5, 128                               # dm 0 dim 2 bound
-// CHECK-NEXT:      li t5, 1
-// CHECK-NEXT:      scfgwi t5, 160                               # dm 0 dim 3 bound
-// CHECK-NEXT:      li t5, 16
-// CHECK-NEXT:      scfgwi t5, 192                               # dm 0 dim 0 stride
-// CHECK-NEXT:      li t5, -40
-// CHECK-NEXT:      scfgwi t5, 224                               # dm 0 dim 1 stride
-// CHECK-NEXT:      li t5, 80
-// CHECK-NEXT:      scfgwi t5, 256                               # dm 0 dim 2 stride
-// CHECK-NEXT:      li t5, -288
-// CHECK-NEXT:      scfgwi t5, 288                               # dm 0 dim 3 stride
-// CHECK-NEXT:      scfgwi zero, 32                              # dm 0 repeat
-// CHECK-NEXT:      li t5, 7
-// CHECK-NEXT:      scfgwi t5, 65                                # dm 1 dim 0 bound
+// CHECK-NEXT:      mul t4, t4, t5                               # multiply by element size
+// CHECK-NEXT:      add t4, t1, t4
 // CHECK-NEXT:      li t5, 8
-// CHECK-NEXT:      scfgwi t5, 193                               # dm 1 dim 0 stride
-// CHECK-NEXT:      scfgwi zero, 33                              # dm 1 repeat
-// CHECK-NEXT:      scfgwi a2, 864                               # dm 0 dim 3 source
-// CHECK-NEXT:      scfgwi t6, 897                               # dm 1 dim 0 destination
-// CHECK-NEXT:      csrrsi zero, 1984, 1                         # SSR enable
+// CHECK-NEXT:      mul t5, t2, t5
+// CHECK-NEXT:      li t6, 8
+// CHECK-NEXT:      mul t5, t5, t6                               # multiply by element size
+// CHECK-NEXT:      add t5, t0, t5
+// CHECK-NEXT:      li t6, 3
+// CHECK-NEXT:      scfgwi t6, 64                                # dm 0 dim 0 bound
 // CHECK-NEXT:      li t6, 2
-// CHECK-NEXT:      mv t5, zero
+// CHECK-NEXT:      scfgwi t6, 96                                # dm 0 dim 1 bound
+// CHECK-NEXT:      li t6, 2
+// CHECK-NEXT:      scfgwi t6, 128                               # dm 0 dim 2 bound
+// CHECK-NEXT:      li t6, 1
+// CHECK-NEXT:      scfgwi t6, 160                               # dm 0 dim 3 bound
+// CHECK-NEXT:      li t6, 16
+// CHECK-NEXT:      scfgwi t6, 192                               # dm 0 dim 0 stride
+// CHECK-NEXT:      li t6, -40
+// CHECK-NEXT:      scfgwi t6, 224                               # dm 0 dim 1 stride
+// CHECK-NEXT:      li t6, 80
+// CHECK-NEXT:      scfgwi t6, 256                               # dm 0 dim 2 stride
+// CHECK-NEXT:      li t6, -288
+// CHECK-NEXT:      scfgwi t6, 288                               # dm 0 dim 3 stride
+// CHECK-NEXT:      scfgwi zero, 32                              # dm 0 repeat
+// CHECK-NEXT:      li t6, 7
+// CHECK-NEXT:      scfgwi t6, 65                                # dm 1 dim 0 bound
+// CHECK-NEXT:      li t6, 8
+// CHECK-NEXT:      scfgwi t6, 193                               # dm 1 dim 0 stride
+// CHECK-NEXT:      scfgwi zero, 33                              # dm 1 repeat
+// CHECK-NEXT:      scfgwi t4, 864                               # dm 0 dim 3 source
+// CHECK-NEXT:      scfgwi t5, 897                               # dm 1 dim 0 destination
+// CHECK-NEXT:      csrrsi zero, 1984, 1                         # SSR enable
+// CHECK-NEXT:      li t5, 2
+// CHECK-NEXT:      mv t4, zero
 // CHECK-NEXT:      # Constant folded riscv_cf.bge
 // CHECK-NEXT:  scf_body_{{\d}}_for:
 // CHECK-NEXT:      fmv.d ft7, ft3
 // CHECK-NEXT:      fmv.d ft6, ft3
 // CHECK-NEXT:      fmv.d ft5, ft3
 // CHECK-NEXT:      fmv.d ft4, ft3
-// CHECK-NEXT:      li a3, 8
-// CHECK-NEXT:      frep.o a3, 4, 0, 0
+// CHECK-NEXT:      li t6, 8
+// CHECK-NEXT:      frep.o t6, 4, 0, 0
 // CHECK-NEXT:      fmax.d ft7, ft0, ft7
 // CHECK-NEXT:      fmax.d ft6, ft0, ft6
 // CHECK-NEXT:      fmax.d ft5, ft0, ft5
@@ -480,8 +480,8 @@ func.func public @pooling_nchw_max_d1_s2_3x3(
 // CHECK-NEXT:      fmv.d ft1, ft6
 // CHECK-NEXT:      fmv.d ft1, ft5
 // CHECK-NEXT:      fmv.d ft1, ft4
-// CHECK-NEXT:      addi t5, t5, 1
-// CHECK-NEXT:      blt t5, t6, scf_body_{{\d}}_for
+// CHECK-NEXT:      addi t4, t4, 1
+// CHECK-NEXT:      blt t4, t5, scf_body_{{\d}}_for
 // CHECK-NEXT:  scf_body_end_{{\d}}_for:
 // CHECK-NEXT:      csrrci zero, 1984, 1                         # SSR disable
 // CHECK-NEXT:      addi t2, t2, 1
@@ -566,7 +566,7 @@ func.func public @pooling_nchw_sum_d1_s2_3x3(
   }
 
 
-// CHECK-NEXT:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1", "ft2"], "preallocated_int": ["a0", "a1", "zero"], "allocated_float": ["ft0", "ft1", "ft3", "ft4", "ft5", "ft6", "ft7"], "allocated_int": ["a0", "a1", "a2", "a3", "t0", "t1", "t2", "t3", "t4", "t5", "t6", "zero"]}
+// CHECK-NEXT:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1", "ft2"], "preallocated_int": ["a0", "a1", "zero"], "allocated_float": ["ft0", "ft1", "ft3", "ft4", "ft5", "ft6", "ft7"], "allocated_int": ["a0", "a1", "t0", "t1", "t2", "t3", "t4", "t5", "t6", "zero"]}
 // CHECK-NEXT:  .globl pooling_nchw_sum_d1_s2_3x3
 // CHECK-NEXT:  .p2align 2
 // CHECK-NEXT:  pooling_nchw_sum_d1_s2_3x3:
@@ -577,53 +577,53 @@ func.func public @pooling_nchw_sum_d1_s2_3x3(
 // CHECK-NEXT:      mv t2, zero
 // CHECK-NEXT:      # Constant folded riscv_cf.bge
 // CHECK-NEXT:  scf_body_{{\d}}_for:
-// CHECK-NEXT:      li a2, 2
-// CHECK-NEXT:      mul a2, t2, a2
-// CHECK-NEXT:      li t6, 18
-// CHECK-NEXT:      mul a2, a2, t6
-// CHECK-NEXT:      li t6, 8
-// CHECK-NEXT:      mul a2, a2, t6                               # multiply by element size
-// CHECK-NEXT:      add a2, t1, a2
-// CHECK-NEXT:      li t6, 8
-// CHECK-NEXT:      mul t6, t2, t6
+// CHECK-NEXT:      li t4, 2
+// CHECK-NEXT:      mul t4, t2, t4
+// CHECK-NEXT:      li t5, 18
+// CHECK-NEXT:      mul t4, t4, t5
 // CHECK-NEXT:      li t5, 8
-// CHECK-NEXT:      mul t6, t6, t5                               # multiply by element size
-// CHECK-NEXT:      add t6, t0, t6
-// CHECK-NEXT:      li t5, 3
-// CHECK-NEXT:      scfgwi t5, 64                                # dm 0 dim 0 bound
-// CHECK-NEXT:      li t5, 2
-// CHECK-NEXT:      scfgwi t5, 96                                # dm 0 dim 1 bound
-// CHECK-NEXT:      li t5, 2
-// CHECK-NEXT:      scfgwi t5, 128                               # dm 0 dim 2 bound
-// CHECK-NEXT:      li t5, 1
-// CHECK-NEXT:      scfgwi t5, 160                               # dm 0 dim 3 bound
-// CHECK-NEXT:      li t5, 16
-// CHECK-NEXT:      scfgwi t5, 192                               # dm 0 dim 0 stride
-// CHECK-NEXT:      li t5, -40
-// CHECK-NEXT:      scfgwi t5, 224                               # dm 0 dim 1 stride
-// CHECK-NEXT:      li t5, 80
-// CHECK-NEXT:      scfgwi t5, 256                               # dm 0 dim 2 stride
-// CHECK-NEXT:      li t5, -288
-// CHECK-NEXT:      scfgwi t5, 288                               # dm 0 dim 3 stride
-// CHECK-NEXT:      scfgwi zero, 32                              # dm 0 repeat
-// CHECK-NEXT:      li t5, 7
-// CHECK-NEXT:      scfgwi t5, 65                                # dm 1 dim 0 bound
+// CHECK-NEXT:      mul t4, t4, t5                               # multiply by element size
+// CHECK-NEXT:      add t4, t1, t4
 // CHECK-NEXT:      li t5, 8
-// CHECK-NEXT:      scfgwi t5, 193                               # dm 1 dim 0 stride
-// CHECK-NEXT:      scfgwi zero, 33                              # dm 1 repeat
-// CHECK-NEXT:      scfgwi a2, 864                               # dm 0 dim 3 source
-// CHECK-NEXT:      scfgwi t6, 897                               # dm 1 dim 0 destination
-// CHECK-NEXT:      csrrsi zero, 1984, 1                         # SSR enable
+// CHECK-NEXT:      mul t5, t2, t5
+// CHECK-NEXT:      li t6, 8
+// CHECK-NEXT:      mul t5, t5, t6                               # multiply by element size
+// CHECK-NEXT:      add t5, t0, t5
+// CHECK-NEXT:      li t6, 3
+// CHECK-NEXT:      scfgwi t6, 64                                # dm 0 dim 0 bound
 // CHECK-NEXT:      li t6, 2
-// CHECK-NEXT:      mv t5, zero
+// CHECK-NEXT:      scfgwi t6, 96                                # dm 0 dim 1 bound
+// CHECK-NEXT:      li t6, 2
+// CHECK-NEXT:      scfgwi t6, 128                               # dm 0 dim 2 bound
+// CHECK-NEXT:      li t6, 1
+// CHECK-NEXT:      scfgwi t6, 160                               # dm 0 dim 3 bound
+// CHECK-NEXT:      li t6, 16
+// CHECK-NEXT:      scfgwi t6, 192                               # dm 0 dim 0 stride
+// CHECK-NEXT:      li t6, -40
+// CHECK-NEXT:      scfgwi t6, 224                               # dm 0 dim 1 stride
+// CHECK-NEXT:      li t6, 80
+// CHECK-NEXT:      scfgwi t6, 256                               # dm 0 dim 2 stride
+// CHECK-NEXT:      li t6, -288
+// CHECK-NEXT:      scfgwi t6, 288                               # dm 0 dim 3 stride
+// CHECK-NEXT:      scfgwi zero, 32                              # dm 0 repeat
+// CHECK-NEXT:      li t6, 7
+// CHECK-NEXT:      scfgwi t6, 65                                # dm 1 dim 0 bound
+// CHECK-NEXT:      li t6, 8
+// CHECK-NEXT:      scfgwi t6, 193                               # dm 1 dim 0 stride
+// CHECK-NEXT:      scfgwi zero, 33                              # dm 1 repeat
+// CHECK-NEXT:      scfgwi t4, 864                               # dm 0 dim 3 source
+// CHECK-NEXT:      scfgwi t5, 897                               # dm 1 dim 0 destination
+// CHECK-NEXT:      csrrsi zero, 1984, 1                         # SSR enable
+// CHECK-NEXT:      li t5, 2
+// CHECK-NEXT:      mv t4, zero
 // CHECK-NEXT:      # Constant folded riscv_cf.bge
 // CHECK-NEXT:  scf_body_{{\d}}_for:
 // CHECK-NEXT:      fmv.d ft7, ft3
 // CHECK-NEXT:      fmv.d ft6, ft3
 // CHECK-NEXT:      fmv.d ft5, ft3
 // CHECK-NEXT:      fmv.d ft4, ft3
-// CHECK-NEXT:      li a3, 8
-// CHECK-NEXT:      frep.o a3, 4, 0, 0
+// CHECK-NEXT:      li t6, 8
+// CHECK-NEXT:      frep.o t6, 4, 0, 0
 // CHECK-NEXT:      fadd.d ft7, ft0, ft7
 // CHECK-NEXT:      fadd.d ft6, ft0, ft6
 // CHECK-NEXT:      fadd.d ft5, ft0, ft5
@@ -632,8 +632,8 @@ func.func public @pooling_nchw_sum_d1_s2_3x3(
 // CHECK-NEXT:      fmv.d ft1, ft6
 // CHECK-NEXT:      fmv.d ft1, ft5
 // CHECK-NEXT:      fmv.d ft1, ft4
-// CHECK-NEXT:      addi t5, t5, 1
-// CHECK-NEXT:      blt t5, t6, scf_body_{{\d}}_for
+// CHECK-NEXT:      addi t4, t4, 1
+// CHECK-NEXT:      blt t4, t5, scf_body_{{\d}}_for
 // CHECK-NEXT:  scf_body_end_{{\d}}_for:
 // CHECK-NEXT:      csrrci zero, 1984, 1                         # SSR disable
 // CHECK-NEXT:      addi t2, t2, 1

--- a/tests/filecheck/projects/riscv-backend-paper/exp_f64.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/exp_f64.mlir
@@ -18,19 +18,19 @@ func.func public @exp_f64(
   func.return
 }
 
-// CHECK:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1", "ft2"], "preallocated_int": ["a0", "a1", "sp", "zero"], "allocated_float": ["ft0", "ft1", "ft3", "ft4", "ft5", "ft6"], "allocated_int": ["a0", "a1", "sp", "t0", "t1", "t2", "t3", "zero"]}
+// CHECK:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1", "ft2"], "preallocated_int": ["a0", "a1", "sp", "zero"], "allocated_float": ["ft0", "ft1", "ft3", "ft4", "ft5", "ft6"], "allocated_int": ["a0", "a1", "sp", "t0", "t1", "t2", "zero"]}
 // CHECK-NEXT:  .text
 // CHECK-NEXT:  .globl exp_f64
 // CHECK-NEXT:  .p2align 2
 // CHECK-NEXT:  exp_f64:
-// CHECK-NEXT:      mv t2, a0
+// CHECK-NEXT:      mv t0, a0
 // CHECK-NEXT:      mv t1, a1
-// CHECK-NEXT:      li t0, 7
-// CHECK-NEXT:      scfgwi t0, 95                                # dm 31 dim 0 bound
-// CHECK-NEXT:      li t0, 8
-// CHECK-NEXT:      scfgwi t0, 223                               # dm 31 dim 0 stride
+// CHECK-NEXT:      li t2, 7
+// CHECK-NEXT:      scfgwi t2, 95                                # dm 31 dim 0 bound
+// CHECK-NEXT:      li t2, 8
+// CHECK-NEXT:      scfgwi t2, 223                               # dm 31 dim 0 stride
 // CHECK-NEXT:      scfgwi zero, 63                              # dm 31 repeat
-// CHECK-NEXT:      scfgwi t2, 768                               # dm 0 dim 0 source
+// CHECK-NEXT:      scfgwi t0, 768                               # dm 0 dim 0 source
 // CHECK-NEXT:      scfgwi t1, 897                               # dm 1 dim 0 destination
 // CHECK-NEXT:      csrrsi zero, 1984, 1                         # SSR enable
 // CHECK-NEXT:      li t1, 8
@@ -38,26 +38,26 @@ func.func public @exp_f64(
 // CHECK-NEXT:      # Constant folded riscv_cf.bge
 // CHECK-NEXT:  scf_body_0_for:
 // CHECK-NEXT:      fmv.d ft4, ft0
-// CHECK-NEXT:      li t3, 1
-// CHECK-NEXT:      fcvt.d.w ft3, t3
-// CHECK-NEXT:      li t3, 1
-// CHECK-NEXT:      fcvt.d.w ft5, t3
-// CHECK-NEXT:      li t3, 1
-// CHECK-NEXT:      fcvt.d.w ft6, t3
+// CHECK-NEXT:      li t2, 1
+// CHECK-NEXT:      fcvt.d.w ft3, t2
+// CHECK-NEXT:      li t2, 1
+// CHECK-NEXT:      fcvt.d.w ft5, t2
+// CHECK-NEXT:      li t2, 1
+// CHECK-NEXT:      fcvt.d.w ft6, t2
 // CHECK-NEXT:      fmul.d ft6, ft4, ft6
 // CHECK-NEXT:      fmul.d ft6, ft6, ft5
 // CHECK-NEXT:      fadd.d ft3, ft3, ft6
-// CHECK-NEXT:      li t3, 1071644672
-// CHECK-NEXT:      sw t3, -4(sp)
+// CHECK-NEXT:      li t2, 1071644672
+// CHECK-NEXT:      sw t2, -4(sp)
 // CHECK-NEXT:      sw zero, -8(sp)
 // CHECK-NEXT:      fld ft5, -8(sp)
 // CHECK-NEXT:      fmul.d ft5, ft4, ft5
 // CHECK-NEXT:      fmul.d ft5, ft5, ft6
 // CHECK-NEXT:      fadd.d ft3, ft3, ft5
-// CHECK-NEXT:      li t3, 1070945621
-// CHECK-NEXT:      sw t3, -4(sp)
-// CHECK-NEXT:      li t3, 1431655765
-// CHECK-NEXT:      sw t3, -8(sp)
+// CHECK-NEXT:      li t2, 1070945621
+// CHECK-NEXT:      sw t2, -4(sp)
+// CHECK-NEXT:      li t2, 1431655765
+// CHECK-NEXT:      sw t2, -8(sp)
 // CHECK-NEXT:      fld ft6, -8(sp)
 // CHECK-NEXT:      fmul.d ft4, ft4, ft6
 // CHECK-NEXT:      fmul.d ft4, ft4, ft5

--- a/xdsl/transforms/test_lower_linalg_to_snitch.py
+++ b/xdsl/transforms/test_lower_linalg_to_snitch.py
@@ -32,6 +32,7 @@ from xdsl.transforms import (
     reconcile_unrealized_casts,
     riscv_allocate_registers,
     riscv_lower_parallel_mov,
+    riscv_scf_for_infer_constant_step,
     riscv_scf_loop_range_folding,
     scf_for_loop_flatten,
     snitch_allocate_registers,
@@ -66,6 +67,7 @@ LOWER_MEMREF_STREAM_TO_SNITCH_STREAM_PASSES: tuple[ModulePass, ...] = (
 
 LOWER_SNITCH_STREAM_TO_ASM_PASSES: tuple[ModulePass, ...] = (
     canonicalize.CanonicalizePass(),
+    riscv_scf_for_infer_constant_step.RiscvScfForInferConstantStepPass(),
     convert_riscv_scf_for_to_frep.ConvertRiscvScfForToFrepPass(),
     snitch_allocate_registers.SnitchAllocateRegistersPass(),
     convert_snitch_stream_to_snitch.ConvertSnitchStreamToSnitch(),


### PR DESCRIPTION
This PR adds the constant step inference to the backend lowering linalg to snitch.
This results in a reduction in register use.

I tested that the updated assembly works by running it in the `riscv-paper-experiments` repo (it required some fixes to the memory effects of RISC-V instructions which I haven't yet opened a PR for).