### PR TITLE
dialects: (riscv_scf) allow constant value for step

### DIFF
--- a/tests/dialects/test_riscv_scf.py
+++ b/tests/dialects/test_riscv_scf.py
@@ -1,6 +1,8 @@
 import pytest
 
 from xdsl.dialects import riscv, riscv_scf
+from xdsl.dialects.builtin import IntegerAttr
+from xdsl.dialects.riscv.attrs import i12
 from xdsl.ir import Block
 from xdsl.utils.test_value import create_ssa_value
 
@@ -12,6 +14,7 @@ def test_for_rof_step(
     lb = create_ssa_value(riscv.Registers.A0)
     ub = create_ssa_value(riscv.Registers.A1)
     step_val = create_ssa_value(riscv.Registers.A2)
+    step_attr = IntegerAttr(1, i12)
 
     op = loop_cls(
         lb,
@@ -22,4 +25,19 @@ def test_for_rof_step(
     )
     op.verify()
 
+    assert op.step_attr is None
+    assert op.step_val is step_val
     assert op.step is step_val
+
+    op = loop_cls(
+        lb,
+        ub,
+        step_attr,
+        (),
+        Block((riscv_scf.YieldOp(),), arg_types=[riscv.Registers.UNALLOCATED_INT]),
+    )
+    op.verify()
+
+    assert op.step_attr is step_attr
+    assert op.step_val is None
+    assert op.step is step_attr

--- a/tests/filecheck/backend/convert_riscv_scf_to_riscv_cf.mlir
+++ b/tests/filecheck/backend/convert_riscv_scf_to_riscv_cf.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -p convert-riscv-scf-to-riscv-cf --split-input-file %s | filecheck %s
+// RUN: xdsl-opt -p convert-riscv-scf-to-riscv-cf --split-input-file --verify-diagnostics %s | filecheck %s
 
 
 builtin.module {
@@ -123,3 +123,21 @@ builtin.module {
 // CHECK-NEXT:      riscv_func.return %14 : !riscv.reg<a1>
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
+
+// -----
+
+
+riscv_func.func @static_step_loop_example(%src: !riscv.reg<a0>, %dst: !riscv.reg<a1>) {
+    %zero = rv32.li 0 : !riscv.reg<a2>
+    %forty = rv32.li 40 : !riscv.reg<a4>
+    riscv_scf.for %offset : !riscv.reg<a5> = %zero to %forty step 4 : si12 {
+        %srcptr = riscv.add %src, %offset : (!riscv.reg<a0>, !riscv.reg<a5>) -> !riscv.reg<a6>
+        %dstptr = riscv.add %dst, %offset : (!riscv.reg<a1>, !riscv.reg<a5>) -> !riscv.reg<a7>
+        %val = riscv.lw %srcptr, 0 : (!riscv.reg<a6>) -> !riscv.reg<t0>
+        riscv.sw %dstptr, %val, 0 : (!riscv.reg<a7>, !riscv.reg<t0>) -> ()
+        riscv_scf.yield
+    }
+    riscv_func.return
+}
+
+// CHECK: Error while applying pattern: Lowering riscv_scf loops with constant step not yet implemented.

--- a/tests/filecheck/backend/riscv/convert_riscv_scf_for_to_frep.mlir
+++ b/tests/filecheck/backend/riscv/convert_riscv_scf_for_to_frep.mlir
@@ -27,6 +27,12 @@ riscv_scf.for %index0 : !riscv.reg<a4> = %i0 to %i1 step %c1 {
     riscv_scf.yield %f4 : !riscv.freg<ft2>
 }
 
+riscv_scf.for %index1b : !riscv.reg<a4> = %i0 to %i1 step 1 : si12 {
+    %f4 = riscv_snitch.read from %readable : !riscv.freg<ft0>
+    %f5 = riscv.fadd.d %f4, %f4 : (!riscv.freg<ft0>, !riscv.freg<ft0>) -> !riscv.freg<ft1>
+    riscv_snitch.write %f5 to %writable : !riscv.freg<ft1>
+}
+
 // CHECK:         riscv_snitch.frep_outer %1 {
 // CHECK-NEXT:      %f4 = riscv_snitch.read from %readable : !riscv.freg<ft0>
 // CHECK-NEXT:      %f5 = riscv.fadd.d %f4, %f4 : (!riscv.freg<ft0>, !riscv.freg<ft0>) -> !riscv.freg<ft1>
@@ -37,6 +43,13 @@ riscv_scf.for %index0 : !riscv.reg<a4> = %i0 to %i1 step %c1 {
 // CHECK-NEXT:    %res_2 = riscv_snitch.frep_outer %res_1 iter_args(%f3 = %f0) -> (!riscv.freg<ft2>) {
 // CHECK-NEXT:      %{{.*}} = riscv.fadd.d %f3, %f3 : (!riscv.freg<ft2>, !riscv.freg<ft2>) -> !riscv.freg<ft2>
 // CHECK-NEXT:      riscv_snitch.frep_yield %{{.*}} : !riscv.freg<ft2>
+// CHECK-NEXT:    }
+// CHECK-NEXT:    %[[C1_1:\w+]] = riscv.sub %i1, %i0 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:    %[[C1_2:\w+]] = riscv.addi %[[C1_1]], -1 : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:    riscv_snitch.frep_outer %[[C1_2]] {
+// CHECK-NEXT:      %[[F4:\w+]] = riscv_snitch.read from %readable : !riscv.freg<ft0>
+// CHECK-NEXT:      %[[F5:\w+]] = riscv.fadd.d %[[F4]], %[[F4]] : (!riscv.freg<ft0>, !riscv.freg<ft0>) -> !riscv.freg<ft1>
+// CHECK-NEXT:      riscv_snitch.write %[[F5]] to %writable : !riscv.freg<ft1>
 // CHECK-NEXT:    }
 
 // Failure
@@ -60,6 +73,14 @@ riscv_scf.for %index3_c2 : !riscv.reg<a4> = %i0 to %i1 step %c2 {
     riscv_snitch.write %f5 to %writable : !riscv.freg<ft1>
 }
 // CHECK:    riscv_scf.for %index3_c2 : !riscv.reg<a4> = %i0 to %i1 step %c2 {
+
+riscv_scf.for %index_c2_imm : !riscv.reg<a4> = %i0 to %i1 step 2 : si12 {
+    %f4 = riscv_snitch.read from %readable : !riscv.freg<ft0>
+    %f5 = riscv.fadd.d %f4, %f4 : (!riscv.freg<ft0>, !riscv.freg<ft0>) -> !riscv.freg<ft1>
+    riscv_snitch.write %f5 to %writable : !riscv.freg<ft1>
+}
+
+// CHECK:    riscv_scf.for %index_c2_imm : !riscv.reg<a4> = %i0 to %i1 step 2 : si12 {
 
 
 // 3. All operations in the loop all operate on float registers

--- a/tests/filecheck/backend/rvscf_lowering_labels.mlir
+++ b/tests/filecheck/backend/rvscf_lowering_labels.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -p lower-riscv-scf-to-labels --split-input-file %s | filecheck %s
+// RUN: xdsl-opt -p lower-riscv-scf-to-labels --split-input-file --verify-diagnostics %s | filecheck %s
 
 // sum(range(arg0, arg1))
 
@@ -128,3 +128,15 @@ builtin.module {
 // CHECK-NEXT:      riscv_func.return %12 : !riscv.reg<a1>
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
+
+// -----
+
+%lb, %ub = "test.op"() : () -> (!riscv.reg<a0>, !riscv.reg<a1>)
+%acc = rv32.li 0 : !riscv.reg<a2>
+%res = riscv_scf.for %i : !riscv.reg<a3> = %lb to %ub step 2 : si12 iter_args(%v = %acc) -> (!riscv.reg<a2>) {
+    %next = riscv.add %i, %v : (!riscv.reg<a3>, !riscv.reg<a2>) -> !riscv.reg<a2>
+    riscv_scf.yield %next : !riscv.reg<a2>
+}
+"test.op"(%res) : (!riscv.reg<a2>) -> ()
+
+// CHECK: Error while applying pattern: Lowering riscv_scf loops with constant step not yet implemented.

--- a/tests/filecheck/dialects/riscv_scf/loop_range_folding.mlir
+++ b/tests/filecheck/dialects/riscv_scf/loop_range_folding.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -p riscv-scf-loop-range-folding %s | filecheck %s
+// RUN: xdsl-opt -p riscv-scf-loop-range-folding --split-input-file --verify-diagnostics %s | filecheck %s
 
 // CHECK:       builtin.module {
 
@@ -53,3 +53,15 @@ riscv_scf.for %2 : !riscv.reg = %lb to %ub step %step {
 // CHECK-NEXT:      "test.op"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
+
+// -----
+
+%lb, %ub, %step = "test.op"() : () -> (!riscv.reg, !riscv.reg, !riscv.reg)
+
+// Static step: folding mul scales the IntegerAttr step
+riscv_scf.for %k : !riscv.reg = %lb to %ub step 2 : si12 {
+    %f = rv32.li 3 : !riscv.reg
+    %p = riscv.mul %k, %f : (!riscv.reg, !riscv.reg) -> !riscv.reg
+    "test.op"(%p) : (!riscv.reg) -> ()
+}
+// CHECK:    Error while applying pattern: Folding riscv_scf loops with constant step not yet implemented.

--- a/tests/filecheck/dialects/riscv_scf/ops.mlir
+++ b/tests/filecheck/dialects/riscv_scf/ops.mlir
@@ -7,7 +7,13 @@
 riscv_scf.for %i : !riscv.reg = %lb to %ub step %step {
     riscv.addi %acc, 1 : (!riscv.reg<t0>) -> !riscv.reg<t0>
 }
+riscv_scf.for %i_static : !riscv.reg = %lb to %ub step 1 : si12 {
+    riscv.addi %acc, 1 : (!riscv.reg<t0>) -> !riscv.reg<t0>
+}
 riscv_scf.rof %j : !riscv.reg = %ub down to %lb step %step {
+    riscv.addi %acc, 1 : (!riscv.reg<t0>) -> !riscv.reg<t0>
+}
+riscv_scf.rof %j_static : !riscv.reg = %ub down to %lb step 2 : si12 {
     riscv.addi %acc, 1 : (!riscv.reg<t0>) -> !riscv.reg<t0>
 }
 %i_last, %ub_last, %step_last = riscv_scf.while (%i0 = %lb, %ub_arg0 = %ub, %step_arg0 = %step) : (!riscv.reg, !riscv.reg, !riscv.reg) -> (!riscv.reg, !riscv.reg, !riscv.reg) {
@@ -28,8 +34,14 @@ riscv_scf.rof %j : !riscv.reg = %ub down to %lb step %step {
 // CHECK-NEXT:   riscv_scf.for %i : !riscv.reg = %lb to %ub step %step {
 // CHECK-NEXT:     %0 = riscv.addi %acc, 1 : (!riscv.reg<t0>) -> !riscv.reg<t0>
 // CHECK-NEXT:   }
-// CHECK-NEXT:   riscv_scf.rof %j : !riscv.reg = %ub down to %lb step %step {
+// CHECK-NEXT:   riscv_scf.for %i_static : !riscv.reg = %lb to %ub step 1 : si12 {
 // CHECK-NEXT:     %1 = riscv.addi %acc, 1 : (!riscv.reg<t0>) -> !riscv.reg<t0>
+// CHECK-NEXT:   }
+// CHECK-NEXT:   riscv_scf.rof %j : !riscv.reg = %ub down to %lb step %step {
+// CHECK-NEXT:     %2 = riscv.addi %acc, 1 : (!riscv.reg<t0>) -> !riscv.reg<t0>
+// CHECK-NEXT:   }
+// CHECK-NEXT:   riscv_scf.rof %j_static : !riscv.reg = %ub down to %lb step 2 : si12 {
+// CHECK-NEXT:     %3 = riscv.addi %acc, 1 : (!riscv.reg<t0>) -> !riscv.reg<t0>
 // CHECK-NEXT:   }
 // CHECK-NEXT:     %i_last, %ub_last, %step_last = riscv_scf.while (%i0 = %lb, %ub_arg0 = %ub, %step_arg0 = %step) : (!riscv.reg, !riscv.reg, !riscv.reg) -> (!riscv.reg, !riscv.reg, !riscv.reg) {
 // CHECK-NEXT:             %cond = riscv.slt %i0, %ub_arg0 : (!riscv.reg, !riscv.reg) -> !riscv.reg

--- a/tests/filecheck/dialects/riscv_scf/verification.mlir
+++ b/tests/filecheck/dialects/riscv_scf/verification.mlir
@@ -1,6 +1,4 @@
-// RUN: xdsl-opt %s --parsing-diagnostics | filecheck %s
-
-
+// RUN: xdsl-opt --parsing-diagnostics --verify-diagnostics --split-input-file %s | filecheck %s
 
 %lb = "rv32.li"() {"immediate" = 0: i32} : () -> !riscv.reg
 %ub = "rv32.li"() {"immediate" = 100: i32} : () -> !riscv.reg
@@ -18,3 +16,24 @@
 }
 
 // CHECK: Mismatch between block argument count (2) and operand count (3)
+
+// -----
+
+%lb, %ub, %step = "test.op"() : () -> (!riscv.reg, !riscv.reg, !riscv.reg)
+
+"riscv_scf.for"(%lb, %ub, %step) <{step_attr = 1 : si12, operandSegmentSizes = array<i32: 1, 1, 1, 0>}> ({
+^bb0(%i: !riscv.reg):
+    yield
+}) : (!riscv.reg, !riscv.reg, !riscv.reg) -> ()
+
+// CHECK: Operation does not verify: Exactly one of step_attr (static) or step_val (dynamic) must be set, got step_attr=1 : si12, step_val=<OpResult[!riscv.reg] name_hint: step, index: 2, operation: test.op, uses: 1>
+
+// -----
+
+%lb, %ub = "test.op"() : () -> (!riscv.reg, !riscv.reg)
+
+riscv_scf.for %i_static : !riscv.reg = %lb to %ub step 1 : f32 {
+    yield
+}
+
+// CHECK: Expected IntegerAttr

--- a/tests/interpreters/test_riscv_scf_interpreter.py
+++ b/tests/interpreters/test_riscv_scf_interpreter.py
@@ -4,7 +4,7 @@ import pytest
 
 from xdsl.builder import Builder, ImplicitBuilder
 from xdsl.dialects import func, riscv, riscv_scf, rv32
-from xdsl.dialects.builtin import IndexType, ModuleOp
+from xdsl.dialects.builtin import IndexType, IntegerAttr, ModuleOp
 from xdsl.dialects.test import TestOp
 from xdsl.interpreter import Interpreter, OpImplResult
 from xdsl.interpreters.func import FuncFunctions
@@ -119,5 +119,22 @@ def test_for_dynamic():
     assert RiscvScfFunctions().run_for(
         interpreter, result, (1, 5, 3, 1)
     ) == OpImplResult((99,), None)
+    interpreter.run_ssacfg_region.assert_called_with(body, (4, 99), "for_loop")
+    assert interpreter.run_ssacfg_region.call_count == 2
+
+
+def test_for_static():
+    r = riscv.Registers.UNALLOCATED_INT
+    lb, ub, initial = TestOp(result_types=(r,) * 3).results
+    body = Region(Block(arg_types=(r, r)))
+
+    result = riscv_scf.ForOp(lb, ub, IntegerAttr(3, riscv.si12), (initial,), body)
+
+    interpreter = Mock(spec=Interpreter)
+    interpreter.run_ssacfg_region = Mock(return_value=(99,))
+
+    assert RiscvScfFunctions().run_for(interpreter, result, (1, 5, 1)) == OpImplResult(
+        (99,), None
+    )
     interpreter.run_ssacfg_region.assert_called_with(body, (4, 99), "for_loop")
     assert interpreter.run_ssacfg_region.call_count == 2

--- a/xdsl/backend/riscv/lowering/convert_riscv_scf_to_riscv_cf.py
+++ b/xdsl/backend/riscv/lowering/convert_riscv_scf_to_riscv_cf.py
@@ -1,5 +1,6 @@
 from xdsl.context import Context
 from xdsl.dialects import builtin, riscv, riscv_cf, riscv_scf
+from xdsl.dialects.builtin import IntegerAttr
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
     PatternRewriter,
@@ -8,6 +9,7 @@ from xdsl.pattern_rewriter import (
     op_type_rewrite_pattern,
 )
 from xdsl.rewriter import BlockInsertPoint, InsertPoint
+from xdsl.utils.exceptions import PassFailedException
 
 
 class LowerRiscvScfForPattern(RewritePattern):
@@ -104,10 +106,18 @@ class LowerRiscvScfForPattern(RewritePattern):
         yield_op = last_body_block.last_op
         assert isinstance(yield_op, riscv_scf.YieldOp)
 
+        match op.step:
+            case IntegerAttr():
+                raise PassFailedException(
+                    "Lowering riscv_scf loops with constant step not yet implemented."
+                )
+            case _:
+                add_op = riscv.AddOp(iv, op.step, rd=iv_reg)
+
         rewriter.replace_op(
             yield_op,
             (
-                add_op := riscv.AddOp(iv, op.step, rd=iv_reg),
+                add_op,
                 riscv_cf.BltOp(
                     add_op.rd,
                     op.ub,

--- a/xdsl/backend/riscv/riscv_scf_to_asm.py
+++ b/xdsl/backend/riscv/riscv_scf_to_asm.py
@@ -2,6 +2,7 @@ from collections.abc import Iterator, Sequence
 
 from xdsl.context import Context
 from xdsl.dialects import builtin, riscv, riscv_scf, rv32
+from xdsl.dialects.builtin import IntegerAttr
 from xdsl.ir import SSAValue
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
@@ -11,6 +12,7 @@ from xdsl.pattern_rewriter import (
     op_type_rewrite_pattern,
 )
 from xdsl.rewriter import InsertPoint
+from xdsl.utils.exceptions import PassFailedException
 
 
 def get_register_ops_from_values(
@@ -69,9 +71,17 @@ class LowerRiscvScfToLabels(RewritePattern):
         yield_op = body.last_op
         assert isinstance(yield_op, riscv_scf.YieldOp)
 
+        match op.step:
+            case IntegerAttr():
+                raise PassFailedException(
+                    "Lowering riscv_scf loops with constant step not yet implemented."
+                )
+            case _:
+                step_add_op = riscv.AddOp(get_loop_var, op.step, rd=loop_var_reg)
+
         rewriter.insert_op(
             [
-                riscv.AddOp(get_loop_var, op.step, rd=loop_var_reg),
+                step_add_op,
                 riscv.BltOp(get_loop_var, op.ub, scf_body),
                 riscv.LabelOp(scf_body_end),
             ],

--- a/xdsl/dialects/riscv_scf.py
+++ b/xdsl/dialects/riscv_scf.py
@@ -13,6 +13,7 @@ from typing_extensions import Self
 from xdsl.backend.register_allocatable import RegisterAllocatableOperation
 from xdsl.backend.register_allocator import BlockAllocator
 from xdsl.backend.register_type import RegisterType
+from xdsl.dialects.builtin import IntegerAttr, IntegerType
 from xdsl.dialects.riscv import IntRegisterType, RISCVRegisterType
 from xdsl.dialects.utils import (
     AbstractYieldOperation,
@@ -21,6 +22,7 @@ from xdsl.dialects.utils import (
 )
 from xdsl.ir import Attribute, Dialect
 from xdsl.irdl import (
+    AttrSizedOperandSegments,
     Block,
     IRDLOperation,
     Operation,
@@ -29,6 +31,8 @@ from xdsl.irdl import (
     irdl_op_definition,
     lazy_traits_def,
     operand_def,
+    opt_operand_def,
+    opt_prop_def,
     region_def,
     traits_def,
     var_operand_def,
@@ -57,7 +61,8 @@ class YieldOp(AbstractYieldOperation[RISCVRegisterType]):
 class ForRofOperation(RegisterAllocatableOperation, IRDLOperation, ABC):
     lb = operand_def(IntRegisterType)
     ub = operand_def(IntRegisterType)
-    step = operand_def(IntRegisterType)
+    step_val = opt_operand_def(IntRegisterType)
+    step_attr = opt_prop_def(IntegerAttr[IntegerType])
 
     iter_args = var_operand_def(RISCVRegisterType)
 
@@ -66,25 +71,50 @@ class ForRofOperation(RegisterAllocatableOperation, IRDLOperation, ABC):
     body = region_def("single_block")
 
     traits = traits_def(SingleBlockImplicitTerminator(YieldOp))
+    irdl_options = (AttrSizedOperandSegments(as_property=True),)
+
+    @property
+    def step(self) -> IntegerAttr[IntegerType] | SSAValue:
+        """Static step (typed integer) or dynamic register SSA value."""
+        if self.step_attr is not None:
+            return self.step_attr
+        else:
+            assert self.step_val is not None, (
+                "Exactly one of step_attr or step_val must be set"
+            )
+            return self.step_val
 
     def __init__(
         self,
         lb: SSAValue | Operation,
         ub: SSAValue | Operation,
-        step: SSAValue | Operation,
+        step: SSAValue | Operation | IntegerAttr,
         iter_args: Sequence[SSAValue | Operation],
         body: Region | Sequence[Operation] | Sequence[Block] | Block,
     ):
         if isinstance(body, Block):
             body = [body]
 
+        if isinstance(step, IntegerAttr):
+            step_attr = step
+            step_val = None
+        else:
+            step_attr = None
+            step_val = step
+
         super().__init__(
-            operands=[lb, ub, step, iter_args],
+            operands=[lb, ub, step_val, iter_args],
+            properties={"step_attr": step_attr},
             result_types=[[SSAValue.get(a).type for a in iter_args]],
             regions=[body],
         )
 
     def verify_(self):
+        if (self.step_attr is None) == (self.step_val is None):
+            raise VerifyException(
+                "Exactly one of step_attr (static) or step_val (dynamic) must be set, "
+                f"got step_attr={self.step_attr}, step_val={self.step_val}"
+            )
         if (len(self.iter_args) + 1) != len(self.body.block.args):
             raise VerifyException(
                 f"Wrong number of block arguments, expected {len(self.iter_args) + 1}, got "
@@ -152,9 +182,10 @@ class ForRofOperation(RegisterAllocatableOperation, IRDLOperation, ABC):
         # Induction variable
         allocator.allocate_value(block_args[0])
 
-        # Step and ub are used throughout loop
+        # ub is used throughout the loop; step_val only when dynamic
         allocator.allocate_value(self.ub)
-        allocator.allocate_value(self.step)
+        if self.step_val is not None:
+            allocator.allocate_value(self.step_val)
 
         # Reserve the loop carried variables for allocation within the body
         regs = self.iter_args.types
@@ -189,7 +220,9 @@ class ForOp(ForRofOperation):
 
     @classmethod
     def parse(cls, parser: Parser) -> Self:
-        lb, ub, step, iter_arg_operands, body = parse_for_op_like(parser)
+        lb, ub, step, iter_arg_operands, body = parse_for_op_like(
+            parser, allow_static_step=True
+        )
         _, *iter_args = body.block.args
 
         for_op = cls(lb, ub, step, iter_arg_operands, body)
@@ -233,7 +266,7 @@ class RofOp(ForRofOperation):
     @classmethod
     def parse(cls, parser: Parser) -> Self:
         ub, lb, step, iter_arg_operands, body = parse_for_op_like(
-            parser, bound_words=["down", "to"]
+            parser, bound_words=["down", "to"], allow_static_step=True
         )
         _, *iter_args = body.block.args
 

--- a/xdsl/dialects/utils/format.py
+++ b/xdsl/dialects/utils/format.py
@@ -5,6 +5,7 @@ from xdsl.dialects.builtin import (
     ArrayAttr,
     DictionaryAttr,
     FunctionType,
+    IntegerAttr,
     LocationAttr,
     StringAttr,
 )
@@ -20,6 +21,7 @@ from xdsl.ir import (
 from xdsl.irdl import IRDLOperation, var_operand_def
 from xdsl.parser import Parser, UnresolvedOperand
 from xdsl.printer import Printer
+from xdsl.utils.hints import isa
 
 
 class AbstractYieldOperation(IRDLOperation, Generic[AttributeInvT]):
@@ -40,7 +42,7 @@ def print_for_op_like(
     printer: Printer,
     lower_bound: SSAValue,
     upper_bound: SSAValue,
-    step: SSAValue,
+    step: IntegerAttr | SSAValue,
     iter_args: Sequence[SSAValue],
     body: Region,
     default_indvar_type: type[TypeAttribute] | None = None,
@@ -57,6 +59,9 @@ def print_for_op_like(
     hence moving the induction variable type printing to the end of the for expression.
     The induction variable type printing is ommited when it matches the expected default
     type (`default_indvar_type`).
+
+    The `step` may be a dynamic SSAValue or a static `IntegerAttr`. When static, the
+    typed integer literal is printed (value and type), not an SSA value reference.
     """
 
     block = body.block
@@ -82,7 +87,10 @@ def print_for_op_like(
 
     printer.print_ssa_value(upper_bound)
     printer.print_string(" step ")
-    printer.print_ssa_value(step)
+    if isinstance(step, IntegerAttr):
+        step.print_builtin(printer)
+    else:
+        printer.print_ssa_value(step)
     printer.print_string(" ")
     if block_iter_args:
         printer.print_string("iter_args(")
@@ -107,11 +115,33 @@ def print_for_op_like(
     )
 
 
+@overload
+def parse_for_op_like(
+    parser: Parser,
+    default_indvar_type: TypeAttribute | None = ...,
+    bound_words: Sequence[str] = ...,
+    *,
+    allow_static_step: Literal[False] = ...,
+) -> tuple[SSAValue, SSAValue, SSAValue, Sequence[SSAValue], Region]: ...
+
+
+@overload
+def parse_for_op_like(
+    parser: Parser,
+    default_indvar_type: TypeAttribute | None = ...,
+    bound_words: Sequence[str] = ...,
+    *,
+    allow_static_step: Literal[True],
+) -> tuple[SSAValue, SSAValue, IntegerAttr | SSAValue, Sequence[SSAValue], Region]: ...
+
+
 def parse_for_op_like(
     parser: Parser,
     default_indvar_type: TypeAttribute | None = None,
     bound_words: Sequence[str] = ["to"],
-) -> tuple[SSAValue, SSAValue, SSAValue, Sequence[SSAValue], Region]:
+    *,
+    allow_static_step: bool = False,
+) -> tuple[SSAValue, SSAValue, IntegerAttr | SSAValue, Sequence[SSAValue], Region]:
     """
     Returns the loop bounds, step, iteration arguments, and body.
 
@@ -121,6 +151,10 @@ def parse_for_op_like(
     all loop control variable types (induction, bounds and step) have the same type,
     hence the induction variable type is potentially expected at the end of the for
     expression.
+
+    When `allow_static_step=True`, the step may be either a static typed integer literal
+    or a dynamic SSA value. The default (`False`) only allows dynamic SSA values and
+    returns `SSAValue` for the step.
     """
 
     unresolved_indvar = parser.parse_argument(expect_type=False)
@@ -139,7 +173,19 @@ def parse_for_op_like(
 
     upper_bound = parser.parse_operand()
     parser.parse_characters("step")
-    step = parser.parse_operand()
+
+    step: IntegerAttr | SSAValue
+    if allow_static_step:
+        if (step_ssa := parser.parse_optional_operand()) is not None:
+            step = step_ssa
+        else:
+            pos = parser.pos
+            step_attr = parser.parse_attribute()
+            if not isa(step_attr, IntegerAttr):
+                parser.raise_error("Expected IntegerAttr", pos)
+            step = step_attr
+    else:
+        step = parser.parse_operand()
 
     # parse iteration arguments
     pos = parser.pos

--- a/xdsl/interpreters/riscv_scf.py
+++ b/xdsl/interpreters/riscv_scf.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from xdsl.dialects import riscv_scf
+from xdsl.dialects.builtin import IntAttr, IntegerAttr
 from xdsl.interpreter import (
     Interpreter,
     InterpreterFunctions,
@@ -26,7 +27,11 @@ class RiscvScfFunctions(InterpreterFunctions):
         args: tuple[Any, ...],
     ):
         args = RiscvFunctions.get_reg_values(interpreter, op.operands, args)
-        lb, ub, step, *loop_args = args
+        match op.step:
+            case IntegerAttr(value=IntAttr(data=step)):
+                lb, ub, *loop_args = args
+            case _:
+                lb, ub, step, *loop_args = args
         loop_args = tuple(loop_args)
 
         for i in range(lb, ub, step):

--- a/xdsl/transforms/convert_riscv_scf_for_to_frep.py
+++ b/xdsl/transforms/convert_riscv_scf_for_to_frep.py
@@ -2,6 +2,8 @@ from itertools import chain
 
 from xdsl.context import Context
 from xdsl.dialects import builtin, riscv, riscv_scf, riscv_snitch, rv32, snitch
+from xdsl.dialects.builtin import IntAttr, IntegerAttr
+from xdsl.ir import SSAValue
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
     GreedyRewritePatternApplier,
@@ -21,13 +23,19 @@ class ScfForLowering(RewritePattern):
             # 1. Induction variable is used
             return
 
-        if not (
-            isinstance(step_op := op.step.owner, rv32.LiOp)
-            and isinstance(step_op.immediate, builtin.IntegerAttr)
-            and step_op.immediate.value.data == 1
-        ):
-            # 2. Step is 1
-            return
+        match op.step:
+            case IntegerAttr(value=IntAttr(1)):
+                pass
+            case step_ssa if (
+                isinstance(step_ssa, SSAValue)
+                and isinstance(step_op := step_ssa.owner, rv32.LiOp)
+                and isinstance(step_op.immediate, builtin.IntegerAttr)
+                and step_op.immediate.value.data == 1
+            ):
+                pass
+            case _:
+                # 2. Step is 1
+                return
 
         if not all(
             isinstance(

--- a/xdsl/transforms/riscv_scf_loop_range_folding.py
+++ b/xdsl/transforms/riscv_scf_loop_range_folding.py
@@ -8,6 +8,7 @@ from xdsl.pattern_rewriter import (
     op_type_rewrite_pattern,
 )
 from xdsl.transforms.canonicalization_patterns.riscv import get_constant_value
+from xdsl.utils.exceptions import PassFailedException
 
 
 class HoistIndexTimesConstantOp(RewritePattern):
@@ -48,15 +49,22 @@ class HoistIndexTimesConstantOp(RewritePattern):
                     )
                 case riscv.MulOp():
                     # All the uses are multiplications by a constant, we can fold
+                    step_attr = op.step_attr
+                    if step_attr is not None:
+                        raise PassFailedException(
+                            "Folding riscv_scf loops with constant step not yet "
+                            "implemented."
+                        )
+
                     rewriter.insert_op(
                         [
                             factor := rv32.LiOp(constant),
                             new_lb := riscv.MulOp(op.lb, factor),
                             new_ub := riscv.MulOp(op.ub, factor),
-                            new_step := riscv.MulOp(op.step, factor),
                         ]
                     )
-
+                    assert op.step_val is not None
+                    rewriter.insert_op(new_step := riscv.MulOp(op.step_val, factor))
                     op.operands[2] = new_step.rd
 
             op.operands[0] = new_lb.rd


### PR DESCRIPTION
Smallest reviewable bit of #5952 that I could pull out:

 * adds a constant step property to riscv_scf.for and rof ops,
 * checks during lowering that we raise an exception if it is actually constant,
 * and adds tests for all the bits of functionality to come.