### PR TITLE
dialects: (acc) Add EnterData OpenACC operation

### DIFF
--- a/tests/dialects/test_acc.py
+++ b/tests/dialects/test_acc.py
@@ -9,6 +9,7 @@ from xdsl.dialects.arith import ConstantOp
 from xdsl.dialects.builtin import (
     ArrayAttr,
     DenseArrayBase,
+    IndexType,
     IntegerAttr,
     MemRefType,
     StringAttr,
@@ -18,7 +19,6 @@ from xdsl.dialects.builtin import (
     i32,
     i64,
 )
-from xdsl.dialects.builtin import IndexType
 from xdsl.dialects.test import TestOp
 from xdsl.ir import Block, Region
 from xdsl.printer import Printer

--- a/tests/dialects/test_acc.py
+++ b/tests/dialects/test_acc.py
@@ -605,3 +605,19 @@ def test_firstprivate_recipe_builder_shortcuts():
     assert len(op.init_region.blocks) == 1
     assert len(op.copy_region.blocks) == 1
     assert len(op.destroy_region.blocks) == 0
+
+
+def test_enter_data_init_bool_shortcuts():
+    """The `async_attr` / `wait_attr` bool-shortcut branches in
+    EnterDataOp.__init__ aren't reachable via the parser (which produces
+    a UnitAttr directly via the custom directive)."""
+    create = acc.CreateOp(var=create_ssa_value(MemRefType(f32, [10])))
+    op = acc.EnterDataOp(
+        data_clause_operands=[create],
+        async_attr=True,
+        wait_attr=True,
+    )
+    op.verify()
+
+    assert isinstance(op.async_attr, UnitAttr)
+    assert isinstance(op.wait_attr, UnitAttr)

--- a/tests/dialects/test_acc.py
+++ b/tests/dialects/test_acc.py
@@ -18,6 +18,7 @@ from xdsl.dialects.builtin import (
     i32,
     i64,
 )
+from xdsl.dialects.builtin import IndexType
 from xdsl.dialects.test import TestOp
 from xdsl.ir import Block, Region
 from xdsl.printer import Printer
@@ -605,6 +606,89 @@ def test_firstprivate_recipe_builder_shortcuts():
     assert len(op.init_region.blocks) == 1
     assert len(op.copy_region.blocks) == 1
     assert len(op.destroy_region.blocks) == 0
+
+
+def test_data_bounds_op_builder():
+    """The `DataBoundsOp` Python builder isn't reached via filecheck (the
+    parser uses IRDL `create`, which bypasses `__init__`) — pytest is the
+    only place its `__init__` body runs."""
+    lb = create_ssa_value(IndexType())
+    ub = create_ssa_value(IndexType())
+    extent = create_ssa_value(IndexType())
+    stride = create_ssa_value(IndexType())
+    start_idx = create_ssa_value(IndexType())
+    op = acc.DataBoundsOp(
+        lowerbound=lb,
+        upperbound=ub,
+        extent=extent,
+        stride=stride,
+        start_idx=start_idx,
+        stride_in_bytes=IntegerAttr.from_bool(True),
+    )
+    op.verify()
+
+    assert op.lowerbound is lb
+    assert op.upperbound is ub
+    assert op.extent is extent
+    assert op.stride is stride
+    assert op.start_idx is start_idx
+    assert op.stride_in_bytes == IntegerAttr.from_bool(True)
+    assert isinstance(op.result.type, acc.DataBoundsType)
+
+
+def test_data_bounds_accessor_builders():
+    """The shared `_DataBoundsAccessorOp.__init__` is exercised by all four
+    accessor ops; constructing each from Python covers the single shared
+    builder body that filecheck never invokes."""
+    bounds = acc.DataBoundsOp(
+        lowerbound=create_ssa_value(IndexType()),
+        upperbound=create_ssa_value(IndexType()),
+    )
+    for cls in (
+        acc.GetLowerboundOp,
+        acc.GetUpperboundOp,
+        acc.GetExtentOp,
+        acc.GetStrideOp,
+    ):
+        op = cls(bounds.result)
+        op.verify()
+        assert op.bounds is bounds.result
+        assert isinstance(op.result.type, IndexType)
+
+
+def test_copyin_explicit_var_and_acc_var_type():
+    """Both `var_type` and `acc_var_type` defaulting branches in
+    `_DataEntryOperation.__init__` are skipped when callers pass them
+    explicitly. The parser supplies these via the assembly format
+    (`type($var)`, `$varType`), so the explicit-value branches are only
+    reachable from a Python builder caller."""
+    var = create_ssa_value(MemRefType(f32, [10]))
+    explicit_var_type = f32
+    explicit_acc_var_type = MemRefType(f32, [10])
+    op = acc.CopyinOp(
+        var=var,
+        var_type=explicit_var_type,
+        acc_var_type=explicit_acc_var_type,
+    )
+    op.verify()
+
+    assert op.var_type is explicit_var_type
+    assert op.acc_var.type is explicit_acc_var_type
+
+
+def test_copyout_explicit_var_type():
+    """`var_type=` shortcut on `_DataExitOperationWithVarPtr.__init__`
+    bypasses the `_default_var_type` fallback. Builder-only branch — the
+    parser always supplies `varType` explicitly via the assembly format."""
+    explicit_var_type = f32
+    op = acc.CopyoutOp(
+        acc_var=create_ssa_value(MemRefType(f32, [10])),
+        var=create_ssa_value(MemRefType(f32, [10])),
+        var_type=explicit_var_type,
+    )
+    op.verify()
+
+    assert op.var_type is explicit_var_type
 
 
 def test_enter_data_init_bool_shortcuts():

--- a/tests/filecheck/dialects/acc/ops.mlir
+++ b/tests/filecheck/dialects/acc/ops.mlir
@@ -1505,6 +1505,63 @@ builtin.module {
   }) : () -> ()
   // CHECK-LABEL: acc.reduction.recipe @red_generic : i64 reduction_operator <add> init {
 
