### PR TITLE
dialects: (acc) OpenACC data entry clause operations

### DIFF
--- a/tests/dialects/test_acc.py
+++ b/tests/dialects/test_acc.py
@@ -9,14 +9,16 @@ from xdsl.dialects.arith import ConstantOp
 from xdsl.dialects.builtin import (
     ArrayAttr,
     DenseArrayBase,
+    IntegerAttr,
     MemRefType,
+    StringAttr,
     UnitAttr,
     f32,
     i1,
     i32,
 )
 from xdsl.dialects.test import TestOp
-from xdsl.ir import Block, Region
+from xdsl.ir import Block, Region, SSAValue
 from xdsl.printer import Printer
 
 
@@ -370,3 +372,44 @@ def test_data_clause_modifier_attr_constructor():
     assert multi.data == frozenset(
         {acc.DataClauseModifier.READONLY, acc.DataClauseModifier.ZERO}
     )
+
+
+def _memref_var() -> SSAValue:
+    """Helper: produce an SSA value of `memref<10xf32>` for use as a `var` operand."""
+    return TestOp(result_types=[MemRefType(f32, [10])]).res[0]
+
+
+def test_copyin_minimal_defaulted_props_absent_from_dict():
+    """Defaulted props (`dataClause` / `structured` / `implicit` / `modifiers`)
+    must be *absent* from `op.properties` when not explicitly set, even though
+    the accessor reads back the default value. This is the load-bearing
+    invariant that drives attr-dict elision on print — filecheck observes the
+    elided text but cannot distinguish "absent from dict" from "present and
+    matching default", so the dict-state assertion lives here."""
+    op = acc.CopyinOp(var=_memref_var())
+    op.verify()
+
+    assert "dataClause" not in op.properties
+    assert "structured" not in op.properties
+    assert "implicit" not in op.properties
+    assert "modifiers" not in op.properties
+
+
+def test_copyin_builder_shortcuts():
+    """The Python `__init__` accepts bool / str / `DataClause` shortcuts and
+    converts them to the right attribute kinds. This is a builder-only
+    code path: the parser never sees these Python types, so filecheck
+    cannot exercise the conversions."""
+    op = acc.CopyinOp(
+        var=_memref_var(),
+        data_clause=acc.DataClause.ACC_COPYIN_READONLY,
+        structured=False,
+        implicit=True,
+        var_name="foo",
+    )
+    op.verify()
+
+    assert op.data_clause == acc.DataClauseAttr(acc.DataClause.ACC_COPYIN_READONLY)
+    assert op.structured == IntegerAttr.from_bool(False)
+    assert op.implicit == IntegerAttr.from_bool(True)
+    assert op.var_name == StringAttr("foo")

--- a/tests/dialects/test_acc.py
+++ b/tests/dialects/test_acc.py
@@ -18,8 +18,9 @@ from xdsl.dialects.builtin import (
     i32,
 )
 from xdsl.dialects.test import TestOp
-from xdsl.ir import Block, Region, SSAValue
+from xdsl.ir import Block, Region
 from xdsl.printer import Printer
+from xdsl.utils.test_value import create_ssa_value
 
 
 def _empty_parallel() -> acc.ParallelOp:
@@ -374,11 +375,6 @@ def test_data_clause_modifier_attr_constructor():
     )
 
 
-def _memref_var() -> SSAValue:
-    """Helper: produce an SSA value of `memref<10xf32>` for use as a `var` operand."""
-    return TestOp(result_types=[MemRefType(f32, [10])]).res[0]
-
-
 def test_copyin_minimal_defaulted_props_absent_from_dict():
     """Defaulted props (`dataClause` / `structured` / `implicit` / `modifiers`)
     must be *absent* from `op.properties` when not explicitly set, even though
@@ -386,7 +382,7 @@ def test_copyin_minimal_defaulted_props_absent_from_dict():
     invariant that drives attr-dict elision on print — filecheck observes the
     elided text but cannot distinguish "absent from dict" from "present and
     matching default", so the dict-state assertion lives here."""
-    op = acc.CopyinOp(var=_memref_var())
+    op = acc.CopyinOp(var=create_ssa_value(MemRefType(f32, [10])))
     op.verify()
 
     assert "dataClause" not in op.properties
