### PR TITLE
dialects: (llvm) add ShuffleVectorOp with backend converter

### DIFF
--- a/tests/dialects/test_llvm.py
+++ b/tests/dialects/test_llvm.py
@@ -1,11 +1,14 @@
 from io import StringIO
 
 import pytest
+from typing_extensions import TypeVar
 
 from xdsl.context import Context
 from xdsl.dialects import arith, builtin, llvm, test
 from xdsl.dialects.builtin import UnitAttr, i32
+from xdsl.dialects.llvm import ShuffleVectorResultConstraint
 from xdsl.ir import Attribute, Block, Region
+from xdsl.irdl import AnyAttr, EqAttrConstraint, TypeVarConstraint, VarConstraint
 from xdsl.parser import Parser
 from xdsl.printer import Printer
 from xdsl.utils.exceptions import VerifyException
@@ -708,3 +711,17 @@ def test_shuffle_vector_op_mask_out_of_range():
     op = llvm.ShuffleVectorOp(v1, v2, mask, result_type)
     with pytest.raises(VerifyException, match="Mask value 5 out of range"):
         op.verify()
+
+
+def test_shuffle_vector_result_constraint_mapping_type_vars():
+    _T = TypeVar("_T", bound=Attribute)
+    elem_constr = TypeVarConstraint(_T, AnyAttr())
+    mask_constr = VarConstraint("MASK", AnyAttr())
+    constr = ShuffleVectorResultConstraint(elem_constr, mask_constr)
+
+    replacement = EqAttrConstraint(builtin.f32)
+    mapped = constr.mapping_type_vars({_T: replacement})
+
+    assert isinstance(mapped, ShuffleVectorResultConstraint)
+    assert mapped.element_constr == replacement
+    assert mapped.mask_constr == mask_constr

--- a/tests/dialects/test_llvm.py
+++ b/tests/dialects/test_llvm.py
@@ -702,17 +702,6 @@ def test_shuffle_vector_op_different_sizes():
     assert op.res.type == result_type
 
 
-def test_shuffle_vector_op_mask_out_of_range():
-    vec_type = builtin.VectorType(builtin.f32, [2])
-    result_type = builtin.VectorType(builtin.f32, [2])
-    v1 = create_ssa_value(vec_type)
-    v2 = create_ssa_value(vec_type)
-    mask = builtin.DenseArrayBase.from_list(builtin.i32, [0, 5])
-    op = llvm.ShuffleVectorOp(v1, v2, mask, result_type)
-    with pytest.raises(VerifyException, match="Mask value 5 out of range"):
-        op.verify()
-
-
 def test_shuffle_vector_result_constraint_mapping_type_vars():
     _T = TypeVar("_T", bound=Attribute)
     elem_constr = TypeVarConstraint(_T, AnyAttr())

--- a/tests/dialects/test_llvm.py
+++ b/tests/dialects/test_llvm.py
@@ -672,3 +672,15 @@ def test_masked_store_op():
     assert op.data == ptr
     assert op.mask == mask
     assert op.alignment.value.data == 16
+
+
+def test_shuffle_vector_op():
+    vec_type = builtin.VectorType(builtin.f32, [4])
+    v1 = create_ssa_value(vec_type)
+    v2 = create_ssa_value(vec_type)
+    mask = builtin.DenseArrayBase.from_list(builtin.i32, [0, 0, 0, 0])
+    op = llvm.ShuffleVectorOp(v1, v2, mask, vec_type)
+    assert op.v1 == v1
+    assert op.v2 == v2
+    assert op.mask is mask
+    assert op.res.type == vec_type

--- a/tests/dialects/test_llvm.py
+++ b/tests/dialects/test_llvm.py
@@ -684,3 +684,16 @@ def test_shuffle_vector_op():
     assert op.v2 == v2
     assert op.mask is mask
     assert op.res.type == vec_type