+  // acc.enter_data — standalone unstructured data-entry op. The optional
+  // clauses appear in upstream-td-definition order on print:
+  //   if, async, wait_devnum, wait, dataOperands.
+  // The custom format encodes both the operand-bearing form `async(%v : ty)`
+  // and the bare-keyword form `async` (UnitAttr) via the
+  // `OperandWithKeywordOnly` directive; same for `wait` via
+  // `OperandsWithKeywordOnly`.
+  func.func @enter_data_minimal(%a : memref<10xf32>) {
+    %d = acc.create varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    acc.enter_data dataOperands(%d : memref<10xf32>)
+    func.return
+  }
+  // CHECK-LABEL: func.func @enter_data_minimal(
+  // CHECK:         acc.enter_data dataOperands(%{{.*}} : memref<10xf32>)
+
+  func.func @enter_data_async_bare(%a : memref<10xf32>) {
+    %d = acc.create varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    acc.enter_data async dataOperands(%d : memref<10xf32>)
+    func.return
+  }
+  // CHECK-LABEL: func.func @enter_data_async_bare(
+  // CHECK:         acc.enter_data async dataOperands(%{{.*}} : memref<10xf32>)
+
+  func.func @enter_data_async_operand(%a : memref<10xf32>, %v : i64) {
+    %d = acc.create varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    acc.enter_data async(%v : i64) dataOperands(%d : memref<10xf32>)
+    func.return
+  }
+  // CHECK-LABEL: func.func @enter_data_async_operand(
+  // CHECK:         acc.enter_data async(%{{.*}} : i64) dataOperands(%{{.*}} : memref<10xf32>)
+
+  func.func @enter_data_wait_bare(%a : memref<10xf32>) {
+    %d = acc.create varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    acc.enter_data wait dataOperands(%d : memref<10xf32>)
+    func.return
+  }
+  // CHECK-LABEL: func.func @enter_data_wait_bare(
+  // CHECK:         acc.enter_data wait dataOperands(%{{.*}} : memref<10xf32>)
+
+  func.func @enter_data_if_wait_devnum(%a : memref<10xf32>, %c : i1, %dn : i64, %w : i32) {
+    %d = acc.create varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    acc.enter_data if(%c) wait_devnum(%dn : i64) wait(%w : i32) dataOperands(%d : memref<10xf32>)
+    func.return
+  }
+  // CHECK-LABEL: func.func @enter_data_if_wait_devnum(
+  // CHECK:         acc.enter_data if(%{{.*}}) wait_devnum(%{{.*}} : i64) wait(%{{.*}} : i32) dataOperands(%{{.*}} : memref<10xf32>)
+
+  // Generic-form roundtrip insurance for `acc.enter_data` — the
+  // `operandSegmentSizes` array gates the five operand groups.
+  func.func @enter_data_generic_roundtrip(%a : memref<10xf32>) {
+    %d = acc.create varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    "acc.enter_data"(%d) <{operandSegmentSizes = array<i32: 0, 0, 0, 0, 1>}> : (memref<10xf32>) -> ()
+    func.return
+  }
+  // CHECK-LABEL: func.func @enter_data_generic_roundtrip(
+  // CHECK:         acc.enter_data dataOperands(%{{.*}} : memref<10xf32>)
+
   // acc.terminator is the value-less generic terminator. It currently only
   // permits `acc.kernels` as a parent (per HasParent on TerminatorOp); other
   // region ops in the OpenACC dialect (acc.data, acc.host_data, …) will be

