### PR TITLE
dialects: (llvm) add ShuffleVectorOp with backend converter

### DIFF
--- a/tests/dialects/test_llvm.py
+++ b/tests/dialects/test_llvm.py
@@ -672,3 +672,15 @@ def test_masked_store_op():
     assert op.data == ptr
     assert op.mask == mask
     assert op.alignment.value.data == 16
+
+
+def test_shuffle_vector_op():
+    vec_type = builtin.VectorType(builtin.f32, [4])
+    v1 = create_ssa_value(vec_type)
+    v2 = create_ssa_value(vec_type)
+    mask = builtin.DenseArrayBase.from_list(builtin.i32, [0, 0, 0, 0])
+    op = llvm.ShuffleVectorOp(v1, v2, mask, vec_type)
+    assert op.v1 == v1
+    assert op.v2 == v2
+    assert op.mask is mask
+    assert op.res.type == vec_type

--- a/tests/filecheck/backend/llvm/convert_op.mlir
+++ b/tests/filecheck/backend/llvm/convert_op.mlir
@@ -894,6 +894,18 @@ builtin.module {
   // CHECK-NEXT:   ret <2 x double> %"[[RES]]"
   // CHECK-NEXT: }
 
+  llvm.func @shuffle_vector_f32(%arg0: vector<4xf32>, %arg1: vector<4xf32>) -> vector<4xf32> {
+    %res = llvm.shufflevector %arg0, %arg1 [0, 0, 0, 0] : vector<4xf32>
+    llvm.return %res : vector<4xf32>
+  }
+
+  // CHECK: define <4 x float> @"shuffle_vector_f32"(<4 x float> %".1", <4 x float> %".2")
+  // CHECK-NEXT: {
+  // CHECK-NEXT: [[ENTRY:.\d+]]:
+  // CHECK-NEXT:   %"[[RES:.\d+]]" = shufflevector <4 x float> %".1", <4 x float> %".2", <4 x i32> <i32 0, i32 0, i32 0, i32 0>
+  // CHECK-NEXT:   ret <4 x float> %"[[RES]]"
+  // CHECK-NEXT: }
+
   llvm.func @callee(!llvm.ptr)
 
   llvm.func @addressof_target() {

--- a/tests/filecheck/dialects/llvm/example.mlir
+++ b/tests/filecheck/dialects/llvm/example.mlir
@@ -99,6 +99,14 @@ builtin.module {
 
 // CHECK-NEXT: %fval3 = llvm.fpext %fval : f32 to f64
 
+  %vec1 = "test.op"() : () -> vector<4xf32>
+  %vec2 = "test.op"() : () -> vector<4xf32>
+  %shuf = llvm.shufflevector %vec1, %vec2 [0, 1, 2, 3] : vector<4xf32>
+
+// CHECK-NEXT: %vec1 = "test.op"() : () -> vector<4xf32>
+// CHECK-NEXT: %vec2 = "test.op"() : () -> vector<4xf32>
+// CHECK-NEXT: %shuf = llvm.shufflevector %vec1, %vec2 [0, 1, 2, 3] : vector<4xf32>
+
   llvm.unreachable {my_attr}
 
 // CHECK-NEXT: llvm.unreachable {my_attr}

--- a/xdsl/backend/llvm/convert_op.py
+++ b/xdsl/backend/llvm/convert_op.py
@@ -413,6 +413,16 @@ def _convert_broadcast(
     val_map[op.vector] = builder.shuffle_vector(inserted, undef, mask)
 
 
+def _convert_shuffle_vector(
+    op: llvm.ShuffleVectorOp,
+    builder: ir.IRBuilder,
+    val_map: dict[SSAValue, ir.Value],
+):
+    mask_values = list(op.mask.iter_values())
+    mask = ir.Constant(ir.VectorType(ir.IntType(32), len(mask_values)), mask_values)
+    val_map[op.res] = builder.shuffle_vector(val_map[op.v1], val_map[op.v2], mask)
+
+
 _CONSTANT_VALUE_MAP: dict[type[Attribute], Callable[[Attribute], object]] = {
     DenseIntOrFPElementsAttr: lambda v: list(
         cast(DenseIntOrFPElementsAttr, v).iter_values()
@@ -512,6 +522,8 @@ def convert_op(
             val_map[op.res] = ir.Constant(convert_type(op.res.type), ir.Undefined)
         case llvm.AddressOfOp():
             _convert_addressof(op, builder, val_map)
+        case llvm.ShuffleVectorOp():
+            _convert_shuffle_vector(op, builder, val_map)
         case FMAOp():
             _convert_fma(op, builder, val_map)
         case vector.BroadcastOp():

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -1802,6 +1802,78 @@ class UndefOp(IRDLOperation):
         super().__init__(result_types=[result_type])
 
 
+@irdl_op_definition
+class ShuffleVectorOp(IRDLOperation):
+    """
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/LLVM/#llvmshufflevector-llvmshufflevectorop).
+    """
+
+    name = "llvm.shufflevector"
+
+    T: ClassVar = VarConstraint("T", VectorType.constr())
+
+    v1 = operand_def(T)
+    v2 = operand_def(T)
+    mask = prop_def(DenseArrayBase.constr(i32))
+    res = result_def(VectorType)
+
+    traits = traits_def(NoMemoryEffect())
+
+    def __init__(
+        self,
+        v1: Operation | SSAValue,
+        v2: Operation | SSAValue,
+        mask: DenseArrayBase[IntegerType],
+        result_type: Attribute | None = None,
+    ):
+        if result_type is None:
+            v1_type = cast(VectorType[Attribute], SSAValue.get(v1).type)
+            result_type = VectorType(v1_type.element_type, [len(mask)])
+        super().__init__(
+            operands=[v1, v2],
+            result_types=[result_type],
+            properties={"mask": mask},
+        )
+
+    def print(self, printer: Printer) -> None:
+        printer.print_string(" ")
+        printer.print_ssa_value(self.v1)
+        printer.print_string(", ")
+        printer.print_ssa_value(self.v2)
+        printer.print_string(" [")
+        printer.print_list(self.mask.iter_values(), printer.print_int)
+        printer.print_string("]")
+        printer.print_op_attributes(self.attributes, reserved_attr_names=("mask",))
+        printer.print_string(" : ")
+        printer.print_attribute(self.v1.type)
+
+    @classmethod
+    def parse(cls, parser: Parser) -> ShuffleVectorOp:
+        v1 = parser.parse_unresolved_operand()
+        parser.parse_punctuation(",")
+        v2 = parser.parse_unresolved_operand()
+        mask_values = parser.parse_comma_separated_list(
+            parser.Delimiter.SQUARE,
+            lambda: parser.parse_integer(allow_boolean=False),
+        )
+        attributes = parser.parse_optional_attr_dict()
+        parser.parse_punctuation(":")
+        v1_type = parser.parse_type()
+        if not isinstance(v1_type, VectorType):
+            parser.raise_error("expected vector type")
+        v1_type = cast(VectorType[Attribute], v1_type)
+        mask = DenseArrayBase.from_list(i32, mask_values)
+        result_type = VectorType(v1_type.element_type, [len(mask_values)])
+        op = cls(
+            parser.resolve_operand(v1, v1_type),
+            parser.resolve_operand(v2, v1_type),
+            mask,
+            result_type,
+        )
+        op.attributes |= attributes
+        return op
+
+
 UNNAMED_ADDR_KEYWORD_BY_KEY: dict[int, str] = {
     1: "local_unnamed_addr",
     2: "unnamed_addr",
@@ -1821,6 +1893,7 @@ UNNAMED_ADDR_KEY_BY_KEYWORD: dict[str, int] = {
 """Reverse mapping from keyword string to integer key."""
 
 
+# TODO: custom assembly format https://github.com/xdslproject/xdsl/issues/5897
 @irdl_op_definition
 class GlobalOp(IRDLOperation):
     name = "llvm.mlir.global"
@@ -3215,6 +3288,7 @@ LLVM = Dialect(
         SIToFPOp,
         SRemOp,
         ShlOp,
+        ShuffleVectorOp,
         StoreOp,
         SubOp,
         TruncOp,


### PR DESCRIPTION
Add `llvm.shufflevector` op definition with custom print/parse matching MLIR upstream pretty syntax, LLVM backend converter, and tests.

Pretty syntax: `llvm.shufflevector %v1, %v2 [0, 1, 2, 3] : vector<4xf32>`

The type after `:` is the input vector type. The result type is inferred from the element type and mask length.

Subset of #5876.