### PR TITLE
dialects: (acc) Add data exit delete and detach OpenACC operations

### DIFF
--- a/tests/dialects/test_acc.py
+++ b/tests/dialects/test_acc.py
@@ -451,6 +451,43 @@ def test_copyout_builder_shortcuts():
     assert op.var_name == StringAttr("myvar")
 
 
+def test_delete_minimal_defaulted_props_absent_from_dict():
+    """Same invariant for the `_DataExitOperationNoVarPtr` mixin (no `var`,
+    no `varType`). `acc.delete` exercises the no-host-pointer branch of the
+    exit-shape `__init__`; the dict-state assertion is independently
+    load-bearing because this mixin's `__init__` is a separate method that
+    must reproduce the absence-on-default behavior."""
+    acc_var = create_ssa_value(MemRefType(f32, [10]))
+    op = acc.DeleteOp(acc_var=acc_var)
+    op.verify()
+
+    assert "dataClause" not in op.properties
+    assert "structured" not in op.properties
+    assert "implicit" not in op.properties
+    assert "modifiers" not in op.properties
+    assert op.acc_var is acc_var
+
+
+def test_delete_builder_shortcuts():
+    """Bool / str / `DataClause` shortcuts on `_DataExitOperationNoVarPtr`'s
+    `__init__`. Builder-only conversions; the parser only sees attribute
+    instances."""
+    acc_var = create_ssa_value(MemRefType(f32, [10]))
+    op = acc.DeleteOp(
+        acc_var=acc_var,
+        data_clause=acc.DataClause.ACC_CREATE,
+        structured=False,
+        implicit=True,
+        var_name="d",
+    )
+    op.verify()
+
+    assert op.data_clause == acc.DataClauseAttr(acc.DataClause.ACC_CREATE)
+    assert op.structured == IntegerAttr.from_bool(False)
+    assert op.implicit == IntegerAttr.from_bool(True)
+    assert op.var_name == StringAttr("d")
+
+
 def test_cache_op_has_no_memory_effect_trait():
     """`acc.cache` is the only entry data-clause op that carries
     `NoMemoryEffect` (per upstream's td definition). Tested in pytest because

--- a/tests/filecheck/dialects/acc/ops.mlir
+++ b/tests/filecheck/dialects/acc/ops.mlir
@@ -1077,4 +1077,73 @@ builtin.module {
   // CHECK-LABEL: func.func @update_device_dataclause_default_elided(
   // CHECK:         %{{.*}} = acc.update_device varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32>
   // CHECK-NOT:     dataClause
+
+  // No-host-pointer exit ops (`acc.delete`, `acc.detach`). These live on
+  // `_DataExitOperationNoVarPtr` — three operand groups (`accVar`,
+  // `bounds`, `asyncOperands`), no host `var`, no `varType`. They share
+  // the `AccVar` custom directive and the bounds/async assembly format
+  // tail with the with-host-pointer exit ops.
+  func.func @delete_minimal(%d : memref<10xf32>) {
+    acc.delete accPtr(%d : memref<10xf32>)
+    func.return
+  }
+  // CHECK-LABEL: func.func @delete_minimal(
+  // CHECK:         acc.delete accPtr(%{{.*}} : memref<10xf32>)
+
+  func.func @delete_with_bounds_async(%d : memref<10xf32>, %async : i32, %c0 : index, %c9 : index) {
+    %b = acc.bounds lowerbound(%c0 : index) upperbound(%c9 : index)
+    acc.delete accPtr(%d : memref<10xf32>) bounds(%b) async(%async : i32)
+    func.return
+  }
+  // CHECK-LABEL: func.func @delete_with_bounds_async(
+  // CHECK:         %{{.*}} = acc.bounds lowerbound(%{{.*}} : index) upperbound(%{{.*}} : index)
+  // CHECK-NEXT:    acc.delete accPtr(%{{.*}} : memref<10xf32>) bounds(%{{.*}}) async(%{{.*}} : i32)
+
+  func.func @delete_async_kw_dt(%d : memref<10xf32>) {
+    acc.delete accPtr(%d : memref<10xf32>) async([#acc.device_type<nvidia>])
+    func.return
+  }
+  // CHECK-LABEL: func.func @delete_async_kw_dt(
+  // CHECK:         acc.delete accPtr(%{{.*}} : memref<10xf32>) async([#acc.device_type<nvidia>])
+
+  func.func @delete_full_attr_dict(%d : memref<10xf32>) {
+    acc.delete accPtr(%d : memref<10xf32>) {dataClause = #acc<data_clause acc_create>, implicit = true, modifiers = #acc<data_clause_modifier alwaysout>, name = "myvar", structured = false}
+    func.return
+  }
+  // CHECK-LABEL: func.func @delete_full_attr_dict(
+  // CHECK:         acc.delete accPtr(%{{.*}} : memref<10xf32>) {dataClause = #acc<data_clause acc_create>, implicit = true, modifiers = #acc<data_clause_modifier alwaysout>, name = "myvar", structured = false}
+
+  // Generic-form roundtrip insurance for the no-varPtr exit shape. Three
+  // operand groups (`accVar`, `bounds`, `asyncOperands`) — distinct from
+  // the four-group WithVarPtr shape, so the `operandSegmentSizes` shape is
+  // independently load-bearing here.
+  func.func @delete_generic_roundtrip(%d : memref<10xf32>) {
+    "acc.delete"(%d) <{operandSegmentSizes = array<i32: 1, 0, 0>}> : (memref<10xf32>) -> ()
+    func.return
+  }
+  // CHECK-LABEL: func.func @delete_generic_roundtrip(
+  // CHECK:         acc.delete accPtr(%{{.*}} : memref<10xf32>)
+
+  func.func @delete_dataclause_default_elided(%d : memref<10xf32>) {
+    "acc.delete"(%d) <{dataClause = #acc<data_clause acc_delete>, operandSegmentSizes = array<i32: 1, 0, 0>}> : (memref<10xf32>) -> ()
+    func.return
+  }
+  // CHECK-LABEL: func.func @delete_dataclause_default_elided(
+  // CHECK:         acc.delete accPtr(%{{.*}} : memref<10xf32>)
+  // CHECK-NOT:     dataClause
+
+  func.func @detach_minimal(%d : memref<10xf32>) {
+    acc.detach accPtr(%d : memref<10xf32>)
+    func.return
+  }
+  // CHECK-LABEL: func.func @detach_minimal(
+  // CHECK:         acc.detach accPtr(%{{.*}} : memref<10xf32>)
+
+  func.func @detach_dataclause_default_elided(%d : memref<10xf32>) {
+    "acc.detach"(%d) <{dataClause = #acc<data_clause acc_detach>, operandSegmentSizes = array<i32: 1, 0, 0>}> : (memref<10xf32>) -> ()
+    func.return
+  }
+  // CHECK-LABEL: func.func @detach_dataclause_default_elided(
+  // CHECK:         acc.detach accPtr(%{{.*}} : memref<10xf32>)
+  // CHECK-NOT:     dataClause
 }

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/ops.mlir
@@ -647,4 +647,34 @@ builtin.module {
   }
   // CHECK:       func.func @update_device_minimal(
   // CHECK:         %{{.*}} = acc.update_device varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32>
+
+  func.func @delete_minimal(%d : memref<10xf32>) {
+    acc.delete accPtr(%d : memref<10xf32>)
+    func.return
+  }
+  // CHECK:       func.func @delete_minimal(
+  // CHECK:         acc.delete accPtr(%{{.*}} : memref<10xf32>)
+
+  func.func @delete_with_bounds_async(%d : memref<10xf32>, %async : i32, %c0 : index, %c9 : index) {
+    %b = acc.bounds lowerbound(%c0 : index) upperbound(%c9 : index)
+    acc.delete accPtr(%d : memref<10xf32>) bounds(%b) async(%async : i32)
+    func.return
+  }
+  // CHECK:       func.func @delete_with_bounds_async(
+  // CHECK:         %{{.*}} = acc.bounds lowerbound(%{{.*}} : index) upperbound(%{{.*}} : index)
+  // CHECK-NEXT:    acc.delete accPtr(%{{.*}} : memref<10xf32>) bounds(%{{.*}}) async(%{{.*}} : i32)
+
+  func.func @delete_clause_override(%d : memref<10xf32>) {
+    acc.delete accPtr(%d : memref<10xf32>) {dataClause = #acc<data_clause acc_create>, modifiers = #acc<data_clause_modifier alwaysout>, name = "myvar"}
+    func.return
+  }
+  // CHECK:       func.func @delete_clause_override(
+  // CHECK:         acc.delete accPtr(%{{.*}} : memref<10xf32>) {dataClause = #acc<data_clause acc_create>, modifiers = #acc<data_clause_modifier alwaysout>, name = "myvar"}
+
+  func.func @detach_minimal(%d : memref<10xf32>) {
+    acc.detach accPtr(%d : memref<10xf32>)
+    func.return
+  }
+  // CHECK:       func.func @detach_minimal(
+  // CHECK:         acc.detach accPtr(%{{.*}} : memref<10xf32>)
 }

--- a/xdsl/dialects/acc.py
+++ b/xdsl/dialects/acc.py
@@ -1593,7 +1593,7 @@ class UpdateDeviceOp(_DataEntryOperation):
 
 
 # ---------------------------------------------------------------------------
-# Exit data-clause ops (with-host-pointer family)
+# Exit data-clause ops
 # ---------------------------------------------------------------------------
 #
 # Upstream models the exit data-clause family as two TableGen base classes:
@@ -1601,8 +1601,9 @@ class UpdateDeviceOp(_DataEntryOperation):
 # *and* device pointer) and `OpenACC_DataExitOpNoVarPtr` (for `delete`,
 # `detach` — device pointer only). They differ in operand layout and
 # assembly format, but share the bounds / async / dataClause / structured /
-# implicit / modifiers / name surface. This file currently models only the
-# WithVarPtr half; the NoVarPtr half lands in a follow-up PR.
+# implicit / modifiers / name surface. The two mixins below mirror that
+# split; concrete leaves inherit one and supply only the per-op
+# `dataClause` default.
 
 
 class _DataExitOperationWithVarPtr(IRDLOperation, ABC):
@@ -1735,6 +1736,129 @@ class UpdateHostOp(_DataExitOperationWithVarPtr):
     data_clause = opt_prop_def(
         DataClauseAttr,
         default_value=DataClauseAttr(DataClause.ACC_UPDATE_HOST),
+        prop_name="dataClause",
+    )
+
+
+class _DataExitOperationNoVarPtr(IRDLOperation, ABC):
+    """Shared shape for `acc.delete` / `acc.detach`.
+
+    Mirrors upstream's `OpenACC_DataExitOpNoVarPtr` td class: just the
+    `accVar` operand (device pointer) plus the shared bounds / async /
+    dataClause / structured / implicit / modifiers / name surface. No host
+    `var` and no `varType` — these ops do not transfer data, so they don't
+    need to know the host-side mapping.
+    """
+
+    acc_var = operand_def()
+    bounds = var_operand_def(DataBoundsType)
+    async_operands = var_operand_def(IntegerType | IndexType)
+
+    async_operands_device_type = opt_prop_def(
+        ArrayAttr[DeviceTypeAttr], prop_name="asyncOperandsDeviceType"
+    )
+    async_only = opt_prop_def(ArrayAttr[DeviceTypeAttr], prop_name="asyncOnly")
+    structured = opt_prop_def(
+        BoolAttr,
+        default_value=IntegerAttr.from_bool(True),
+        prop_name="structured",
+    )
+    implicit = opt_prop_def(
+        BoolAttr,
+        default_value=IntegerAttr.from_bool(False),
+        prop_name="implicit",
+    )
+    modifiers = opt_prop_def(
+        DataClauseModifierAttr,
+        default_value=DataClauseModifierAttr(frozenset[DataClauseModifier]()),
+        prop_name="modifiers",
+    )
+    var_name = opt_prop_def(StringAttr, prop_name="name")
+
+    irdl_options = (
+        AttrSizedOperandSegments(as_property=True),
+        ParsePropInAttrDict(),
+    )
+
+    custom_directives = (AccVar, DeviceTypeOperandsWithKeywordOnly)
+
+    assembly_format = (
+        "custom<AccVar>($acc_var, type($acc_var))"
+        " (`bounds` `(` $bounds^ `)`)?"
+        " (`async` custom<DeviceTypeOperandsWithKeywordOnly>($async_operands,"
+        " type($async_operands), $asyncOperandsDeviceType, $asyncOnly)^)?"
+        " attr-dict"
+    )
+
+    def __init__(
+        self,
+        *,
+        acc_var: SSAValue | Operation,
+        bounds: Sequence[SSAValue | Operation] = (),
+        async_operands: Sequence[SSAValue | Operation] = (),
+        async_operands_device_type: ArrayAttr[DeviceTypeAttr] | None = None,
+        async_only: ArrayAttr[DeviceTypeAttr] | None = None,
+        data_clause: DataClauseAttr | DataClause | None = None,
+        structured: BoolAttr | bool | None = None,
+        implicit: BoolAttr | bool | None = None,
+        modifiers: DataClauseModifierAttr | None = None,
+        var_name: StringAttr | str | None = None,
+    ) -> None:
+        structured_prop: BoolAttr | None = (
+            IntegerAttr.from_bool(structured)
+            if isinstance(structured, bool)
+            else structured
+        )
+        implicit_prop: BoolAttr | None = (
+            IntegerAttr.from_bool(implicit) if isinstance(implicit, bool) else implicit
+        )
+        data_clause_prop: DataClauseAttr | None = (
+            DataClauseAttr(data_clause)
+            if isinstance(data_clause, DataClause)
+            else data_clause
+        )
+        var_name_prop: StringAttr | None = (
+            StringAttr(var_name) if isinstance(var_name, str) else var_name
+        )
+
+        super().__init__(
+            operands=[
+                [acc_var],
+                list(bounds),
+                list(async_operands),
+            ],
+            properties={
+                "asyncOperandsDeviceType": async_operands_device_type,
+                "asyncOnly": async_only,
+                "dataClause": data_clause_prop,
+                "structured": structured_prop,
+                "implicit": implicit_prop,
+                "modifiers": modifiers,
+                "name": var_name_prop,
+            },
+        )
+
+
+@irdl_op_definition
+class DeleteOp(_DataExitOperationNoVarPtr):
+    """Implementation of upstream acc.delete."""
+
+    name = "acc.delete"
+    data_clause = opt_prop_def(
+        DataClauseAttr,
+        default_value=DataClauseAttr(DataClause.ACC_DELETE),
+        prop_name="dataClause",
+    )
+
+
+@irdl_op_definition
+class DetachOp(_DataExitOperationNoVarPtr):
+    """Implementation of upstream acc.detach."""
+
+    name = "acc.detach"
+    data_clause = opt_prop_def(
+        DataClauseAttr,
+        default_value=DataClauseAttr(DataClause.ACC_DETACH),
         prop_name="dataClause",
     )
 
@@ -1899,6 +2023,8 @@ ACC = Dialect(
         UpdateDeviceOp,
         CopyoutOp,
         UpdateHostOp,
+        DeleteOp,
+        DetachOp,
         YieldOp,
     ],
     [


### PR DESCRIPTION
Adds data delete and detach OpenACC operations, which both extend the same base class. This completes OpenACC's data exist operations in the dialect.