--- a/tests/filecheck/dialects/acc/ops_invalid.mlir
+++ b/tests/filecheck/dialects/acc/ops_invalid.mlir
@@ -323,3 +323,57 @@ func.func @host_data_wrong_defining_op(%a : memref<10xf32>) {
   func.return
 }
 // CHECK: expect data entry operation as defining op
+
+// -----
+
+// acc.enter_data: 2.6.6 requires at least one copyin/create/attach clause.
+// An op with empty `dataOperands` fails the per-op verifier.
+func.func @enter_data_empty() {
+  acc.enter_data
+  func.return
+}
+// CHECK: at least one operand must be present in dataOperands on the enter data operation
+
+// -----
+
+// acc.enter_data: each `dataOperands` value must be defined by an
+// `acc.copyin` / `acc.create` / `acc.attach`. A bare memref fails.
+func.func @enter_data_wrong_defining_op(%a : memref<10xf32>) {
+  acc.enter_data dataOperands(%a : memref<10xf32>)
+  func.return
+}
+// CHECK: expect data entry operation as defining op
+
+// -----
+
+// acc.enter_data: the bare `async` UnitAttr and an `asyncOperand` cannot
+// both be set — the keyword-only spelling is mutually exclusive with the
+// operand-bearing spelling.
+func.func @enter_data_async_conflict(%a : memref<10xf32>, %v : i64) {
+  %d = acc.create varPtr(%a : memref<10xf32>) -> memref<10xf32>
+  "acc.enter_data"(%v, %d) <{async, operandSegmentSizes = array<i32: 0, 1, 0, 0, 1>}> : (i64, memref<10xf32>) -> ()
+  func.return
+}
+// CHECK: async attribute cannot appear with asyncOperand
+
+// -----
+
+// acc.enter_data: the bare `wait` UnitAttr and `waitOperands` cannot both
+// be set.
+func.func @enter_data_wait_conflict(%a : memref<10xf32>, %w : i32) {
+  %d = acc.create varPtr(%a : memref<10xf32>) -> memref<10xf32>
+  "acc.enter_data"(%w, %d) <{wait, operandSegmentSizes = array<i32: 0, 0, 0, 1, 1>}> : (i32, memref<10xf32>) -> ()
+  func.return
+}
+// CHECK: wait attribute cannot appear with waitOperands
+
+// -----
+
+// acc.enter_data: `wait_devnum` requires `waitOperands` to be non-empty.
+func.func @enter_data_wait_devnum_alone(%a : memref<10xf32>, %dn : i64) {
+  %d = acc.create varPtr(%a : memref<10xf32>) -> memref<10xf32>
+  "acc.enter_data"(%dn, %d) <{operandSegmentSizes = array<i32: 0, 0, 1, 0, 1>}> : (i64, memref<10xf32>) -> ()
+  func.return
+}
+// CHECK: wait_devnum cannot appear without waitOperands
+

--- a/tests/filecheck/dialects/acc/ops_invalid.mlir
+++ b/tests/filecheck/dialects/acc/ops_invalid.mlir
@@ -376,4 +376,3 @@ func.func @enter_data_wait_devnum_alone(%a : memref<10xf32>, %dn : i64) {
   func.return
 }
 // CHECK: wait_devnum cannot appear without waitOperands
