### PR TITLE
dialects: (acc) Private recipe and firstprivate recipe OpenACC operations

### DIFF
--- a/tests/dialects/test_acc.py
+++ b/tests/dialects/test_acc.py
@@ -499,3 +499,49 @@ def test_cache_op_has_no_memory_effect_trait():
     assert not acc.CopyinOp.has_trait(NoMemoryEffect)
     assert not acc.AttachOp.has_trait(NoMemoryEffect)
     assert not acc.DeclareDeviceResidentOp.has_trait(NoMemoryEffect)
+
+
+def test_private_recipe_builder_shortcuts():
+    """The Python `__init__` accepts a `str` shortcut for `sym_name` and
+    defaults a missing `destroy_region` to an empty `Region()`. Both
+    branches are unreachable from filecheck — the parser only sees an
+    already-built `StringAttr` and always supplies a (possibly empty)
+    region — so they live here."""
+    init_block = Block(arg_types=[i32])
+    init_block.add_op(acc.YieldOp(init_block.args[0]))
+    op = acc.PrivateRecipeOp(
+        sym_name="priv",
+        var_type=i32,
+        init_region=Region([init_block]),
+    )
+    op.verify()
+
+    assert op.sym_name == StringAttr("priv")
+    assert op.var_type == i32
+    assert len(op.init_region.blocks) == 1
+    # `destroy_region=None` defaults to an empty Region, not absent.
+    assert len(op.destroy_region.blocks) == 0
+
+
+def test_firstprivate_recipe_builder_shortcuts():
+    """Same builder-only branches as `PrivateRecipeOp`'s test, but on the
+    firstprivate constructor — the `__init__` is a separate method that
+    must independently exercise the `str` → `StringAttr` shortcut and the
+    `destroy_region=None` default."""
+    init_block = Block(arg_types=[i32])
+    init_block.add_op(acc.YieldOp(init_block.args[0]))
+    copy_block = Block(arg_types=[i32, i32])
+    copy_block.add_op(acc.YieldOp())
+    op = acc.FirstprivateRecipeOp(
+        sym_name="fp",
+        var_type=i32,
+        init_region=Region([init_block]),
+        copy_region=Region([copy_block]),
+    )
+    op.verify()
+
+    assert op.sym_name == StringAttr("fp")
+    assert op.var_type == i32
+    assert len(op.init_region.blocks) == 1
+    assert len(op.copy_region.blocks) == 1
+    assert len(op.destroy_region.blocks) == 0

