### PR TITLE
dialects: (llvm) fix ConstantOp parsing of zero-valued attributes

### DIFF
--- a/tests/filecheck/dialects/llvm/arithmetic.mlir
+++ b/tests/filecheck/dialects/llvm/arithmetic.mlir
@@ -92,6 +92,9 @@
 %cst32 = llvm.mlir.constant(25 : i32) : i32
 // CHECK: %cst32 = llvm.mlir.constant(25 : i32) : i32
 
+%cst_zero = llvm.mlir.constant(0 : i32) : i32
+// CHECK: %cst_zero = llvm.mlir.constant(0 : i32) : i32
+
 %icmp_eq = llvm.icmp "eq" %arg0, %arg1 : i32
 // CHECK: %icmp_eq = llvm.icmp "eq" %arg0, %arg1 : i32
 

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -2184,7 +2184,7 @@ class ConstantOp(IRDLOperation):
         if b is not None:
             return IntegerAttr.from_bool(b)
         attr = parser.parse_optional_attribute()
-        if attr:
+        if attr is not None:
             return attr
         return IntegerAttr(parser.parse_integer(), 64)
 


### PR DESCRIPTION
Fixes `ConstantOp.parse_value` using `if attr:` instead of `if attr is not None:`, which caused `llvm.mlir.constant(0 : i32)` to silently fall through because `IntegerAttr(0)` is falsy in Python. Split off from #5876.