### PR TITLE
[WIP] dialects: (acc) Privatisation OpenACC operations

### DIFF
--- a/tests/dialects/test_acc.py
+++ b/tests/dialects/test_acc.py
@@ -499,3 +499,48 @@ def test_cache_op_has_no_memory_effect_trait():
     assert not acc.CopyinOp.has_trait(NoMemoryEffect)
     assert not acc.AttachOp.has_trait(NoMemoryEffect)
     assert not acc.DeclareDeviceResidentOp.has_trait(NoMemoryEffect)
+
+
+def test_private_minimal_defaulted_props_absent_from_dict():
+    """Privatization ops share the `_DataEntryOperation` mixin, so the
+    same defaulted-prop absence invariant applies: defaulted props
+    (`dataClause` / `structured` / `implicit` / `modifiers`) must be
+    *absent* from `op.properties` when not explicitly set."""
+    op = acc.PrivateOp(var=create_ssa_value(MemRefType(f32, [10])))
+
+    assert "dataClause" not in op.properties
+    assert "structured" not in op.properties
+    assert "implicit" not in op.properties
+    assert "modifiers" not in op.properties
+
+
+def test_private_builder_shortcuts():
+    """Bool / str / `DataClause` shortcuts on `_DataEntryOperation`'s
+    `__init__` for `acc.private`. Builder-only conversions; the parser only
+    sees attribute instances."""
+    op = acc.PrivateOp(
+        var=create_ssa_value(MemRefType(f32, [10])),
+        data_clause=acc.DataClause.ACC_PRIVATE,
+        structured=False,
+        implicit=True,
+        var_name="myvar",
+    )
+
+    assert op.data_clause == acc.DataClauseAttr(acc.DataClause.ACC_PRIVATE)
+    assert op.structured == IntegerAttr.from_bool(False)
+    assert op.implicit == IntegerAttr.from_bool(True)
+    assert op.var_name == StringAttr("myvar")
+
+
+def test_privatization_leaf_dataclause_defaults_absent_from_dict():
+    """The defaulted `dataClause` prop must be *absent* from `op.properties`
+    on each privatization leaf when not explicitly set — otherwise attr-dict
+    elision on print silently fails. Filecheck owns the *value* of each
+    leaf's default (via the `*_dataclause_default_elided` cases); the
+    dict-state invariant is Python-only."""
+    fp = acc.FirstprivateOp(var=create_ssa_value(MemRefType(f32, [10])))
+    fpm = acc.FirstprivateMapOp(var=create_ssa_value(MemRefType(f32, [10])))
+    red = acc.ReductionOp(var=create_ssa_value(MemRefType(f32, [10])))
+    assert "dataClause" not in fp.properties
+    assert "dataClause" not in fpm.properties
+    assert "dataClause" not in red.properties

--- a/tests/filecheck/dialects/acc/attrs.mlir
+++ b/tests/filecheck/dialects/acc/attrs.mlir
@@ -37,8 +37,40 @@
                 // CHECK-SAME: #acc<variable_type_category uncategorized>
                 #acc<variable_type_category scalar>,
                 // CHECK-SAME: #acc<variable_type_category scalar>
-                #acc<variable_type_category array,composite>
+                #acc<variable_type_category array,composite>,
                 // CHECK-SAME: #acc<variable_type_category array,composite>
+
+                // Like `device_type`, `reduction_operator` prints with the
+                // dialect-qualified name and `<value>` braces (no
+                // `SpacedOpaqueSyntaxAttribute`), to match upstream's
+                // `assemblyFormat = "`<` $value `>`"`. Enumerate every
+                // member so the `ReductionOperator` enum / attribute pair
+                // is fully exercised even though no IRDL op consumes it
+                // in this PR.
+                #acc.reduction_operator<none>,
+                // CHECK-SAME: #acc.reduction_operator<none>
+                #acc.reduction_operator<add>,
+                // CHECK-SAME: #acc.reduction_operator<add>
+                #acc.reduction_operator<mul>,
+                // CHECK-SAME: #acc.reduction_operator<mul>
+                #acc.reduction_operator<max>,
+                // CHECK-SAME: #acc.reduction_operator<max>
+                #acc.reduction_operator<min>,
+                // CHECK-SAME: #acc.reduction_operator<min>
+                #acc.reduction_operator<iand>,
+                // CHECK-SAME: #acc.reduction_operator<iand>
+                #acc.reduction_operator<ior>,
+                // CHECK-SAME: #acc.reduction_operator<ior>
+                #acc.reduction_operator<xor>,
+                // CHECK-SAME: #acc.reduction_operator<xor>
+                #acc.reduction_operator<eqv>,
+                // CHECK-SAME: #acc.reduction_operator<eqv>
+                #acc.reduction_operator<neqv>,
+                // CHECK-SAME: #acc.reduction_operator<neqv>
+                #acc.reduction_operator<land>,
+                // CHECK-SAME: #acc.reduction_operator<land>
+                #acc.reduction_operator<lor>
+                // CHECK-SAME: #acc.reduction_operator<lor>
 
             ]}: () -> !acc.data_bounds_ty
                 // CHECK-SAME: !acc.data_bounds_ty

