### PR TITLE
transformations: handle constant step in riscv_scf lowering passes

### DIFF
--- a/tests/filecheck/backend/convert_riscv_scf_to_riscv_cf.mlir
+++ b/tests/filecheck/backend/convert_riscv_scf_to_riscv_cf.mlir
@@ -140,4 +140,34 @@ riscv_func.func @static_step_loop_example(%src: !riscv.reg<a0>, %dst: !riscv.reg
     riscv_func.return
 }
 
-// CHECK: Error while applying pattern: Lowering riscv_scf loops with constant step not yet implemented.
+// CHECK:         riscv_func.func @static_step_loop_example(%src: !riscv.reg<a0>, %dst: !riscv.reg<a1>) {
+// CHECK-NEXT:      %zero = rv32.li 0 : !riscv.reg<a2>
+// CHECK-NEXT:      %forty = rv32.li 40 : !riscv.reg<a4>
+// CHECK-NEXT:      %0 = riscv.mv %zero : (!riscv.reg<a2>) -> !riscv.reg<a5>
+// CHECK-NEXT:      riscv_cf.bge %0 : !riscv.reg<a5>, %forty : !riscv.reg<a4>, ^bb0(%0 : !riscv.reg<a5>), ^bb1(%0 : !riscv.reg<a5>)
+// CHECK-NEXT:    ^bb1(%offset: !riscv.reg<a5>):
+// CHECK-NEXT:      riscv.label "scf_body_0_for"
+// CHECK-NEXT:      %srcptr = riscv.add %src, %offset : (!riscv.reg<a0>, !riscv.reg<a5>) -> !riscv.reg<a6>
+// CHECK-NEXT:      %dstptr = riscv.add %dst, %offset : (!riscv.reg<a1>, !riscv.reg<a5>) -> !riscv.reg<a7>
+// CHECK-NEXT:      %val = riscv.lw %srcptr, 0 : (!riscv.reg<a6>) -> !riscv.reg<t0>
+// CHECK-NEXT:      riscv.sw %dstptr, %val, 0 : (!riscv.reg<a7>, !riscv.reg<t0>) -> ()
+// CHECK-NEXT:      %1 = riscv.addi %offset, 4 : (!riscv.reg<a5>) -> !riscv.reg<a5>
+// CHECK-NEXT:      riscv_cf.blt %1 : !riscv.reg<a5>, %forty : !riscv.reg<a4>, ^bb1(%1 : !riscv.reg<a5>), ^bb0(%1 : !riscv.reg<a5>)
+// CHECK-NEXT:    ^bb0(%2: !riscv.reg<a5>):
+// CHECK-NEXT:      riscv.label "scf_body_end_0_for"
+// CHECK-NEXT:      riscv_func.return
+// CHECK-NEXT:    }
+
+// -----
+
+%lb, %ub = "test.op"() : () -> (!riscv.reg<a0>, !riscv.reg<a1>)
+%acc = rv32.li 0 : !riscv.reg<a2>
+
+%res = riscv_scf.for %i : !riscv.reg<a3> = %lb to %ub step 2 : i12 iter_args(%v = %acc) -> (!riscv.reg<a2>) {
+    %next = riscv.add %i, %v : (!riscv.reg<a3>, !riscv.reg<a2>) -> !riscv.reg<a2>
+    riscv_scf.yield %next : !riscv.reg<a2>
+}
+
+"test.op"(%res) : (!riscv.reg<a2>) -> ()
+
+// CHECK:    Error while applying pattern: riscv_scf.for static step must use type si12 (signed 12-bit) for addi lowering; got i12