--- a/tests/filecheck/dialects/acc/ops.mlir
+++ b/tests/filecheck/dialects/acc/ops.mlir
@@ -1146,4 +1146,83 @@ builtin.module {
   // CHECK-LABEL: func.func @detach_dataclause_default_elided(
   // CHECK:         acc.detach accPtr(%{{.*}} : memref<10xf32>)
   // CHECK-NOT:     dataClause
+
+  // Privatization recipes — `acc.private.recipe` / `acc.firstprivate.recipe`
+  // are top-level Symbol ops (`IsolatedFromAbove`). Each carries a
+  // `sym_name` + `type` plus named regions; the `acc.yield`-as-init-result
+  // body terminator works because both ops were appended to YieldOp's
+  // `HasParent` list.
+  acc.private.recipe @priv_min : memref<10xf32> init {
+  ^bb0(%arg0: memref<10xf32>):
+    acc.yield %arg0 : memref<10xf32>
+  }
+  // CHECK-LABEL: acc.private.recipe @priv_min : memref<10xf32> init {
+  // CHECK-NEXT:    ^{{.*}}(%{{.*}}: memref<10xf32>):
+  // CHECK-NEXT:      acc.yield %{{.*}} : memref<10xf32>
+  // CHECK-NEXT:    }
+
+  acc.private.recipe @priv_with_destroy : memref<10xf32> init {
+  ^bb0(%arg0: memref<10xf32>):
+    acc.yield %arg0 : memref<10xf32>
+  } destroy {
+  ^bb0(%arg0: memref<10xf32>):
+    acc.yield
+  }
+  // CHECK-LABEL: acc.private.recipe @priv_with_destroy : memref<10xf32> init {
+  // CHECK:         } destroy {
+  // CHECK:           acc.yield
+  // CHECK-NEXT:    }
+
+  // Generic-form roundtrip insurance for `acc.private.recipe` — the destroy
+  // region is always part of `op.regions` (always printed in generic form),
+  // even when it's empty, in which case the optional `destroy` keyword is
+  // elided in the pretty form.
+  "acc.private.recipe"() <{sym_name = "priv_generic", type = memref<10xf32>}> ({
+  ^bb0(%arg0: memref<10xf32>):
+    "acc.yield"(%arg0) : (memref<10xf32>) -> ()
+  }, {
+  }) : () -> ()
+  // CHECK-LABEL: acc.private.recipe @priv_generic : memref<10xf32> init {
+
+  acc.firstprivate.recipe @fp_min : memref<10xf32> init {
+  ^bb0(%arg0: memref<10xf32>):
+    acc.yield %arg0 : memref<10xf32>
+  } copy {
+  ^bb0(%arg0: memref<10xf32>, %arg1: memref<10xf32>):
+    acc.yield
+  }
+  // CHECK-LABEL: acc.firstprivate.recipe @fp_min : memref<10xf32> init {
+  // CHECK:         } copy {
+  // CHECK-NEXT:    ^{{.*}}(%{{.*}}: memref<10xf32>, %{{.*}}: memref<10xf32>):
+  // CHECK-NEXT:      acc.yield
+  // CHECK-NEXT:    }
+
+  acc.firstprivate.recipe @fp_with_destroy : memref<10xf32> init {
+  ^bb0(%arg0: memref<10xf32>):
+    acc.yield %arg0 : memref<10xf32>
+  } copy {
+  ^bb0(%arg0: memref<10xf32>, %arg1: memref<10xf32>):
+    acc.yield
+  } destroy {
+  ^bb0(%arg0: memref<10xf32>):
+    acc.yield
+  }
+  // CHECK-LABEL: acc.firstprivate.recipe @fp_with_destroy : memref<10xf32> init {
+  // CHECK:         } copy {
+  // CHECK:         } destroy {
+  // CHECK-NEXT:    ^{{.*}}(%{{.*}}: memref<10xf32>):
+  // CHECK-NEXT:      acc.yield
+  // CHECK-NEXT:    }
+
+  // Generic-form roundtrip for the firstprivate three-region shape. An
+  // empty trailing region elides `destroy` in pretty form.
+  "acc.firstprivate.recipe"() <{sym_name = "fp_generic", type = memref<10xf32>}> ({
+  ^bb0(%arg0: memref<10xf32>):
+    "acc.yield"(%arg0) : (memref<10xf32>) -> ()
+  }, {
+  ^bb1(%arg1: memref<10xf32>, %arg2: memref<10xf32>):
+    "acc.yield"() : () -> ()
+  }, {
+  }) : () -> ()
+  // CHECK-LABEL: acc.firstprivate.recipe @fp_generic : memref<10xf32> init {
 }

--- a/tests/filecheck/dialects/acc/ops_invalid.mlir
+++ b/tests/filecheck/dialects/acc/ops_invalid.mlir
@@ -69,3 +69,75 @@ func.func @bounds_missing_extent_and_upperbound() {
   func.return
 }
 // CHECK: Operation does not verify: expected extent or upperbound.