--- a/tests/filecheck/dialects/acc/ops.mlir
+++ b/tests/filecheck/dialects/acc/ops.mlir
@@ -1146,4 +1146,84 @@ builtin.module {
   // CHECK-LABEL: func.func @detach_dataclause_default_elided(
   // CHECK:         acc.detach accPtr(%{{.*}} : memref<10xf32>)
   // CHECK-NOT:     dataClause
+
+  // Privatization data-clause leaves (`acc.private`, `acc.firstprivate`,
+  // `acc.firstprivate_map`, `acc.reduction`). Same `_DataEntryOperation`
+  // shape as `acc.copyin`, so the operand / property surface is already
+  // covered there — the cases below pin the per-op `dataClause` default
+  // and show the inherited optional `recipe` symbol slot rendered through
+  // attr-dict.
+  func.func @private_minimal(%a : memref<10xf32>) {
+    %r = acc.private varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    func.return
+  }
+  // CHECK-LABEL: func.func @private_minimal(
+  // CHECK:         %{{.*}} = acc.private varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32>
+
+  func.func @private_with_recipe(%a : memref<10xf32>) {
+    // The `recipe` symbol slot is an attr-dict-only property on
+    // `_DataEntryOperation`; this case proves it round-trips for
+    // `acc.private` even though no recipe op exists yet in xDSL.
+    %r = acc.private varPtr(%a : memref<10xf32>) -> memref<10xf32> {recipe = @priv_recipe}
+    func.return
+  }
+  // CHECK-LABEL: func.func @private_with_recipe(
+  // CHECK:         %{{.*}} = acc.private varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32> {recipe = @priv_recipe}
+
+  func.func @private_dataclause_default_elided(%a : memref<10xf32>) {
+    %r = "acc.private"(%a) <{dataClause = #acc<data_clause acc_private>, operandSegmentSizes = array<i32: 1, 0, 0, 0>, varType = f32}> : (memref<10xf32>) -> memref<10xf32>
+    func.return
+  }
+  // CHECK-LABEL: func.func @private_dataclause_default_elided(
+  // CHECK:         %{{.*}} = acc.private varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32>
+  // CHECK-NOT:     dataClause
+
+  func.func @firstprivate_minimal(%a : memref<10xf32>) {
+    %r = acc.firstprivate varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    func.return
+  }
+  // CHECK-LABEL: func.func @firstprivate_minimal(
+  // CHECK:         %{{.*}} = acc.firstprivate varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32>
+
+  func.func @firstprivate_dataclause_default_elided(%a : memref<10xf32>) {
+    %r = "acc.firstprivate"(%a) <{dataClause = #acc<data_clause acc_firstprivate>, operandSegmentSizes = array<i32: 1, 0, 0, 0>, varType = f32}> : (memref<10xf32>) -> memref<10xf32>
+    func.return
+  }
+  // CHECK-LABEL: func.func @firstprivate_dataclause_default_elided(
+  // CHECK:         %{{.*}} = acc.firstprivate varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32>
+  // CHECK-NOT:     dataClause
+
+  // `acc.firstprivate_map` shares `acc.firstprivate`'s `dataClause` default
+  // (`acc_firstprivate`) — the two ops are distinguished by name, not
+  // dataClause. So the generic-form input here also carries the same
+  // `acc_firstprivate` default to verify it elides on the pretty form.
+  func.func @firstprivate_map_minimal(%a : memref<10xf32>) {
+    %r = acc.firstprivate_map varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    func.return
+  }
+  // CHECK-LABEL: func.func @firstprivate_map_minimal(
+  // CHECK:         %{{.*}} = acc.firstprivate_map varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32>
+
+  func.func @firstprivate_map_dataclause_default_elided(%a : memref<10xf32>) {
+    %r = "acc.firstprivate_map"(%a) <{dataClause = #acc<data_clause acc_firstprivate>, operandSegmentSizes = array<i32: 1, 0, 0, 0>, varType = f32}> : (memref<10xf32>) -> memref<10xf32>
+    func.return
+  }
+  // CHECK-LABEL: func.func @firstprivate_map_dataclause_default_elided(
+  // CHECK:         %{{.*}} = acc.firstprivate_map varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32>
+  // CHECK-NOT:     dataClause
+
+  func.func @reduction_minimal(%a : memref<i64>) {
+    %r = acc.reduction varPtr(%a : memref<i64>) -> memref<i64>
+    func.return
+  }
+  // CHECK-LABEL: func.func @reduction_minimal(
+  // CHECK:         %{{.*}} = acc.reduction varPtr(%{{.*}} : memref<i64>) -> memref<i64>
+
+  func.func @reduction_dataclause_default_elided(%a : memref<i64>) {
+    %r = "acc.reduction"(%a) <{dataClause = #acc<data_clause acc_reduction>, operandSegmentSizes = array<i32: 1, 0, 0, 0>, varType = i64}> : (memref<i64>) -> memref<i64>
+    func.return
+  }
+  // CHECK-LABEL: func.func @reduction_dataclause_default_elided(
+  // CHECK:         %{{.*}} = acc.reduction varPtr(%{{.*}} : memref<i64>) -> memref<i64>
+  // CHECK-NOT:     dataClause
 }

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/ops.mlir
@@ -677,4 +677,26 @@ builtin.module {
   }
   // CHECK:       func.func @detach_minimal(
   // CHECK:         acc.detach accPtr(%{{.*}} : memref<10xf32>)
+
+  // `acc.firstprivate_map` is the only privatization-family op that does
+  // *not* require a `recipe` symbol per upstream's verifier — so it's the
+  // one we can interop-test without first standing up the recipe ops
+  // (deferred to PR 13). For `acc.private`, `acc.firstprivate`, and
+  // `acc.reduction`, the upstream verifier rejects the op when the var is
+  // a pointer-like memref and no recipe is set; xDSL-only roundtrip
+  // coverage in `tests/filecheck/dialects/acc/ops.mlir` exercises the
+  // operand/property surface in the meantime.
+  func.func @firstprivate_map_minimal(%a : memref<10xf32>) {
+    %r = acc.firstprivate_map varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    func.return
+  }
+  // CHECK:       func.func @firstprivate_map_minimal(
+  // CHECK:         %{{.*}} = acc.firstprivate_map varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32>
+
+  func.func @firstprivate_map_with_var_type(%a : memref<10xf32>) {
+    %r = acc.firstprivate_map varPtr(%a : memref<10xf32>) varType(tensor<10xf32>) -> memref<10xf32>
+    func.return
+  }
+  // CHECK:       func.func @firstprivate_map_with_var_type(
+  // CHECK:         %{{.*}} = acc.firstprivate_map varPtr(%{{.*}} : memref<10xf32>) varType(tensor<10xf32>) -> memref<10xf32>
 }

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/ops.mlir
@@ -679,13 +679,12 @@ builtin.module {
   // CHECK:         acc.detach accPtr(%{{.*}} : memref<10xf32>)
 
   // `acc.firstprivate_map` is the only privatization-family op that does
-  // *not* require a `recipe` symbol per upstream's verifier — so it's the
-  // one we can interop-test without first standing up the recipe ops
-  // (deferred to PR 13). For `acc.private`, `acc.firstprivate`, and
-  // `acc.reduction`, the upstream verifier rejects the op when the var is
-  // a pointer-like memref and no recipe is set; xDSL-only roundtrip
-  // coverage in `tests/filecheck/dialects/acc/ops.mlir` exercises the
-  // operand/property surface in the meantime.
+  // *not* require a `recipe` symbol per upstream's verifier, so it
+  // round-trips with the standard MLIR_ROUNDTRIP / MLIR_GENERIC_ROUNDTRIP
+  // substitutions used by this file. The other three (`acc.private`,
+  // `acc.firstprivate`, `acc.reduction`) are interop-tested in the
+  // companion `ops_with_recipe.mlir`, which uses custom RUN lines to
+  // declare the recipe ops in generic form for the moment.
   func.func @firstprivate_map_minimal(%a : memref<10xf32>) {
     %r = acc.firstprivate_map varPtr(%a : memref<10xf32>) -> memref<10xf32>
     func.return

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/ops_with_recipe.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/ops_with_recipe.mlir
@@ -1,0 +1,96 @@
+// RUN: xdsl-opt --allow-unregistered-dialect --disable-verify %s --print-op-generic | mlir-opt --allow-unregistered-dialect --mlir-print-op-generic --mlir-print-local-scope | xdsl-opt --allow-unregistered-dialect --disable-verify | filecheck %s
+
+// MLIR interop coverage for the privatization data-clause ops that
+// upstream's verifier requires a `recipe` SymbolRefAttr to resolve to a
+// real `acc.private.recipe` / `acc.firstprivate.recipe` /
+// `acc.reduction.recipe` op (per `checkRecipe` in OpenACC.cpp): the var
+// type is memref (`PointerLikeType`, not `MappableType`), so a recipe is
+// mandatory.
+//
+// The recipe ops themselves are deferred to a later PR
+// so xDSL has no IRDL classes for them yet. To still
+// exercise the data-op interop, we declare the three recipes inline in
+// *generic form* and pass `--allow-unregistered-dialect --disable-verify`
+// on each xdsl-opt invocation:
+//   - `--allow-unregistered-dialect` lets xdsl-opt print/parse the
+//     recipe ops as unregistered (they're in the registered acc dialect
+//     but xDSL has no classes yet).
+//   - `--disable-verify` skips `acc.yield`'s `HasParent` check, since
+//     the parent is one of the unregistered recipe ops.
+// `mlir-opt` parses the recipes as the real registered ops (it has
+// classes for them) and runs its full verifier over the data ops + their
+// `recipe` symbol references; the round-trip back through xdsl-opt then
+// re-emits the recipes in generic form. When PR 13 lands, this file
+// should be folded into `ops.mlir` with the standard MLIR_ROUNDTRIP /
+// MLIR_GENERIC_ROUNDTRIP substitutions.
+
+"acc.private.recipe"() <{sym_name = "priv_recipe", type = memref<10xf32>}> ({
+^bb0(%arg0: memref<10xf32>):
+  "acc.yield"(%arg0) : (memref<10xf32>) -> ()
+}, {
+^bb0(%arg0: memref<10xf32>):
+  "acc.yield"(%arg0) : (memref<10xf32>) -> ()
+}) : () -> ()
+// CHECK:      "acc.private.recipe"() <{sym_name = "priv_recipe", type = memref<10xf32>}> ({
+// CHECK-NEXT:   ^{{.*}}(%{{.*}}: memref<10xf32>):
+// CHECK-NEXT:     acc.yield %{{.*}} : memref<10xf32>
+// CHECK-NEXT:   }, {
+// CHECK-NEXT:   ^{{.*}}(%{{.*}}: memref<10xf32>):
+// CHECK-NEXT:     acc.yield %{{.*}} : memref<10xf32>
+// CHECK-NEXT:   }) : () -> ()
+
+"acc.firstprivate.recipe"() <{sym_name = "fp_recipe", type = memref<10xf32>}> ({
+^bb0(%arg0: memref<10xf32>):
+  "acc.yield"(%arg0) : (memref<10xf32>) -> ()
+}, {
+^bb0(%arg0: memref<10xf32>, %arg1: memref<10xf32>):
+  "acc.yield"(%arg1) : (memref<10xf32>) -> ()
+}, {
+^bb0(%arg0: memref<10xf32>):
+  "acc.terminator"() : () -> ()
+}) : () -> ()
+// CHECK:      "acc.firstprivate.recipe"() <{sym_name = "fp_recipe", type = memref<10xf32>}> ({
+// CHECK-NEXT:   ^{{.*}}(%{{.*}}: memref<10xf32>):
+// CHECK-NEXT:     acc.yield %{{.*}} : memref<10xf32>
+// CHECK-NEXT:   }, {
+// CHECK-NEXT:   ^{{.*}}(%{{.*}}: memref<10xf32>, %{{.*}}: memref<10xf32>):
+// CHECK-NEXT:     acc.yield %{{.*}} : memref<10xf32>
+// CHECK-NEXT:   }, {
+// CHECK-NEXT:   ^{{.*}}(%{{.*}}: memref<10xf32>):
+// CHECK-NEXT:     "acc.terminator"() : () -> ()
+// CHECK-NEXT:   }) : () -> ()
+
+"acc.reduction.recipe"() <{sym_name = "red_recipe", type = memref<i64>, reductionOperator = #acc.reduction_operator<add>}> ({
+^bb0(%arg0: memref<i64>):
+  "acc.yield"(%arg0) : (memref<i64>) -> ()
+}, {
+^bb0(%arg0: memref<i64>, %arg1: memref<i64>):
+  "acc.yield"(%arg0) : (memref<i64>) -> ()
+}, {
+^bb0(%arg0: memref<i64>):
+  "acc.terminator"() : () -> ()
+}) : () -> ()
+// `reductionOperator` lives in the recipe op's properties dict alongside
+// `sym_name` / `type`; mlir-opt's generic-form printer sorts them
+// alphabetically, hence the `reductionOperator` slot prints first.
+// CHECK:      "acc.reduction.recipe"() <{reductionOperator = #acc.reduction_operator<add>, sym_name = "red_recipe", type = memref<i64>}> ({
+// CHECK-NEXT:   ^{{.*}}(%{{.*}}: memref<i64>):
+// CHECK-NEXT:     acc.yield %{{.*}} : memref<i64>
+// CHECK-NEXT:   }, {
+// CHECK-NEXT:   ^{{.*}}(%{{.*}}: memref<i64>, %{{.*}}: memref<i64>):
+// CHECK-NEXT:     acc.yield %{{.*}} : memref<i64>
+// CHECK-NEXT:   }, {
+// CHECK-NEXT:   ^{{.*}}(%{{.*}}: memref<i64>):
+// CHECK-NEXT:     "acc.terminator"() : () -> ()
+// CHECK-NEXT:   }) : () -> ()
+
+func.func @privatization_data_ops(%a : memref<10xf32>, %b : memref<i64>) {
+  %p = acc.private varPtr(%a : memref<10xf32>) -> memref<10xf32> {recipe = @priv_recipe}
+  %fp = acc.firstprivate varPtr(%a : memref<10xf32>) -> memref<10xf32> {recipe = @fp_recipe}
+  %r = acc.reduction varPtr(%b : memref<i64>) -> memref<i64> {recipe = @red_recipe}
+  func.return
+}
+// CHECK:      func.func @privatization_data_ops(
+// CHECK:        %{{.*}} = acc.private varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32> {recipe = @priv_recipe}
+// CHECK-NEXT:   %{{.*}} = acc.firstprivate varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32> {recipe = @fp_recipe}
+// CHECK-NEXT:   %{{.*}} = acc.reduction varPtr(%{{.*}} : memref<i64>) -> memref<i64> {recipe = @red_recipe}

--- a/xdsl/dialects/acc.py
+++ b/xdsl/dialects/acc.py
@@ -159,6 +159,28 @@ class VariableTypeCategory(StrEnum):
     NONSCALAR = "nonscalar"
 
 
+class ReductionOperator(StrEnum):
+    """Built-in OpenACC reduction operators.
+
+    Matches upstream `mlir::acc::ReductionOperator`. Not yet consumed by an
+    op in this PR — it's introduced here for the upcoming `acc.loop` and
+    `acc.reduction.recipe` ops, per the dialect roadmap.
+    """
+
+    NONE = "none"
+    ADD = "add"
+    MUL = "mul"
+    MAX = "max"
+    MIN = "min"
+    IAND = "iand"
+    IOR = "ior"
+    XOR = "xor"
+    EQV = "eqv"
+    NEQV = "neqv"
+    LAND = "land"
+    LOR = "lor"
+
+
 @irdl_attr_definition
 class DeviceTypeAttr(EnumAttribute[DeviceType]):
     """
@@ -232,6 +254,26 @@ class VariableTypeCategoryAttr(
     none_value = "uncategorized"
     separator_value = ","
     delimiter_value = AttrParser.Delimiter.NONE
+
+
+@irdl_attr_definition
+class ReductionOperatorAttr(EnumAttribute[ReductionOperator]):
+    """
+    Reduction operator attribute. Prints using the pretty form
+    `#acc.reduction_operator<value>` to match upstream MLIR (which defines
+    `assemblyFormat = "`<` $value `>`"`).
+    """
+
+    name = "acc.reduction_operator"
+
+    def print_parameter(self, printer: Printer) -> None:
+        with printer.in_angle_brackets():
+            printer.print_string(self.data.value)
+
+    @classmethod
+    def parse_parameter(cls, parser: AttrParser) -> ReductionOperator:
+        with parser.in_angle_brackets():
+            return parser.parse_str_enum(ReductionOperator)
 
 
 @irdl_attr_definition
@@ -1593,6 +1635,80 @@ class UpdateDeviceOp(_DataEntryOperation):
 
 
 # ---------------------------------------------------------------------------
+# Privatization data-clause ops
+# ---------------------------------------------------------------------------
+#
+# Upstream models the privatization family (`private`, `firstprivate`,
+# `firstprivate_map`, `reduction`) as plain `OpenACC_DataEntryOp` leaves —
+# same operand-and-attribute shape as the entry ops above. They differ only
+# in the per-op `dataClause` default. The `recipe` slot inherited from
+# `_DataEntryOperation` is what carries the privatization/reduction logic;
+# upstream's verifier requires it to be set when the var is a pointer-like
+# type (memref). The recipe ops themselves are introduced in a later PR.
+
+
+@irdl_op_definition
+class PrivateOp(_DataEntryOperation):
+    """Implementation of upstream acc.private."""
+
+    name = "acc.private"
+    data_clause = opt_prop_def(
+        DataClauseAttr,
+        default_value=DataClauseAttr(DataClause.ACC_PRIVATE),
+        prop_name="dataClause",
+    )
+
+
+@irdl_op_definition
+class FirstprivateOp(_DataEntryOperation):
+    """Implementation of upstream acc.firstprivate."""
+
+    name = "acc.firstprivate"
+    data_clause = opt_prop_def(
+        DataClauseAttr,
+        default_value=DataClauseAttr(DataClause.ACC_FIRSTPRIVATE),
+        prop_name="dataClause",
+    )
+
+
+@irdl_op_definition
+class FirstprivateMapOp(_DataEntryOperation):
+    """Implementation of upstream acc.firstprivate_map.
+
+    Used to decompose firstprivate semantics: this op represents the mapping
+    of the host's initial value (which the per-iteration private copies are
+    initialized from). It shares `acc.firstprivate`'s `dataClause` default
+    (`acc_firstprivate`) — the two ops are distinguished by op name, not by
+    their `dataClause` attribute.
+    """
+
+    name = "acc.firstprivate_map"
+    data_clause = opt_prop_def(
+        DataClauseAttr,
+        default_value=DataClauseAttr(DataClause.ACC_FIRSTPRIVATE),
+        prop_name="dataClause",
+    )
+
+
+@irdl_op_definition
+class ReductionOp(_DataEntryOperation):
+    """Implementation of upstream acc.reduction.
+
+    Plain entry-shape op per upstream `OpenACC_ReductionOp`. The reduction
+    operator (add / mul / max / ...) is *not* carried on this op — it lives
+    on the corresponding `acc.reduction.recipe` referenced via the inherited
+    `recipe` symbol slot.
+    """
+
+    name = "acc.reduction"
+    data_clause = opt_prop_def(
+        DataClauseAttr,
+        default_value=DataClauseAttr(DataClause.ACC_REDUCTION),
+        prop_name="dataClause",
+    )
+
+
+# ---------------------------------------------------------------------------
 # Exit data-clause ops
 # ---------------------------------------------------------------------------
 #
@@ -2021,6 +2137,10 @@ ACC = Dialect(
         DeclareLinkOp,
         GetDevicePtrOp,
         UpdateDeviceOp,
+        PrivateOp,
+        FirstprivateOp,
+        FirstprivateMapOp,
+        ReductionOp,
         CopyoutOp,
         UpdateHostOp,
         DeleteOp,
@@ -2033,6 +2153,7 @@ ACC = Dialect(
         DataClauseAttr,
         DataClauseModifierAttr,
         VariableTypeCategoryAttr,
+        ReductionOperatorAttr,
         DataBoundsType,
     ],
 )


### PR DESCRIPTION
This PR adds privatisation operations in OpenACC into the dialect. Note that for some of these we need OpenACC recipes in order to fully test mlir interoperability, hence a new filecheck test which uses unregistered dialects and mocks this in for now. This enables the operations in this PR to be tested with MLIR interoperability, and in a future PR that mock in for recipes will be replaced with the corresponding dialect constructs that are added in that PR. 

As a note, in that new MLIR interoperability test we use --disable-verify to xDSL, as the scf.YieldOp would fail verification as it can only terminate parallel or serial op at the moment. In the future it will terminate the recipe but that needs to be added (in a subsequent PR) first