@@ -401,7 +397,7 @@ def test_copyin_builder_shortcuts():
     code path: the parser never sees these Python types, so filecheck
     cannot exercise the conversions."""
     op = acc.CopyinOp(
-        var=_memref_var(),
+        var=create_ssa_value(MemRefType(f32, [10])),
         data_clause=acc.DataClause.ACC_COPYIN_READONLY,
         structured=False,
         implicit=True,

--- a/tests/filecheck/dialects/acc/ops.mlir
+++ b/tests/filecheck/dialects/acc/ops.mlir
@@ -669,8 +669,8 @@ builtin.module {
   // CHECK-NEXT:    %{{.*}} = acc.get_stride %{{.*}} : (!acc.data_bounds_ty) -> index
   // CHECK-NEXT:    %{{.*}} = acc.get_extent %{{.*}} : (!acc.data_bounds_ty) -> index
 
-  // Entry data-clause ops (PR 6b lands the `_DataEntryOp` shape and three
-  // leaves: copyin / create / present). All three share the same operand
+  // Entry data-clause ops sharing the abstract `_DataEntryOperation` mixin:
+  // copyin / create / present (more leaves follow). All three share the same operand
   // and property surface; cover it thoroughly via `acc.copyin` and
   // spot-check the per-op `dataClause` default elision via `acc.create` /
   // `acc.present`.

--- a/tests/filecheck/dialects/acc/ops.mlir
+++ b/tests/filecheck/dialects/acc/ops.mlir
@@ -668,4 +668,172 @@ builtin.module {
   // CHECK-NEXT:    %{{.*}} = acc.get_upperbound %{{.*}} : (!acc.data_bounds_ty) -> index
   // CHECK-NEXT:    %{{.*}} = acc.get_stride %{{.*}} : (!acc.data_bounds_ty) -> index
   // CHECK-NEXT:    %{{.*}} = acc.get_extent %{{.*}} : (!acc.data_bounds_ty) -> index
+
+  // Entry data-clause ops (PR 6b lands the `_DataEntryOp` shape and three
+  // leaves: copyin / create / present). All three share the same operand
+  // and property surface; cover it thoroughly via `acc.copyin` and
+  // spot-check the per-op `dataClause` default elision via `acc.create` /
+  // `acc.present`.
+  func.func @copyin_minimal(%a : memref<10xf32>) {
+    %r = acc.copyin varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    func.return
+  }
+  // CHECK-LABEL: func.func @copyin_minimal(
+  // CHECK:         %{{.*}} = acc.copyin varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32>
+
+  func.func @copyin_var_keyword(%a : memref<10xf32>) {
+    // The `var` keyword is also accepted on parse (the printer always emits
+    // `varPtr`). Exercises the alternative branch in `Var.parse`.
+    %r = acc.copyin var(%a : memref<10xf32>) -> memref<10xf32>
+    func.return
+  }
+  // CHECK-LABEL: func.func @copyin_var_keyword(
+  // CHECK:         %{{.*}} = acc.copyin varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32>
+
+  func.func @copyin_with_var_type(%a : memref<10xf32>) {
+    // varType differs from the var's element type, so `Var.print` emits the
+    // optional `varType(...)` slot.
+    %r = acc.copyin varPtr(%a : memref<10xf32>) varType(tensor<10xf32>) -> memref<10xf32>
+    func.return
+  }
+  // CHECK-LABEL: func.func @copyin_with_var_type(
+  // CHECK:         %{{.*}} = acc.copyin varPtr(%{{.*}} : memref<10xf32>) varType(tensor<10xf32>) -> memref<10xf32>
+
+  func.func @copyin_with_var_ptr_ptr(%a : memref<10xf32>, %p : memref<memref<10xf32>>) {
+    %r = acc.copyin varPtr(%a : memref<10xf32>) varPtrPtr(%p : memref<memref<10xf32>>) -> memref<10xf32>
+    func.return
+  }
+  // CHECK-LABEL: func.func @copyin_with_var_ptr_ptr(
+  // CHECK:         %{{.*}} = acc.copyin varPtr(%{{.*}} : memref<10xf32>) varPtrPtr(%{{.*}} : memref<memref<10xf32>>) -> memref<10xf32>
+
+  func.func @copyin_with_bounds(%a : memref<10xf32>, %c0 : index, %c9 : index) {
+    %b = acc.bounds lowerbound(%c0 : index) upperbound(%c9 : index)
+    %r = acc.copyin varPtr(%a : memref<10xf32>) bounds(%b) -> memref<10xf32>
+    func.return
+  }
+  // CHECK-LABEL: func.func @copyin_with_bounds(
+  // CHECK:         %{{.*}} = acc.bounds lowerbound(%{{.*}} : index) upperbound(%{{.*}} : index)
+  // CHECK-NEXT:    %{{.*}} = acc.copyin varPtr(%{{.*}} : memref<10xf32>) bounds(%{{.*}}) -> memref<10xf32>
+
+  func.func @copyin_async_bare(%a : memref<10xf32>) {
+    %r = acc.copyin varPtr(%a : memref<10xf32>) async -> memref<10xf32>
+    func.return
+  }
+  // CHECK-LABEL: func.func @copyin_async_bare(
+  // CHECK:         %{{.*}} = acc.copyin varPtr(%{{.*}} : memref<10xf32>) async -> memref<10xf32>
+
+  func.func @copyin_async_kw_dt(%a : memref<10xf32>) {
+    %r = acc.copyin varPtr(%a : memref<10xf32>) async([#acc.device_type<nvidia>]) -> memref<10xf32>
+    func.return
+  }
+  // CHECK-LABEL: func.func @copyin_async_kw_dt(
+  // CHECK:         %{{.*}} = acc.copyin varPtr(%{{.*}} : memref<10xf32>) async([#acc.device_type<nvidia>]) -> memref<10xf32>
+
+  func.func @copyin_async_operand(%a : memref<10xf32>, %async : i32) {
+    %r = acc.copyin varPtr(%a : memref<10xf32>) async(%async : i32) -> memref<10xf32>
+    func.return
+  }
+  // CHECK-LABEL: func.func @copyin_async_operand(
+  // CHECK:         %{{.*}} = acc.copyin varPtr(%{{.*}} : memref<10xf32>) async(%{{.*}} : i32) -> memref<10xf32>
+
+  func.func @copyin_async_operand_dt(%a : memref<10xf32>, %async : i32) {
+    %r = acc.copyin varPtr(%a : memref<10xf32>) async(%async : i32 [#acc.device_type<nvidia>]) -> memref<10xf32>
+    func.return
+  }
+  // CHECK-LABEL: func.func @copyin_async_operand_dt(
+  // CHECK:         %{{.*}} = acc.copyin varPtr(%{{.*}} : memref<10xf32>) async(%{{.*}} : i32 [#acc.device_type<nvidia>]) -> memref<10xf32>
+
+  func.func @copyin_full_attr_dict(%a : memref<10xf32>) {
+    // Every defaulted prop overridden in attr-dict, to verify each round-trips
+    // (rather than collapsing to the per-op default and silently disappearing).
+    %r = acc.copyin varPtr(%a : memref<10xf32>) -> memref<10xf32> {dataClause = #acc<data_clause acc_copyin_readonly>, implicit = true, modifiers = #acc<data_clause_modifier readonly>, name = "myvar", structured = false}
+    func.return
+  }
+  // CHECK-LABEL: func.func @copyin_full_attr_dict(
+  // CHECK:         %{{.*}} = acc.copyin varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32> {dataClause = #acc<data_clause acc_copyin_readonly>, implicit = true, modifiers = #acc<data_clause_modifier readonly>, name = "myvar", structured = false}
+
+  // Generic-form input retained per dialect convention — insurance that
+  // operandSegmentSizes round-trips through the generic surface even after
+  // the pretty form lands.
+  func.func @copyin_generic_roundtrip(%a : memref<10xf32>) {
+    %r = "acc.copyin"(%a) <{operandSegmentSizes = array<i32: 1, 0, 0, 0>, varType = f32}> : (memref<10xf32>) -> memref<10xf32>
+    func.return
+  }
+  // CHECK-LABEL: func.func @copyin_generic_roundtrip(
+  // CHECK:         %{{.*}} = acc.copyin varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32>
+
+  func.func @create_minimal(%a : memref<10xf32>) {
+    // No dataClause in attr-dict: matches the per-op default (acc_create),
+    // so attr-dict elision suppresses it on print.
+    %r = acc.create varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    func.return
+  }
+  // CHECK-LABEL: func.func @create_minimal(
+  // CHECK:         %{{.*}} = acc.create varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32>
+
+  func.func @create_with_clause_override(%a : memref<10xf32>) {
+    // `acc.create` decomposed from `copyout` keeps the original clause name
+    // in its `dataClause` attr — non-default value, so attr-dict prints it.
+    %r = acc.create varPtr(%a : memref<10xf32>) -> memref<10xf32> {dataClause = #acc<data_clause acc_copyout>}
+    func.return
+  }
+  // CHECK-LABEL: func.func @create_with_clause_override(
+  // CHECK:         %{{.*}} = acc.create varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32> {dataClause = #acc<data_clause acc_copyout>}
+
+  func.func @present_minimal(%a : memref<10xf32>) {
+    %r = acc.present varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    func.return
+  }
+  // CHECK-LABEL: func.func @present_minimal(
+  // CHECK:         %{{.*}} = acc.present varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32>
+
+  // Non-memref var: `_default_var_type` falls back to the var's own type
+  // (the upstream `printVarPtrType` heuristic for non-pointer-like types).
+  // Both parser-side defaulting and printer-side elision exercised here.
+  // mlir-opt rejects this case (its operand constraint requires a pointer-
+  // like or mappable type), so it lives only in the xDSL-only roundtrip.
+  func.func @copyin_non_memref_var(%a : i32) {
+    %r = acc.copyin varPtr(%a : i32) -> i32
+    func.return
+  }
+  // CHECK-LABEL: func.func @copyin_non_memref_var(
+  // CHECK:         %{{.*}} = acc.copyin varPtr(%{{.*}} : i32) -> i32
+
+  // Result type differs from the var's type: the assembly format's
+  // `type($acc_var)` slot is honored independently of `var.type`.
+  func.func @copyin_explicit_acc_var_type(%a : memref<10xf32>) {
+    %r = acc.copyin varPtr(%a : memref<10xf32>) -> memref<20xf32>
+    func.return
+  }
+  // CHECK-LABEL: func.func @copyin_explicit_acc_var_type(
+  // CHECK:         %{{.*}} = acc.copyin varPtr(%{{.*}} : memref<10xf32>) -> memref<20xf32>
+
+  // Per-op `dataClause` default wiring. Generic-form input carries the
+  // default value explicitly; the pretty-form output must elide it. If a
+  // leaf class were wired to the wrong default, the round-trip would
+  // either keep the attr (when input differs from the leaf's actual
+  // default) or drop the wrong one — either way visible in the CHECK.
+  func.func @copyin_dataclause_default_elided(%a : memref<10xf32>) {
+    %r = "acc.copyin"(%a) <{dataClause = #acc<data_clause acc_copyin>, operandSegmentSizes = array<i32: 1, 0, 0, 0>, varType = f32}> : (memref<10xf32>) -> memref<10xf32>
+    func.return
+  }
+  // CHECK-LABEL: func.func @copyin_dataclause_default_elided(
+  // CHECK:         %{{.*}} = acc.copyin varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32>
+  // CHECK-NOT:     dataClause
+
+  func.func @create_dataclause_default_elided(%a : memref<10xf32>) {
+    %r = "acc.create"(%a) <{dataClause = #acc<data_clause acc_create>, operandSegmentSizes = array<i32: 1, 0, 0, 0>, varType = f32}> : (memref<10xf32>) -> memref<10xf32>
+    func.return
+  }
+  // CHECK-LABEL: func.func @create_dataclause_default_elided(
+  // CHECK:         %{{.*}} = acc.create varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32>
+  // CHECK-NOT:     dataClause
+
+  func.func @present_dataclause_default_elided(%a : memref<10xf32>) {
+    %r = "acc.present"(%a) <{dataClause = #acc<data_clause acc_present>, operandSegmentSizes = array<i32: 1, 0, 0, 0>, varType = f32}> : (memref<10xf32>) -> memref<10xf32>
+    func.return
+  }
+  // CHECK-LABEL: func.func @present_dataclause_default_elided(
+  // CHECK:         %{{.*}} = acc.present varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32>
+  // CHECK-NOT:     dataClause
 }

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/ops.mlir
@@ -455,4 +455,86 @@ builtin.module {
   // CHECK-NEXT:    %{{.*}} = acc.get_upperbound %{{.*}} : (!acc.data_bounds_ty) -> index
   // CHECK-NEXT:    %{{.*}} = acc.get_stride %{{.*}} : (!acc.data_bounds_ty) -> index
   // CHECK-NEXT:    %{{.*}} = acc.get_extent %{{.*}} : (!acc.data_bounds_ty) -> index
+
+  // Entry data-clause ops (PR 6b: copyin / create / present). Each MLIR
+  // interop entry round-trips through both the pretty and generic surfaces;
+  // covers `acc.copyin` exhaustively and the other two minimally.
+  func.func @copyin_minimal(%a : memref<10xf32>) {
+    %r = acc.copyin varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    func.return
+  }
+  // CHECK:       func.func @copyin_minimal(
+  // CHECK:         %{{.*}} = acc.copyin varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32>
+
+  func.func @copyin_with_var_type(%a : memref<10xf32>) {
+    %r = acc.copyin varPtr(%a : memref<10xf32>) varType(tensor<10xf32>) -> memref<10xf32>
+    func.return
+  }
+  // CHECK:       func.func @copyin_with_var_type(
+  // CHECK:         %{{.*}} = acc.copyin varPtr(%{{.*}} : memref<10xf32>) varType(tensor<10xf32>) -> memref<10xf32>
+
+  func.func @copyin_with_var_ptr_ptr(%a : memref<10xf32>, %p : memref<memref<10xf32>>) {
+    %r = acc.copyin varPtr(%a : memref<10xf32>) varPtrPtr(%p : memref<memref<10xf32>>) -> memref<10xf32>
+    func.return
+  }
+  // CHECK:       func.func @copyin_with_var_ptr_ptr(
+  // CHECK:         %{{.*}} = acc.copyin varPtr(%{{.*}} : memref<10xf32>) varPtrPtr(%{{.*}} : memref<memref<10xf32>>) -> memref<10xf32>
+
+  func.func @copyin_with_bounds(%a : memref<10xf32>, %c0 : index, %c9 : index) {
+    %b = acc.bounds lowerbound(%c0 : index) upperbound(%c9 : index)
+    %r = acc.copyin varPtr(%a : memref<10xf32>) bounds(%b) -> memref<10xf32>
+    func.return
+  }
+  // CHECK:       func.func @copyin_with_bounds(
+  // CHECK:         %{{.*}} = acc.bounds lowerbound(%{{.*}} : index) upperbound(%{{.*}} : index)
+  // CHECK-NEXT:    %{{.*}} = acc.copyin varPtr(%{{.*}} : memref<10xf32>) bounds(%{{.*}}) -> memref<10xf32>
+
+  func.func @copyin_async_bare(%a : memref<10xf32>) {
+    %r = acc.copyin varPtr(%a : memref<10xf32>) async -> memref<10xf32>
+    func.return
+  }
+  // CHECK:       func.func @copyin_async_bare(
+  // CHECK:         %{{.*}} = acc.copyin varPtr(%{{.*}} : memref<10xf32>) async -> memref<10xf32>
+
+  func.func @copyin_async_operand(%a : memref<10xf32>, %async : i32) {
+    %r = acc.copyin varPtr(%a : memref<10xf32>) async(%async : i32) -> memref<10xf32>
+    func.return
+  }
+  // CHECK:       func.func @copyin_async_operand(
+  // CHECK:         %{{.*}} = acc.copyin varPtr(%{{.*}} : memref<10xf32>) async(%{{.*}} : i32) -> memref<10xf32>
+
+  func.func @copyin_async_operand_dt(%a : memref<10xf32>, %async : i32) {
+    %r = acc.copyin varPtr(%a : memref<10xf32>) async(%async : i32 [#acc.device_type<nvidia>]) -> memref<10xf32>
+    func.return
+  }
+  // CHECK:       func.func @copyin_async_operand_dt(
+  // CHECK:         %{{.*}} = acc.copyin varPtr(%{{.*}} : memref<10xf32>) async(%{{.*}} : i32 [#acc.device_type<nvidia>]) -> memref<10xf32>
+
+  func.func @copyin_clause_override(%a : memref<10xf32>) {
+    %r = acc.copyin varPtr(%a : memref<10xf32>) -> memref<10xf32> {dataClause = #acc<data_clause acc_copyin_readonly>, modifiers = #acc<data_clause_modifier readonly>, name = "myvar"}
+    func.return
+  }
+  // CHECK:       func.func @copyin_clause_override(
+  // CHECK:         %{{.*}} = acc.copyin varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32> {dataClause = #acc<data_clause acc_copyin_readonly>, modifiers = #acc<data_clause_modifier readonly>, name = "myvar"}
+
+  func.func @create_minimal(%a : memref<10xf32>) {
+    %r = acc.create varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    func.return
+  }
+  // CHECK:       func.func @create_minimal(
+  // CHECK:         %{{.*}} = acc.create varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32>
+
+  func.func @create_with_copyout_clause(%a : memref<10xf32>) {
+    %r = acc.create varPtr(%a : memref<10xf32>) -> memref<10xf32> {dataClause = #acc<data_clause acc_copyout>}
+    func.return
+  }
+  // CHECK:       func.func @create_with_copyout_clause(
+  // CHECK:         %{{.*}} = acc.create varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32> {dataClause = #acc<data_clause acc_copyout>}
+
+  func.func @present_minimal(%a : memref<10xf32>) {
+    %r = acc.present varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    func.return
+  }
+  // CHECK:       func.func @present_minimal(
+  // CHECK:         %{{.*}} = acc.present varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32>
 }

--- a/xdsl/dialects/acc.py
+++ b/xdsl/dialects/acc.py
@@ -11,6 +11,7 @@ See external [documentation](https://mlir.llvm.org/docs/Dialects/OpenACCDialect/
 
 from abc import ABC
 from collections.abc import Sequence
+from typing import cast
 
 from xdsl.dialects.builtin import (
     I1,
@@ -20,6 +21,9 @@ from xdsl.dialects.builtin import (
     IndexType,
     IntegerAttr,
     IntegerType,
+    MemRefType,
+    StringAttr,
+    SymbolRefAttr,
     UnitAttr,
     i32,
 )
@@ -46,6 +50,7 @@ from xdsl.irdl import (
     operand_def,
     opt_operand_def,
     opt_prop_def,
+    prop_def,
     region_def,
     result_def,
     var_operand_def,
@@ -53,6 +58,7 @@ from xdsl.irdl import (
 from xdsl.irdl.declarative_assembly_format import (
     AttributeVariable,
     CustomDirective,
+    OperandVariable,
     ParsingState,
     PrintingState,
     TypeDirective,
@@ -706,6 +712,73 @@ class WaitClause(CustomDirective):
         state.last_was_punctuation = False
 
 
+def _default_var_type(var_type: Attribute) -> Attribute:
+    """Default `varType` value for a `var` operand.
+
+    Mirrors upstream's `parseVarPtrType`/`printVarPtrType` heuristic: when
+    `var` has a pointer-like type, the implied `varType` is the pointee
+    element type; otherwise the variable's own type is used.
+    """
+    if isa(var_type, MemRefType):
+        return var_type.element_type
+    return var_type
+
+
+@irdl_custom_directive
+class Var(CustomDirective):
+    """Port of upstream `custom<Var>($var) `:` custom<VarPtrType>(type($var), $varType)`.
+
+    Renders `varPtr(%v : type) (varType(t))?`. Accepts both `varPtr` and `var`
+    keywords on parse; always emits `varPtr` (xDSL doesn't distinguish
+    `PointerLikeType` vs `MappableType` here, and the OpenACC tests target
+    memref types which are pointer-like). The `varType` slot is omitted on
+    print whenever it matches `_default_var_type(var.type)`.
+    """
+
+    var: OperandVariable
+    var_type: TypeDirective
+    var_type_attr: AttributeVariable
+
+    def is_anchorable(self) -> bool:
+        return False
+
+    def is_optional_like(self) -> bool:
+        return False
+
+    def parse(self, parser: Parser, state: ParsingState) -> bool:
+        if parser.parse_optional_keyword("varPtr") is None:
+            parser.parse_keyword("var")
+        with parser.in_parens():
+            operand = parser.parse_unresolved_operand()
+            parser.parse_punctuation(":")
+            ty = parser.parse_type()
+        self.var.set(state, operand)
+        self.var_type.set(state, (ty,))
+
+        if parser.parse_optional_keyword("varType") is not None:
+            with parser.in_parens():
+                self.var_type_attr.set(state, parser.parse_type())
+        else:
+            self.var_type_attr.set(state, _default_var_type(ty))
+        return True
+
+    def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
+        state.print_whitespace(printer)
+        ssa = self.var.get(op)
+        printer.print_string("varPtr(")
+        printer.print_ssa_value(ssa)
+        printer.print_string(" : ")
+        printer.print_attribute(ssa.type)
+        printer.print_string(")")
+        attr = self.var_type_attr.get(op)
+        if attr is not None and attr != _default_var_type(ssa.type):
+            printer.print_string(" varType(")
+            printer.print_attribute(attr)
+            printer.print_string(")")
+        state.should_emit_space = True
+        state.last_was_punctuation = False
+
+
 @irdl_op_definition
 class ParallelOp(IRDLOperation):
     """