-

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/ops.mlir
@@ -969,4 +969,58 @@ builtin.module {
   // CHECK-NEXT:    acc.kernels {
   // CHECK-NEXT:      acc.terminator
   // CHECK-NEXT:    }
+
+  // acc.enter_data — both pretty and generic-form spellings round-trip
+  // through `mlir-opt`. The five-segment operand shape and the `async` /
+  // `wait` UnitAttrs are the load-bearing properties. xDSL emits clauses
+  // in upstream's td-definition order (if, async, wait_devnum, wait,
+  // dataOperands); mlir-opt's `oilist` printer preserves input order.
+  func.func @enter_data_minimal(%a : memref<10xf32>) {
+    %d = acc.create varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    acc.enter_data dataOperands(%d : memref<10xf32>)
+    func.return
+  }
+  // CHECK:       func.func @enter_data_minimal(
+  // CHECK:         acc.enter_data dataOperands(%{{.*}} : memref<10xf32>)
+
+  func.func @enter_data_async_bare(%a : memref<10xf32>) {
+    %d = acc.create varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    acc.enter_data async dataOperands(%d : memref<10xf32>)
+    func.return
+  }
+  // CHECK:       func.func @enter_data_async_bare(
+  // CHECK:         acc.enter_data async dataOperands(%{{.*}} : memref<10xf32>)
+
+  func.func @enter_data_async_operand(%a : memref<10xf32>, %v : i64) {
+    %d = acc.create varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    acc.enter_data async(%v : i64) dataOperands(%d : memref<10xf32>)
+    func.return
+  }
+  // CHECK:       func.func @enter_data_async_operand(
+  // CHECK:         acc.enter_data async(%{{.*}} : i64) dataOperands(%{{.*}} : memref<10xf32>)
+
+  func.func @enter_data_wait_bare(%a : memref<10xf32>) {
+    %d = acc.create varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    acc.enter_data wait dataOperands(%d : memref<10xf32>)
+    func.return
+  }
+  // CHECK:       func.func @enter_data_wait_bare(
+  // CHECK:         acc.enter_data wait dataOperands(%{{.*}} : memref<10xf32>)
+
+  func.func @enter_data_if(%a : memref<10xf32>, %c : i1) {
+    %d = acc.create varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    acc.enter_data if(%c) dataOperands(%d : memref<10xf32>)
+    func.return
+  }
+  // CHECK:       func.func @enter_data_if(
+  // CHECK:         acc.enter_data if(%{{.*}}) dataOperands(%{{.*}} : memref<10xf32>)
+
+  func.func @enter_data_wait_devnum(%a : memref<10xf32>, %dn : i64, %w : i32) {
+    %d = acc.create varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    acc.enter_data wait_devnum(%dn : i64) wait(%w : i32) dataOperands(%d : memref<10xf32>)
+    func.return
+  }
+  // CHECK:       func.func @enter_data_wait_devnum(
+  // CHECK:         acc.enter_data wait_devnum(%{{.*}} : i64) wait(%{{.*}} : i32) dataOperands(%{{.*}} : memref<10xf32>)
+
 }

--- a/xdsl/dialects/acc.py
+++ b/xdsl/dialects/acc.py
@@ -795,6 +795,119 @@ class WaitClause(CustomDirective):
         state.last_was_punctuation = False
 
 
