### PR TITLE
bench: fix LLVM backend benchmark for ASV discovery

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -94,6 +94,11 @@
     // new environments.  A value of ``null`` means that the variable
     // will not be set for the current combination.
     //
+    "matrix": {
+        "req": {
+            "llvmlite": [""]
+        }
+    },
     // "matrix": {
     //     "req": {
     //         "numpy": ["1.6", "1.7"],

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -94,11 +94,6 @@
     // new environments.  A value of ``null`` means that the variable
     // will not be set for the current combination.
     //
-    "matrix": {
-        "req": {
-            "llvmlite": [""]
-        }
-    },
     // "matrix": {
     //     "req": {
     //         "numpy": ["1.6", "1.7"],

--- a/benchmarks/llvm_backend.py
+++ b/benchmarks/llvm_backend.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
 from pathlib import Path
 
-from bench_utils import Benchmark, profile
-
 from xdsl.backend.llvm.convert import convert_module
 from xdsl.context import Context
 from xdsl.dialects.builtin import Builtin, ModuleOp
@@ -38,6 +36,8 @@ class LLVMBackend:
 
 
 if __name__ == "__main__":
+    from bench_utils import Benchmark, profile
+
     BACKEND = LLVMBackend()
     profile(
         {


### PR DESCRIPTION
Moves `bench_utils` import inside `if __name__ == "__main__":` to match all other benchmarks. ASV discovers benchmarks by importing modules, and the module-level import fails because `bench_utils` is not on the path in ASV's virtualenv.

Fixes the xdsl-bench CI failure: https://github.com/xdslproject/xdsl-bench/actions/runs/25035114773