### PR TITLE
dialects: (llvm) add InsertElementOp with backend converter

### DIFF
--- a/tests/filecheck/backend/llvm/convert_op.mlir
+++ b/tests/filecheck/backend/llvm/convert_op.mlir
@@ -937,6 +937,18 @@ builtin.module {
   // CHECK-NEXT:   ret void
   // CHECK-NEXT: }
 
+  llvm.func @insert_element(%arg0: vector<4xf32>, %arg1: f32, %arg2: i32) -> vector<4xf32> {
+    %0 = llvm.insertelement %arg1, %arg0[%arg2 : i32] : vector<4xf32>
+    llvm.return %0 : vector<4xf32>
+  }
+
+  // CHECK: define <4 x float> @"insert_element"(<4 x float> %".1", float %".2", i32 %".3")
+  // CHECK-NEXT: {
+  // CHECK-NEXT: [[ENTRY:.\d+]]:
+  // CHECK-NEXT:   %"[[RES:.\d+]]" = insertelement <4 x float> %".1", float %".2", i32 %".3"
+  // CHECK-NEXT:   ret <4 x float> %"[[RES]]"
+  // CHECK-NEXT: }
+
   llvm.func @broadcast_f32(%arg0: f32) -> vector<4xf32> {
     %0 = vector.broadcast %arg0 : f32 to vector<4xf32>
     llvm.return %0 : vector<4xf32>

--- a/tests/filecheck/dialects/llvm/invalid.mlir
+++ b/tests/filecheck/dialects/llvm/invalid.mlir
@@ -152,3 +152,14 @@ builtin.module {
 }
 
 // CHECK: expected `:` followed by global type
+
+// -----
+
+func.func @insertelement_2d_vector() {
+  %vec, %val, %idx = "test.op"() : () -> (vector<4x4xf32>, f32, i32)
+  %r = llvm.insertelement %val, %vec[%idx : i32] : vector<4x4xf32>
+  func.return
+}
+
+// CHECK: incorrect length for range variable:
+// CHECK-NEXT: Invalid value 2, expected 1

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/llvm_pointer_ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/llvm_pointer_ops.mlir
@@ -25,6 +25,9 @@ builtin.module {
   %ev_arr = llvm.extractvalue %agg[1, 2] : !llvm.struct<(i32, !llvm.array<3 x i32>)>
   %iv = llvm.insertvalue %ev_field, %agg[0] : !llvm.struct<(i32, !llvm.array<3 x i32>)>
   %iv_arr = llvm.insertvalue %ev_field, %agg[1, 0] : !llvm.struct<(i32, !llvm.array<3 x i32>)>
+
+  %vec, %val, %idx = "test.op"() : () -> (vector<4xf32>, f32, i32)
+  %ie = llvm.insertelement %val, %vec[%idx : i32] : vector<4xf32>
 }
 
 // CHECK:       builtin.module {
@@ -50,4 +53,6 @@ builtin.module {
 // CHECK-NEXT:    {{%.*}} = llvm.extractvalue [[AGG]][1, 2] : !llvm.struct<(i32, !llvm.array<3 x i32>)>
 // CHECK-NEXT:    {{%.*}} = llvm.insertvalue [[EVF]], [[AGG]][0] : !llvm.struct<(i32, !llvm.array<3 x i32>)>
 // CHECK-NEXT:    {{%.*}} = llvm.insertvalue [[EVF]], [[AGG]][1, 0] : !llvm.struct<(i32, !llvm.array<3 x i32>)>
+// CHECK-NEXT:    [[VEC:%.*]], [[VAL:%.*]], [[IDX:%.*]] = "test.op"() : () -> (vector<4xf32>, f32, i32)
+// CHECK-NEXT:    {{%.*}} = llvm.insertelement [[VAL]], [[VEC]]{{\[}}[[IDX]] : i32] : vector<4xf32>
 // CHECK-NEXT:  }

--- a/xdsl/backend/llvm/convert_op.py
+++ b/xdsl/backend/llvm/convert_op.py
@@ -540,6 +540,12 @@ def convert_op(
             _convert_addressof(op, builder, val_map)
         case llvm.CallIntrinsicOp():
             _convert_call_intrinsic(op, builder, val_map)
+        case llvm.InsertElementOp():
+            val_map[op.res] = builder.insert_element(
+                val_map[op.vector],
+                val_map[op.value],
+                val_map[op.index],
+            )
         case FMAOp():
             _convert_fma(op, builder, val_map)
         case vector.BroadcastOp():

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -59,6 +59,7 @@ from xdsl.irdl import (
     AttrSizedOperandSegments,
     IRDLOperation,
     ParsePropInAttrDict,
+    RangeOf,
     VarConstraint,
     base,
     irdl_attr_definition,
@@ -1785,6 +1786,46 @@ class InsertValueOp(IRDLOperation):
 
 
 @irdl_op_definition
+class InsertElementOp(IRDLOperation):
+    """
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/LLVM/#llvminsertelement-llvminsertelementop).
+    """
+
+    name = "llvm.insertelement"
+
+    ELEMENT: ClassVar = VarConstraint("ELEMENT", AnyAttr())
+    VECTOR: ClassVar = VarConstraint(
+        "VECTOR_T",
+        VectorType.constr(
+            ELEMENT,
+            shape=ArrayAttr.constr(RangeOf(IntAttr).of_length(1)),
+        ),
+    )
+
+    vector = operand_def(VECTOR)
+    value = operand_def(ELEMENT)
+    index = operand_def(SignlessIntegerConstraint)
+    res = result_def(VECTOR)
+
+    assembly_format = (
+        "$value `,` $vector `[` $index `:` type($index) `]` attr-dict `:` type($vector)"
+    )
+
+    traits = traits_def(NoMemoryEffect())
+
+    def __init__(
+        self,
+        vector: Operation | SSAValue,
+        value: Operation | SSAValue,
+        index: Operation | SSAValue,
+    ):
+        super().__init__(
+            operands=[vector, value, index],
+            result_types=[SSAValue.get(vector).type],
+        )
+
+
+@irdl_op_definition
 class UndefOp(IRDLOperation):
     """
     See external [documentation](https://mlir.llvm.org/docs/Dialects/LLVM/#llvmmlirundef-mlirllvmundefop).
@@ -3199,6 +3240,7 @@ LLVM = Dialect(
         GlobalOp,
         ICmpOp,
         InlineAsmOp,
+        InsertElementOp,
         InsertValueOp,
         IntToPtrOp,
         LShrOp,


### PR DESCRIPTION
Adds `llvm.insertelement` op with MLIR-compatible declarative assembly format, LLVM backend conversion, and full test coverage (unit test, backend converter test, filecheck test).

Subset of #5876.