+@irdl_custom_directive
+class OperandWithKeywordOnly(CustomDirective):
+    """Port of upstream `custom<OperandWithKeywordOnly>`.
+
+    Follows a bare keyword (e.g. `async`) in the format. After the keyword:
+      bare                       → keyword-only UnitAttr set
+      `(` operand `:` type `)`   → operand set
+    """
+
+    operand: OptionalOperandVariable
+    operand_type: TypeDirective
+    attr: AttributeVariable
+
+    def is_anchorable(self) -> bool:
+        return True
+
+    def is_optional_like(self) -> bool:
+        return True
+
+    def is_present(self, op: IRDLOperation) -> bool:
+        return self.operand.get(op) is not None or self.attr.get(op) is not None
+
+    def set_empty(self, state: ParsingState) -> None:
+        self.operand.set(state, None)
+        self.operand_type.set(state, ())
+
+    def parse(self, parser: Parser, state: ParsingState) -> bool:
+        if not parser.parse_optional_punctuation("("):
+            self.attr.set(state, UnitAttr())
+            self.operand.set(state, None)
+            self.operand_type.set(state, ())
+            return True
+        operand, ty = _parse_typed_operand(parser)
+        parser.parse_punctuation(")")
+        self.operand.set(state, operand)
+        self.operand_type.set(state, (ty,))
+        return True
+
+    def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
+        # Mirror upstream's `if (attr) return;`: when the bare-keyword
+        # UnitAttr is set, the parent already emitted the keyword and we
+        # contribute nothing further.
+        if self.attr.get(op) is not None:
+            return
+        operand = self.operand.get(op)
+        assert operand is not None  # is_present excludes the all-None case
+        printer.print_string("(")
+        _print_typed_operand(printer, operand)
+        printer.print_string(")")
+        state.should_emit_space = True
+        state.last_was_punctuation = False
+
+
+@irdl_custom_directive
+class OperandsWithKeywordOnly(CustomDirective):
+    """Port of upstream `custom<OperandsWithKeywordOnly>`.
+
+    Follows a bare keyword (e.g. `wait`) in the format. After the keyword:
+      bare                                         → keyword-only UnitAttr
+      `(` op (`,` op)* `:` ty (`,` ty)* `)`        → variadic operand list
+    """
+
+    operands: VariadicOperandVariable
+    operand_types: TypeDirective
+    attr: AttributeVariable
+
+    def is_anchorable(self) -> bool:
+        return True
+
+    def is_optional_like(self) -> bool:
+        return True
+
+    def is_present(self, op: IRDLOperation) -> bool:
+        return bool(self.operands.get(op)) or self.attr.get(op) is not None
+
+    def set_empty(self, state: ParsingState) -> None:
+        self.operands.set(state, ())
+        self.operand_types.set(state, ())
+
+    def parse(self, parser: Parser, state: ParsingState) -> bool:
+        if not parser.parse_optional_punctuation("("):
+            self.attr.set(state, UnitAttr())
+            self.operands.set(state, ())
+            self.operand_types.set(state, ())
+            return True
+        operands = parser.parse_comma_separated_list(
+            parser.Delimiter.NONE, parser.parse_unresolved_operand
+        )
+        parser.parse_punctuation(":")
+        types = parser.parse_comma_separated_list(
+            parser.Delimiter.NONE, parser.parse_type
+        )
+        parser.parse_punctuation(")")
+        self.operands.set(state, operands)
+        self.operand_types.set(state, types)
+        return True
+
+    def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
+        if self.attr.get(op) is not None:
+            return
+        operands = self.operands.get(op)
+        assert operands  # is_present excludes the empty/no-attr case
+        printer.print_string("(")
+        printer.print_list(operands, printer.print_ssa_value)
+        printer.print_string(" : ")
+        printer.print_list(
+            (operand.type for operand in operands), printer.print_attribute
+        )
+        printer.print_string(")")
+        state.should_emit_space = True
+        state.last_was_punctuation = False
+
+
 def _default_var_type(var_type: Attribute) -> Attribute:
     """Default `varType` value for a `var` operand.
 
@@ -2353,6 +2466,109 @@ class DetachOp(_DataExitOperationNoVarPtr):
     )
 
 
+# ---------------------------------------------------------------------------
+# Standalone unstructured data-movement ops: acc.enter_data.
+# ---------------------------------------------------------------------------
+#
+# `enter_data` has no region. It carries a single optional `asyncOperand` (no
+# per-device-type array), a single optional `waitDevnum`, variadic
+# `waitOperands`, and `dataClauseOperands`, plus `async` / `wait` UnitAttrs
+# that mirror the bare-keyword spellings.
+
+
+@irdl_op_definition
+class EnterDataOp(IRDLOperation):
+    """
+    Implementation of upstream acc.enter_data — the OpenACC enter data directive.
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/OpenACCDialect/#accenter_data-accenterdataop).
+    """
+
+    name = "acc.enter_data"
+
+    if_cond = opt_operand_def(I1)
+    async_operand = opt_operand_def(IntegerType | IndexType)
+    wait_devnum = opt_operand_def(IntegerType | IndexType)
+    wait_operands = var_operand_def(IntegerType | IndexType)
+    data_clause_operands = var_operand_def()
+
+    async_attr = opt_prop_def(UnitAttr, prop_name="async")
+    wait_attr = opt_prop_def(UnitAttr, prop_name="wait")
+
+    irdl_options = (
+        AttrSizedOperandSegments(as_property=True),
+        ParsePropInAttrDict(),
+    )
+
+    custom_directives = (
+        OperandWithKeywordOnly,
+        OperandsWithKeywordOnly,
+    )
+
+    assembly_format = (
+        "(`if` `(` $if_cond^ `)`)?"
+        " (`async` custom<OperandWithKeywordOnly>($async_operand,"
+        " type($async_operand), $async)^)?"
+        " (`wait_devnum` `(` $wait_devnum^ `:` type($wait_devnum) `)`)?"
+        " (`wait` custom<OperandsWithKeywordOnly>($wait_operands,"
+        " type($wait_operands), $wait)^)?"
+        " (`dataOperands` `(` $data_clause_operands^ `:`"
+        " type($data_clause_operands) `)`)?"
+        " attr-dict-with-keyword"
+    )
+
+    def __init__(
+        self,
+        *,
+        if_cond: SSAValue | Operation | None = None,
+        async_operand: SSAValue | Operation | None = None,
+        wait_devnum: SSAValue | Operation | None = None,
+        wait_operands: Sequence[SSAValue | Operation] = (),
+        data_clause_operands: Sequence[SSAValue | Operation] = (),
+        async_attr: UnitAttr | bool = False,
+        wait_attr: UnitAttr | bool = False,
+    ) -> None:
+        async_prop: UnitAttr | None = (
+            (UnitAttr() if async_attr else None)
+            if isinstance(async_attr, bool)
+            else async_attr
+        )
+        wait_prop: UnitAttr | None = (
+            (UnitAttr() if wait_attr else None)
+            if isinstance(wait_attr, bool)
+            else wait_attr
+        )
+        super().__init__(
+            operands=[
+                [if_cond] if if_cond is not None else [],
+                [async_operand] if async_operand is not None else [],
+                [wait_devnum] if wait_devnum is not None else [],
+                wait_operands,
+                data_clause_operands,
+            ],
+            properties={
+                "async": async_prop,
+                "wait": wait_prop,
+            },
+        )
+
+    def verify_(self) -> None:
+        # Mirrors `acc::EnterDataOp::verify` (2.6.6 Data Enter Directive).
+        if not self.data_clause_operands:
+            raise VerifyException(
+                "at least one operand must be present in dataOperands on "
+                "the enter data operation"
+            )
+        if self.async_operand is not None and self.async_attr is not None:
+            raise VerifyException("async attribute cannot appear with asyncOperand")
+        if self.wait_operands and self.wait_attr is not None:
+            raise VerifyException("wait attribute cannot appear with waitOperands")
+        if self.wait_devnum is not None and not self.wait_operands:
+            raise VerifyException("wait_devnum cannot appear without waitOperands")
+        for operand in self.data_clause_operands:
+            if not isinstance(operand.owner, (AttachOp, CreateOp, CopyinOp)):
+                raise VerifyException("expect data entry operation as defining op")
+
+
 @irdl_op_definition
 class DataBoundsOp(IRDLOperation):
     """
@@ -2825,6 +3041,7 @@ ACC = Dialect(
         UpdateHostOp,
         DeleteOp,
         DetachOp,
+        EnterDataOp,
         PrivateRecipeOp,
         FirstprivateRecipeOp,
         ReductionRecipeOp,

--- a/xdsl/dialects/acc.py
+++ b/xdsl/dialects/acc.py
@@ -811,9 +811,6 @@ class OperandWithKeywordOnly(CustomDirective):
     def is_anchorable(self) -> bool:
         return True
 
-    def is_optional_like(self) -> bool:
-        return True
-
     def is_present(self, op: IRDLOperation) -> bool:
         return self.operand.get(op) is not None or self.attr.get(op) is not None
 
@@ -862,9 +859,6 @@ class OperandsWithKeywordOnly(CustomDirective):
     attr: AttributeVariable
 
     def is_anchorable(self) -> bool:
-        return True
-
-    def is_optional_like(self) -> bool:
         return True
 
     def is_present(self, op: IRDLOperation) -> bool:


### PR DESCRIPTION
Adds the EnterData OpenACC operation, along with underlying custom assembly syntax for unstructured data movement operations (the next PR will add some more unstructured data movement operations that also leverage this custom assembly syntax)