### PR TITLE
bench: fix LLVM backend benchmark and add CI smoke test

### DIFF
--- a/.github/workflows/ci-bench.yml
+++ b/.github/workflows/ci-bench.yml
@@ -50,6 +50,8 @@ jobs:
               raise SystemExit(1)
           "
 
+      # Verify [llvm] extra is installed.
+      # On failure check asv.conf.json install_command and pyproject.toml.
       - name: Install xdsl[llvm]
         run: uv pip install --system ".[llvm]"
 

--- a/.github/workflows/ci-bench.yml
+++ b/.github/workflows/ci-bench.yml
@@ -1,0 +1,73 @@
+name: CI - Benchmarks
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  bench:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      # ASV discovery imports all benchmark modules without optional extras.
+      - name: Install xdsl (no extras)
+        run: uv pip install --system .
+
+      - name: Verify benchmark discovery without extras
+        run: |
+          python -c "
+          import importlib
+          from pathlib import Path
+
+          failures = []
+          for p in sorted(Path('benchmarks').glob('*.py')):
+              if p.stem == '__init__':
+                  continue
+              mod = f'benchmarks.{p.stem}'
+              try:
+                  importlib.import_module(mod)
+              except ImportError as e:
+                  failures.append(f'{mod}: {e}')
+
+          if failures:
+              for f in failures:
+                  print(f)
+              raise SystemExit(1)
+          "
+
+      - name: Install xdsl[llvm]
+        run: uv pip install --system ".[llvm]"
+
+      - name: Verify benchmark entrypoints
+        run: |
+          failed=""
+          for f in benchmarks/*.py; do
+            if grep -q 'if __name__ == "__main__":' "$f"; then
+              echo "Testing $f --help"
+              if ! python "$f" --help > /dev/null; then
+                failed="$failed $f"
+              fi
+            fi
+          done
+          if [ -n "$failed" ]; then
+            echo "Failed:$failed"
+            exit 1
+          fi
+
+      - name: Prune uv cache
+        run: uv cache prune --ci

--- a/.github/workflows/ci-bench.yml
+++ b/.github/workflows/ci-bench.yml
@@ -53,6 +53,9 @@ jobs:
       - name: Install xdsl[llvm]
         run: uv pip install --system ".[llvm]"
 
+      - name: Verify llvm extra is installed
+        run: python -c "import llvmlite"
+
       - name: Verify benchmark entrypoints
         run: |
           failed=""

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -34,7 +34,7 @@
 
     // Customizable commands for installing and uninstalling the project.
     // See asv.conf.json documentation.
-    // "install_command": ["in-dir={env_dir} python -mpip install {wheel_file}"],
+    "install_command": ["in-dir={env_dir} python -mpip install {wheel_file}[llvm]"],
     // "uninstall_command": ["return-code=any python -mpip uninstall -y {project}"],
 
     // List of branches to benchmark. If not provided, defaults to "main"

--- a/benchmarks/llvm_backend.py
+++ b/benchmarks/llvm_backend.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 from pathlib import Path
 
-from xdsl.backend.llvm.convert import convert_module
 from xdsl.context import Context
 from xdsl.dialects.builtin import Builtin, ModuleOp
 from xdsl.dialects.llvm import LLVM
@@ -32,6 +31,8 @@ class LLVMBackend:
     MODULE = _parse_module()
 
     def time_convert_module(self) -> None:
+        from xdsl.backend.llvm.convert import convert_module
+
         convert_module(LLVMBackend.MODULE)
 
 


### PR DESCRIPTION
ASV virtualenvs only install `[project.dependencies]`, so `llvmlite` is missing and the `llvm_backend` benchmark is discovered but never runs. Using `install_command` with `{wheel_file}[llvm]` tells ASV to install the llvm extra from pyproject.toml, making pyproject.toml the single source of truth.

Also adds a CI workflow (`ci-bench.yml`) that installs `xdsl[llvm]` and runs `--help` on every benchmark file with a `__main__` guard, catching missing dependencies and broken imports before they reach ASV.

Follow-up to #5976, discussed in https://github.com/xdslproject/xdsl/pull/5976#issuecomment-4351623896.