### PR TITLE
bench: defer llvmlite import in LLVM backend benchmark

### DIFF
--- a/.github/workflows/ci-bench-imports.yml
+++ b/.github/workflows/ci-bench-imports.yml
@@ -24,8 +24,8 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install without bench dependencies
-        run: uv sync
+      - name: Install without optional dependencies
+        run: uv sync --no-dev
 
       - name: Import all benchmark files
         run: |

--- a/benchmarks/llvm_backend.py
+++ b/benchmarks/llvm_backend.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 from pathlib import Path
 
-from xdsl.backend.llvm.convert import convert_module
 from xdsl.context import Context
 from xdsl.dialects.builtin import Builtin, ModuleOp
 from xdsl.dialects.llvm import LLVM
@@ -32,6 +31,8 @@ class LLVMBackend:
     MODULE = _parse_module()
 
     def time_convert_module(self) -> None:
+        from xdsl.backend.llvm.convert import convert_module
+
         convert_module(LLVMBackend.MODULE)
 
 


### PR DESCRIPTION
The module-level `from xdsl.backend.llvm.convert import convert_module` triggers `import llvmlite.ir` at import time, which crashes ASV benchmark discovery because llvmlite is not installed in the ASV virtualenv. Moves the import into `time_convert_module()` so discovery can find the `LLVMBackend` class without llvmlite.

Fixes the xdsl-bench CI failure: https://github.com/xdslproject/xdsl-bench/actions/runs/25091973529