--- a/tests/filecheck/backend/rvscf_lowering_labels.mlir
+++ b/tests/filecheck/backend/rvscf_lowering_labels.mlir
@@ -133,10 +133,38 @@ builtin.module {
 
 %lb, %ub = "test.op"() : () -> (!riscv.reg<a0>, !riscv.reg<a1>)
 %acc = rv32.li 0 : !riscv.reg<a2>
+// CHECK:         %lb, %ub = "test.op"() : () -> (!riscv.reg<a0>, !riscv.reg<a1>)
+// CHECK-NEXT:    %acc = rv32.li 0 : !riscv.reg<a2>
+
 %res = riscv_scf.for %i : !riscv.reg<a3> = %lb to %ub step 2 : si12 iter_args(%v = %acc) -> (!riscv.reg<a2>) {
     %next = riscv.add %i, %v : (!riscv.reg<a3>, !riscv.reg<a2>) -> !riscv.reg<a2>
     riscv_scf.yield %next : !riscv.reg<a2>
 }
+// CHECK-NEXT:    %0 = riscv.mv %lb : (!riscv.reg<a0>) -> !riscv.reg<a3>
+// CHECK-NEXT:    riscv.label "scf_cond_0_for"
+// CHECK-NEXT:    riscv.bge %0, %ub, "scf_body_end_0_for" : (!riscv.reg<a3>, !riscv.reg<a1>) -> ()
+// CHECK-NEXT:    riscv.label "scf_body_0_for"
+// CHECK-NEXT:    %v = rv32.get_register : !riscv.reg<a2>
+// CHECK-NEXT:    %i = rv32.get_register : !riscv.reg<a3>
+// CHECK-NEXT:    %next = riscv.add %i, %v : (!riscv.reg<a3>, !riscv.reg<a2>) -> !riscv.reg<a2>
+// CHECK-NEXT:    %1 = riscv.addi %0, 2 : (!riscv.reg<a3>) -> !riscv.reg<a3>
+// CHECK-NEXT:    riscv.blt %0, %ub, "scf_body_0_for" : (!riscv.reg<a3>, !riscv.reg<a1>) -> ()
+// CHECK-NEXT:    riscv.label "scf_body_end_0_for"
+// CHECK-NEXT:    %res = rv32.get_register : !riscv.reg<a2>
+
+"test.op"(%res) : (!riscv.reg<a2>) -> ()
+// CHECK-NEXT:    "test.op"(%res) : (!riscv.reg<a2>) -> ()
+
+// -----
+
+%lb, %ub = "test.op"() : () -> (!riscv.reg<a0>, !riscv.reg<a1>)
+%acc = rv32.li 0 : !riscv.reg<a2>
+
+%res = riscv_scf.for %i : !riscv.reg<a3> = %lb to %ub step 2 : i12 iter_args(%v = %acc) -> (!riscv.reg<a2>) {
+    %next = riscv.add %i, %v : (!riscv.reg<a3>, !riscv.reg<a2>) -> !riscv.reg<a2>
+    riscv_scf.yield %next : !riscv.reg<a2>
+}
+
 "test.op"(%res) : (!riscv.reg<a2>) -> ()
 
-// CHECK: Error while applying pattern: Lowering riscv_scf loops with constant step not yet implemented.
+// CHECK:    Error while applying pattern: riscv_scf.for static step must use type si12 (signed 12-bit) for addi lowering; got i12

--- a/xdsl/backend/riscv/lowering/convert_riscv_scf_to_riscv_cf.py
+++ b/xdsl/backend/riscv/lowering/convert_riscv_scf_to_riscv_cf.py
@@ -10,6 +10,7 @@ from xdsl.pattern_rewriter import (
 )
 from xdsl.rewriter import BlockInsertPoint, InsertPoint
 from xdsl.utils.exceptions import PassFailedException
+from xdsl.utils.hints import isa
 
 
 class LowerRiscvScfForPattern(RewritePattern):
@@ -107,10 +108,14 @@ class LowerRiscvScfForPattern(RewritePattern):
         assert isinstance(yield_op, riscv_scf.YieldOp)
 
         match op.step:
-            case IntegerAttr():
-                raise PassFailedException(
-                    "Lowering riscv_scf loops with constant step not yet implemented."
-                )
+            case IntegerAttr() as step_attr:
+                if isa(step_attr, IntegerAttr[riscv.SI12]):
+                    add_op = riscv.AddiOp(iv, step_attr, rd=loop_var_reg)
+                else:
+                    raise PassFailedException(
+                        "riscv_scf.for static step must use type si12 (signed 12-bit) for "
+                        f"addi lowering; got {step_attr.type}"
+                    )
             case _:
                 add_op = riscv.AddOp(iv, op.step, rd=iv_reg)
 

--- a/xdsl/backend/riscv/riscv_scf_to_asm.py
+++ b/xdsl/backend/riscv/riscv_scf_to_asm.py
@@ -13,6 +13,7 @@ from xdsl.pattern_rewriter import (
 )
 from xdsl.rewriter import InsertPoint
 from xdsl.utils.exceptions import PassFailedException
+from xdsl.utils.hints import isa
 
 
 def get_register_ops_from_values(
@@ -72,10 +73,14 @@ class LowerRiscvScfToLabels(RewritePattern):
         assert isinstance(yield_op, riscv_scf.YieldOp)
 
         match op.step:
-            case IntegerAttr():
-                raise PassFailedException(
-                    "Lowering riscv_scf loops with constant step not yet implemented."
-                )
+            case IntegerAttr() as step_attr:
+                if isa(step_attr, IntegerAttr[riscv.SI12]):
+                    step_add_op = riscv.AddiOp(get_loop_var, step_attr, rd=loop_var_reg)
+                else:
+                    raise PassFailedException(
+                        "riscv_scf.for static step must use type si12 (signed 12-bit) for "
+                        f"addi lowering; got {step_attr.type}"
+                    )
             case _:
                 step_add_op = riscv.AddOp(get_loop_var, op.step, rd=loop_var_reg)
 


### PR DESCRIPTION
For historical reasons, we have two near-identical passes to lower riscv_scf, one to basic blocks with jumps as terminators, and one to a big region with control flow not tracked. Since the logic is about the same this PR adds support for both.