### PR TITLE
dialects: (acc) Support for OpenACC ReductionRecipe operation

### DIFF
--- a/tests/dialects/test_acc.py
+++ b/tests/dialects/test_acc.py
@@ -16,6 +16,7 @@ from xdsl.dialects.builtin import (
     f32,
     i1,
     i32,
+    i64,
 )
 from xdsl.dialects.test import TestOp
 from xdsl.ir import Block, Region
@@ -520,6 +521,34 @@ def test_private_recipe_builder_shortcuts():
     assert op.var_type == i32
     assert len(op.init_region.blocks) == 1
     # `destroy_region=None` defaults to an empty Region, not absent.
+    assert len(op.destroy_region.blocks) == 0
+
+
+def test_reduction_recipe_builder_shortcuts():
+    """The Python `__init__` accepts `str` for `sym_name` and a
+    `ReductionOpKind` value for `reduction_operator`, defaulting a missing
+    `destroy_region` to an empty `Region()`. All three branches are
+    builder-only — the parser only sees an already-built `StringAttr`,
+    a `ReductionOpKindAttr`, and (via the optional format clause) either
+    a parsed region or no region argument at all — so they live here."""
+    init_block = Block(arg_types=[i64])
+    init_block.add_op(acc.YieldOp(init_block.args[0]))
+    combiner_block = Block(arg_types=[i64, i64])
+    combiner_block.add_op(acc.YieldOp(combiner_block.args[0]))
+    op = acc.ReductionRecipeOp(
+        sym_name="red",
+        var_type=i64,
+        reduction_operator=acc.ReductionOpKind.ADD,
+        init_region=Region([init_block]),
+        combiner_region=Region([combiner_block]),
+    )
+    op.verify()
+
+    assert op.sym_name == StringAttr("red")
+    assert op.var_type == i64
+    assert op.reduction_operator == acc.ReductionOpKindAttr(acc.ReductionOpKind.ADD)
+    assert len(op.init_region.blocks) == 1
+    assert len(op.combiner_region.blocks) == 1
     assert len(op.destroy_region.blocks) == 0
 
 

--- a/tests/filecheck/dialects/acc/ops.mlir
+++ b/tests/filecheck/dialects/acc/ops.mlir
@@ -1225,4 +1225,53 @@ builtin.module {
   }, {
   }) : () -> ()
   // CHECK-LABEL: acc.firstprivate.recipe @fp_generic : memref<10xf32> init {
+
+  // Reduction recipe — same Symbol / IsolatedFromAbove shape as the
+  // private / firstprivate recipes plus a `reductionOperator` property.
+  // The pretty form spells the operator inline as `<add>` (just the enum
+  // value), matching upstream's `assemblyFormat = "`<` $value `>`"` on the
+  // `ReductionOpKindAttr`. The full `#acc.reduction_operator<add>`
+  // opaque form only appears in the generic / attr-dict spellings.
+  acc.reduction.recipe @red_add_i64 : i64 reduction_operator <add> init {
+  ^bb0(%arg0: i64):
+    %c0 = arith.constant 0 : i64
+    acc.yield %c0 : i64
+  } combiner {
+  ^bb0(%arg0: i64, %arg1: i64):
+    %r = arith.addi %arg0, %arg1 : i64
+    acc.yield %r : i64
+  }
+  // CHECK-LABEL: acc.reduction.recipe @red_add_i64 : i64 reduction_operator <add> init {
+  // CHECK:         } combiner {
+  // CHECK-NEXT:    ^{{.*}}(%{{.*}}: i64, %{{.*}}: i64):
+  // CHECK:           acc.yield %{{.*}} : i64
+  // CHECK-NEXT:    }
+
+  acc.reduction.recipe @red_max_f32 : f32 reduction_operator <max> init {
+  ^bb0(%arg0: f32):
+    acc.yield %arg0 : f32
+  } combiner {
+  ^bb0(%arg0: f32, %arg1: f32):
+    acc.yield %arg0 : f32
+  } destroy {
+  ^bb0(%arg0: f32):
+    acc.yield
+  }
+  // CHECK-LABEL: acc.reduction.recipe @red_max_f32 : f32 reduction_operator <max> init {
+  // CHECK:         } combiner {
+  // CHECK:         } destroy {
+
+  // Generic-form roundtrip insurance for the reduction recipe — the
+  // `reductionOperator` rides as `#acc.reduction_operator<add>` in the
+  // properties dict (the long opaque form), and the optional `destroy`
+  // region is always present in `op.regions` even when empty.
+  "acc.reduction.recipe"() <{sym_name = "red_generic", type = i64, reductionOperator = #acc.reduction_operator<add>}> ({
+  ^bb0(%arg0: i64):
+    "acc.yield"(%arg0) : (i64) -> ()
+  }, {
+  ^bb1(%arg1: i64, %arg2: i64):
+    "acc.yield"(%arg1) : (i64) -> ()
+  }, {
+  }) : () -> ()
+  // CHECK-LABEL: acc.reduction.recipe @red_generic : i64 reduction_operator <add> init {
 }

