### PR TITLE
dialects: (acc) Reduction recipe kind attribute

### DIFF
--- a/tests/filecheck/dialects/acc/attrs.mlir
+++ b/tests/filecheck/dialects/acc/attrs.mlir
@@ -37,8 +37,39 @@
                 // CHECK-SAME: #acc<variable_type_category uncategorized>
                 #acc<variable_type_category scalar>,
                 // CHECK-SAME: #acc<variable_type_category scalar>
-                #acc<variable_type_category array,composite>
+                #acc<variable_type_category array,composite>,
                 // CHECK-SAME: #acc<variable_type_category array,composite>
+
+                // Reduction operator attribute. Prints with `<value>`
+                // surrounding the parameter (matching upstream MLIR's
+                // `assemblyFormat = "`<` $value `>`"`), so when consumed
+                // inline via `$reductionOperator` in a future op format the
+                // spelling is `reduction_operator <add>` rather than the
+                // long-form `#acc.reduction_operator<add>`.
+                #acc.reduction_operator<none>,
+                // CHECK-SAME: #acc.reduction_operator<none>
+                #acc.reduction_operator<add>,
+                // CHECK-SAME: #acc.reduction_operator<add>
+                #acc.reduction_operator<mul>,
+                // CHECK-SAME: #acc.reduction_operator<mul>
+                #acc.reduction_operator<max>,
+                // CHECK-SAME: #acc.reduction_operator<max>
+                #acc.reduction_operator<min>,
+                // CHECK-SAME: #acc.reduction_operator<min>
+                #acc.reduction_operator<iand>,
+                // CHECK-SAME: #acc.reduction_operator<iand>
+                #acc.reduction_operator<ior>,
+                // CHECK-SAME: #acc.reduction_operator<ior>
+                #acc.reduction_operator<xor>,
+                // CHECK-SAME: #acc.reduction_operator<xor>
+                #acc.reduction_operator<eqv>,
+                // CHECK-SAME: #acc.reduction_operator<eqv>
+                #acc.reduction_operator<neqv>,
+                // CHECK-SAME: #acc.reduction_operator<neqv>
+                #acc.reduction_operator<land>,
+                // CHECK-SAME: #acc.reduction_operator<land>
+                #acc.reduction_operator<lor>
+                // CHECK-SAME: #acc.reduction_operator<lor>
 
             ]}: () -> !acc.data_bounds_ty
                 // CHECK-SAME: !acc.data_bounds_ty

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/attrs.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/attrs.mlir
@@ -1,0 +1,85 @@
+// RUN: MLIR_ROUNDTRIP
+// RUN: MLIR_GENERIC_ROUNDTRIP
+
+// Proves xDSL emits each `acc` dialect attribute in a spelling that
+// upstream `mlir-opt` accepts and re-emits identically. The attrs are
+// hung off an unregistered `"test.op"` so that no concrete op is needed
+// to exercise them — `--allow-unregistered-dialect` (set in the
+// MLIR_ROUNDTRIP substitution) lets mlir-opt parse the carrier op.
+//
+// Pre-existing attrs (`device_type`, `defaultvalue`, `data_clause`,
+// `data_clause_modifier`, `variable_type_category`) currently have no
+// MLIR interop test of their own — they were only covered indirectly
+// through the data-clause ops. Including them here gives every `acc`
+// attribute its own MLIR-interop CHECK and makes `attrs.mlir` the
+// canonical place to extend coverage when new attributes land.
+"test.op"() {attrs = [
+                #acc.device_type<none>,
+                // CHECK: #acc.device_type<none>
+                #acc.device_type<nvidia>,
+                // CHECK-SAME: #acc.device_type<nvidia>
+
+                #acc<defaultvalue none>,
+                // CHECK-SAME: #acc<defaultvalue none>
+                #acc<defaultvalue present>,
+                // CHECK-SAME: #acc<defaultvalue present>
+
+                #acc<data_clause acc_copyin>,
+                // CHECK-SAME: #acc<data_clause acc_copyin>
+                #acc<data_clause acc_copyin_readonly>,
+                // CHECK-SAME: #acc<data_clause acc_copyin_readonly>
+                #acc<data_clause acc_copyout>,
+                // CHECK-SAME: #acc<data_clause acc_copyout>
+                #acc<data_clause acc_create_zero>,
+                // CHECK-SAME: #acc<data_clause acc_create_zero>
+                #acc<data_clause acc_cache_readonly>,
+                // CHECK-SAME: #acc<data_clause acc_cache_readonly>
+
+                #acc<data_clause_modifier none>,
+                // CHECK-SAME: #acc<data_clause_modifier none>
+                #acc<data_clause_modifier readonly>,
+                // CHECK-SAME: #acc<data_clause_modifier readonly>
+                // Multi-bit sets parse in any order but print in the
+                // declaration order of the enum (zero before readonly).
+                #acc<data_clause_modifier zero,readonly>,
+                // CHECK-SAME: #acc<data_clause_modifier zero,readonly>
+                // Note: combining `alwaysin,alwaysout` triggers upstream's
+                // group alias `always` on re-emit, which xDSL doesn't model.
+                // Stick to single-bit cases here; the full multi-bit
+                // coverage stays in `tests/filecheck/dialects/acc/attrs.mlir`.
+                #acc<data_clause_modifier alwaysin>,
+                // CHECK-SAME: #acc<data_clause_modifier alwaysin>
+                #acc<data_clause_modifier capture>,
+                // CHECK-SAME: #acc<data_clause_modifier capture>
+
+                // `#acc<variable_type_category ...>` is xDSL-only — upstream
+                // models VariableTypeCategory as a type-categorization bit
+                // enum, not a registered attribute, so mlir-opt does not
+                // accept it. Coverage stays in `tests/filecheck/dialects/acc/attrs.mlir`.
+
+                #acc.reduction_operator<none>,
+                // CHECK-SAME: #acc.reduction_operator<none>
+                #acc.reduction_operator<add>,
+                // CHECK-SAME: #acc.reduction_operator<add>
+                #acc.reduction_operator<mul>,
+                // CHECK-SAME: #acc.reduction_operator<mul>
+                #acc.reduction_operator<max>,
+                // CHECK-SAME: #acc.reduction_operator<max>
+                #acc.reduction_operator<min>,
+                // CHECK-SAME: #acc.reduction_operator<min>
+                #acc.reduction_operator<iand>,
+                // CHECK-SAME: #acc.reduction_operator<iand>
+                #acc.reduction_operator<ior>,
+                // CHECK-SAME: #acc.reduction_operator<ior>
+                #acc.reduction_operator<xor>,
+                // CHECK-SAME: #acc.reduction_operator<xor>
+                #acc.reduction_operator<eqv>,
+                // CHECK-SAME: #acc.reduction_operator<eqv>
+                #acc.reduction_operator<neqv>,
+                // CHECK-SAME: #acc.reduction_operator<neqv>
+                #acc.reduction_operator<land>,
+                // CHECK-SAME: #acc.reduction_operator<land>
+                #acc.reduction_operator<lor>
+                // CHECK-SAME: #acc.reduction_operator<lor>
+
+            ]} : () -> ()

