### PR TITLE
docs: (CONTRIBUTING) prefer `is not None` over truthiness for Optional values [NFC]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -237,6 +237,9 @@ We aim to follow these rules for all changes in this repository:
 - We fail fast by detecting unexpected conditions immediately and raising exceptions
   rather than corrupting state, as this makes debugging easier.
 
+- We use `is not None` to check Optional values, not truthiness (`if x:`). Many xDSL
+  types define `__bool__`, so a bare truthiness check silently skips valid falsy values.
+
 - We follow the Python philosophy of
   "[ask for forgiveness not permission](https://docs.python.org/3/glossary.html#term-EAFP)":
   assume keys and attributes exist and catch exceptions when they don't. For single-value

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -237,8 +237,9 @@ We aim to follow these rules for all changes in this repository:
 - We fail fast by detecting unexpected conditions immediately and raising exceptions
   rather than corrupting state, as this makes debugging easier.
 
-- We use `is not None` to check Optional values, not truthiness (`if x:`). Many xDSL
-  types define `__bool__`, so a bare truthiness check silently skips valid falsy values.
+- We use `is not None` to check Optional values, not truthiness (`if x:`), because many
+  xDSL types define `__bool__` and truthiness silently skips valid falsy values. In other
+  cases, prefer truthiness over `len` as `__bool__` is often O(1).
 
 - We follow the Python philosophy of
   "[ask for forgiveness not permission](https://docs.python.org/3/glossary.html#term-EAFP)":

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -237,9 +237,10 @@ We aim to follow these rules for all changes in this repository:
 - We fail fast by detecting unexpected conditions immediately and raising exceptions
   rather than corrupting state, as this makes debugging easier.
 
-- We use `is not None` to check Optional values, not truthiness (`if x:`), because many
-  xDSL types define `__bool__` and truthiness silently skips valid falsy values. In other
-  cases, prefer truthiness over `len` as `__bool__` is often O(1).
+- We use truthiness (`if x:`) instead of length checks (`len(x) == 0`), as `__bool__`
+  is often O(1). The one exception is Optional values: use `is not None` instead of
+  truthiness, because many xDSL types define `__bool__` and truthiness silently skips
+  valid falsy values.
 
 - We follow the Python philosophy of
   "[ask for forgiveness not permission](https://docs.python.org/3/glossary.html#term-EAFP)":

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -237,10 +237,10 @@ We aim to follow these rules for all changes in this repository:
 - We fail fast by detecting unexpected conditions immediately and raising exceptions
   rather than corrupting state, as this makes debugging easier.
 
-- We use truthiness (`if x:`) instead of length checks (`len(x) == 0`), as `__bool__`
-  is often O(1). The one exception is Optional values: use `is not None` instead of
-  truthiness, because many xDSL types define `__bool__` and truthiness silently skips
-  valid falsy values.
+- We use truthiness (`if x:`) whenever possible, e.g. instead of length checks
+  (`len(x) == 0`), as `__bool__` is often O(1). The one exception is Optional values:
+  use `is not None` instead of truthiness, because many xDSL types define `__bool__`
+  and truthiness silently skips valid falsy values.
 
 - We follow the Python philosophy of
   "[ask for forgiveness not permission](https://docs.python.org/3/glossary.html#term-EAFP)":


### PR DESCRIPTION
Many xDSL types define `__bool__`, so checking `if x:` on an Optional value silently skips valid falsy values like `IntegerAttr(0)` or empty `ArrayAttr`. Adds a code style guideline to use `is not None` instead. No standard linter enforces this, so it needs to be caught in review.

Follow-up to #5975.