### PR TITLE
dialects: (llvm) add backend converter for UndefOp

### DIFF
--- a/tests/filecheck/backend/llvm/convert_op.mlir
+++ b/tests/filecheck/backend/llvm/convert_op.mlir
@@ -845,6 +845,17 @@ builtin.module {
   // CHECK-NEXT:   ret ptr null
   // CHECK-NEXT: }
 
+  llvm.func @undef_i32() -> i32 {
+    %0 = llvm.mlir.undef : i32
+    llvm.return %0 : i32
+  }
+
+  // CHECK: define i32 @"undef_i32"()
+  // CHECK-NEXT: {
+  // CHECK-NEXT: {{.[0-9]+}}:
+  // CHECK-NEXT:   ret i32 undef
+  // CHECK-NEXT: }
+
   llvm.func @fma_op_f32(%arg0: vector<4xf32>, %arg1: vector<4xf32>, %arg2: vector<4xf32>) -> vector<4xf32> {
     %0 = vector.fma %arg0, %arg1, %arg2 : vector<4xf32>
     llvm.return %0 : vector<4xf32>

--- a/xdsl/backend/llvm/convert_op.py
+++ b/xdsl/backend/llvm/convert_op.py
@@ -508,6 +508,8 @@ def convert_op(
             _convert_return(op, builder, val_map)
         case llvm.ZeroOp():
             val_map[op.res] = ir.Constant(convert_type(op.res.type), None)
+        case llvm.UndefOp():
+            val_map[op.res] = ir.Constant(convert_type(op.res.type), ir.Undefined)
         case llvm.AddressOfOp():
             _convert_addressof(op, builder, val_map)
         case FMAOp():


### PR DESCRIPTION
Maps `llvm.mlir.undef` to `ir.Constant(type, ir.Undefined)` in the LLVM backend, mirroring the existing `ZeroOp` converter pattern. Adds a filecheck test.