### PR TITLE
dialects: (acc) Full data entry clause family of operations

### DIFF
--- a/tests/dialects/test_acc.py
+++ b/tests/dialects/test_acc.py
@@ -20,6 +20,7 @@ from xdsl.dialects.builtin import (
 from xdsl.dialects.test import TestOp
 from xdsl.ir import Block, Region
 from xdsl.printer import Printer
+from xdsl.traits import NoMemoryEffect
 from xdsl.utils.test_value import create_ssa_value
 
 
@@ -409,3 +410,16 @@ def test_copyin_builder_shortcuts():
     assert op.structured == IntegerAttr.from_bool(False)
     assert op.implicit == IntegerAttr.from_bool(True)
     assert op.var_name == StringAttr("foo")
+
+
+def test_cache_op_has_no_memory_effect_trait():
+    """`acc.cache` is the only entry data-clause op that carries
+    `NoMemoryEffect` (per upstream's td definition). Tested in pytest because
+    a trait's presence on a class isn't observable via filecheck — it shapes
+    what *transformations* are allowed, not how the op is printed."""
+    assert acc.CacheOp.has_trait(NoMemoryEffect)
+    # The other entry data-clause ops should *not* carry NoMemoryEffect —
+    # upstream models them as touching runtime counters / device memory.
+    assert not acc.CopyinOp.has_trait(NoMemoryEffect)
+    assert not acc.AttachOp.has_trait(NoMemoryEffect)
+    assert not acc.DeclareDeviceResidentOp.has_trait(NoMemoryEffect)

--- a/tests/filecheck/dialects/acc/ops.mlir
+++ b/tests/filecheck/dialects/acc/ops.mlir
@@ -836,4 +836,113 @@ builtin.module {
   // CHECK-LABEL: func.func @present_dataclause_default_elided(
   // CHECK:         %{{.*}} = acc.present varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32>
   // CHECK-NOT:     dataClause
+
+  // Remaining seven entry data-clause leaves. Each gets one minimal pretty-
+  // form roundtrip and one generic-form input that carries the leaf's
+  // `dataClause` default explicitly — pretty-form output must elide it,
+  // proving the per-op default is wired correctly.
+  func.func @nocreate_minimal(%a : memref<10xf32>) {
+    %r = acc.nocreate varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    func.return
+  }
+  // CHECK-LABEL: func.func @nocreate_minimal(
+  // CHECK:         %{{.*}} = acc.nocreate varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32>
+
+  func.func @nocreate_dataclause_default_elided(%a : memref<10xf32>) {
+    %r = "acc.nocreate"(%a) <{dataClause = #acc<data_clause acc_no_create>, operandSegmentSizes = array<i32: 1, 0, 0, 0>, varType = f32}> : (memref<10xf32>) -> memref<10xf32>
+    func.return
+  }
+  // CHECK-LABEL: func.func @nocreate_dataclause_default_elided(
+  // CHECK:         %{{.*}} = acc.nocreate varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32>
+  // CHECK-NOT:     dataClause
+
+  func.func @attach_minimal(%a : memref<10xf32>) {
+    %r = acc.attach varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    func.return
+  }
+  // CHECK-LABEL: func.func @attach_minimal(
+  // CHECK:         %{{.*}} = acc.attach varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32>
+
+  func.func @attach_dataclause_default_elided(%a : memref<10xf32>) {
+    %r = "acc.attach"(%a) <{dataClause = #acc<data_clause acc_attach>, operandSegmentSizes = array<i32: 1, 0, 0, 0>, varType = f32}> : (memref<10xf32>) -> memref<10xf32>
+    func.return
+  }
+  // CHECK-LABEL: func.func @attach_dataclause_default_elided(
+  // CHECK:         %{{.*}} = acc.attach varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32>
+  // CHECK-NOT:     dataClause
+
+  func.func @deviceptr_minimal(%a : memref<10xf32>) {
+    %r = acc.deviceptr varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    func.return
+  }
+  // CHECK-LABEL: func.func @deviceptr_minimal(
+  // CHECK:         %{{.*}} = acc.deviceptr varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32>
+
+  func.func @deviceptr_dataclause_default_elided(%a : memref<10xf32>) {
+    %r = "acc.deviceptr"(%a) <{dataClause = #acc<data_clause acc_deviceptr>, operandSegmentSizes = array<i32: 1, 0, 0, 0>, varType = f32}> : (memref<10xf32>) -> memref<10xf32>
+    func.return
+  }
+  // CHECK-LABEL: func.func @deviceptr_dataclause_default_elided(
+  // CHECK:         %{{.*}} = acc.deviceptr varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32>
+  // CHECK-NOT:     dataClause
+
+  func.func @use_device_minimal(%a : memref<10xf32>) {
+    %r = acc.use_device varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    func.return
+  }
+  // CHECK-LABEL: func.func @use_device_minimal(
+  // CHECK:         %{{.*}} = acc.use_device varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32>
+
+  func.func @use_device_dataclause_default_elided(%a : memref<10xf32>) {
+    %r = "acc.use_device"(%a) <{dataClause = #acc<data_clause acc_use_device>, operandSegmentSizes = array<i32: 1, 0, 0, 0>, varType = f32}> : (memref<10xf32>) -> memref<10xf32>
+    func.return
+  }
+  // CHECK-LABEL: func.func @use_device_dataclause_default_elided(
+  // CHECK:         %{{.*}} = acc.use_device varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32>
+  // CHECK-NOT:     dataClause
+
+  func.func @cache_minimal(%a : memref<10xf32>) {
+    %r = acc.cache varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    func.return
+  }
+  // CHECK-LABEL: func.func @cache_minimal(
+  // CHECK:         %{{.*}} = acc.cache varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32>
+
+  func.func @cache_dataclause_default_elided(%a : memref<10xf32>) {
+    %r = "acc.cache"(%a) <{dataClause = #acc<data_clause acc_cache>, operandSegmentSizes = array<i32: 1, 0, 0, 0>, varType = f32}> : (memref<10xf32>) -> memref<10xf32>
+    func.return
+  }
+  // CHECK-LABEL: func.func @cache_dataclause_default_elided(
+  // CHECK:         %{{.*}} = acc.cache varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32>
+  // CHECK-NOT:     dataClause
+
+  func.func @declare_device_resident_minimal(%a : memref<10xf32>) {
+    %r = acc.declare_device_resident varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    func.return
+  }
+  // CHECK-LABEL: func.func @declare_device_resident_minimal(
+  // CHECK:         %{{.*}} = acc.declare_device_resident varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32>
+
+  func.func @declare_device_resident_dataclause_default_elided(%a : memref<10xf32>) {
+    %r = "acc.declare_device_resident"(%a) <{dataClause = #acc<data_clause acc_declare_device_resident>, operandSegmentSizes = array<i32: 1, 0, 0, 0>, varType = f32}> : (memref<10xf32>) -> memref<10xf32>
+    func.return
+  }
+  // CHECK-LABEL: func.func @declare_device_resident_dataclause_default_elided(
+  // CHECK:         %{{.*}} = acc.declare_device_resident varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32>
+  // CHECK-NOT:     dataClause
+
+  func.func @declare_link_minimal(%a : memref<10xf32>) {
+    %r = acc.declare_link varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    func.return
+  }
+  // CHECK-LABEL: func.func @declare_link_minimal(
+  // CHECK:         %{{.*}} = acc.declare_link varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32>
+
+  func.func @declare_link_dataclause_default_elided(%a : memref<10xf32>) {
+    %r = "acc.declare_link"(%a) <{dataClause = #acc<data_clause acc_declare_link>, operandSegmentSizes = array<i32: 1, 0, 0, 0>, varType = f32}> : (memref<10xf32>) -> memref<10xf32>
+    func.return
+  }
+  // CHECK-LABEL: func.func @declare_link_dataclause_default_elided(
+  // CHECK:         %{{.*}} = acc.declare_link varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32>
+  // CHECK-NOT:     dataClause
 }

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/ops.mlir
@@ -537,4 +537,56 @@ builtin.module {
   }
   // CHECK:       func.func @present_minimal(
   // CHECK:         %{{.*}} = acc.present varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32>
+
+  // Remaining seven entry data-clause leaves (PR 6c). Each gets one MLIR
+  // interop entry — proves xDSL emission is bit-compatible with upstream
+  // and the per-op `dataClause` default round-trips through MLIR.
+  func.func @nocreate_minimal(%a : memref<10xf32>) {
+    %r = acc.nocreate varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    func.return
+  }
+  // CHECK:       func.func @nocreate_minimal(
+  // CHECK:         %{{.*}} = acc.nocreate varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32>
+
+  func.func @attach_minimal(%a : memref<10xf32>) {
+    %r = acc.attach varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    func.return
+  }
+  // CHECK:       func.func @attach_minimal(
+  // CHECK:         %{{.*}} = acc.attach varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32>
+
+  func.func @deviceptr_minimal(%a : memref<10xf32>) {
+    %r = acc.deviceptr varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    func.return
+  }
+  // CHECK:       func.func @deviceptr_minimal(
+  // CHECK:         %{{.*}} = acc.deviceptr varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32>
+
+  func.func @use_device_minimal(%a : memref<10xf32>) {
+    %r = acc.use_device varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    func.return
+  }
+  // CHECK:       func.func @use_device_minimal(
+  // CHECK:         %{{.*}} = acc.use_device varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32>
+
+  func.func @cache_minimal(%a : memref<10xf32>) {
+    %r = acc.cache varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    func.return
+  }
+  // CHECK:       func.func @cache_minimal(
+  // CHECK:         %{{.*}} = acc.cache varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32>
+
+  func.func @declare_device_resident_minimal(%a : memref<10xf32>) {
+    %r = acc.declare_device_resident varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    func.return
+  }
+  // CHECK:       func.func @declare_device_resident_minimal(
+  // CHECK:         %{{.*}} = acc.declare_device_resident varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32>
+
+  func.func @declare_link_minimal(%a : memref<10xf32>) {
+    %r = acc.declare_link varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    func.return
+  }
+  // CHECK:       func.func @declare_link_minimal(
+  // CHECK:         %{{.*}} = acc.declare_link varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32>
 }

--- a/xdsl/dialects/acc.py
+++ b/xdsl/dialects/acc.py
@@ -53,6 +53,7 @@ from xdsl.irdl import (
     prop_def,
     region_def,
     result_def,
+    traits_def,
     var_operand_def,
 )
 from xdsl.irdl.declarative_assembly_format import (
@@ -1436,6 +1437,92 @@ class PresentOp(_DataEntryOperation):
 
 
 @irdl_op_definition
+class NoCreateOp(_DataEntryOperation):
+    """Implementation of upstream acc.nocreate."""
+
+    name = "acc.nocreate"
+    data_clause = opt_prop_def(
+        DataClauseAttr,
+        default_value=DataClauseAttr(DataClause.ACC_NO_CREATE),
+        prop_name="dataClause",
+    )
+
+
+@irdl_op_definition
+class AttachOp(_DataEntryOperation):
+    """Implementation of upstream acc.attach."""
+
+    name = "acc.attach"
+    data_clause = opt_prop_def(
+        DataClauseAttr,
+        default_value=DataClauseAttr(DataClause.ACC_ATTACH),
+        prop_name="dataClause",
+    )
+
+
+@irdl_op_definition
+class DevicePtrOp(_DataEntryOperation):
+    """Implementation of upstream acc.deviceptr."""
+
+    name = "acc.deviceptr"
+    data_clause = opt_prop_def(
+        DataClauseAttr,
+        default_value=DataClauseAttr(DataClause.ACC_DEVICEPTR),
+        prop_name="dataClause",
+    )
+
+
+@irdl_op_definition
+class UseDeviceOp(_DataEntryOperation):
+    """Implementation of upstream acc.use_device."""
+
+    name = "acc.use_device"
+    data_clause = opt_prop_def(
+        DataClauseAttr,
+        default_value=DataClauseAttr(DataClause.ACC_USE_DEVICE),
+        prop_name="dataClause",
+    )
+
+
+@irdl_op_definition
+class CacheOp(_DataEntryOperation):
+    """Implementation of upstream acc.cache. Carries `NoMemoryEffect` per upstream."""
+
+    name = "acc.cache"
+    data_clause = opt_prop_def(
+        DataClauseAttr,
+        default_value=DataClauseAttr(DataClause.ACC_CACHE),
+        prop_name="dataClause",
+    )
+
+    traits = traits_def(NoMemoryEffect())
+
+
+@irdl_op_definition
+class DeclareDeviceResidentOp(_DataEntryOperation):
+    """Implementation of upstream acc.declare_device_resident."""
+
+    name = "acc.declare_device_resident"
+    data_clause = opt_prop_def(
+        DataClauseAttr,
+        default_value=DataClauseAttr(DataClause.ACC_DECLARE_DEVICE_RESIDENT),
+        prop_name="dataClause",
+    )
+
+
+@irdl_op_definition
+class DeclareLinkOp(_DataEntryOperation):
+    """Implementation of upstream acc.declare_link."""
+
+    name = "acc.declare_link"
+    data_clause = opt_prop_def(
+        DataClauseAttr,
+        default_value=DataClauseAttr(DataClause.ACC_DECLARE_LINK),
+        prop_name="dataClause",
+    )
+
+
+@irdl_op_definition
 class DataBoundsOp(IRDLOperation):
     """
     Implementation of upstream acc.bounds.
@@ -1584,6 +1671,13 @@ ACC = Dialect(
         CopyinOp,
         CreateOp,
         PresentOp,
+        NoCreateOp,
+        AttachOp,
+        DevicePtrOp,
+        UseDeviceOp,
+        CacheOp,
+        DeclareDeviceResidentOp,
+        DeclareLinkOp,
         YieldOp,
     ],
     [


### PR DESCRIPTION
This PR completes the data entry clause family of OpenACC operations, which all extend the _DataEntryOperation base class which was created in the previous PR, and leverages the DataClauseAttr we added in the PR before that.