+
+
+def test_shuffle_vector_op_different_sizes():
+    input_type = builtin.VectorType(builtin.f32, [4])
+    result_type = builtin.VectorType(builtin.f32, [2])
+    v1 = create_ssa_value(input_type)
+    v2 = create_ssa_value(input_type)
+    mask = builtin.DenseArrayBase.from_list(builtin.i32, [0, 5])
+    op = llvm.ShuffleVectorOp(v1, v2, mask, result_type)
+    assert op.v1 == v1
+    assert op.v2 == v2
+    assert op.mask is mask
+    assert op.res.type == result_type

--- a/tests/dialects/test_llvm.py
+++ b/tests/dialects/test_llvm.py
@@ -697,3 +697,14 @@ def test_shuffle_vector_op_different_sizes():
     assert op.v2 == v2
     assert op.mask is mask
     assert op.res.type == result_type
+
+
+def test_shuffle_vector_op_mask_out_of_range():
+    vec_type = builtin.VectorType(builtin.f32, [2])
+    result_type = builtin.VectorType(builtin.f32, [2])
+    v1 = create_ssa_value(vec_type)
+    v2 = create_ssa_value(vec_type)
+    mask = builtin.DenseArrayBase.from_list(builtin.i32, [0, 5])
+    op = llvm.ShuffleVectorOp(v1, v2, mask, result_type)
+    with pytest.raises(VerifyException, match="Mask value 5 out of range"):
+        op.verify()

