### PR TITLE
dialects: (llvm) remove stale TODO on CallOp

### DIFF
--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -2627,7 +2627,6 @@ class CallOpSymbolUserOpInterface(SymbolUserOpInterface):
             )
 
 
-# TODO: custom assembly format https://github.com/xdslproject/xdsl/issues/5897
 @irdl_op_definition
 class CallOp(IRDLOperation):
     name = "llvm.call"


### PR DESCRIPTION
All 4 #5897 TODOs are stale. Custom assembly formats already landed: CallOp (#5946), InlineAsmOp (#5947), GlobalOp (#5948), CallIntrinsicOp (#5938).