+
+// -----
+
+// acc.private.recipe: empty init region is rejected (mirrors upstream's
+// `verifyInitLikeSingleArgRegion`).
+"acc.private.recipe"() <{sym_name = "p", type = i32}> ({
+}, {
+}) : () -> ()
+// CHECK: Operation does not verify: expects non-empty init region
+
+// -----
+
+// acc.private.recipe: init region's first arg type must match `type`.
+"acc.private.recipe"() <{sym_name = "p", type = i32}> ({
+^bb0(%a: i64):
+  "acc.yield"() : () -> ()
+}, {
+}) : () -> ()
+// CHECK: Operation does not verify: expects init region first argument of the privatization type
+
+// -----
+
+// acc.private.recipe: when `destroy` is supplied, its first arg must
+// match `type` too.
+"acc.private.recipe"() <{sym_name = "p", type = i32}> ({
+^bb0(%a: i32):
+  "acc.yield"() : () -> ()
+}, {
+^bb0(%a: i64):
+  "acc.yield"() : () -> ()
+}) : () -> ()
+// CHECK: Operation does not verify: expects destroy region first argument of the privatization type
+
+// -----
+
+// acc.firstprivate.recipe: empty copy region is rejected.
+"acc.firstprivate.recipe"() <{sym_name = "p", type = i32}> ({
+^bb0(%a: i32):
+  "acc.yield"() : () -> ()
+}, {
+}, {
+}) : () -> ()
+// CHECK: Operation does not verify: expects non-empty copy region
+
+// -----
+
+// acc.firstprivate.recipe: copy region must take two args of `type`.
+"acc.firstprivate.recipe"() <{sym_name = "p", type = i32}> ({
+^bb0(%a: i32):
+  "acc.yield"() : () -> ()
+}, {
+^bb0(%a: i32):
+  "acc.yield"() : () -> ()
+}, {
+}) : () -> ()
+// CHECK: Operation does not verify: expects copy region with two arguments of the privatization type
+
+// -----
+
+// `IsolatedFromAbove` on `acc.private.recipe` is enforced by the verifier:
+// nested ops cannot reference SSA values defined outside the recipe. Same
+// trait is on `acc.firstprivate.recipe`; one case is enough since it
+// fires from the trait's verifier rather than the per-op `verify_`.
+func.func @recipe_leaks_outer_value(%outer: i32) {
+  acc.private.recipe @p : i32 init {
+  ^bb0(%a: i32):
+    %r = arith.addi %outer, %a : i32
+    acc.yield %r : i32
+  }
+  func.return
+}
+// CHECK: Operation using value defined out of its IsolatedFromAbove parent

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/ops.mlir
@@ -677,4 +677,58 @@ builtin.module {
   }
   // CHECK:       func.func @detach_minimal(
   // CHECK:         acc.detach accPtr(%{{.*}} : memref<10xf32>)
+
+  // Privatization recipes — top-level Symbol ops. Pretty form is
+  // `@sym : type init { ... } [destroy { ... }]?` (and `copy {...}` between
+  // for firstprivate). Both MLIR_ROUNDTRIP and MLIR_GENERIC_ROUNDTRIP must
+  // pass — the latter exercises the `<{sym_name = ..., type = ...}>` props
+  // dict that any consumer (e.g. `acc.private` referencing this recipe by
+  // SymbolRefAttr) will need to round-trip.
+  acc.private.recipe @priv_min : memref<10xf32> init {
+  ^bb0(%arg0: memref<10xf32>):
+    acc.yield %arg0 : memref<10xf32>
+  }
+  // CHECK:       acc.private.recipe @priv_min : memref<10xf32> init {
+  // CHECK-NEXT:    ^{{.*}}(%{{.*}}: memref<10xf32>):
+  // CHECK-NEXT:      acc.yield %{{.*}} : memref<10xf32>
+  // CHECK-NEXT:    }
+
+  acc.private.recipe @priv_with_destroy : memref<10xf32> init {
+  ^bb0(%arg0: memref<10xf32>):
+    acc.yield %arg0 : memref<10xf32>
+  } destroy {
+  ^bb0(%arg0: memref<10xf32>):
+    acc.yield
+  }
+  // CHECK:       acc.private.recipe @priv_with_destroy : memref<10xf32> init {
+  // CHECK:         } destroy {
+  // CHECK:           acc.yield
+  // CHECK-NEXT:    }
+
+  acc.firstprivate.recipe @fp_min : memref<10xf32> init {
+  ^bb0(%arg0: memref<10xf32>):
+    acc.yield %arg0 : memref<10xf32>
+  } copy {
+  ^bb0(%arg0: memref<10xf32>, %arg1: memref<10xf32>):
+    acc.yield
+  }
+  // CHECK:       acc.firstprivate.recipe @fp_min : memref<10xf32> init {
+  // CHECK:         } copy {
+  // CHECK-NEXT:    ^{{.*}}(%{{.*}}: memref<10xf32>, %{{.*}}: memref<10xf32>):
+  // CHECK-NEXT:      acc.yield
+  // CHECK-NEXT:    }
+
+  acc.firstprivate.recipe @fp_with_destroy : memref<10xf32> init {
+  ^bb0(%arg0: memref<10xf32>):
+    acc.yield %arg0 : memref<10xf32>
+  } copy {
+  ^bb0(%arg0: memref<10xf32>, %arg1: memref<10xf32>):
+    acc.yield
+  } destroy {
+  ^bb0(%arg0: memref<10xf32>):
+    acc.yield
+  }
+  // CHECK:       acc.firstprivate.recipe @fp_with_destroy : memref<10xf32> init {
+  // CHECK:         } copy {
+  // CHECK:         } destroy {
 }

