### PR TITLE
dialects: (acc) OpenACC data operations

### DIFF
--- a/tests/dialects/test_acc.py
+++ b/tests/dialects/test_acc.py
@@ -367,6 +367,29 @@ def test_terminator_construction():
     assert term.name == "acc.terminator"
 
 
+def test_data_init_enum_shortcut():
+    """The `default_attr=ClauseDefaultValue.X` enum-shortcut branch in
+    DataOp.__init__ is not reachable via the parser (which produces a
+    fully-formed ClauseDefaultValueAttr)."""
+    op = acc.DataOp(
+        region=Region(Block([acc.TerminatorOp()])),
+        default_attr=acc.ClauseDefaultValue.PRESENT,
+    )
+    assert op.default_attr == acc.ClauseDefaultValueAttr(acc.ClauseDefaultValue.PRESENT)
+
+
+def test_host_data_init_bool_shortcut():
+    """The `if_present=True` bool-shortcut branch in HostDataOp.__init__ is
+    not reachable via the parser (which produces a UnitAttr directly)."""
+    use_dev = acc.UseDeviceOp(var=create_ssa_value(MemRefType(f32, [10])))
+    op = acc.HostDataOp(
+        region=Region(Block([acc.TerminatorOp()])),
+        data_clause_operands=[use_dev],
+        if_present=True,
+    )
+    assert isinstance(op.if_present, UnitAttr)
+
+
 def test_data_clause_modifier_attr_constructor():
     """The bit-enum constructor accepts a frozenset of enum members and stores
     it on `.data`. Pretty-form printing/parsing is covered by filecheck in

--- a/tests/filecheck/dialects/acc/ops.mlir
+++ b/tests/filecheck/dialects/acc/ops.mlir
@@ -619,6 +619,103 @@ builtin.module {
   // CHECK-NEXT:    acc.kernels {
   // CHECK-NEXT:    }
 
+  // acc.data — structured data construct. Body uses acc.terminator (same
+  // SingleBlockImplicitTerminator(TerminatorOp) shape as kernels). The
+  // verifier additionally requires either at least one operand or
+  // `defaultAttr`, so a body-only case must carry one of them.
+  func.func @data_default_attr() {
+    acc.data {
+    } attributes {defaultAttr = #acc<defaultvalue none>}
+    func.return
+  }
+  // CHECK-LABEL: func.func @data_default_attr() {
+  // CHECK-NEXT:    acc.data {
+  // CHECK-NEXT:    } attributes {defaultAttr = #acc<defaultvalue none>}
+
+  func.func @data_data_operand(%a : memref<10xf32>) {
+    %p = acc.present varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    acc.data dataOperands(%p : memref<10xf32>) {
+    }
+    func.return
+  }
+  // CHECK-LABEL: func.func @data_data_operand(
+  // CHECK:         acc.data dataOperands(%{{.*}} : memref<10xf32>) {
+  // CHECK-NEXT:    }
+
+  func.func @data_if_async_wait(%c : i1, %a : i64, %w : i64) {
+    acc.data if(%c) async(%a : i64) wait({%w : i64}) {
+    } attributes {defaultAttr = #acc<defaultvalue none>}
+    func.return
+  }
+  // CHECK-LABEL: func.func @data_if_async_wait(
+  // CHECK:         acc.data if(%{{.*}}) async(%{{.*}} : i64) wait({%{{.*}} : i64}) {
+  // CHECK-NEXT:    } attributes {defaultAttr = #acc<defaultvalue none>}
+
+  func.func @data_async_bare() {
+    acc.data async {
+    } attributes {defaultAttr = #acc<defaultvalue none>}
+    func.return
+  }
+  // CHECK-LABEL: func.func @data_async_bare() {
+  // CHECK-NEXT:    acc.data async {
+  // CHECK-NEXT:    } attributes {defaultAttr = #acc<defaultvalue none>}
+
+  // Generic-form roundtrip retains insurance that the operandSegmentSizes
+  // (4 segments: ifCond / async / wait / data) round-trip.
+  func.func @data_generic_roundtrip_retained() {
+    "acc.data"() <{operandSegmentSizes = array<i32: 0, 0, 0, 0>}> ({
+    }) {defaultAttr = #acc<defaultvalue none>} : () -> ()
+    func.return
+  }
+  // CHECK-LABEL: func.func @data_generic_roundtrip_retained() {
+  // CHECK-NEXT:    acc.data {
+  // CHECK-NEXT:    } attributes {defaultAttr = #acc<defaultvalue none>}
+
+  // acc.host_data — like acc.data but the operands must be defined by
+  // acc.use_device, and there is an `ifPresent` UnitAttr instead of a
+  // default clause.
+  func.func @host_data_minimal(%a : memref<10xf32>) {
+    %u = acc.use_device varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    acc.host_data dataOperands(%u : memref<10xf32>) {
+    }
+    func.return
+  }
+  // CHECK-LABEL: func.func @host_data_minimal(
+  // CHECK:         acc.host_data dataOperands(%{{.*}} : memref<10xf32>) {
+  // CHECK-NEXT:    }
+
+  func.func @host_data_if_present(%a : memref<10xf32>) {
+    %u = acc.use_device varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    acc.host_data dataOperands(%u : memref<10xf32>) {
+    } attributes {ifPresent}
+    func.return
+  }
+  // CHECK-LABEL: func.func @host_data_if_present(
+  // CHECK:         acc.host_data dataOperands(%{{.*}} : memref<10xf32>) {
+  // CHECK-NEXT:    } attributes {ifPresent}
+
+  func.func @host_data_if_cond(%c : i1, %a : memref<10xf32>) {
+    %u = acc.use_device varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    acc.host_data if(%c) dataOperands(%u : memref<10xf32>) {
+    }
+    func.return
+  }
+  // CHECK-LABEL: func.func @host_data_if_cond(
+  // CHECK:         acc.host_data if(%{{.*}}) dataOperands(%{{.*}} : memref<10xf32>) {
+  // CHECK-NEXT:    }
+
+  // Generic-form roundtrip insurance: 2 segments (ifCond / data) and the
+  // ifPresent UnitAttr ride in the trailing attr-dict.
+  func.func @host_data_generic_roundtrip_retained(%a : memref<10xf32>) {
+    %u = acc.use_device varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    "acc.host_data"(%u) <{operandSegmentSizes = array<i32: 0, 1>, ifPresent}> ({
+    }) : (memref<10xf32>) -> ()
+    func.return
+  }
+  // CHECK-LABEL: func.func @host_data_generic_roundtrip_retained(
+  // CHECK:         acc.host_data dataOperands(%{{.*}} : memref<10xf32>) {
+  // CHECK-NEXT:    } attributes {ifPresent}
+
   func.func @bounds_full(%c0 : index, %c9 : index, %c1 : index) {
     %b = acc.bounds lowerbound(%c0 : index) upperbound(%c9 : index) stride(%c1 : index)
     func.return

--- a/tests/filecheck/dialects/acc/ops_invalid.mlir
+++ b/tests/filecheck/dialects/acc/ops_invalid.mlir
@@ -270,10 +270,56 @@ func.func @copyin_duplicate_recipe(%a : memref<10xf32>) {
 
 // -----
 
-// acc.terminator's HasParent constraint accepts only acc.kernels (additional
-// region ops will be appended in later stages); using it directly under a
+// acc.terminator's HasParent constraint accepts only the OpenACC region ops
+// that lack a yield (kernels / data / host_data); using it directly under a
 // `func.func` must fail the parent check.
 func.func @terminator_wrong_parent() {
   "acc.terminator"() : () -> ()
 }
-// CHECK: 'acc.terminator' expects parent op 'acc.kernels'
+// CHECK: 'acc.terminator' expects parent op to be one of 'acc.kernels', 'acc.data', 'acc.host_data'
+
+// -----
+
+// acc.data: 2.6.5 mandates at least one operand or `defaultAttr`. An empty
+// op with no operands and no default attribute fails the per-op verifier.
+func.func @data_empty_no_default() {
+  acc.data {
+  }
+  func.return
+}
+// CHECK: at least one operand or the default attribute must appear on the data operation
+
+// -----
+
+// acc.data: each `dataOperands` value must be defined by one of the OpenACC
+// data-clause ops (copyin / create / present / …). A bare memref operand
+// fails the per-op verifier.
+func.func @data_wrong_defining_op(%a : memref<10xf32>) {
+  acc.data dataOperands(%a : memref<10xf32>) {
+  }
+  func.return
+}
+// CHECK: expect data entry/exit operation or acc.getdeviceptr as defining op
+
+// -----
+
+// acc.host_data: at least one operand is required, period (no `default`
+// escape hatch like acc.data has).
+func.func @host_data_empty() {
+  acc.host_data {
+  }
+  func.return
+}
+// CHECK: at least one operand must appear on the host_data operation
+
+// -----
+
+// acc.host_data: every operand must be defined by acc.use_device. Other
+// data-clause ops (e.g. acc.copyin) are rejected.
+func.func @host_data_wrong_defining_op(%a : memref<10xf32>) {
+  %0 = acc.copyin varPtr(%a : memref<10xf32>) -> memref<10xf32>
+  acc.host_data dataOperands(%0 : memref<10xf32>) {
+  }
+  func.return
+}
+// CHECK: expect data entry operation as defining op

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/ops.mlir
@@ -418,6 +418,78 @@ builtin.module {
   // CHECK:         acc.kernels combined(loop) async(%{{.*}} : i64) num_workers(%{{.*}} : i64) vector_length(%{{.*}} : i32) wait({%{{.*}} : i64}) self(%{{.*}}) if(%{{.*}}) {
   // CHECK-NEXT:    } attributes {defaultAttr = #acc<defaultvalue present>, selfAttr}
 
+  // acc.data — round-trips through mlir-opt's OpenACC dialect in both
+  // pretty and generic form. defaultAttr is required on bodies with no
+  // operand to satisfy upstream's verifier (matches xDSL's port).
+  func.func @data_default_attr() {
+    acc.data {
+    } attributes {defaultAttr = #acc<defaultvalue none>}
+    func.return
+  }
+  // CHECK:       func.func @data_default_attr() {
+  // CHECK-NEXT:    acc.data {
+  // CHECK-NEXT:    } attributes {defaultAttr = #acc<defaultvalue none>}
+
+  func.func @data_data_operand(%a : memref<10xf32>) {
+    %p = acc.present varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    acc.data dataOperands(%p : memref<10xf32>) {
+    }
+    func.return
+  }
+  // CHECK:       func.func @data_data_operand(
+  // CHECK:         acc.data dataOperands(%{{.*}} : memref<10xf32>) {
+  // CHECK-NEXT:    }
+
+  func.func @data_if_async_wait(%c : i1, %a : i64, %w : i64) {
+    acc.data if(%c) async(%a : i64) wait({%w : i64}) {
+    } attributes {defaultAttr = #acc<defaultvalue none>}
+    func.return
+  }
+  // CHECK:       func.func @data_if_async_wait(
+  // CHECK:         acc.data if(%{{.*}}) async(%{{.*}} : i64) wait({%{{.*}} : i64}) {
+  // CHECK-NEXT:    } attributes {defaultAttr = #acc<defaultvalue none>}
+
+  func.func @data_async_bare() {
+    acc.data async {
+    } attributes {defaultAttr = #acc<defaultvalue none>}
+    func.return
+  }
+  // CHECK:       func.func @data_async_bare() {
+  // CHECK-NEXT:    acc.data async {
+  // CHECK-NEXT:    } attributes {defaultAttr = #acc<defaultvalue none>}
+
+  // acc.host_data — operands must be defined by acc.use_device, and the
+  // op carries an `ifPresent` UnitAttr instead of a default clause.
+  func.func @host_data_minimal(%a : memref<10xf32>) {
+    %u = acc.use_device varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    acc.host_data dataOperands(%u : memref<10xf32>) {
+    }
+    func.return
+  }
+  // CHECK:       func.func @host_data_minimal(
+  // CHECK:         acc.host_data dataOperands(%{{.*}} : memref<10xf32>) {
+  // CHECK-NEXT:    }
+
+  func.func @host_data_if_present(%a : memref<10xf32>) {
+    %u = acc.use_device varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    acc.host_data dataOperands(%u : memref<10xf32>) {
+    } attributes {ifPresent}
+    func.return
+  }
+  // CHECK:       func.func @host_data_if_present(
+  // CHECK:         acc.host_data dataOperands(%{{.*}} : memref<10xf32>) {
+  // CHECK-NEXT:    } attributes {ifPresent}
+
+  func.func @host_data_if_cond(%c : i1, %a : memref<10xf32>) {
+    %u = acc.use_device varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    acc.host_data if(%c) dataOperands(%u : memref<10xf32>) {
+    }
+    func.return
+  }
+  // CHECK:       func.func @host_data_if_cond(
+  // CHECK:         acc.host_data if(%{{.*}}) dataOperands(%{{.*}} : memref<10xf32>) {
+  // CHECK-NEXT:    }
+
   // The trailing `strideInBytes = false` attribute is omitted by mlir-opt's
   // pretty printer (it matches the default) but appears explicitly in the
   // generic roundtrip path because mlir-opt prints the property in generic

--- a/xdsl/dialects/acc.py
+++ b/xdsl/dialects/acc.py
@@ -1510,6 +1510,212 @@ class KernelsOp(IRDLOperation):
         )
 
 
+@irdl_op_definition
+class DataOp(IRDLOperation):
+    """
+    Implementation of upstream acc.data — the structured data construct.
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/OpenACCDialect/#accdata-accdataop).
+    """
+
+    name = "acc.data"
+
+    if_cond = opt_operand_def(I1)
+    async_operands = var_operand_def(IntegerType | IndexType)
+    wait_operands = var_operand_def(IntegerType | IndexType)
+    data_clause_operands = var_operand_def()
+
+    async_operands_device_type = opt_prop_def(
+        ArrayAttr[DeviceTypeAttr], prop_name="asyncOperandsDeviceType"
+    )
+    async_only = opt_prop_def(ArrayAttr[DeviceTypeAttr], prop_name="asyncOnly")
+    wait_operands_segments = opt_prop_def(
+        DenseArrayBase.constr(IntegerType(32)), prop_name="waitOperandsSegments"
+    )
+    wait_operands_device_type = opt_prop_def(
+        ArrayAttr[DeviceTypeAttr], prop_name="waitOperandsDeviceType"
+    )
+    has_wait_devnum = opt_prop_def(ArrayAttr[BoolAttr], prop_name="hasWaitDevnum")
+    wait_only = opt_prop_def(ArrayAttr[DeviceTypeAttr], prop_name="waitOnly")
+    default_attr = opt_prop_def(ClauseDefaultValueAttr, prop_name="defaultAttr")
+
+    region = region_def()
+
+    irdl_options = (
+        AttrSizedOperandSegments(as_property=True),
+        ParsePropInAttrDict(),
+    )
+
+    custom_directives = (
+        DeviceTypeOperandsWithKeywordOnly,
+        WaitClause,
+    )
+
+    assembly_format = (
+        "(`if` `(` $if_cond^ `)`)?"
+        " (`async` custom<DeviceTypeOperandsWithKeywordOnly>($async_operands,"
+        " type($async_operands), $asyncOperandsDeviceType, $asyncOnly)^)?"
+        " (`dataOperands` `(` $data_clause_operands^ `:`"
+        " type($data_clause_operands) `)`)?"
+        " (`wait` custom<WaitClause>($wait_operands, type($wait_operands),"
+        " $waitOperandsDeviceType, $waitOperandsSegments, $hasWaitDevnum,"
+        " $waitOnly)^)?"
+        " $region attr-dict-with-keyword"
+    )
+
+    traits = lazy_traits_def(
+        lambda: (
+            SingleBlockImplicitTerminator(TerminatorOp),
+            RecursiveMemoryEffect(),
+        )
+    )
+
+    def __init__(
+        self,
+        *,
+        region: Region,
+        if_cond: SSAValue | Operation | None = None,
+        async_operands: Sequence[SSAValue | Operation] = (),
+        wait_operands: Sequence[SSAValue | Operation] = (),
+        data_clause_operands: Sequence[SSAValue | Operation] = (),
+        async_operands_device_type: ArrayAttr[DeviceTypeAttr] | None = None,
+        async_only: ArrayAttr[DeviceTypeAttr] | None = None,
+        wait_operands_segments: DenseArrayBase | None = None,
+        wait_operands_device_type: ArrayAttr[DeviceTypeAttr] | None = None,
+        has_wait_devnum: ArrayAttr[BoolAttr] | None = None,
+        wait_only: ArrayAttr[DeviceTypeAttr] | None = None,
+        default_attr: ClauseDefaultValueAttr | ClauseDefaultValue | None = None,
+    ) -> None:
+        default_prop: ClauseDefaultValueAttr | None = (
+            ClauseDefaultValueAttr(default_attr)
+            if isinstance(default_attr, ClauseDefaultValue)
+            else default_attr
+        )
+        super().__init__(
+            operands=[
+                [if_cond] if if_cond is not None else [],
+                async_operands,
+                wait_operands,
+                data_clause_operands,
+            ],
+            properties={
+                "asyncOperandsDeviceType": async_operands_device_type,
+                "asyncOnly": async_only,
+                "waitOperandsSegments": wait_operands_segments,
+                "waitOperandsDeviceType": wait_operands_device_type,
+                "hasWaitDevnum": has_wait_devnum,
+                "waitOnly": wait_only,
+                "defaultAttr": default_prop,
+            },
+            regions=[region],
+        )
+
+    def verify_(self) -> None:
+        # Mirrors `acc::DataOp::verify`: 2.6.5 requires at least one of the
+        # data clauses (copy/copyin/copyout/create/no_create/present/deviceptr/
+        # attach) or the `default` attribute.
+        if (
+            len(self.async_operands) == 0
+            and len(self.wait_operands) == 0
+            and len(self.data_clause_operands) == 0
+            and self.if_cond is None
+            and self.default_attr is None
+        ):
+            raise VerifyException(
+                "at least one operand or the default attribute "
+                "must appear on the data operation"
+            )
+        for operand in self.data_clause_operands:
+            defining_op = operand.owner
+            if not isinstance(
+                defining_op,
+                (
+                    AttachOp,
+                    CopyinOp,
+                    CopyoutOp,
+                    CreateOp,
+                    DeleteOp,
+                    DetachOp,
+                    DevicePtrOp,
+                    GetDevicePtrOp,
+                    NoCreateOp,
+                    PresentOp,
+                ),
+            ):
+                raise VerifyException(
+                    "expect data entry/exit operation or acc.getdeviceptr "
+                    "as defining op"
+                )
+
+
+@irdl_op_definition
+class HostDataOp(IRDLOperation):
+    """
+    Implementation of upstream acc.host_data.
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/OpenACCDialect/#acchost_data-acchost_dataop).
+    """
+
+    name = "acc.host_data"
+
+    if_cond = opt_operand_def(I1)
+    data_clause_operands = var_operand_def()
+
+    if_present = opt_prop_def(UnitAttr, prop_name="ifPresent")
+
+    region = region_def()
+
+    irdl_options = (
+        AttrSizedOperandSegments(as_property=True),
+        ParsePropInAttrDict(),
+    )
+
+    assembly_format = (
+        "(`if` `(` $if_cond^ `)`)?"
+        " (`dataOperands` `(` $data_clause_operands^ `:`"
+        " type($data_clause_operands) `)`)?"
+        " $region attr-dict-with-keyword"
+    )
+
+    traits = lazy_traits_def(
+        lambda: (
+            SingleBlockImplicitTerminator(TerminatorOp),
+            RecursiveMemoryEffect(),
+        )
+    )
+
+    def __init__(
+        self,
+        *,
+        region: Region,
+        if_cond: SSAValue | Operation | None = None,
+        data_clause_operands: Sequence[SSAValue | Operation] = (),
+        if_present: UnitAttr | bool = False,
+    ) -> None:
+        if_present_prop: UnitAttr | None = (
+            (UnitAttr() if if_present else None)
+            if isinstance(if_present, bool)
+            else if_present
+        )
+        super().__init__(
+            operands=[
+                [if_cond] if if_cond is not None else [],
+                data_clause_operands,
+            ],
+            properties={"ifPresent": if_present_prop},
+            regions=[region],
+        )
+
+    def verify_(self) -> None:
+        # Mirrors `acc::HostDataOp::verify`: at least one operand and each
+        # operand must be defined by an `acc.use_device`.
+        if len(self.data_clause_operands) == 0:
+            raise VerifyException(
+                "at least one operand must appear on the host_data operation"
+            )
+        for operand in self.data_clause_operands:
+            if not isinstance(operand.owner, UseDeviceOp):
+                raise VerifyException("expect data entry operation as defining op")
+
+
 # ---------------------------------------------------------------------------
 # Entry data-clause ops
 # ---------------------------------------------------------------------------
@@ -2554,7 +2760,7 @@ class TerminatorOp(IRDLOperation):
         lambda: (
             IsTerminator(),
             NoMemoryEffect(),
-            HasParent(KernelsOp),
+            HasParent(KernelsOp, DataOp, HostDataOp),
         )
     )
 
@@ -2592,6 +2798,8 @@ ACC = Dialect(
         ParallelOp,
         SerialOp,
         KernelsOp,
+        DataOp,
+        HostDataOp,
         DataBoundsOp,
         GetLowerboundOp,
         GetUpperboundOp,

--- a/xdsl/dialects/acc.py
+++ b/xdsl/dialects/acc.py
@@ -1614,9 +1614,9 @@ class DataOp(IRDLOperation):
         # data clauses (copy/copyin/copyout/create/no_create/present/deviceptr/
         # attach) or the `default` attribute.
         if (
-            len(self.async_operands) == 0
-            and len(self.wait_operands) == 0
-            and len(self.data_clause_operands) == 0
+            not self.async_operands
+            and not self.wait_operands
+            and not self.data_clause_operands
             and self.if_cond is None
             and self.default_attr is None
         ):
@@ -1707,7 +1707,7 @@ class HostDataOp(IRDLOperation):
     def verify_(self) -> None:
         # Mirrors `acc::HostDataOp::verify`: at least one operand and each
         # operand must be defined by an `acc.use_device`.
-        if len(self.data_clause_operands) == 0:
+        if not self.data_clause_operands:
             raise VerifyException(
                 "at least one operand must appear on the host_data operation"
             )


### PR DESCRIPTION
This PR adds OpenACC data and host_data operations which are logically grouped together and form variations of each other in a user's code. Both leverage the terminator operation that was added in a previous PR in preparation for this.
