### PR TITLE
dialects: (riscv_scf, x86_scf) use RecursiveMemoryEffect

### DIFF
--- a/tests/dialects/test_riscv_scf.py
+++ b/tests/dialects/test_riscv_scf.py
@@ -1,9 +1,12 @@
+from collections.abc import Callable
+
 import pytest
 
-from xdsl.dialects import riscv, riscv_scf
+from xdsl import ir
+from xdsl.dialects import riscv, riscv_scf, test
 from xdsl.dialects.builtin import IntegerAttr
 from xdsl.dialects.riscv.attrs import i12
-from xdsl.ir import Block
+from xdsl.traits import EffectInstance, MemoryEffect, MemoryEffectKind, get_effects
 from xdsl.utils.test_value import create_ssa_value
 
 
@@ -21,7 +24,7 @@ def test_for_rof_step(
         ub,
         step_val,
         (),
-        Block((riscv_scf.YieldOp(),), arg_types=[riscv.Registers.UNALLOCATED_INT]),
+        ir.Block((riscv_scf.YieldOp(),), arg_types=[riscv.Registers.UNALLOCATED_INT]),
     )
     op.verify()
 
@@ -34,10 +37,88 @@ def test_for_rof_step(
         ub,
         step_attr,
         (),
-        Block((riscv_scf.YieldOp(),), arg_types=[riscv.Registers.UNALLOCATED_INT]),
+        ir.Block((riscv_scf.YieldOp(),), arg_types=[riscv.Registers.UNALLOCATED_INT]),
     )
     op.verify()
 
     assert op.step_attr is step_attr
     assert op.step_val is None
     assert op.step is step_attr
+
+
+@pytest.mark.parametrize("loop_cls", [riscv_scf.ForOp, riscv_scf.RofOp])
+@pytest.mark.parametrize(
+    "op_factory,effects",
+    [
+        (test.TestOp, None),
+        (test.TestPureOp, set[MemoryEffect]()),
+        (test.TestReadOp, {EffectInstance(MemoryEffectKind.READ)}),
+        (test.TestWriteOp, {EffectInstance(MemoryEffectKind.WRITE)}),
+    ],
+)
+def test_for_rof_recursive_memory_effects(
+    loop_cls: type[riscv_scf.ForOp | riscv_scf.RofOp],
+    op_factory: Callable[[], ir.Operation],
+    effects: set[EffectInstance] | None,
+):
+    reg = riscv.Registers.UNALLOCATED_INT
+    lb = create_ssa_value(reg)
+    ub = create_ssa_value(reg)
+    step_val = create_ssa_value(reg)
+
+    op = loop_cls(
+        lb,
+        ub,
+        step_val,
+        (),
+        ir.Block(
+            (
+                op_factory(),
+                riscv_scf.YieldOp(),
+            ),
+            arg_types=[reg],
+        ),
+    )
+    op.verify()
+
+    assert get_effects(op) == effects
+
+
+@pytest.mark.parametrize(
+    "op_factory,effects",
+    [
+        (test.TestOp, None),
+        (test.TestPureOp, set[MemoryEffect]()),
+        (test.TestReadOp, {EffectInstance(MemoryEffectKind.READ)}),
+        (test.TestWriteOp, {EffectInstance(MemoryEffectKind.WRITE)}),
+    ],
+)
+def test_while_recursive_memory_effects(
+    op_factory: Callable[[], ir.Operation],
+    effects: set[EffectInstance] | None,
+):
+    reg = riscv.Registers.UNALLOCATED_INT
+    arguments = (create_ssa_value(reg),)
+    result_types = (reg,)
+
+    op = riscv_scf.WhileOp(
+        arguments,
+        result_types,
+        ir.Region(
+            ir.Block(
+                (riscv_scf.ConditionOp(create_ssa_value(reg)),),
+                arg_types=[reg],
+            )
+        ),
+        ir.Region(
+            ir.Block(
+                (
+                    op_factory(),
+                    riscv_scf.YieldOp(),
+                ),
+                arg_types=[reg],
+            )
+        ),
+    )
+    op.verify()
+    assert get_effects(op) == effects