--- a/xdsl/dialects/acc.py
+++ b/xdsl/dialects/acc.py
@@ -23,6 +23,7 @@ from xdsl.dialects.builtin import (
     IntegerType,
     MemRefType,
     StringAttr,
+    SymbolNameConstraint,
     SymbolRefAttr,
     UnitAttr,
     i32,
@@ -70,11 +71,13 @@ from xdsl.parser import AttrParser, Parser, UnresolvedOperand
 from xdsl.printer import Printer
 from xdsl.traits import (
     HasParent,
+    IsolatedFromAbove,
     IsTerminator,
     NoMemoryEffect,
     NoTerminator,
     RecursiveMemoryEffect,
     SingleBlockImplicitTerminator,
+    SymbolOpInterface,
 )
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.hints import isa
@@ -2026,6 +2029,182 @@ class GetExtentOp(_DataBoundsAccessorOp):
     name = "acc.get_extent"
 
 
+# ---------------------------------------------------------------------------
+# Privatization recipes
+# ---------------------------------------------------------------------------
+#
+# `acc.private.recipe` and `acc.firstprivate.recipe` declare reusable
+# templates for how to allocate / initialize / copy / destroy a privatized
+# value. Both are top-level symbol ops (`Symbol` + `IsolatedFromAbove`); the
+# `private` / `firstprivate` data ops then reference the recipe by name.
+# `acc.reduction.recipe` shares the same shape and lands in a follow-up
+# PR with its `ReductionOpKindAttr` consumer.
+#
+# The two ops here share `sym_name` + `type` props, so we factor that into
+# the abstract `_RecipeOperation` mixin; concrete leaves declare only their
+# own regions, traits, assembly format, and per-op `verify_`.
+
+
+def _verify_init_like_region(
+    region: Region,
+    region_type: str,
+    region_name: str,
+    expected_type: Attribute,
+    *,
+    optional: bool = False,
+) -> None:
+    """Port of upstream `verifyInitLikeSingleArgRegion`.
+
+    The init / destroy region must be non-empty (unless `optional`) and the
+    first argument of its first block must be of the recipe's type.
+    """
+    if optional and not region.blocks:
+        return
+    if not region.blocks:
+        raise VerifyException(f"expects non-empty {region_name} region")
+    first_block = region.block
+    if not first_block.args or first_block.args[0].type != expected_type:
+        raise VerifyException(
+            f"expects {region_name} region first argument of the {region_type} type"
+        )
+
+
+class _RecipeOperation(IRDLOperation, ABC):
+    """Shared `sym_name` + `type` shape for the recipe ops.
+
+    Mirrors upstream's near-identical `OpenACC_*RecipeOp` td classes.
+    Concrete leaves declare their own regions, traits, assembly format, and
+    per-op `verify_`.
+    """
+
+    sym_name = prop_def(SymbolNameConstraint())
+    var_type = prop_def(TypeAttribute, prop_name="type")
+
+
+@irdl_op_definition
+class PrivateRecipeOp(_RecipeOperation):
+    """
+    Implementation of upstream acc.private.recipe.
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/OpenACCDialect/#accprivaterecipe-accprivaterecipeop).
+    """
+
+    name = "acc.private.recipe"
+
+    init_region = region_def()
+    destroy_region = region_def()
+
+    traits = lazy_traits_def(lambda: (IsolatedFromAbove(), SymbolOpInterface()))
+
+    assembly_format = (
+        "$sym_name `:` $type attr-dict-with-keyword"
+        " `init` $init_region"
+        " (`destroy` $destroy_region^)?"
+    )
+
+    def __init__(
+        self,
+        *,
+        sym_name: StringAttr | str,
+        var_type: TypeAttribute,
+        init_region: Region,
+        destroy_region: Region | None = None,
+    ) -> None:
+        sym_name_attr: StringAttr = (
+            StringAttr(sym_name) if isinstance(sym_name, str) else sym_name
+        )
+        super().__init__(
+            properties={
+                "sym_name": sym_name_attr,
+                "type": var_type,
+            },
+            regions=[init_region, destroy_region or Region()],
+        )
+
+    def verify_(self) -> None:
+        _verify_init_like_region(
+            self.init_region,
+            "privatization",
+            "init",
+            self.var_type,
+        )
+        _verify_init_like_region(
+            self.destroy_region,
+            "privatization",
+            "destroy",
+            self.var_type,
+            optional=True,
+        )
+
+
+@irdl_op_definition
+class FirstprivateRecipeOp(_RecipeOperation):
+    """
+    Implementation of upstream acc.firstprivate.recipe.
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/OpenACCDialect/#accfirstprivaterecipe-accfirstprivaterecipeop).
+    """
+
+    name = "acc.firstprivate.recipe"
+
+    init_region = region_def()
+    copy_region = region_def()
+    destroy_region = region_def()
+
+    traits = lazy_traits_def(lambda: (IsolatedFromAbove(), SymbolOpInterface()))
+
+    assembly_format = (
+        "$sym_name `:` $type attr-dict-with-keyword"
+        " `init` $init_region"
+        " `copy` $copy_region"
+        " (`destroy` $destroy_region^)?"
+    )
+
+    def __init__(
+        self,
+        *,
+        sym_name: StringAttr | str,
+        var_type: TypeAttribute,
+        init_region: Region,
+        copy_region: Region,
+        destroy_region: Region | None = None,
+    ) -> None:
+        sym_name_attr: StringAttr = (
+            StringAttr(sym_name) if isinstance(sym_name, str) else sym_name
+        )
+        super().__init__(
+            properties={
+                "sym_name": sym_name_attr,
+                "type": var_type,
+            },
+            regions=[init_region, copy_region, destroy_region or Region()],
+        )
+
+    def verify_(self) -> None:
+        _verify_init_like_region(
+            self.init_region,
+            "privatization",
+            "init",
+            self.var_type,
+        )
+        if not self.copy_region.blocks:
+            raise VerifyException("expects non-empty copy region")
+        copy_block = self.copy_region.block
+        if (
+            len(copy_block.args) < 2
+            or copy_block.args[0].type != self.var_type
+            or copy_block.args[1].type != self.var_type
+        ):
+            raise VerifyException(
+                "expects copy region with two arguments of the privatization type"
+            )
+        if self.destroy_region.blocks:
+            _verify_init_like_region(
+                self.destroy_region,
+                "privatization",
+                "destroy",
+                self.var_type,
+            )
+
+
 @irdl_op_definition
 class YieldOp(AbstractYieldOperation[Attribute]):
     """
@@ -2039,7 +2218,7 @@ class YieldOp(AbstractYieldOperation[Attribute]):
         lambda: (
             IsTerminator(),
             NoMemoryEffect(),
-            HasParent(ParallelOp, SerialOp),
+            HasParent(ParallelOp, SerialOp, PrivateRecipeOp, FirstprivateRecipeOp),
         )
     )
 
@@ -2071,6 +2250,8 @@ ACC = Dialect(
         UpdateHostOp,
         DeleteOp,
         DetachOp,
+        PrivateRecipeOp,
+        FirstprivateRecipeOp,
         YieldOp,
     ],
     [


### PR DESCRIPTION
This PR adds the private recipe and firstprivate recipe OpenACC opertions which both extend from the RecipeOperation abstract base class which is also added as part of this. Includes a minor tweak to yield operation to enable this to be used from within regions of these new operations
