### PR TITLE
dialects: (llvm) add CallIntrinsicOp backend converter and assembly format

### DIFF
--- a/tests/backend/llvm/test_convert_op.py
+++ b/tests/backend/llvm/test_convert_op.py
@@ -6,6 +6,7 @@ import pytest
 from xdsl.backend.llvm.convert_op import convert_op
 from xdsl.dialects import llvm
 from xdsl.dialects.builtin import i32
+from xdsl.dialects.utils import FastMathFlag
 from xdsl.ir import Block, SSAValue
 
 
@@ -22,6 +23,25 @@ def test_convert_indirect_call_raises():
 
     with pytest.raises(NotImplementedError, match="Indirect calls not yet implemented"):
         convert_op(op, builder, val_map)
+
+
+def test_call_intrinsic_op_bundle_raises():
+    block = Block(arg_types=[i32])
+    arg = block.args[0]
+    op = llvm.CallIntrinsicOp("llvm.donothing", [arg], [], op_bundle_operands=[arg])
+
+    with pytest.raises(NotImplementedError, match="Operand bundles not supported"):
+        convert_op(op, MagicMock(), {arg: MagicMock()})
+
+
+def test_call_intrinsic_fastmath_raises():
+    block = Block(arg_types=[i32])
+    arg = block.args[0]
+    op = llvm.CallIntrinsicOp("llvm.donothing", [arg], [])
+    op.properties["fastmathFlags"] = llvm.FastMathAttr([FastMathFlag.NO_NANS])
+
+    with pytest.raises(NotImplementedError, match="Fast-math flags not supported"):
+        convert_op(op, MagicMock(), {arg: MagicMock()})
 
 
 def test_convert_zero():

--- a/tests/filecheck/backend/llvm/convert_op.mlir
+++ b/tests/filecheck/backend/llvm/convert_op.mlir
@@ -894,6 +894,30 @@ builtin.module {
   // CHECK-NEXT:   ret <2 x double> %"[[RES]]"
   // CHECK-NEXT: }
 
+  llvm.func @call_intrinsic_fma(%arg0: vector<4xf32>, %arg1: vector<4xf32>, %arg2: vector<4xf32>) -> vector<4xf32> {
+    %0 = llvm.call_intrinsic "llvm.fma.v4f32"(%arg0, %arg1, %arg2) : (vector<4xf32>, vector<4xf32>, vector<4xf32>) -> vector<4xf32>
+    llvm.return %0 : vector<4xf32>
+  }
+
+  // CHECK: define <4 x float> @"call_intrinsic_fma"(<4 x float> %".1", <4 x float> %".2", <4 x float> %".3")
+  // CHECK-NEXT: {
+  // CHECK-NEXT: [[ENTRY:.\d+]]:
+  // CHECK-NEXT:   %"[[RES:.\d+]]" = call <4 x float> @"llvm.fma.v4f32"(<4 x float> %".1", <4 x float> %".2", <4 x float> %".3")
+  // CHECK-NEXT:   ret <4 x float> %"[[RES]]"
+  // CHECK-NEXT: }
+
+  llvm.func @call_intrinsic_void(%arg0: i32) {
+    llvm.call_intrinsic "llvm.donothing"(%arg0) : (i32) -> ()
+    llvm.return
+  }
+
+  // CHECK: define void @"call_intrinsic_void"(i32 %".1")
+  // CHECK-NEXT: {
+  // CHECK-NEXT: [[ENTRY:.\d+]]:
+  // CHECK-NEXT:   call void @"llvm.donothing"(i32 %".1")
+  // CHECK-NEXT:   ret void
+  // CHECK-NEXT: }
+
   llvm.func @callee(!llvm.ptr)
 
   llvm.func @addressof_target() {

--- a/xdsl/backend/llvm/convert_op.py
+++ b/xdsl/backend/llvm/convert_op.py
@@ -399,6 +399,32 @@ def _convert_addressof(
     val_map[op.result] = builder.module.get_global(op.global_name.root_reference.data)
 
 
+def _convert_call_intrinsic(
+    op: llvm.CallIntrinsicOp,
+    builder: ir.IRBuilder,
+    val_map: dict[SSAValue, ir.Value],
+):
+    if op.op_bundle_operands:
+        raise NotImplementedError("Operand bundles not supported")
+    if op.fastmathFlags is not None and any(op.fastmathFlags.data):
+        raise NotImplementedError("Fast-math flags not supported")
+    args = [val_map[arg] for arg in op.args]
+    arg_types = [a.type for a in args]
+    name = op.intrin.data
+    if op.ress is not None:
+        ret_type = convert_type(op.ress.type)
+    else:
+        ret_type = ir.VoidType()
+    fn_type = ir.FunctionType(ret_type, arg_types)
+    try:
+        intrinsic = builder.module.get_global(name)
+    except KeyError:
+        intrinsic = ir.Function(builder.module, fn_type, name=name)
+    result = builder.call(intrinsic, args)
+    if op.ress is not None:
+        val_map[op.ress] = result
+
+
 def _convert_broadcast(
     op: vector.BroadcastOp,
     builder: ir.IRBuilder,
@@ -512,6 +538,8 @@ def convert_op(
             val_map[op.res] = ir.Constant(convert_type(op.res.type), ir.Undefined)
         case llvm.AddressOfOp():
             _convert_addressof(op, builder, val_map)
+        case llvm.CallIntrinsicOp():
+            _convert_call_intrinsic(op, builder, val_map)
         case FMAOp():
             _convert_fma(op, builder, val_map)
         case vector.BroadcastOp():

--- a/xdsl/backend/llvm/convert_op.py
+++ b/xdsl/backend/llvm/convert_op.py
@@ -406,7 +406,7 @@ def _convert_call_intrinsic(
 ):
     if op.op_bundle_operands:
         raise NotImplementedError("Operand bundles not supported")
-    if op.fastmathFlags is not None and any(op.fastmathFlags.data):
+    if any(op.fastmathFlags.data):
         raise NotImplementedError("Fast-math flags not supported")
     args = [val_map[arg] for arg in op.args]
     arg_types = [a.type for a in args]

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -2407,7 +2407,6 @@ class FastMathAttr(FastMathAttrBase):
     name = "llvm.fastmath"
 
 
-# TODO: custom assembly format https://github.com/xdslproject/xdsl/issues/5897
 @irdl_op_definition
 class CallIntrinsicOp(IRDLOperation):
     """


### PR DESCRIPTION
Add a backend converter for `llvm.call_intrinsic` that lowers to LLVM IR via llvmlite. Also add a declarative `assembly_format` so the op uses pretty syntax instead of generic format.

Converter handles intrinsics with and without return values, declares the intrinsic function on first use, and rejects unsupported operand bundles and fast-math flags.

Subset of #5876.