### PR TITLE
dialects: (llvm) drop stale custom assembly format TODOs [NFC]

### DIFF
--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -2407,7 +2407,6 @@ class FastMathAttr(FastMathAttrBase):
     name = "llvm.fastmath"
 
 
-# TODO: custom assembly format https://github.com/xdslproject/xdsl/issues/5897
 @irdl_op_definition
 class CallIntrinsicOp(IRDLOperation):
     """
@@ -2484,7 +2483,6 @@ class CallOpSymbolUserOpInterface(SymbolUserOpInterface):
             )
 
 
-# TODO: custom assembly format https://github.com/xdslproject/xdsl/issues/5897
 @irdl_op_definition
 class CallOp(IRDLOperation):
     name = "llvm.call"


### PR DESCRIPTION
Remove 4 TODO comments referencing #5897 from `InlineAsmOp`, `GlobalOp`, `CallIntrinsicOp`, and `CallOp`. The custom assembly format work they point to is already done.