--- a/tests/filecheck/backend/llvm/convert_op.mlir
+++ b/tests/filecheck/backend/llvm/convert_op.mlir
@@ -930,6 +930,18 @@ builtin.module {
   // CHECK-NEXT:   ret <4 x float> %"[[RES]]"
   // CHECK-NEXT: }
 
+  llvm.func @shuffle_vector_different_sizes(%arg0: vector<4xf32>, %arg1: vector<4xf32>) -> vector<2xf32> {
+    %res = llvm.shufflevector %arg0, %arg1 [0, 5] : vector<4xf32>
+    llvm.return %res : vector<2xf32>
+  }
+
+  // CHECK: define <2 x float> @"shuffle_vector_different_sizes"(<4 x float> %".1", <4 x float> %".2")
+  // CHECK-NEXT: {
+  // CHECK-NEXT: [[ENTRY:.\d+]]:
+  // CHECK-NEXT:   %"[[RES:.\d+]]" = shufflevector <4 x float> %".1", <4 x float> %".2", <2 x i32> <i32 0, i32 5>
+  // CHECK-NEXT:   ret <2 x float> %"[[RES]]"
+  // CHECK-NEXT: }
+
   llvm.func @callee(!llvm.ptr)
 
   llvm.func @addressof_target() {

--- a/tests/filecheck/backend/llvm/convert_op.mlir
+++ b/tests/filecheck/backend/llvm/convert_op.mlir
@@ -918,6 +918,18 @@ builtin.module {
   // CHECK-NEXT:   ret void
   // CHECK-NEXT: }
 
+  llvm.func @shuffle_vector_f32(%arg0: vector<4xf32>, %arg1: vector<4xf32>) -> vector<4xf32> {
+    %res = llvm.shufflevector %arg0, %arg1 [0, 0, 0, 0] : vector<4xf32>
+    llvm.return %res : vector<4xf32>
+  }
+
+  // CHECK: define <4 x float> @"shuffle_vector_f32"(<4 x float> %".1", <4 x float> %".2")
+  // CHECK-NEXT: {
+  // CHECK-NEXT: [[ENTRY:.\d+]]:
+  // CHECK-NEXT:   %"[[RES:.\d+]]" = shufflevector <4 x float> %".1", <4 x float> %".2", <4 x i32> <i32 0, i32 0, i32 0, i32 0>
+  // CHECK-NEXT:   ret <4 x float> %"[[RES]]"
+  // CHECK-NEXT: }
+
   llvm.func @callee(!llvm.ptr)
 
   llvm.func @addressof_target() {

--- a/tests/filecheck/dialects/llvm/example.mlir
+++ b/tests/filecheck/dialects/llvm/example.mlir
@@ -99,6 +99,14 @@ builtin.module {
 
 // CHECK-NEXT: %fval3 = llvm.fpext %fval : f32 to f64
 
+  %vec1 = "test.op"() : () -> vector<4xf32>
+  %vec2 = "test.op"() : () -> vector<4xf32>
+  %shuf = llvm.shufflevector %vec1, %vec2 [0, 1, 2, 3] : vector<4xf32>
+
+// CHECK-NEXT: %vec1 = "test.op"() : () -> vector<4xf32>
+// CHECK-NEXT: %vec2 = "test.op"() : () -> vector<4xf32>
+// CHECK-NEXT: %shuf = llvm.shufflevector %vec1, %vec2 [0, 1, 2, 3] : vector<4xf32>
+
   llvm.unreachable {my_attr}
 
 // CHECK-NEXT: llvm.unreachable {my_attr}

--- a/tests/filecheck/dialects/llvm/example.mlir
+++ b/tests/filecheck/dialects/llvm/example.mlir
@@ -107,6 +107,10 @@ builtin.module {
 // CHECK-NEXT: %vec2 = "test.op"() : () -> vector<4xf32>
 // CHECK-NEXT: %shuf = llvm.shufflevector %vec1, %vec2 [0, 1, 2, 3] : vector<4xf32>
 
+  %shuf2 = llvm.shufflevector %vec1, %vec2 [0, 5] : vector<4xf32>
+
+// CHECK-NEXT: %shuf2 = llvm.shufflevector %vec1, %vec2 [0, 5] : vector<4xf32>
+
   llvm.unreachable {my_attr}
 
 // CHECK-NEXT: llvm.unreachable {my_attr}

--- a/tests/filecheck/dialects/llvm/invalid.mlir
+++ b/tests/filecheck/dialects/llvm/invalid.mlir
@@ -163,3 +163,14 @@ func.func @insertelement_2d_vector() {
 
 // CHECK: incorrect length for range variable:
 // CHECK-NEXT: Invalid value 2, expected 1
+
+// -----
+
+func.func @shufflevector_mask_out_of_range() {
+  %v1 = "test.op"() : () -> vector<2xf32>
+  %v2 = "test.op"() : () -> vector<2xf32>
+  %shuf = llvm.shufflevector %v1, %v2 [0, 5] : vector<2xf32>
+  func.return
+}
+
+// CHECK: Mask value 5 out of range [-1, 4)

--- a/xdsl/backend/llvm/convert_op.py
+++ b/xdsl/backend/llvm/convert_op.py
@@ -444,7 +444,7 @@ def _convert_shuffle_vector(
     builder: ir.IRBuilder,
     val_map: dict[SSAValue, ir.Value],
 ):
-    mask_values = list(op.mask.iter_values())
+    mask_values = op.mask.get_values()
     mask = ir.Constant(ir.VectorType(ir.IntType(32), len(mask_values)), mask_values)
     val_map[op.res] = builder.shuffle_vector(val_map[op.v1], val_map[op.v2], mask)
 

--- a/xdsl/backend/llvm/convert_op.py
+++ b/xdsl/backend/llvm/convert_op.py
@@ -439,6 +439,16 @@ def _convert_broadcast(
     val_map[op.vector] = builder.shuffle_vector(inserted, undef, mask)
 
 
+def _convert_shuffle_vector(
+    op: llvm.ShuffleVectorOp,
+    builder: ir.IRBuilder,
+    val_map: dict[SSAValue, ir.Value],
+):
+    mask_values = list(op.mask.iter_values())
+    mask = ir.Constant(ir.VectorType(ir.IntType(32), len(mask_values)), mask_values)
+    val_map[op.res] = builder.shuffle_vector(val_map[op.v1], val_map[op.v2], mask)
+
+
 _CONSTANT_VALUE_MAP: dict[type[Attribute], Callable[[Attribute], object]] = {
     DenseIntOrFPElementsAttr: lambda v: list(
         cast(DenseIntOrFPElementsAttr, v).iter_values()
@@ -546,6 +556,8 @@ def convert_op(
                 val_map[op.value],
                 val_map[op.index],
             )
+        case llvm.ShuffleVectorOp():
+            _convert_shuffle_vector(op, builder, val_map)
         case FMAOp():
             _convert_fma(op, builder, val_map)
         case vector.BroadcastOp():

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -1900,9 +1900,7 @@ class ShuffleVectorOp(IRDLOperation):
         "VEC_TYPE",
         VectorType.constr(
             T,
-            shape=ArrayAttr.constr(
-                RangeOf(base(IntAttr)).of_length(1)
-            ),
+            shape=ArrayAttr.constr(RangeOf(base(IntAttr)).of_length(1)),
         ),
     )
     MASK: ClassVar = VarConstraint("MASK", irdl_to_attr_constraint(DenseArrayBase[I32]))
@@ -1915,6 +1913,18 @@ class ShuffleVectorOp(IRDLOperation):
     traits = traits_def(NoMemoryEffect())
 
     assembly_format = "$v1 `,` $v2 $mask attr-dict `:` type($v1)"
+
+    def verify_(self) -> None:
+        v1_type = cast(VectorType, self.v1.type)
+        v1_size = v1_type.get_shape()[0]
+        v2_type = cast(VectorType, self.v2.type)
+        v2_size = v2_type.get_shape()[0]
+        dim_bound = v1_size + v2_size
+        for idx in self.mask.iter_values():
+            if not (-1 <= idx < dim_bound):
+                raise VerifyException(
+                    f"Mask value {idx} out of range [-1, {dim_bound})"
+                )
 
     def __init__(
         self,

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -15,7 +15,6 @@ from xdsl.dialects.builtin import (
     I64,
     AnyFloatConstr,
     ArrayAttr,
-    BoolAttr,
     DenseArrayBase,
     DenseIntOrFPElementsAttr,
     DictionaryAttr,
@@ -1888,16 +1887,11 @@ class ShuffleVectorOp(IRDLOperation):
     name = "llvm.shufflevector"
 
     T: ClassVar = VarConstraint("T", AnyAttr())
-    SHAPE: ClassVar = VarConstraint(
-        "SHAPE", irdl_to_attr_constraint(ArrayAttr[IntAttr])
-    )
-    SCALABLE: ClassVar = VarConstraint(
-        "SCALABLE", irdl_to_attr_constraint(ArrayAttr[BoolAttr])
-    )
+    VEC_TYPE: ClassVar = VarConstraint("VEC_TYPE", VectorType.constr(T))
     MASK: ClassVar = VarConstraint("MASK", irdl_to_attr_constraint(DenseArrayBase[I32]))
 
-    v1 = operand_def(VectorType.constr(T, shape=SHAPE, scalable_dims=SCALABLE))
-    v2 = operand_def(VectorType.constr(T, shape=SHAPE, scalable_dims=SCALABLE))
+    v1 = operand_def(VEC_TYPE)
+    v2 = operand_def(VEC_TYPE)
     mask = prop_def(MASK)
     res = result_def(_ShuffleVectorResultConstraint(T, MASK))
 

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -1850,7 +1850,13 @@ class UndefOp(IRDLOperation):
 
 
 @dataclass(frozen=True)
-class _ShuffleVectorResultConstraint(AttrConstraint[VectorType]):
+class ShuffleVectorResultConstraint(AttrConstraint[VectorType]):
+    """Infers a 1D VectorType result from the input element type and mask length.
+
+    The result shape is determined by the number of elements in the mask,
+    while the element type is propagated from the input vectors.
+    """
+
     element_constr: AttrConstraint
     mask_constr: VarConstraint
 
@@ -1878,7 +1884,7 @@ class _ShuffleVectorResultConstraint(AttrConstraint[VectorType]):
     def mapping_type_vars(
         self, type_var_mapping: Mapping[TypeVar, AttrConstraint | IntConstraint]
     ) -> AttrConstraint[VectorType]:
-        return _ShuffleVectorResultConstraint(
+        return ShuffleVectorResultConstraint(
             self.element_constr.mapping_type_vars(type_var_mapping),
             self.mask_constr.mapping_type_vars(type_var_mapping),
         )
@@ -1908,7 +1914,7 @@ class ShuffleVectorOp(IRDLOperation):
     v1 = operand_def(VEC_TYPE)
     v2 = operand_def(VEC_TYPE)
     mask = prop_def(MASK)
-    res = result_def(_ShuffleVectorResultConstraint(T, MASK))
+    res = result_def(ShuffleVectorResultConstraint(T, MASK))
 
     traits = traits_def(NoMemoryEffect())
 

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 from abc import ABC
 from collections.abc import Mapping, Sequence
+from collections.abc import Set as AbstractSet
 from dataclasses import dataclass
 from types import EllipsisType
 from typing import ClassVar, cast
 
-from typing_extensions import deprecated
+from typing_extensions import TypeVar, deprecated
 
 from xdsl.dialects.builtin import (
     I1,
@@ -14,6 +15,7 @@ from xdsl.dialects.builtin import (
     I64,
     AnyFloatConstr,
     ArrayAttr,
+    BoolAttr,
     DenseArrayBase,
     DenseIntOrFPElementsAttr,
     DictionaryAttr,
@@ -56,7 +58,10 @@ from xdsl.ir import (
 )
 from xdsl.irdl import (
     AnyAttr,
+    AttrConstraint,
     AttrSizedOperandSegments,
+    ConstraintContext,
+    IntConstraint,
     IRDLOperation,
     ParsePropInAttrDict,
     RangeOf,
@@ -64,6 +69,7 @@ from xdsl.irdl import (
     base,
     irdl_attr_definition,
     irdl_op_definition,
+    irdl_to_attr_constraint,
     operand_def,
     opt_operand_def,
     opt_prop_def,
@@ -1843,6 +1849,76 @@ class UndefOp(IRDLOperation):
         super().__init__(result_types=[result_type])
 
 
+@dataclass(frozen=True)
+class _ShuffleVectorResultConstraint(AttrConstraint[VectorType]):
+    element_constr: AttrConstraint
+    mask_constr: VarConstraint
+
+    def verify(self, attr: Attribute, constraint_context: ConstraintContext) -> None:
+        VectorType.constr(self.element_constr).verify(attr, constraint_context)
+
+    def can_infer(self, var_constraint_names: AbstractSet[str]) -> bool:
+        return (
+            self.element_constr.can_infer(var_constraint_names)
+            and self.mask_constr.name in var_constraint_names
+        )
+
+    def infer(self, context: ConstraintContext) -> VectorType:
+        mask = context.get_variable(self.mask_constr.name)
+        assert mask is not None
+        mask = cast(DenseArrayBase[IntegerType], mask)
+        element_type = self.element_constr.infer(context)
+        return VectorType(element_type, [len(mask)])
+
+    def mapping_type_vars(
+        self, type_var_mapping: Mapping[TypeVar, AttrConstraint | IntConstraint]
+    ) -> AttrConstraint[VectorType]:
+        return _ShuffleVectorResultConstraint(
+            self.element_constr.mapping_type_vars(type_var_mapping),
+            self.mask_constr.mapping_type_vars(type_var_mapping),
+        )
+
+
+@irdl_op_definition
+class ShuffleVectorOp(IRDLOperation):
+    """
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/LLVM/#llvmshufflevector-llvmshufflevectorop).
+    """
+
+    name = "llvm.shufflevector"
+
+    T: ClassVar = VarConstraint("T", AnyAttr())
+    SHAPE: ClassVar = VarConstraint(
+        "SHAPE", irdl_to_attr_constraint(ArrayAttr[IntAttr])
+    )
+    SCALABLE: ClassVar = VarConstraint(
+        "SCALABLE", irdl_to_attr_constraint(ArrayAttr[BoolAttr])
+    )
+    MASK: ClassVar = VarConstraint("MASK", irdl_to_attr_constraint(DenseArrayBase[I32]))
+
+    v1 = operand_def(VectorType.constr(T, shape=SHAPE, scalable_dims=SCALABLE))
+    v2 = operand_def(VectorType.constr(T, shape=SHAPE, scalable_dims=SCALABLE))
+    mask = prop_def(MASK)
+    res = result_def(_ShuffleVectorResultConstraint(T, MASK))
+
+    traits = traits_def(NoMemoryEffect())
+
+    assembly_format = "$v1 `,` $v2 $mask attr-dict `:` type($v1)"
+
+    def __init__(
+        self,
+        v1: Operation | SSAValue,
+        v2: Operation | SSAValue,
+        mask: DenseArrayBase,
+        result_type: Attribute,
+    ):
+        super().__init__(
+            operands=[v1, v2],
+            result_types=[result_type],
+            properties={"mask": mask},
+        )
+
+
 UNNAMED_ADDR_KEYWORD_BY_KEY: dict[int, str] = {
     1: "local_unnamed_addr",
     2: "unnamed_addr",
@@ -3256,6 +3332,7 @@ LLVM = Dialect(
         SIToFPOp,
         SRemOp,
         ShlOp,
+        ShuffleVectorOp,
         StoreOp,
         SubOp,
         TruncOp,

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -60,6 +60,7 @@ from xdsl.irdl import (
     AttrConstraint,
     AttrSizedOperandSegments,
     ConstraintContext,
+    EqIntConstraint,
     IntConstraint,
     IRDLOperation,
     ParsePropInAttrDict,
@@ -1854,7 +1855,12 @@ class _ShuffleVectorResultConstraint(AttrConstraint[VectorType]):
     mask_constr: VarConstraint
 
     def verify(self, attr: Attribute, constraint_context: ConstraintContext) -> None:
-        VectorType.constr(self.element_constr).verify(attr, constraint_context)
+        VectorType.constr(
+            self.element_constr,
+            shape=ArrayAttr.constr(
+                RangeOf(base(IntAttr)).of_length(EqIntConstraint(1))
+            ),
+        ).verify(attr, constraint_context)
 
     def can_infer(self, var_constraint_names: AbstractSet[str]) -> bool:
         return (
@@ -1890,7 +1896,15 @@ class ShuffleVectorOp(IRDLOperation):
     name = "llvm.shufflevector"
 
     T: ClassVar = VarConstraint("T", AnyAttr())
-    VEC_TYPE: ClassVar = VarConstraint("VEC_TYPE", VectorType.constr(T))
+    VEC_TYPE: ClassVar = VarConstraint(
+        "VEC_TYPE",
+        VectorType.constr(
+            T,
+            shape=ArrayAttr.constr(
+                RangeOf(base(IntAttr)).of_length(EqIntConstraint(1))
+            ),
+        ),
+    )
     MASK: ClassVar = VarConstraint("MASK", irdl_to_attr_constraint(DenseArrayBase[I32]))
 
     v1 = operand_def(VEC_TYPE)

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -1901,7 +1901,7 @@ class ShuffleVectorOp(IRDLOperation):
         VectorType.constr(
             T,
             shape=ArrayAttr.constr(
-                RangeOf(base(IntAttr)).of_length(EqIntConstraint(1))
+                RangeOf(base(IntAttr)).of_length(1)
             ),
         ),
     )

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -1881,6 +1881,9 @@ class _ShuffleVectorResultConstraint(AttrConstraint[VectorType]):
 @irdl_op_definition
 class ShuffleVectorOp(IRDLOperation):
     """
+    Constructs a new 1D vector by selecting elements from two input vectors
+    according to a static mask of indices.
+
     See external [documentation](https://mlir.llvm.org/docs/Dialects/LLVM/#llvmshufflevector-llvmshufflevectorop).
     """
 


### PR DESCRIPTION
Add `llvm.shufflevector` op definition using `assembly_format` and constraint-based result type inference instead of custom parse/print. Includes LLVM backend converter and tests.

Pretty syntax: `llvm.shufflevector %v1, %v2 [0, 1, 2, 3] : vector<4xf32>`

The result type is inferred from the input element type and mask length via `_ShuffleVectorResultConstraint`, following the same pattern as `vector.ShuffleOp`. The type after `:` is the input vector type.

