### PR TITLE
dialects: (acc) OpenACC copyout update_host data exit clauses

### DIFF
--- a/tests/dialects/test_acc.py
+++ b/tests/dialects/test_acc.py
@@ -412,6 +412,45 @@ def test_copyin_builder_shortcuts():
     assert op.var_name == StringAttr("foo")
 
 
+def test_copyout_minimal_defaulted_props_absent_from_dict():
+    """Same load-bearing invariant as `acc.copyin` — defaulted props on the
+    `_DataExitOperationWithVarPtr` mixin must be *absent* from the dict when
+    not set, otherwise attr-dict elision on print silently fails."""
+    acc_var = create_ssa_value(MemRefType(f32, [10]))
+    var = create_ssa_value(MemRefType(f32, [10]))
+    op = acc.CopyoutOp(acc_var=acc_var, var=var)
+    op.verify()
+
+    assert "dataClause" not in op.properties
+    assert "structured" not in op.properties
+    assert "implicit" not in op.properties
+    assert "modifiers" not in op.properties
+    assert op.acc_var is acc_var
+    assert op.var is var
+
+
+def test_copyout_builder_shortcuts():
+    """Bool / str / `DataClause` shortcuts on `_DataExitOperationWithVarPtr`'s
+    `__init__`. Builder-only code path; the parser only sees attribute
+    instances, so filecheck cannot exercise these conversions."""
+    acc_var = create_ssa_value(MemRefType(f32, [10]))
+    var = create_ssa_value(MemRefType(f32, [10]))
+    op = acc.CopyoutOp(
+        acc_var=acc_var,
+        var=var,
+        data_clause=acc.DataClause.ACC_COPYOUT_ZERO,
+        structured=False,
+        implicit=True,
+        var_name="myvar",
+    )
+    op.verify()
+
+    assert op.data_clause == acc.DataClauseAttr(acc.DataClause.ACC_COPYOUT_ZERO)
+    assert op.structured == IntegerAttr.from_bool(False)
+    assert op.implicit == IntegerAttr.from_bool(True)
+    assert op.var_name == StringAttr("myvar")
+
+
 def test_cache_op_has_no_memory_effect_trait():
     """`acc.cache` is the only entry data-clause op that carries
     `NoMemoryEffect` (per upstream's td definition). Tested in pytest because

--- a/tests/filecheck/dialects/acc/ops.mlir
+++ b/tests/filecheck/dialects/acc/ops.mlir
@@ -945,4 +945,125 @@ builtin.module {
   // CHECK-LABEL: func.func @declare_link_dataclause_default_elided(
   // CHECK:         %{{.*}} = acc.declare_link varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32>
   // CHECK-NOT:     dataClause
+
+  func.func @copyout_minimal(%d : memref<10xf32>, %h : memref<10xf32>) {
+    acc.copyout accPtr(%d : memref<10xf32>) to varPtr(%h : memref<10xf32>)
+    func.return
+  }
+  // CHECK-LABEL: func.func @copyout_minimal(
+  // CHECK:         acc.copyout accPtr(%{{.*}} : memref<10xf32>) to varPtr(%{{.*}} : memref<10xf32>)
+
+  func.func @copyout_with_var_type(%d : memref<10xf32>, %h : memref<10xf32>) {
+    acc.copyout accPtr(%d : memref<10xf32>) to varPtr(%h : memref<10xf32>) varType(tensor<10xf32>)
+    func.return
+  }
+  // CHECK-LABEL: func.func @copyout_with_var_type(
+  // CHECK:         acc.copyout accPtr(%{{.*}} : memref<10xf32>) to varPtr(%{{.*}} : memref<10xf32>) varType(tensor<10xf32>)
+
+  func.func @copyout_with_bounds(%d : memref<10xf32>, %h : memref<10xf32>, %c0 : index, %c9 : index) {
+    %b = acc.bounds lowerbound(%c0 : index) upperbound(%c9 : index)
+    acc.copyout accPtr(%d : memref<10xf32>) bounds(%b) to varPtr(%h : memref<10xf32>)
+    func.return
+  }
+  // CHECK-LABEL: func.func @copyout_with_bounds(
+  // CHECK:         %{{.*}} = acc.bounds lowerbound(%{{.*}} : index) upperbound(%{{.*}} : index)
+  // CHECK-NEXT:    acc.copyout accPtr(%{{.*}} : memref<10xf32>) bounds(%{{.*}}) to varPtr(%{{.*}} : memref<10xf32>)
+
+  func.func @copyout_async_bare(%d : memref<10xf32>, %h : memref<10xf32>) {
+    acc.copyout accPtr(%d : memref<10xf32>) async to varPtr(%h : memref<10xf32>)
+    func.return
+  }
+  // CHECK-LABEL: func.func @copyout_async_bare(
+  // CHECK:         acc.copyout accPtr(%{{.*}} : memref<10xf32>) async to varPtr(%{{.*}} : memref<10xf32>)
+
+  func.func @copyout_async_operand(%d : memref<10xf32>, %h : memref<10xf32>, %async : i32) {
+    acc.copyout accPtr(%d : memref<10xf32>) async(%async : i32) to varPtr(%h : memref<10xf32>)
+    func.return
+  }
+  // CHECK-LABEL: func.func @copyout_async_operand(
+  // CHECK:         acc.copyout accPtr(%{{.*}} : memref<10xf32>) async(%{{.*}} : i32) to varPtr(%{{.*}} : memref<10xf32>)
+
+  func.func @copyout_async_operand_dt(%d : memref<10xf32>, %h : memref<10xf32>, %async : i32) {
+    acc.copyout accPtr(%d : memref<10xf32>) async(%async : i32 [#acc.device_type<nvidia>]) to varPtr(%h : memref<10xf32>)
+    func.return
+  }
+  // CHECK-LABEL: func.func @copyout_async_operand_dt(
+  // CHECK:         acc.copyout accPtr(%{{.*}} : memref<10xf32>) async(%{{.*}} : i32 [#acc.device_type<nvidia>]) to varPtr(%{{.*}} : memref<10xf32>)
+
+  func.func @copyout_full_attr_dict(%d : memref<10xf32>, %h : memref<10xf32>) {
+    acc.copyout accPtr(%d : memref<10xf32>) to varPtr(%h : memref<10xf32>) {dataClause = #acc<data_clause acc_copyout_zero>, implicit = true, modifiers = #acc<data_clause_modifier zero>, name = "myvar", structured = false}
+    func.return
+  }
+  // CHECK-LABEL: func.func @copyout_full_attr_dict(
+  // CHECK:         acc.copyout accPtr(%{{.*}} : memref<10xf32>) to varPtr(%{{.*}} : memref<10xf32>) {dataClause = #acc<data_clause acc_copyout_zero>, implicit = true, modifiers = #acc<data_clause_modifier zero>, name = "myvar", structured = false}
+
+  // Generic-form roundtrip insurance for `acc.copyout` — proves the four-
+  // group `operandSegmentSizes` shape (`accVar`, `var`, `bounds`,
+  // `asyncOperands`) survives the generic surface even after the pretty
+  // form lands.
+  func.func @copyout_generic_roundtrip(%d : memref<10xf32>, %h : memref<10xf32>) {
+    "acc.copyout"(%d, %h) <{operandSegmentSizes = array<i32: 1, 1, 0, 0>, varType = f32}> : (memref<10xf32>, memref<10xf32>) -> ()
+    func.return
+  }
+  // CHECK-LABEL: func.func @copyout_generic_roundtrip(
+  // CHECK:         acc.copyout accPtr(%{{.*}} : memref<10xf32>) to varPtr(%{{.*}} : memref<10xf32>)
+
+  // Per-op `dataClause` default elision for each exit leaf — generic-form
+  // input carries the leaf's default explicitly; pretty-form output must
+  // elide it. Catches a wrong-default wiring per leaf.
+  func.func @copyout_dataclause_default_elided(%d : memref<10xf32>, %h : memref<10xf32>) {
+    "acc.copyout"(%d, %h) <{dataClause = #acc<data_clause acc_copyout>, operandSegmentSizes = array<i32: 1, 1, 0, 0>, varType = f32}> : (memref<10xf32>, memref<10xf32>) -> ()
+    func.return
+  }
+  // CHECK-LABEL: func.func @copyout_dataclause_default_elided(
+  // CHECK:         acc.copyout accPtr(%{{.*}} : memref<10xf32>) to varPtr(%{{.*}} : memref<10xf32>)
+  // CHECK-NOT:     dataClause
+
+  func.func @update_host_minimal(%d : memref<10xf32>, %h : memref<10xf32>) {
+    acc.update_host accPtr(%d : memref<10xf32>) to varPtr(%h : memref<10xf32>)
+    func.return
+  }
+  // CHECK-LABEL: func.func @update_host_minimal(
+  // CHECK:         acc.update_host accPtr(%{{.*}} : memref<10xf32>) to varPtr(%{{.*}} : memref<10xf32>)
+
+  func.func @update_host_dataclause_default_elided(%d : memref<10xf32>, %h : memref<10xf32>) {
+    "acc.update_host"(%d, %h) <{dataClause = #acc<data_clause acc_update_host>, operandSegmentSizes = array<i32: 1, 1, 0, 0>, varType = f32}> : (memref<10xf32>, memref<10xf32>) -> ()
+    func.return
+  }
+  // CHECK-LABEL: func.func @update_host_dataclause_default_elided(
+  // CHECK:         acc.update_host accPtr(%{{.*}} : memref<10xf32>) to varPtr(%{{.*}} : memref<10xf32>)
+  // CHECK-NOT:     dataClause
+
+  // The two entry-shape leaves — they live on `_DataEntryOperation`
+  // (same shape as `acc.copyin`), they just differ in the per-op
+  // `dataClause` default.
+  func.func @getdeviceptr_minimal(%a : memref<10xf32>) {
+    %r = acc.getdeviceptr varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    func.return
+  }
+  // CHECK-LABEL: func.func @getdeviceptr_minimal(
+  // CHECK:         %{{.*}} = acc.getdeviceptr varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32>
+
+  func.func @getdeviceptr_dataclause_default_elided(%a : memref<10xf32>) {
+    %r = "acc.getdeviceptr"(%a) <{dataClause = #acc<data_clause acc_getdeviceptr>, operandSegmentSizes = array<i32: 1, 0, 0, 0>, varType = f32}> : (memref<10xf32>) -> memref<10xf32>
+    func.return
+  }
+  // CHECK-LABEL: func.func @getdeviceptr_dataclause_default_elided(
+  // CHECK:         %{{.*}} = acc.getdeviceptr varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32>
+  // CHECK-NOT:     dataClause
+
+  func.func @update_device_minimal(%a : memref<10xf32>) {
+    %r = acc.update_device varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    func.return
+  }
+  // CHECK-LABEL: func.func @update_device_minimal(
+  // CHECK:         %{{.*}} = acc.update_device varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32>
+
+  func.func @update_device_dataclause_default_elided(%a : memref<10xf32>) {
+    %r = "acc.update_device"(%a) <{dataClause = #acc<data_clause acc_update_device>, operandSegmentSizes = array<i32: 1, 0, 0, 0>, varType = f32}> : (memref<10xf32>) -> memref<10xf32>
+    func.return
+  }
+  // CHECK-LABEL: func.func @update_device_dataclause_default_elided(
+  // CHECK:         %{{.*}} = acc.update_device varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32>
+  // CHECK-NOT:     dataClause
 }

--- a/tests/filecheck/dialects/acc/ops.mlir
+++ b/tests/filecheck/dialects/acc/ops.mlir
@@ -953,6 +953,17 @@ builtin.module {
   // CHECK-LABEL: func.func @copyout_minimal(
   // CHECK:         acc.copyout accPtr(%{{.*}} : memref<10xf32>) to varPtr(%{{.*}} : memref<10xf32>)
 
+  // The `AccVar` directive accepts either `accPtr` or `accVar` on parse and
+  // always emits `accPtr` on print (mirroring `Var`'s `varPtr` choice). Input
+  // uses the `accVar` spelling; the output must normalize to `accPtr`,
+  // proving the parser fallback is reachable.
+  func.func @copyout_acc_var_keyword(%d : memref<10xf32>, %h : memref<10xf32>) {
+    acc.copyout accVar(%d : memref<10xf32>) to varPtr(%h : memref<10xf32>)
+    func.return
+  }
+  // CHECK-LABEL: func.func @copyout_acc_var_keyword(
+  // CHECK:         acc.copyout accPtr(%{{.*}} : memref<10xf32>) to varPtr(%{{.*}} : memref<10xf32>)
+
   func.func @copyout_with_var_type(%d : memref<10xf32>, %h : memref<10xf32>) {
     acc.copyout accPtr(%d : memref<10xf32>) to varPtr(%h : memref<10xf32>) varType(tensor<10xf32>)
     func.return

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/ops.mlir
@@ -589,4 +589,62 @@ builtin.module {
   }
   // CHECK:       func.func @declare_link_minimal(
   // CHECK:         %{{.*}} = acc.declare_link varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32>
+
+  func.func @copyout_minimal(%d : memref<10xf32>, %h : memref<10xf32>) {
+    acc.copyout accPtr(%d : memref<10xf32>) to varPtr(%h : memref<10xf32>)
+    func.return
+  }
+  // CHECK:       func.func @copyout_minimal(
+  // CHECK:         acc.copyout accPtr(%{{.*}} : memref<10xf32>) to varPtr(%{{.*}} : memref<10xf32>)
+
+  func.func @copyout_with_var_type(%d : memref<10xf32>, %h : memref<10xf32>) {
+    acc.copyout accPtr(%d : memref<10xf32>) to varPtr(%h : memref<10xf32>) varType(tensor<10xf32>)
+    func.return
+  }
+  // CHECK:       func.func @copyout_with_var_type(
+  // CHECK:         acc.copyout accPtr(%{{.*}} : memref<10xf32>) to varPtr(%{{.*}} : memref<10xf32>) varType(tensor<10xf32>)
+
+  func.func @copyout_with_bounds(%d : memref<10xf32>, %h : memref<10xf32>, %c0 : index, %c9 : index) {
+    %b = acc.bounds lowerbound(%c0 : index) upperbound(%c9 : index)
+    acc.copyout accPtr(%d : memref<10xf32>) bounds(%b) to varPtr(%h : memref<10xf32>)
+    func.return
+  }
+  // CHECK:       func.func @copyout_with_bounds(
+  // CHECK:         %{{.*}} = acc.bounds lowerbound(%{{.*}} : index) upperbound(%{{.*}} : index)
+  // CHECK-NEXT:    acc.copyout accPtr(%{{.*}} : memref<10xf32>) bounds(%{{.*}}) to varPtr(%{{.*}} : memref<10xf32>)
+
+  func.func @copyout_async_operand_dt(%d : memref<10xf32>, %h : memref<10xf32>, %async : i32) {
+    acc.copyout accPtr(%d : memref<10xf32>) async(%async : i32 [#acc.device_type<nvidia>]) to varPtr(%h : memref<10xf32>)
+    func.return
+  }
+  // CHECK:       func.func @copyout_async_operand_dt(
+  // CHECK:         acc.copyout accPtr(%{{.*}} : memref<10xf32>) async(%{{.*}} : i32 [#acc.device_type<nvidia>]) to varPtr(%{{.*}} : memref<10xf32>)
+
+  func.func @copyout_clause_override(%d : memref<10xf32>, %h : memref<10xf32>) {
+    acc.copyout accPtr(%d : memref<10xf32>) to varPtr(%h : memref<10xf32>) {dataClause = #acc<data_clause acc_copyout_zero>, modifiers = #acc<data_clause_modifier zero>, name = "myvar"}
+    func.return
+  }
+  // CHECK:       func.func @copyout_clause_override(
+  // CHECK:         acc.copyout accPtr(%{{.*}} : memref<10xf32>) to varPtr(%{{.*}} : memref<10xf32>) {dataClause = #acc<data_clause acc_copyout_zero>, modifiers = #acc<data_clause_modifier zero>, name = "myvar"}
+
+  func.func @update_host_minimal(%d : memref<10xf32>, %h : memref<10xf32>) {
+    acc.update_host accPtr(%d : memref<10xf32>) to varPtr(%h : memref<10xf32>)
+    func.return
+  }
+  // CHECK:       func.func @update_host_minimal(
+  // CHECK:         acc.update_host accPtr(%{{.*}} : memref<10xf32>) to varPtr(%{{.*}} : memref<10xf32>)
+
+  func.func @getdeviceptr_minimal(%a : memref<10xf32>) {
+    %r = acc.getdeviceptr varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    func.return
+  }
+  // CHECK:       func.func @getdeviceptr_minimal(
+  // CHECK:         %{{.*}} = acc.getdeviceptr varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32>
+
+  func.func @update_device_minimal(%a : memref<10xf32>) {
+    %r = acc.update_device varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    func.return
+  }
+  // CHECK:       func.func @update_device_minimal(
+  // CHECK:         %{{.*}} = acc.update_device varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32>
 }

--- a/xdsl/dialects/acc.py
+++ b/xdsl/dialects/acc.py
@@ -726,6 +726,48 @@ def _default_var_type(var_type: Attribute) -> Attribute:
 
 
 @irdl_custom_directive
+class AccVar(CustomDirective):
+    """Port of upstream `custom<AccVar>($accVar, type($accVar))`.
+
+    Renders `accPtr(%v : type)`. Accepts both `accPtr` and `accVar`
+    keywords on parse; always emits `accPtr` (xDSL doesn't distinguish
+    `PointerLikeType` vs `MappableType` here, mirroring `Var`'s `varPtr`
+    choice).
+    """
+
+    acc_var: OperandVariable
+    acc_var_type: TypeDirective
+
+    def is_anchorable(self) -> bool:
+        return False
+
+    def is_optional_like(self) -> bool:
+        return False
+
+    def parse(self, parser: Parser, state: ParsingState) -> bool:
+        if parser.parse_optional_keyword("accPtr") is None:
+            parser.parse_keyword("accVar")
+        with parser.in_parens():
+            operand = parser.parse_unresolved_operand()
+            parser.parse_punctuation(":")
+            ty = parser.parse_type()
+        self.acc_var.set(state, operand)
+        self.acc_var_type.set(state, (ty,))
+        return True
+
+    def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
+        state.print_whitespace(printer)
+        ssa = self.acc_var.get(op)
+        printer.print_string("accPtr(")
+        printer.print_ssa_value(ssa)
+        printer.print_string(" : ")
+        printer.print_attribute(ssa.type)
+        printer.print_string(")")
+        state.should_emit_space = True
+        state.last_was_punctuation = False
+
+
+@irdl_custom_directive
 class Var(CustomDirective):
     """Port of upstream `custom<Var>($var) `:` custom<VarPtrType>(type($var), $varType)`.
 