--- a/xdsl/dialects/acc.py
+++ b/xdsl/dialects/acc.py
@@ -159,6 +159,29 @@ class VariableTypeCategory(StrEnum):
     NONSCALAR = "nonscalar"
 
 
+class ReductionOpKind(StrEnum):
+    """Built-in reduction operators supported by OpenACC.
+
+    See upstream `mlir::acc::ReductionOperator` (renamed in xDSL to avoid
+    clashing with the `Operator` / `Operation` naming used elsewhere).
+    Carried on `acc.reduction.recipe` to identify which reduction the recipe
+    encodes.
+    """
+
+    NONE = "none"
+    ADD = "add"
+    MUL = "mul"
+    MAX = "max"
+    MIN = "min"
+    IAND = "iand"
+    IOR = "ior"
+    XOR = "xor"
+    EQV = "eqv"
+    NEQV = "neqv"
+    LAND = "land"
+    LOR = "lor"
+
+
 @irdl_attr_definition
 class DeviceTypeAttr(EnumAttribute[DeviceType]):
     """
@@ -232,6 +255,29 @@ class VariableTypeCategoryAttr(
     none_value = "uncategorized"
     separator_value = ","
     delimiter_value = AttrParser.Delimiter.NONE
+
+
+@irdl_attr_definition
+class ReductionOpKindAttr(EnumAttribute[ReductionOpKind]):
+    """
+    Reduction operator attribute carried by `acc.reduction.recipe`. Prints
+    using the pretty form `#acc.reduction_operator<value>` to match upstream
+    MLIR (which defines `assemblyFormat = "`<` $value `>`"`). When referenced
+    as `$reductionOperator` in an op assembly format, xDSL prints just the
+    `<value>` parameter — matching upstream's inline spelling
+    `reduction_operator <add>`.
+    """
+
+    name = "acc.reduction_operator"
+
+    def print_parameter(self, printer: Printer) -> None:
+        with printer.in_angle_brackets():
+            printer.print_string(self.data.value)
+
+    @classmethod
+    def parse_parameter(cls, parser: AttrParser) -> ReductionOpKind:
+        with parser.in_angle_brackets():
+            return parser.parse_str_enum(ReductionOpKind)
 
 
 @irdl_attr_definition
@@ -2033,6 +2079,7 @@ ACC = Dialect(
         DataClauseAttr,
         DataClauseModifierAttr,
         VariableTypeCategoryAttr,
+        ReductionOpKindAttr,
         DataBoundsType,
     ],
 )


### PR DESCRIPTION
The first PR to add support for OpenACC recipes, this adds the reduction recipe kind attribute
