### PR TITLE
bench: fix benchmark import CI and defer llvmlite import

### DIFF
--- a/.github/workflows/ci-bench-imports.yml
+++ b/.github/workflows/ci-bench-imports.yml
@@ -24,8 +24,8 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install without bench dependencies
-        run: uv sync
+      - name: Install without optional dependencies
+        run: uv sync --no-dev
 
       - name: Import all benchmark files
         run: |

--- a/benchmarks/llvm_backend.py
+++ b/benchmarks/llvm_backend.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 from pathlib import Path
 
-from xdsl.backend.llvm.convert import convert_module
 from xdsl.context import Context
 from xdsl.dialects.builtin import Builtin, ModuleOp
 from xdsl.dialects.llvm import LLVM
@@ -32,6 +31,8 @@ class LLVMBackend:
     MODULE = _parse_module()
 
     def time_convert_module(self) -> None:
+        from xdsl.backend.llvm.convert import convert_module
+
         convert_module(LLVMBackend.MODULE)
 
 


### PR DESCRIPTION
Supersedes #5976. Defers the llvmlite import in `benchmarks/llvm_backend.py` so ASV discovery doesn't crash in virtualenvs without the llvm extra. Also fixes the benchmark import CI from #5965 to use `uv sync --no-dev` instead of `uv sync`, matching ASV's environment (base deps only, no optional extras like llvm/gui). Without `--no-dev`, the CI installs the dev group which includes `xdsl[llvm]` and would never catch this class of bug.


See discussion with @superlopuh in: https://github.com/xdslproject/xdsl/pull/5976#issuecomment-4350215140