@@ -1523,6 +1565,181 @@ class DeclareLinkOp(_DataEntryOperation):
 
 
 @irdl_op_definition
+class GetDevicePtrOp(_DataEntryOperation):
+    """Implementation of upstream acc.getdeviceptr.
+
+    Used to get the `accVar` for a host variable when a structured data-entry
+    op is not available; the natural pair for the unstructured exit ops below.
+    """
+
+    name = "acc.getdeviceptr"
+    data_clause = opt_prop_def(
+        DataClauseAttr,
+        default_value=DataClauseAttr(DataClause.ACC_GETDEVICEPTR),
+        prop_name="dataClause",
+    )
+
+
+@irdl_op_definition
+class UpdateDeviceOp(_DataEntryOperation):
+    """Implementation of upstream acc.update_device."""
+
+    name = "acc.update_device"
+    data_clause = opt_prop_def(
+        DataClauseAttr,
+        default_value=DataClauseAttr(DataClause.ACC_UPDATE_DEVICE),
+        prop_name="dataClause",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Exit data-clause ops (with-host-pointer family)
+# ---------------------------------------------------------------------------
+#
+# Upstream models the exit data-clause family as two TableGen base classes:
+# `OpenACC_DataExitOpWithVarPtr` (for `copyout`, `update_host` — both host
+# *and* device pointer) and `OpenACC_DataExitOpNoVarPtr` (for `delete`,
+# `detach` — device pointer only). They differ in operand layout and
+# assembly format, but share the bounds / async / dataClause / structured /
+# implicit / modifiers / name surface. This file currently models only the
+# WithVarPtr half; the NoVarPtr half lands in a follow-up PR.
+
+
+class _DataExitOperationWithVarPtr(IRDLOperation, ABC):
+    """Shared shape for `acc.copyout` / `acc.update_host`.
+
+    Mirrors upstream's `OpenACC_DataExitOpWithVarPtr` td class: an `accVar`
+    operand (the device pointer, sourced from a matching data-entry op) plus
+    a `var` operand (the host pointer to copy/move to) carrying a `varType`
+    attr. The bounds / async groups, all shared properties, the assembly
+    format, and the keyword-only `__init__` live here.
+    """
+
+    acc_var = operand_def()
+    var = operand_def()
+    bounds = var_operand_def(DataBoundsType)
+    async_operands = var_operand_def(IntegerType | IndexType)
+
+    var_type = prop_def(TypeAttribute, prop_name="varType")
+    async_operands_device_type = opt_prop_def(
+        ArrayAttr[DeviceTypeAttr], prop_name="asyncOperandsDeviceType"
+    )
+    async_only = opt_prop_def(ArrayAttr[DeviceTypeAttr], prop_name="asyncOnly")
+    structured = opt_prop_def(
+        BoolAttr,
+        default_value=IntegerAttr.from_bool(True),
+        prop_name="structured",
+    )
+    implicit = opt_prop_def(
+        BoolAttr,
+        default_value=IntegerAttr.from_bool(False),
+        prop_name="implicit",
+    )
+    modifiers = opt_prop_def(
+        DataClauseModifierAttr,
+        default_value=DataClauseModifierAttr(frozenset[DataClauseModifier]()),
+        prop_name="modifiers",
+    )
+    var_name = opt_prop_def(StringAttr, prop_name="name")
+
+    irdl_options = (
+        AttrSizedOperandSegments(as_property=True),
+        ParsePropInAttrDict(),
+    )
+
+    custom_directives = (AccVar, Var, DeviceTypeOperandsWithKeywordOnly)
+
+    assembly_format = (
+        "custom<AccVar>($acc_var, type($acc_var))"
+        " (`bounds` `(` $bounds^ `)`)?"
+        " (`async` custom<DeviceTypeOperandsWithKeywordOnly>($async_operands,"
+        " type($async_operands), $asyncOperandsDeviceType, $asyncOnly)^)?"
+        " `to` custom<Var>($var, type($var), $varType)"
+        " attr-dict"
+    )
+
+    def __init__(
+        self,
+        *,
+        acc_var: SSAValue | Operation,
+        var: SSAValue | Operation,
+        bounds: Sequence[SSAValue | Operation] = (),
+        async_operands: Sequence[SSAValue | Operation] = (),
+        var_type: TypeAttribute | None = None,
+        async_operands_device_type: ArrayAttr[DeviceTypeAttr] | None = None,
+        async_only: ArrayAttr[DeviceTypeAttr] | None = None,
+        data_clause: DataClauseAttr | DataClause | None = None,
+        structured: BoolAttr | bool | None = None,
+        implicit: BoolAttr | bool | None = None,
+        modifiers: DataClauseModifierAttr | None = None,
+        var_name: StringAttr | str | None = None,
+    ) -> None:
+        var_value = SSAValue.get(var)
+        if var_type is None:
+            var_type = cast(TypeAttribute, _default_var_type(var_value.type))
+
+        structured_prop: BoolAttr | None = (
+            IntegerAttr.from_bool(structured)
+            if isinstance(structured, bool)
+            else structured
+        )
+        implicit_prop: BoolAttr | None = (
+            IntegerAttr.from_bool(implicit) if isinstance(implicit, bool) else implicit
+        )
+        data_clause_prop: DataClauseAttr | None = (
+            DataClauseAttr(data_clause)
+            if isinstance(data_clause, DataClause)
+            else data_clause
+        )
+        var_name_prop: StringAttr | None = (
+            StringAttr(var_name) if isinstance(var_name, str) else var_name
+        )
+
+        super().__init__(
+            operands=[
+                [acc_var],
+                [var],
+                list(bounds),
+                list(async_operands),
+            ],
+            properties={
+                "varType": var_type,
+                "asyncOperandsDeviceType": async_operands_device_type,
+                "asyncOnly": async_only,
+                "dataClause": data_clause_prop,
+                "structured": structured_prop,
+                "implicit": implicit_prop,
+                "modifiers": modifiers,
+                "name": var_name_prop,
+            },
+        )
+
+
+@irdl_op_definition
+class CopyoutOp(_DataExitOperationWithVarPtr):
+    """Implementation of upstream acc.copyout."""
+
+    name = "acc.copyout"
+    data_clause = opt_prop_def(
+        DataClauseAttr,
+        default_value=DataClauseAttr(DataClause.ACC_COPYOUT),
+        prop_name="dataClause",
+    )
+
+
+@irdl_op_definition
+class UpdateHostOp(_DataExitOperationWithVarPtr):
+    """Implementation of upstream acc.update_host."""
+
+    name = "acc.update_host"
+    data_clause = opt_prop_def(
+        DataClauseAttr,
+        default_value=DataClauseAttr(DataClause.ACC_UPDATE_HOST),
+        prop_name="dataClause",
+    )
+
+
+@irdl_op_definition
 class DataBoundsOp(IRDLOperation):
     """
     Implementation of upstream acc.bounds.
@@ -1678,6 +1895,10 @@ ACC = Dialect(
         CacheOp,
         DeclareDeviceResidentOp,
         DeclareLinkOp,
+        GetDevicePtrOp,
+        UpdateDeviceOp,
+        CopyoutOp,
+        UpdateHostOp,
         YieldOp,
     ],
     [


### PR DESCRIPTION
This is one of two PRs for OpenACC data exit clauses, it adds copyout and update_host clauses (which inherit from the same base class) along with some other bits of machinery that are required here (and will also be used in the next PR too)