--- a/tests/filecheck/dialects/acc/ops_invalid.mlir
+++ b/tests/filecheck/dialects/acc/ops_invalid.mlir
@@ -130,8 +130,9 @@ func.func @bounds_missing_extent_and_upperbound() {
 
 // `IsolatedFromAbove` on `acc.private.recipe` is enforced by the verifier:
 // nested ops cannot reference SSA values defined outside the recipe. Same
-// trait is on `acc.firstprivate.recipe`; one case is enough since it
-// fires from the trait's verifier rather than the per-op `verify_`.
+// trait is on `acc.firstprivate.recipe` and `acc.reduction.recipe`; one
+// case is enough since it fires from the trait's verifier rather than
+// from any per-op `verify_`.
 func.func @recipe_leaks_outer_value(%outer: i32) {
   acc.private.recipe @p : i32 init {
   ^bb0(%a: i32):
@@ -141,3 +142,54 @@ func.func @recipe_leaks_outer_value(%outer: i32) {
   func.return
 }
 // CHECK: Operation using value defined out of its IsolatedFromAbove parent
+
+// -----
+
+// acc.reduction.recipe: empty init region is rejected (mirrors the same
+// `verifyInitLikeSingleArgRegion` port used by the privatization recipes).
+"acc.reduction.recipe"() <{sym_name = "r", type = i32, reductionOperator = #acc.reduction_operator<add>}> ({
+}, {
+}, {
+}) : () -> ()
+// CHECK: Operation does not verify: expects non-empty init region
+
+// -----
+
+// acc.reduction.recipe: empty combiner region is rejected.
+"acc.reduction.recipe"() <{sym_name = "r", type = i32, reductionOperator = #acc.reduction_operator<add>}> ({
+^bb0(%a: i32):
+  "acc.yield"(%a) : (i32) -> ()
+}, {
+}, {
+}) : () -> ()
+// CHECK: Operation does not verify: expects non-empty combiner region
+
+// -----
+
+// acc.reduction.recipe: combiner region's first two args must match `type`.
+"acc.reduction.recipe"() <{sym_name = "r", type = i32, reductionOperator = #acc.reduction_operator<add>}> ({
+^bb0(%a: i32):
+  "acc.yield"(%a) : (i32) -> ()
+}, {
+^bb0(%a: i64, %b: i64):
+  "acc.yield"(%a) : (i64) -> ()
+}, {
+}) : () -> ()
+// CHECK: Operation does not verify: expects combiner region with the first two arguments of the reduction type
+
+// -----
+
+// acc.reduction.recipe: every `acc.yield` in the combiner region must
+// yield exactly one value of the reduction type. Distinct from the
+// init-region check — combiner-region `acc.yield`s are walked
+// post-block-shape verification.
+"acc.reduction.recipe"() <{sym_name = "r", type = i32, reductionOperator = #acc.reduction_operator<add>}> ({
+^bb0(%a: i32):
+  "acc.yield"(%a) : (i32) -> ()
+}, {
+^bb0(%a: i32, %b: i32):
+  %c0 = "arith.constant"() <{value = 0 : i64}> : () -> i64
+  "acc.yield"(%c0) : (i64) -> ()
+}, {
+}) : () -> ()
+// CHECK: Operation does not verify: expects combiner region to yield a value of the reduction type

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/ops.mlir
@@ -456,7 +456,7 @@ builtin.module {
   // CHECK-NEXT:    %{{.*}} = acc.get_stride %{{.*}} : (!acc.data_bounds_ty) -> index
   // CHECK-NEXT:    %{{.*}} = acc.get_extent %{{.*}} : (!acc.data_bounds_ty) -> index
 
-  // Entry data-clause ops (PR 6b: copyin / create / present). Each MLIR
+  // Entry data-clause ops — `copyin` / `create` / `present`. Each MLIR
   // interop entry round-trips through both the pretty and generic surfaces;
   // covers `acc.copyin` exhaustively and the other two minimally.
   func.func @copyin_minimal(%a : memref<10xf32>) {
@@ -538,9 +538,9 @@ builtin.module {
   // CHECK:       func.func @present_minimal(
   // CHECK:         %{{.*}} = acc.present varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32>
 
-  // Remaining seven entry data-clause leaves (PR 6c). Each gets one MLIR
-  // interop entry — proves xDSL emission is bit-compatible with upstream
-  // and the per-op `dataClause` default round-trips through MLIR.
+  // Remaining seven entry data-clause leaves. Each gets one MLIR interop
+  // entry — proves xDSL emission is bit-compatible with upstream and the
+  // per-op `dataClause` default round-trips through MLIR.
   func.func @nocreate_minimal(%a : memref<10xf32>) {
     %r = acc.nocreate varPtr(%a : memref<10xf32>) -> memref<10xf32>
     func.return
@@ -730,5 +730,41 @@ builtin.module {
   }
   // CHECK:       acc.firstprivate.recipe @fp_with_destroy : memref<10xf32> init {
   // CHECK:         } copy {
+  // CHECK:         } destroy {
+
+  // Reduction recipe — load-bearing for MLIR interop because xDSL's pretty
+  // form spells the operator inline as `<add>` (the
+  // `ReductionOpKindAttr.print_parameter` output) which is exactly what
+  // upstream's `assemblyFormat = "`<` $value `>`"` expects after the
+  // `reduction_operator` keyword. Both `MLIR_ROUNDTRIP` and
+  // `MLIR_GENERIC_ROUNDTRIP` must pass — the latter exercises the
+  // `reductionOperator = #acc.reduction_operator<add>` opaque spelling
+  // in the properties dict.
+  acc.reduction.recipe @red_add_i64 : i64 reduction_operator <add> init {
+  ^bb0(%arg0: i64):
+    %c0 = arith.constant 0 : i64
+    acc.yield %c0 : i64
+  } combiner {
+  ^bb0(%arg0: i64, %arg1: i64):
+    %r = arith.addi %arg0, %arg1 : i64
+    acc.yield %r : i64
+  }
+  // CHECK:       acc.reduction.recipe @red_add_i64 : i64 reduction_operator <add> init {
+  // CHECK:         } combiner {
+  // CHECK:           acc.yield %{{.*}} : i64
+  // CHECK-NEXT:    }
+
+  acc.reduction.recipe @red_max_f32 : f32 reduction_operator <max> init {
+  ^bb0(%arg0: f32):
+    acc.yield %arg0 : f32
+  } combiner {
+  ^bb0(%arg0: f32, %arg1: f32):
+    acc.yield %arg0 : f32
+  } destroy {
+  ^bb0(%arg0: f32):
+    acc.yield
+  }
+  // CHECK:       acc.reduction.recipe @red_max_f32 : f32 reduction_operator <max> init {
+  // CHECK:         } combiner {
   // CHECK:         } destroy {
 }

--- a/xdsl/dialects/acc.py
+++ b/xdsl/dialects/acc.py
@@ -2030,19 +2030,20 @@ class GetExtentOp(_DataBoundsAccessorOp):
 
 
 # ---------------------------------------------------------------------------
-# Privatization recipes
+# Privatization / reduction recipes
 # ---------------------------------------------------------------------------
 #
-# `acc.private.recipe` and `acc.firstprivate.recipe` declare reusable
-# templates for how to allocate / initialize / copy / destroy a privatized
-# value. Both are top-level symbol ops (`Symbol` + `IsolatedFromAbove`); the
-# `private` / `firstprivate` data ops then reference the recipe by name.
-# `acc.reduction.recipe` shares the same shape and lands in a follow-up
-# PR with its `ReductionOpKindAttr` consumer.
+# `acc.private.recipe`, `acc.firstprivate.recipe`, and
+# `acc.reduction.recipe` declare reusable templates for how to allocate /
+# initialize / copy / combine / destroy a privatized or reduction value.
+# Each is a top-level symbol op (`Symbol` + `IsolatedFromAbove`); the
+# corresponding data-clause ops reference the recipe by name.
 #
-# The two ops here share `sym_name` + `type` props, so we factor that into
+# The three ops share `sym_name` + `type` props, so we factor that into
 # the abstract `_RecipeOperation` mixin; concrete leaves declare only their
 # own regions, traits, assembly format, and per-op `verify_`.
+# `acc.reduction.recipe` additionally carries a `reductionOperator`
+# property typed against `ReductionOpKindAttr`.
 
 
 def _verify_init_like_region(
@@ -2206,6 +2207,103 @@ class FirstprivateRecipeOp(_RecipeOperation):
 
 
 @irdl_op_definition
+class ReductionRecipeOp(_RecipeOperation):
+    """
+    Implementation of upstream acc.reduction.recipe.
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/OpenACCDialect/#accreductionrecipe-accreductionrecipeop).
+    """
+
+    name = "acc.reduction.recipe"
+
+    reduction_operator = prop_def(ReductionOpKindAttr, prop_name="reductionOperator")
+
+    init_region = region_def()
+    combiner_region = region_def()
+    destroy_region = region_def()
+
+    traits = lazy_traits_def(lambda: (IsolatedFromAbove(), SymbolOpInterface()))
+
+    # Note: `$reductionOperator` prints/parses as `<value>` (just the
+    # parameter, no dialect prefix) because `ReductionOpKindAttr` overrides
+    # `print_parameter`/`parse_parameter` to wrap the value in angle
+    # brackets — matching upstream's `assemblyFormat = "`<` $value `>`"`.
+    # The declarative format machinery uses `UniqueBaseAttributeVariable`
+    # for non-builtin attrs, which calls `print_parameter` directly and
+    # bypasses the `#acc.reduction_operator` opaque prefix.
+    assembly_format = (
+        "$sym_name `:` $type attr-dict-with-keyword"
+        " `reduction_operator` $reductionOperator"
+        " `init` $init_region"
+        " `combiner` $combiner_region"
+        " (`destroy` $destroy_region^)?"
+    )
+
+    def __init__(
+        self,
+        *,
+        sym_name: StringAttr | str,
+        var_type: TypeAttribute,
+        reduction_operator: ReductionOpKindAttr | ReductionOpKind,
+        init_region: Region,
+        combiner_region: Region,
+        destroy_region: Region | None = None,
+    ) -> None:
+        sym_name_attr: StringAttr = (
+            StringAttr(sym_name) if isinstance(sym_name, str) else sym_name
+        )
+        operator_attr: ReductionOpKindAttr = (
+            ReductionOpKindAttr(reduction_operator)
+            if isinstance(reduction_operator, ReductionOpKind)
+            else reduction_operator
+        )
+        super().__init__(
+            properties={
+                "sym_name": sym_name_attr,
+                "type": var_type,
+                "reductionOperator": operator_attr,
+            },
+            regions=[init_region, combiner_region, destroy_region or Region()],
+        )
+
+    def verify_(self) -> None:
+        _verify_init_like_region(
+            self.init_region,
+            "reduction",
+            "init",
+            self.var_type,
+        )
+        if not self.combiner_region.blocks:
+            raise VerifyException("expects non-empty combiner region")
+        combiner_block = self.combiner_region.block
+        if (
+            len(combiner_block.args) < 2
+            or combiner_block.args[0].type != self.var_type
+            or combiner_block.args[1].type != self.var_type
+        ):
+            raise VerifyException(
+                "expects combiner region with the first two arguments of the "
+                "reduction type"
+            )
+        for yield_op in self.combiner_region.walk():
+            if not isinstance(yield_op, YieldOp):
+                continue
+            if (
+                len(yield_op.arguments) != 1
+                or yield_op.arguments[0].type != self.var_type
+            ):
+                raise VerifyException(
+                    "expects combiner region to yield a value of the reduction type"
+                )
+        if self.destroy_region.blocks:
+            _verify_init_like_region(
+                self.destroy_region,
+                "reduction",
+                "destroy",
+                self.var_type,
+            )
+
+
+@irdl_op_definition
 class YieldOp(AbstractYieldOperation[Attribute]):
     """
     Implementation of upstream acc.yield.
@@ -2218,7 +2316,13 @@ class YieldOp(AbstractYieldOperation[Attribute]):
         lambda: (
             IsTerminator(),
             NoMemoryEffect(),
-            HasParent(ParallelOp, SerialOp, PrivateRecipeOp, FirstprivateRecipeOp),
+            HasParent(
+                ParallelOp,
+                SerialOp,
+                PrivateRecipeOp,
+                FirstprivateRecipeOp,
+                ReductionRecipeOp,
+            ),
         )
     )
 
@@ -2252,6 +2356,7 @@ ACC = Dialect(
         DetachOp,
         PrivateRecipeOp,
         FirstprivateRecipeOp,
+        ReductionRecipeOp,
         YieldOp,
     ],
     [


### PR DESCRIPTION
This adds the ReductionRecipe operation to the OpenACC dialects and completes support in the dialect for recipes