### PR TITLE
dialects: (acc) OpenACC data privatization operations

### DIFF
--- a/tests/filecheck/dialects/acc/ops.mlir
+++ b/tests/filecheck/dialects/acc/ops.mlir
@@ -1184,6 +1184,102 @@ builtin.module {
   // CHECK-LABEL: func.func @copyin_clauses_reordered(
   // CHECK:         %{{.*}} = acc.copyin varPtr(%{{.*}} : memref<10xf32>) varPtrPtr(%{{.*}} : memref<memref<10xf32>>) bounds(%{{.*}}) async recipe(@some_recipe) -> memref<10xf32>
 
+  // Privatization data-clause ops (`acc.private`, `acc.firstprivate`,
+  // `acc.firstprivate_map`, `acc.reduction`). These share the entry
+  // `_DataEntryOperation` mixin — same operand and assembly-format
+  // surface as `acc.copyin` etc. — and differ only in the per-op
+  // `dataClause` default. The natural extra coverage here is the
+  // `recipe(@sym)` reference case: `acc.private` / `acc.firstprivate` /
+  // `acc.reduction` all carry a recipe pointing at one of the
+  // privatization / reduction recipe symbol ops introduced in PR 13.
+  func.func @private_minimal(%a : memref<10xf32>) {
+    %r = acc.private varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    func.return
+  }
+  // CHECK-LABEL: func.func @private_minimal(
+  // CHECK:         %{{.*}} = acc.private varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32>
+
+  func.func @private_with_recipe(%a : memref<10xf32>) {
+    %r = acc.private varPtr(%a : memref<10xf32>) recipe(@priv_min) -> memref<10xf32>
+    func.return
+  }
+  // CHECK-LABEL: func.func @private_with_recipe(
+  // CHECK:         %{{.*}} = acc.private varPtr(%{{.*}} : memref<10xf32>) recipe(@priv_min) -> memref<10xf32>
+
+  func.func @private_dataclause_default_elided(%a : memref<10xf32>) {
+    %r = "acc.private"(%a) <{dataClause = #acc<data_clause acc_private>, operandSegmentSizes = array<i32: 1, 0, 0, 0>, varType = f32}> : (memref<10xf32>) -> memref<10xf32>
+    func.return
+  }
+  // CHECK-LABEL: func.func @private_dataclause_default_elided(
+  // CHECK:         %{{.*}} = acc.private varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32>
+  // CHECK-NOT:     dataClause
+
+  func.func @firstprivate_minimal(%a : memref<10xf32>) {
+    %r = acc.firstprivate varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    func.return
+  }
+  // CHECK-LABEL: func.func @firstprivate_minimal(
+  // CHECK:         %{{.*}} = acc.firstprivate varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32>
+
+  func.func @firstprivate_with_recipe(%a : memref<10xf32>) {
+    %r = acc.firstprivate varPtr(%a : memref<10xf32>) recipe(@fp_min) -> memref<10xf32>
+    func.return
+  }
+  // CHECK-LABEL: func.func @firstprivate_with_recipe(
+  // CHECK:         %{{.*}} = acc.firstprivate varPtr(%{{.*}} : memref<10xf32>) recipe(@fp_min) -> memref<10xf32>
+
+  func.func @firstprivate_dataclause_default_elided(%a : memref<10xf32>) {
+    %r = "acc.firstprivate"(%a) <{dataClause = #acc<data_clause acc_firstprivate>, operandSegmentSizes = array<i32: 1, 0, 0, 0>, varType = f32}> : (memref<10xf32>) -> memref<10xf32>
+    func.return
+  }
+  // CHECK-LABEL: func.func @firstprivate_dataclause_default_elided(
+  // CHECK:         %{{.*}} = acc.firstprivate varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32>
+  // CHECK-NOT:     dataClause
+
+  func.func @firstprivate_map_minimal(%a : memref<10xf32>) {
+    %r = acc.firstprivate_map varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    func.return
+  }
+  // CHECK-LABEL: func.func @firstprivate_map_minimal(
+  // CHECK:         %{{.*}} = acc.firstprivate_map varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32>
+
+  // `acc.firstprivate_map` decomposes the same user-level
+  // `acc_firstprivate` clause as `acc.firstprivate` — its `dataClause`
+  // default is `acc_firstprivate` (not the op-name-derived value a typo
+  // would land on).
+  func.func @firstprivate_map_dataclause_default_elided(%a : memref<10xf32>) {
+    %r = "acc.firstprivate_map"(%a) <{dataClause = #acc<data_clause acc_firstprivate>, operandSegmentSizes = array<i32: 1, 0, 0, 0>, varType = f32}> : (memref<10xf32>) -> memref<10xf32>
+    func.return
+  }
+  // CHECK-LABEL: func.func @firstprivate_map_dataclause_default_elided(
+  // CHECK:         %{{.*}} = acc.firstprivate_map varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32>
+  // CHECK-NOT:     dataClause
+
+  func.func @reduction_minimal(%a : memref<10xf32>) {
+    %r = acc.reduction varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    func.return
+  }
+  // CHECK-LABEL: func.func @reduction_minimal(
+  // CHECK:         %{{.*}} = acc.reduction varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32>
+
+  // `acc.reduction` references the operator via `recipe(@sym)` — the
+  // operator itself lives on `acc.reduction.recipe`, not on the data-entry
+  // op.
+  func.func @reduction_with_recipe(%a : memref<10xf32>) {
+    %r = acc.reduction varPtr(%a : memref<10xf32>) recipe(@red_add_i64) -> memref<10xf32>
+    func.return
+  }
+  // CHECK-LABEL: func.func @reduction_with_recipe(
+  // CHECK:         %{{.*}} = acc.reduction varPtr(%{{.*}} : memref<10xf32>) recipe(@red_add_i64) -> memref<10xf32>
+
+  func.func @reduction_dataclause_default_elided(%a : memref<10xf32>) {
+    %r = "acc.reduction"(%a) <{dataClause = #acc<data_clause acc_reduction>, operandSegmentSizes = array<i32: 1, 0, 0, 0>, varType = f32}> : (memref<10xf32>) -> memref<10xf32>
+    func.return
+  }
+  // CHECK-LABEL: func.func @reduction_dataclause_default_elided(
+  // CHECK:         %{{.*}} = acc.reduction varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32>
+  // CHECK-NOT:     dataClause
+
   // Privatization recipes — `acc.private.recipe` / `acc.firstprivate.recipe`
   // are top-level Symbol ops (`IsolatedFromAbove`). Each carries a
   // `sym_name` + `type` plus named regions; the `acc.yield`-as-init-result

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/ops.mlir
@@ -712,6 +712,87 @@ builtin.module {
   // CHECK:       func.func @copyin_clauses_reordered(
   // CHECK:         %{{.*}} = acc.copyin varPtr(%{{.*}} : memref<10xf32>) varPtrPtr(%{{.*}} : memref<memref<10xf32>>) bounds(%{{.*}}) async recipe(@some_recipe) -> memref<10xf32>
 
+  // Privatization data-clause ops. Same `_DataEntryOperation` shape as
+  // `acc.copyin` / `acc.create` etc., differing only in per-op `dataClause`
+  // default and op name. Upstream's verifier requires a `recipe` attribute
+  // on `acc.private` / `acc.firstprivate` / `acc.reduction` (recipe is
+  // mandatory whenever the op decomposes a privatization / reduction
+  // clause). `acc.firstprivate_map` does *not* require a recipe upstream,
+  // so its minimal form is exercised here too. Recipe-less variants for
+  // the other three live in the xDSL-only test.
+  func.func @private_with_recipe(%a : memref<10xf32>) {
+    %r = acc.private varPtr(%a : memref<10xf32>) recipe(@priv_min) -> memref<10xf32>
+    func.return
+  }
+  // CHECK:       func.func @private_with_recipe(
+  // CHECK:         %{{.*}} = acc.private varPtr(%{{.*}} : memref<10xf32>) recipe(@priv_min) -> memref<10xf32>
+
+  func.func @firstprivate_with_recipe(%a : memref<10xf32>) {
+    %r = acc.firstprivate varPtr(%a : memref<10xf32>) recipe(@fp_min) -> memref<10xf32>
+    func.return
+  }
+  // CHECK:       func.func @firstprivate_with_recipe(
+  // CHECK:         %{{.*}} = acc.firstprivate varPtr(%{{.*}} : memref<10xf32>) recipe(@fp_min) -> memref<10xf32>
+
+  func.func @firstprivate_map_minimal(%a : memref<10xf32>) {
+    %r = acc.firstprivate_map varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    func.return
+  }
+  // CHECK:       func.func @firstprivate_map_minimal(
+  // CHECK:         %{{.*}} = acc.firstprivate_map varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32>
+
+  func.func @reduction_with_recipe(%a : memref<10xf32>) {
+    %r = acc.reduction varPtr(%a : memref<10xf32>) recipe(@red_add_i64) -> memref<10xf32>
+    func.return
+  }
+  // CHECK:       func.func @reduction_with_recipe(
+  // CHECK:         %{{.*}} = acc.reduction varPtr(%{{.*}} : memref<10xf32>) recipe(@red_add_i64) -> memref<10xf32>
+
+  // Per-op `dataClause` default agreement: feeding each leaf's expected
+  // default explicitly through the attr-dict and asserting that *both*
+  // xDSL and mlir-opt elide it on print proves the two sides agree on
+  // each leaf's default value. A wrong default at either end would
+  // surface here as `dataClause` no longer eliding through the
+  // round-trip. Recipe attached on the three ops where upstream's
+  // verifier requires it; `firstprivate_map` carries no recipe (upstream
+  // does not require one).
+  func.func @private_dataclause_default_elided(%a : memref<10xf32>) {
+    %r = acc.private varPtr(%a : memref<10xf32>) recipe(@priv_min) -> memref<10xf32> {dataClause = #acc<data_clause acc_private>}
+    func.return
+  }
+  // CHECK:       func.func @private_dataclause_default_elided(
+  // CHECK:         %{{.*}} = acc.private varPtr(%{{.*}} : memref<10xf32>) recipe(@priv_min) -> memref<10xf32>
+  // CHECK-NOT:     dataClause
+
+  func.func @firstprivate_dataclause_default_elided(%a : memref<10xf32>) {
+    %r = acc.firstprivate varPtr(%a : memref<10xf32>) recipe(@fp_min) -> memref<10xf32> {dataClause = #acc<data_clause acc_firstprivate>}
+    func.return
+  }
+  // CHECK:       func.func @firstprivate_dataclause_default_elided(
+  // CHECK:         %{{.*}} = acc.firstprivate varPtr(%{{.*}} : memref<10xf32>) recipe(@fp_min) -> memref<10xf32>
+  // CHECK-NOT:     dataClause
+
+  // `acc.firstprivate_map` shares the `acc_firstprivate` user-level
+  // clause with `acc.firstprivate`, so its default is also
+  // `acc_firstprivate`. Load-bearing under interop — if either xDSL or
+  // mlir-opt thought the default was the op-name-derived value, the
+  // elision would fail.
+  func.func @firstprivate_map_dataclause_default_elided(%a : memref<10xf32>) {
+    %r = acc.firstprivate_map varPtr(%a : memref<10xf32>) -> memref<10xf32> {dataClause = #acc<data_clause acc_firstprivate>}
+    func.return
+  }
+  // CHECK:       func.func @firstprivate_map_dataclause_default_elided(
+  // CHECK:         %{{.*}} = acc.firstprivate_map varPtr(%{{.*}} : memref<10xf32>) -> memref<10xf32>
+  // CHECK-NOT:     dataClause
+
+  func.func @reduction_dataclause_default_elided(%a : memref<10xf32>) {
+    %r = acc.reduction varPtr(%a : memref<10xf32>) recipe(@red_add_i64) -> memref<10xf32> {dataClause = #acc<data_clause acc_reduction>}
+    func.return
+  }
+  // CHECK:       func.func @reduction_dataclause_default_elided(
+  // CHECK:         %{{.*}} = acc.reduction varPtr(%{{.*}} : memref<10xf32>) recipe(@red_add_i64) -> memref<10xf32>
+  // CHECK-NOT:     dataClause
+
   // Privatization recipes — top-level Symbol ops. Pretty form is
   // `@sym : type init { ... } [destroy { ... }]?` (and `copy {...}` between
   // for firstprivate). Both MLIR_ROUNDTRIP and MLIR_GENERIC_ROUNDTRIP must

--- a/xdsl/dialects/acc.py
+++ b/xdsl/dialects/acc.py
@@ -1807,6 +1807,80 @@ class UpdateDeviceOp(_DataEntryOperation):
 
 
 # ---------------------------------------------------------------------------
+# Privatization data-clause ops
+# ---------------------------------------------------------------------------
+#
+# `acc.private`, `acc.firstprivate`, `acc.firstprivate_map`, and
+# `acc.reduction` are all `OpenACC_DataEntryOp` instances upstream — same
+# operands and properties as the entry data-clause ops above, with the
+# leaves differing only in `name` and the per-op `dataClause` default. The
+# associated reduction operator is not carried on `acc.reduction` itself;
+# it lives on the `acc.reduction.recipe` referenced via the inherited
+# `recipe` SymbolRefAttr property. Both `acc.firstprivate` and
+# `acc.firstprivate_map` use `acc_firstprivate` as their `dataClause`
+# default — `firstprivate_map` is the decomposed mapping half of the
+# firstprivate clause and shares the user-level clause name.
+
+
+@irdl_op_definition
+class PrivateOp(_DataEntryOperation):
+    """Implementation of upstream acc.private."""
+
+    name = "acc.private"
+    data_clause = opt_prop_def(
+        DataClauseAttr,
+        default_value=DataClauseAttr(DataClause.ACC_PRIVATE),
+        prop_name="dataClause",
+    )
+
+
+@irdl_op_definition
+class FirstprivateOp(_DataEntryOperation):
+    """Implementation of upstream acc.firstprivate."""
+
+    name = "acc.firstprivate"
+    data_clause = opt_prop_def(
+        DataClauseAttr,
+        default_value=DataClauseAttr(DataClause.ACC_FIRSTPRIVATE),
+        prop_name="dataClause",
+    )
+
+
+@irdl_op_definition
+class FirstprivateMapOp(_DataEntryOperation):
+    """Implementation of upstream acc.firstprivate_map.
+
+    Used to decompose firstprivate semantics — represents the mapping of the
+    initial value used to initialize the privatized copies. Shares the
+    `acc_firstprivate` user-level clause with `acc.firstprivate`.
+    """
+
+    name = "acc.firstprivate_map"
+    data_clause = opt_prop_def(
+        DataClauseAttr,
+        default_value=DataClauseAttr(DataClause.ACC_FIRSTPRIVATE),
+        prop_name="dataClause",
+    )
+
+
+@irdl_op_definition
+class ReductionOp(_DataEntryOperation):
+    """Implementation of upstream acc.reduction.
+
+    The reduction operator (`add`, `mul`, `max`, ...) is carried on the
+    `acc.reduction.recipe` referenced via the inherited `recipe`
+    SymbolRefAttr property — not on the data-entry op itself.
+    """
+
+    name = "acc.reduction"
+    data_clause = opt_prop_def(
+        DataClauseAttr,
+        default_value=DataClauseAttr(DataClause.ACC_REDUCTION),
+        prop_name="dataClause",
+    )
+
+
+# ---------------------------------------------------------------------------
 # Exit data-clause ops
 # ---------------------------------------------------------------------------
 #
@@ -2515,6 +2589,10 @@ ACC = Dialect(
         DeclareLinkOp,
         GetDevicePtrOp,
         UpdateDeviceOp,
+        PrivateOp,
+        FirstprivateOp,
+        FirstprivateMapOp,
+        ReductionOp,
         CopyoutOp,
         UpdateHostOp,
         DeleteOp,


### PR DESCRIPTION
This PR adds four data privatization operations that all extend the DataEntryOperation base class. This builds on the previous few PRs which means that these operations in this PR are now pretty trivial changes as they leverage all the machinery committed in the previous PRs.
