### PR TITLE
dialects: (acc) Kernel operation has terminator operation as implicit terminator

### DIFF
--- a/tests/dialects/test_acc.py
+++ b/tests/dialects/test_acc.py
@@ -343,7 +343,7 @@ def test_kernels_init_bool_shortcuts():
     / default_attr=enum) cannot be reached via the parser — filecheck would have to
     pass already-constructed attributes — so this Python-only branch lives here."""
     op = acc.KernelsOp(
-        region=Region(Block()),
+        region=Region(Block([acc.TerminatorOp()])),
         self_attr=True,
         default_attr=acc.ClauseDefaultValue.PRESENT,
         combined=True,
@@ -354,7 +354,7 @@ def test_kernels_init_bool_shortcuts():
     assert isinstance(op.combined, UnitAttr)
     assert op.default_attr == acc.ClauseDefaultValueAttr(acc.ClauseDefaultValue.PRESENT)
 
-    op_off = acc.KernelsOp(region=Region(Block()))
+    op_off = acc.KernelsOp(region=Region(Block([acc.TerminatorOp()])))
     assert op_off.self_attr is None
     assert op_off.combined is None
 

--- a/tests/filecheck/dialects/acc/ops.mlir
+++ b/tests/filecheck/dialects/acc/ops.mlir
@@ -434,11 +434,11 @@ builtin.module {
   // CHECK-NEXT:      acc.yield
   // CHECK-NEXT:    }
 
-  // acc.kernels uses the upstream `NoTerminator` body shape: the body can
-  // be empty or contain ops that lower to a kernels region. acc.yield is
-  // *not* a valid terminator inside acc.kernels (upstream's acc.yield
-  // ParentOneOf list excludes KernelsOp); the dedicated acc.terminator op
-  // lands later in the roadmap.
+  // acc.kernels uses `SingleBlockImplicitTerminator(TerminatorOp)`: the
+  // pretty-form parser auto-inserts `acc.terminator` when the body is
+  // written as `{ }` and the printer elides it again on output. acc.yield
+  // is *not* a valid terminator inside acc.kernels (upstream's acc.yield
+  // ParentOneOf list excludes KernelsOp).
   func.func @kernels_empty() {
     acc.kernels {
     }

--- a/tests/filecheck/dialects/acc/ops_invalid.mlir
+++ b/tests/filecheck/dialects/acc/ops_invalid.mlir
@@ -47,10 +47,9 @@ func.func @serial_wrong_terminator(%arg0: i32) {
 
 // -----
 
-// acc.kernels uses upstream's NoTerminator body modeling (AnyRegion with no
-// implicit terminator), so empty blocks and non-terminator final ops are
-// accepted; the only verifier failure unique to that trait is a multi-block
-// region.
+// acc.kernels uses `SingleBlockImplicitTerminator(TerminatorOp)`: a multi-
+// block region fails the single-block check before terminator handling can
+// run, so this case still exercises that trait branch.
 func.func @kernels_multi_block() {
   "acc.kernels"() <{operandSegmentSizes = array<i32: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>}> ({
   ^bb0:
@@ -60,6 +59,45 @@ func.func @kernels_multi_block() {
   func.return
 }
 // CHECK: 'acc.kernels' does not contain single-block regions
+
+// -----
+
+// Generic-form region with a single, empty block — the implicit-terminator
+// trait expects at least a terminator. (Pretty form auto-inserts the
+// terminator; this generic spelling bypasses that helper.)
+func.func @kernels_empty_block() {
+  "acc.kernels"() <{operandSegmentSizes = array<i32: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>}> ({
+  ^bb0:
+  }) : () -> ()
+  func.return
+}
+// CHECK: Operation acc.kernels contains empty block in single-block region that expects at least a terminator
+
+// -----
+
+// Final op in the body is not a terminator at all — caught by the generic
+// "must end in a terminator" check.
+func.func @kernels_wrong_terminator(%arg0: i32) {
+  "acc.kernels"() <{operandSegmentSizes = array<i32: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>}> ({
+    %0 = "builtin.unrealized_conversion_cast"(%arg0) : (i32) -> i32
+  }) : () -> ()
+  func.return
+}
+// CHECK: Operation builtin.unrealized_conversion_cast terminates block in single-block region but is not a terminator
+
+// -----
+
+// Final op IS a terminator (`test.termop` carries `IsTerminator()`) but is
+// not the specific terminator type required — directly exercises
+// `SingleBlockImplicitTerminator(TerminatorOp)`'s type-mismatch branch and
+// proves the trait was wired against `acc.terminator` specifically.
+func.func @kernels_wrong_terminator_type() {
+  "acc.kernels"() <{operandSegmentSizes = array<i32: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>}> ({
+    "test.termop"() : () -> ()
+  }) : () -> ()
+  func.return
+}
+// CHECK: 'acc.kernels' terminates with operation test.termop instead of acc.terminator
 
 // -----
 

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/ops.mlir
@@ -288,10 +288,10 @@ builtin.module {
   // CHECK-NEXT:      acc.yield
   // CHECK-NEXT:    } attributes {defaultAttr = #acc<defaultvalue present>, selfAttr}
 
-  // acc.kernels models upstream's `AnyRegion` body (NoTerminator); upstream
-  // mlir-opt rejects acc.yield inside acc.kernels (yield's ParentOneOf list
-  // excludes KernelsOp), so all bodies here are empty until acc.terminator
-  // is introduced later in the roadmap.
+  // acc.kernels uses `SingleBlockImplicitTerminator(TerminatorOp)` on both
+  // sides: the pretty parser auto-inserts `acc.terminator`, the printer
+  // elides it. So `acc.kernels { }` round-trips identically through xDSL
+  // and mlir-opt even though the in-memory IR has the terminator present.
   func.func @kernels_empty() {
     acc.kernels {
     }

--- a/xdsl/dialects/acc.py
+++ b/xdsl/dialects/acc.py
@@ -75,7 +75,6 @@ from xdsl.traits import (
     IsolatedFromAbove,
     IsTerminator,
     NoMemoryEffect,
-    NoTerminator,
     RecursiveMemoryEffect,
     SingleBlockImplicitTerminator,
     SymbolOpInterface,
@@ -1401,10 +1400,6 @@ class KernelsOp(IRDLOperation):
         WaitClause,
     )
 
-    # Upstream `acc.kernels` body uses `acc.terminator` rather than `acc.yield`.
-    # The terminator op is now defined (`TerminatorOp`) but kernels still uses
-    # `NoTerminator` here — switching to `SingleBlockImplicitTerminator(TerminatorOp)`
-    # is a follow-up stage that updates the existing empty-body tests.
     assembly_format = (
         "(`combined` `(` `loop` `)` $combined^)?"
         " (`dataOperands` `(` $data_clause_operands^ `:`"
@@ -1433,7 +1428,7 @@ class KernelsOp(IRDLOperation):
 
     traits = lazy_traits_def(
         lambda: (
-            NoTerminator(),
+            SingleBlockImplicitTerminator(TerminatorOp),
             RecursiveMemoryEffect(),
         )
     )


### PR DESCRIPTION
Previously the OpenACC kernel operator had no terminator, but this was not strictly correct wrt MLIR. This PR aligns with MLIR where the implicit terminator for this acc.kernel operation is now the OpenACC terminator operation (which was added in the previous PR). This brings acc.kernel into alignment with MLIR.