### PR TITLE
dialects: (acc) Add OpenACC terminator operation

### DIFF
--- a/tests/dialects/test_acc.py
+++ b/tests/dialects/test_acc.py
@@ -359,6 +359,14 @@ def test_kernels_init_bool_shortcuts():
     assert op_off.combined is None
 
 
+def test_terminator_construction():
+    """TerminatorOp's `__init__` is unreachable from the round-trip parser
+    (declarative `attr-dict` builds the op via IRDL's generic constructor),
+    so its body lives or dies by a Python-side construction call."""
+    term = acc.TerminatorOp()
+    assert term.name == "acc.terminator"
+
+
 def test_data_clause_modifier_attr_constructor():
     """The bit-enum constructor accepts a frozenset of enum members and stores
     it on `.data`. Pretty-form printing/parsing is covered by filecheck in

--- a/tests/filecheck/dialects/acc/ops.mlir
+++ b/tests/filecheck/dialects/acc/ops.mlir
@@ -1407,4 +1407,31 @@ builtin.module {
   }, {
   }) : () -> ()
   // CHECK-LABEL: acc.reduction.recipe @red_generic : i64 reduction_operator <add> init {
+
+  // acc.terminator is the value-less generic terminator. It currently only
+  // permits `acc.kernels` as a parent (per HasParent on TerminatorOp); other
+  // region ops in the OpenACC dialect (acc.data, acc.host_data, …) will be
+  // appended to the parent tuple as they land.
+  func.func @terminator_inside_kernels() {
+    acc.kernels {
+      acc.terminator
+    }
+    func.return
+  }
+  // CHECK-LABEL: func.func @terminator_inside_kernels() {
+  // CHECK-NEXT:    acc.kernels {
+  // CHECK-NEXT:      acc.terminator
+  // CHECK-NEXT:    }
+
+  // Generic-form roundtrip insurance for the value-less terminator.
+  func.func @terminator_generic_roundtrip_retained() {
+    acc.kernels {
+      "acc.terminator"() : () -> ()
+    }
+    func.return
+  }
+  // CHECK-LABEL: func.func @terminator_generic_roundtrip_retained() {
+  // CHECK-NEXT:    acc.kernels {
+  // CHECK-NEXT:      acc.terminator
+  // CHECK-NEXT:    }
 }

--- a/tests/filecheck/dialects/acc/ops_invalid.mlir
+++ b/tests/filecheck/dialects/acc/ops_invalid.mlir
@@ -229,3 +229,13 @@ func.func @copyin_duplicate_recipe(%a : memref<10xf32>) {
   func.return
 }
 // CHECK: 'recipe' clause specified twice
+
+// -----
+
+// acc.terminator's HasParent constraint accepts only acc.kernels (additional
+// region ops will be appended in later stages); using it directly under a
+// `func.func` must fail the parent check.
+func.func @terminator_wrong_parent() {
+  "acc.terminator"() : () -> ()
+}
+// CHECK: 'acc.terminator' expects parent op 'acc.kernels'

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/ops.mlir
@@ -882,4 +882,19 @@ builtin.module {
   // CHECK:       acc.reduction.recipe @red_max_f32 : f32 reduction_operator <max> init {
   // CHECK:         } combiner {
   // CHECK:         } destroy {
+
+  // acc.terminator round-trips (pretty + generic) through mlir-opt's OpenACC
+  // dialect. Upstream `acc.kernels` actually models its body via
+  // `SingleBlockImplicitTerminator<"TerminatorOp">`, so mlir-opt re-emits the
+  // body with the terminator on its own line.
+  func.func @terminator_inside_kernels() {
+    acc.kernels {
+      acc.terminator
+    }
+    func.return
+  }
+  // CHECK:       func.func @terminator_inside_kernels() {
+  // CHECK-NEXT:    acc.kernels {
+  // CHECK-NEXT:      acc.terminator
+  // CHECK-NEXT:    }
 }

--- a/xdsl/dialects/acc.py
+++ b/xdsl/dialects/acc.py
@@ -1401,9 +1401,10 @@ class KernelsOp(IRDLOperation):
         WaitClause,
     )
 
-    # Upstream `acc.kernels` body uses `acc.terminator` rather than `acc.yield`
-    # That will be supported later, until that op exists we accept any (or empty)
-    # body via NoTerminator, mirroring upstream's `AnyRegion` modeling.
+    # Upstream `acc.kernels` body uses `acc.terminator` rather than `acc.yield`.
+    # The terminator op is now defined (`TerminatorOp`) but kernels still uses
+    # `NoTerminator` here — switching to `SingleBlockImplicitTerminator(TerminatorOp)`
+    # is a follow-up stage that updates the existing empty-body tests.
     assembly_format = (
         "(`combined` `(` `loop` `)` $combined^)?"
         " (`dataOperands` `(` $data_clause_operands^ `:`"
@@ -2543,6 +2544,30 @@ class ReductionRecipeOp(_RecipeOperation):
 
 
 @irdl_op_definition
+class TerminatorOp(IRDLOperation):
+    """
+    Implementation of upstream acc.terminator. Generic, value-less terminator
+    used by OpenACC region ops whose bodies do not return a value.
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/OpenACCDialect/#accterminator-accterminatorop).
+    """
+
+    name = "acc.terminator"
+
+    assembly_format = "attr-dict"
+
+    traits = lazy_traits_def(
+        lambda: (
+            IsTerminator(),
+            NoMemoryEffect(),
+            HasParent(KernelsOp),
+        )
+    )
+
+    def __init__(self) -> None:
+        super().__init__()
+
+
+@irdl_op_definition
 class YieldOp(AbstractYieldOperation[Attribute]):
     """
     Implementation of upstream acc.yield.
@@ -2600,6 +2625,7 @@ ACC = Dialect(
         PrivateRecipeOp,
         FirstprivateRecipeOp,
         ReductionRecipeOp,
+        TerminatorOp,
         YieldOp,
     ],
     [


### PR DESCRIPTION
This PR adds the OpenACC terminator operation which is used by regions that do not return a specific SSA value (and will be required in subsequent PRs)