@@ -1191,6 +1264,177 @@ class KernelsOp(IRDLOperation):
         )
 
 
+# ---------------------------------------------------------------------------
+# Entry data-clause ops
+# ---------------------------------------------------------------------------
+#
+# Upstream models the entry data-clause family (`copyin`, `create`, `present`,
+# `nocreate`, `attach`, `deviceptr`, `use_device`, `cache`,
+# `declare_device_resident`, `declare_link`) as a single `OpenACC_DataEntryOp`
+# class with one operand-and-attribute shape. The xDSL port mirrors that shape
+# in the abstract `_DataEntryOp` mixin below; concrete leaves inherit it and
+# add only what differs per op (`name`, the per-op `dataClause` default, and
+# eventually the `NoMemoryEffect` trait on `acc.cache`). The IRDL field
+# descriptors are inherited — same pattern already used by
+# `_DataBoundsAccessorOp`.
+
+
+class _DataEntryOp(IRDLOperation, ABC):
+    """Shared shape for the OpenACC entry data-clause ops.
+
+    Mirrors upstream's `OpenACC_DataEntryOp` td class. Concrete leaves
+    override `name` and supply their own `dataClause` default. Everything else
+    — the four operand groups, the `varType` / async / structured / implicit
+    / modifiers properties, the optional `name` / `recipe`, the `accVar`
+    result, the assembly format, and the keyword-only `__init__` — lives
+    here.
+    """
+
+    var = operand_def()
+    var_ptr_ptr = opt_operand_def()
+    bounds = var_operand_def(DataBoundsType)
+    async_operands = var_operand_def(IntegerType | IndexType)
+
+    var_type = prop_def(TypeAttribute, prop_name="varType")
+    async_operands_device_type = opt_prop_def(
+        ArrayAttr[DeviceTypeAttr], prop_name="asyncOperandsDeviceType"
+    )
+    async_only = opt_prop_def(ArrayAttr[DeviceTypeAttr], prop_name="asyncOnly")
+    structured = opt_prop_def(
+        BoolAttr,
+        default_value=IntegerAttr.from_bool(True),
+        prop_name="structured",
+    )
+    implicit = opt_prop_def(
+        BoolAttr,
+        default_value=IntegerAttr.from_bool(False),
+        prop_name="implicit",
+    )
+    modifiers = opt_prop_def(
+        DataClauseModifierAttr,
+        default_value=DataClauseModifierAttr(frozenset[DataClauseModifier]()),
+        prop_name="modifiers",
+    )
+    var_name = opt_prop_def(StringAttr, prop_name="name")
+    recipe = opt_prop_def(SymbolRefAttr, prop_name="recipe")
+
+    acc_var = result_def()
+
+    irdl_options = (
+        AttrSizedOperandSegments(as_property=True),
+        ParsePropInAttrDict(),
+    )
+
+    custom_directives = (Var, DeviceTypeOperandsWithKeywordOnly)
+
+    assembly_format = (
+        "custom<Var>($var, type($var), $varType)"
+        " (`varPtrPtr` `(` $var_ptr_ptr^ `:` type($var_ptr_ptr) `)`)?"
+        " (`bounds` `(` $bounds^ `)`)?"
+        " (`async` custom<DeviceTypeOperandsWithKeywordOnly>($async_operands,"
+        " type($async_operands), $asyncOperandsDeviceType, $asyncOnly)^)?"
+        " `->` type($acc_var) attr-dict"
+    )
+
+    def __init__(
+        self,
+        *,
+        var: SSAValue | Operation,
+        var_ptr_ptr: SSAValue | Operation | None = None,
+        bounds: Sequence[SSAValue | Operation] = (),
+        async_operands: Sequence[SSAValue | Operation] = (),
+        var_type: TypeAttribute | None = None,
+        async_operands_device_type: ArrayAttr[DeviceTypeAttr] | None = None,
+        async_only: ArrayAttr[DeviceTypeAttr] | None = None,
+        data_clause: DataClauseAttr | DataClause | None = None,
+        structured: BoolAttr | bool | None = None,
+        implicit: BoolAttr | bool | None = None,
+        modifiers: DataClauseModifierAttr | None = None,
+        var_name: StringAttr | str | None = None,
+        recipe: SymbolRefAttr | None = None,
+        acc_var_type: Attribute | None = None,
+    ) -> None:
+        var_value = SSAValue.get(var)
+        if var_type is None:
+            var_type = cast(TypeAttribute, _default_var_type(var_value.type))
+        if acc_var_type is None:
+            acc_var_type = var_value.type
+
+        structured_prop: BoolAttr | None = (
+            IntegerAttr.from_bool(structured)
+            if isinstance(structured, bool)
+            else structured
+        )
+        implicit_prop: BoolAttr | None = (
+            IntegerAttr.from_bool(implicit) if isinstance(implicit, bool) else implicit
+        )
+        data_clause_prop: DataClauseAttr | None = (
+            DataClauseAttr(data_clause)
+            if isinstance(data_clause, DataClause)
+            else data_clause
+        )
+        var_name_prop: StringAttr | None = (
+            StringAttr(var_name) if isinstance(var_name, str) else var_name
+        )
+
+        super().__init__(
+            operands=[
+                [var],
+                [var_ptr_ptr] if var_ptr_ptr is not None else [],
+                list(bounds),
+                list(async_operands),
+            ],
+            properties={
+                "varType": var_type,
+                "asyncOperandsDeviceType": async_operands_device_type,
+                "asyncOnly": async_only,
+                "dataClause": data_clause_prop,
+                "structured": structured_prop,
+                "implicit": implicit_prop,
+                "modifiers": modifiers,
+                "name": var_name_prop,
+                "recipe": recipe,
+            },
+            result_types=[acc_var_type],
+        )
+
+
+@irdl_op_definition
+class CopyinOp(_DataEntryOp):
+    """Implementation of upstream acc.copyin."""
+
+    name = "acc.copyin"
+    data_clause = opt_prop_def(
+        DataClauseAttr,
+        default_value=DataClauseAttr(DataClause.ACC_COPYIN),
+        prop_name="dataClause",
+    )
+
+
+@irdl_op_definition
+class CreateOp(_DataEntryOp):
+    """Implementation of upstream acc.create."""
+
+    name = "acc.create"
+    data_clause = opt_prop_def(
+        DataClauseAttr,
+        default_value=DataClauseAttr(DataClause.ACC_CREATE),
+        prop_name="dataClause",
+    )
+
+
+@irdl_op_definition
+class PresentOp(_DataEntryOp):
+    """Implementation of upstream acc.present."""
+
+    name = "acc.present"
+    data_clause = opt_prop_def(
+        DataClauseAttr,
+        default_value=DataClauseAttr(DataClause.ACC_PRESENT),
+        prop_name="dataClause",
+    )
+
+
 @irdl_op_definition
 class DataBoundsOp(IRDLOperation):
     """
@@ -1337,6 +1581,9 @@ ACC = Dialect(
         GetUpperboundOp,
         GetStrideOp,
         GetExtentOp,
+        CopyinOp,
+        CreateOp,
+        PresentOp,
         YieldOp,
     ],
     [

--- a/xdsl/dialects/acc.py
+++ b/xdsl/dialects/acc.py
@@ -1270,19 +1270,19 @@ class KernelsOp(IRDLOperation):
 #
 # Upstream models the entry data-clause family (`copyin`, `create`, `present`,
 # `nocreate`, `attach`, `deviceptr`, `use_device`, `cache`,
-# `declare_device_resident`, `declare_link`) as a single `OpenACC_DataEntryOp`
+# `declare_device_resident`, `declare_link`) as a single `OpenACC_DataEntryOperation`
 # class with one operand-and-attribute shape. The xDSL port mirrors that shape
-# in the abstract `_DataEntryOp` mixin below; concrete leaves inherit it and
+# in the abstract `_DataEntryOperation` mixin below; concrete leaves inherit it and
 # add only what differs per op (`name`, the per-op `dataClause` default, and
 # eventually the `NoMemoryEffect` trait on `acc.cache`). The IRDL field
 # descriptors are inherited — same pattern already used by
 # `_DataBoundsAccessorOp`.
 
 
-class _DataEntryOp(IRDLOperation, ABC):
+class _DataEntryOperation(IRDLOperation, ABC):
     """Shared shape for the OpenACC entry data-clause ops.
 