--- a/tests/dialects/test_x86_scf.py
+++ b/tests/dialects/test_x86_scf.py
@@ -1,0 +1,46 @@
+from collections.abc import Callable
+
+import pytest
+
+from xdsl import ir
+from xdsl.dialects import test, x86, x86_scf
+from xdsl.traits import EffectInstance, MemoryEffect, MemoryEffectKind, get_effects
+from xdsl.utils.test_value import create_ssa_value
+
+
+@pytest.mark.parametrize("loop_cls", [x86_scf.ForOp, x86_scf.RofOp])
+@pytest.mark.parametrize(
+    "op_factory,effects",
+    [
+        (test.TestOp, None),
+        (test.TestPureOp, set[MemoryEffect]()),
+        (test.TestReadOp, {EffectInstance(MemoryEffectKind.READ)}),
+        (test.TestWriteOp, {EffectInstance(MemoryEffectKind.WRITE)}),
+    ],
+)
+def test_for_rof_recursive_memory_effects(
+    loop_cls: type[x86_scf.ForOp | x86_scf.RofOp],
+    op_factory: Callable[[], ir.Operation],
+    effects: set[EffectInstance] | None,
+):
+    reg = x86.registers.UNALLOCATED_REG64
+    lb = create_ssa_value(reg)
+    ub = create_ssa_value(reg)
+    step_val = create_ssa_value(reg)
+
+    op = loop_cls(
+        lb,
+        ub,
+        step_val,
+        (),
+        ir.Block(
+            (
+                op_factory(),
+                x86_scf.YieldOp(),
+            ),
+            arg_types=[reg],
+        ),
+    )
+    op.verify()
+
+    assert get_effects(op) == effects

--- a/xdsl/dialects/riscv_scf.py
+++ b/xdsl/dialects/riscv_scf.py
@@ -43,6 +43,8 @@ from xdsl.printer import Printer
 from xdsl.traits import (
     HasParent,
     IsTerminator,
+    NoMemoryEffect,
+    RecursiveMemoryEffect,
     SingleBlockImplicitTerminator,
     ensure_terminator,
 )
@@ -54,7 +56,11 @@ class YieldOp(AbstractYieldOperation[RISCVRegisterType]):
     name = "riscv_scf.yield"
 
     traits = lazy_traits_def(
-        lambda: (IsTerminator(), HasParent(WhileOp, ForRofOperation))
+        lambda: (
+            IsTerminator(),
+            HasParent(WhileOp, ForRofOperation),
+            NoMemoryEffect(),
+        )
     )
 
 
@@ -70,7 +76,7 @@ class ForRofOperation(RegisterAllocatableOperation, IRDLOperation, ABC):
 
     body = region_def("single_block")
 
-    traits = traits_def(SingleBlockImplicitTerminator(YieldOp))
+    traits = traits_def(SingleBlockImplicitTerminator(YieldOp), RecursiveMemoryEffect())
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
     @property
@@ -288,6 +294,8 @@ class WhileOp(IRDLOperation):
     before_region = region_def()
     after_region = region_def()
 
+    traits = traits_def(RecursiveMemoryEffect())
+
     def __init__(
         self,
         arguments: Sequence[SSAValue | Operation],
@@ -409,7 +417,7 @@ class ConditionOp(IRDLOperation):
     cond = operand_def(IntRegisterType)
     arguments = var_operand_def(RISCVRegisterType)
 
-    traits = traits_def(HasParent(WhileOp), IsTerminator())
+    traits = traits_def(HasParent(WhileOp), IsTerminator(), NoMemoryEffect())
 
     def __init__(self, cond: SSAValue | Operation, *output_ops: SSAValue | Operation):
         super().__init__(operands=[cond, output_ops])

--- a/xdsl/dialects/x86_scf.py
+++ b/xdsl/dialects/x86_scf.py
@@ -35,6 +35,8 @@ from xdsl.printer import Printer
 from xdsl.traits import (
     HasParent,
     IsTerminator,
+    NoMemoryEffect,
+    RecursiveMemoryEffect,
     SingleBlockImplicitTerminator,
     ensure_terminator,
 )
@@ -45,7 +47,13 @@ from xdsl.utils.exceptions import VerifyException
 class YieldOp(AbstractYieldOperation[X86RegisterType]):
     name = "x86_scf.yield"
 
-    traits = lazy_traits_def(lambda: (IsTerminator(), HasParent(ForRofOperation)))
+    traits = lazy_traits_def(
+        lambda: (
+            IsTerminator(),
+            HasParent(ForRofOperation),
+            NoMemoryEffect(),
+        )
+    )
 
 
 class ForRofOperation(RegisterAllocatableOperation, IRDLOperation, ABC):
@@ -59,7 +67,7 @@ class ForRofOperation(RegisterAllocatableOperation, IRDLOperation, ABC):
 
     body = region_def("single_block")
 
-    traits = traits_def(SingleBlockImplicitTerminator(YieldOp))
+    traits = traits_def(SingleBlockImplicitTerminator(YieldOp), RecursiveMemoryEffect())
 
     def __init__(
         self,


### PR DESCRIPTION
Both the x86 and riscv structured control flow abstractions don't currently handle effects well, this implements behaviour analogous to scf for propagating known effects up.