-    Mirrors upstream's `OpenACC_DataEntryOp` td class. Concrete leaves
+    Mirrors upstream's `OpenACC_DataEntryOperation` td class. Concrete leaves
     override `name` and supply their own `dataClause` default. Everything else
     — the four operand groups, the `varType` / async / structured / implicit
     / modifiers properties, the optional `name` / `recipe`, the `accVar`
@@ -1400,7 +1400,7 @@ class _DataEntryOp(IRDLOperation, ABC):
 
 
 @irdl_op_definition
-class CopyinOp(_DataEntryOp):
+class CopyinOp(_DataEntryOperation):
     """Implementation of upstream acc.copyin."""
 
     name = "acc.copyin"
@@ -1412,7 +1412,7 @@ class CopyinOp(_DataEntryOp):
 
 
 @irdl_op_definition
-class CreateOp(_DataEntryOp):
+class CreateOp(_DataEntryOperation):
     """Implementation of upstream acc.create."""
 
     name = "acc.create"
@@ -1424,7 +1424,7 @@ class CreateOp(_DataEntryOp):
 
 
 @irdl_op_definition
-class PresentOp(_DataEntryOp):
+class PresentOp(_DataEntryOperation):
     """Implementation of upstream acc.present."""
 
     name = "acc.present"


### PR DESCRIPTION
Adds OpenACC data entry clause operations to the dialect, these leverage the data entry attributes added in the previous PR. Also adds support for handling the custom assembly syntax that these follow.
