### PR TITLE
backend: all used regs within region is a set instead of iterable

### DIFF
--- a/tests/backend/riscv/test_preallocated.py
+++ b/tests/backend/riscv/test_preallocated.py
@@ -11,11 +11,7 @@ def test_gather_allocated():
         v2 = rv32.GetRegisterOp(riscv.Registers.UNALLOCATED_INT).res
         _ = riscv.AddOp(v1, v2).rd
 
-    pa_regs = set(
-        RegisterAllocatableOperation.iter_all_used_registers(no_preallocated_body)
-    )
-
-    assert pa_regs == set()
+    assert not (RegisterAllocatableOperation.all_used_registers(no_preallocated_body))
 
     @Builder.implicit_region
     def one_preallocated_body() -> None:
@@ -25,7 +21,7 @@ def test_gather_allocated():
         _ = riscv.AddOp(v1, v2).rd
 
     pa_regs = set(
-        RegisterAllocatableOperation.iter_all_used_registers(one_preallocated_body)
+        RegisterAllocatableOperation.all_used_registers(one_preallocated_body)
     )
 
     assert pa_regs == {riscv.Registers.A7}
@@ -37,11 +33,9 @@ def test_gather_allocated():
         sum1 = riscv.AddOp(v1, v2).rd
         _ = riscv.AddiOp(sum1, 1, rd=riscv.Registers.A7).rd
 
-    pa_regs = set(
-        RegisterAllocatableOperation.iter_all_used_registers(repeated_preallocated_body)
-    )
-
-    assert pa_regs == {riscv.Registers.A7}
+    assert RegisterAllocatableOperation.all_used_registers(
+        repeated_preallocated_body
+    ) == {riscv.Registers.A7}
 
     @Builder.implicit_region
     def multiple_preallocated_body() -> None:
@@ -50,11 +44,9 @@ def test_gather_allocated():
         sum1 = riscv.AddOp(v1, v2).rd
         _ = riscv.AddiOp(sum1, 1, rd=riscv.Registers.A6).rd
 
-    pa_regs = set(
-        RegisterAllocatableOperation.iter_all_used_registers(multiple_preallocated_body)
-    )
-
-    assert pa_regs == {riscv.Registers.A6, riscv.Registers.A7}
+    assert RegisterAllocatableOperation.all_used_registers(
+        multiple_preallocated_body
+    ) == {riscv.Registers.A6, riscv.Registers.A7}
 
     @Builder.implicit_region
     def func_call_preallocated_body() -> None:
@@ -62,10 +54,8 @@ def test_gather_allocated():
         v2 = rv32.GetRegisterOp(riscv.Registers.S0).res
         riscv_func.CallOp(SymbolRefAttr("hello"), (v1, v2), ())
 
-    pa_regs = set(
-        RegisterAllocatableOperation.iter_all_used_registers(
-            func_call_preallocated_body
-        )
+    pa_regs = RegisterAllocatableOperation.all_used_registers(
+        func_call_preallocated_body
     )
 
     assert len(pa_regs) == 36

--- a/tests/backend/test_register_allocation.py
+++ b/tests/backend/test_register_allocation.py
@@ -132,11 +132,7 @@ def test_gather_allocated():
         (v2,) = op((), u).results
         op((v1, v2), u)
 
-    pa_regs = set(
-        RegisterAllocatableOperation.iter_all_used_registers(no_preallocated_body)
-    )
-
-    assert pa_regs == set()
+    assert not (RegisterAllocatableOperation.all_used_registers(no_preallocated_body))
 
     @Builder.implicit_region
     def one_preallocated_body() -> None:
@@ -144,11 +140,9 @@ def test_gather_allocated():
         (v2,) = op((), x0).results
         op((v1, v2), u)
 
-    pa_regs = set(
-        RegisterAllocatableOperation.iter_all_used_registers(one_preallocated_body)
-    )
-
-    assert pa_regs == {x0}
+    assert RegisterAllocatableOperation.all_used_registers(one_preallocated_body) == {
+        x0
+    }
 
     @Builder.implicit_region
     def repeated_preallocated_body() -> None:
@@ -157,11 +151,9 @@ def test_gather_allocated():
         (v3,) = op((), x0).results
         op((v1, v2, v3), u)
 
-    pa_regs = set(
-        RegisterAllocatableOperation.iter_all_used_registers(repeated_preallocated_body)
-    )
-
-    assert pa_regs == {x0}
+    assert RegisterAllocatableOperation.all_used_registers(
+        repeated_preallocated_body
+    ) == {x0}
 
     @Builder.implicit_region
     def multiple_preallocated_body() -> None:
@@ -170,11 +162,9 @@ def test_gather_allocated():
         (v3,) = op((), x1).results
         op((v1, v2, v3), u)
 
-    pa_regs = set(
-        RegisterAllocatableOperation.iter_all_used_registers(multiple_preallocated_body)
-    )
-
-    assert pa_regs == {x0, x1}
+    assert RegisterAllocatableOperation.all_used_registers(
+        multiple_preallocated_body
+    ) == {x0, x1}
 
 
 def test_new_type_for_value():

--- a/xdsl/backend/register_allocatable.py
+++ b/xdsl/backend/register_allocatable.py
@@ -1,5 +1,6 @@
 import abc
 from collections.abc import Iterator, Sequence
+from collections.abc import Set as AbstractSet
 from typing import NamedTuple
 
 from xdsl.backend.register_allocator import BlockAllocator
@@ -36,18 +37,18 @@ class RegisterAllocatableOperation(Operation, abc.ABC):
         """
 
     @staticmethod
-    def iter_all_used_registers(
+    def all_used_registers(
         region: Region,
-    ) -> Iterator[RegisterType]:
+    ) -> AbstractSet[RegisterType]:
         """
         All used registers of all operations within a region.
         """
-        return (
+        return {
             reg
             for op in region.walk()
             if isinstance(op, RegisterAllocatableOperation)
             for reg in op.iter_used_registers()
-        )
+        }
 
 
 class RegisterConstraints(NamedTuple):

--- a/xdsl/backend/riscv/register_allocation.py
+++ b/xdsl/backend/riscv/register_allocation.py
@@ -14,7 +14,7 @@ from xdsl.rewriter import InsertPoint, Rewriter
 from xdsl.transforms.canonicalization_patterns.riscv import get_constant_value
 
 
-def reg_types_by_name(regs: Iterable[RISCVRegisterType]) -> dict[str, set[str]]:
+def reg_types_by_name(regs: Iterable[RegisterType]) -> dict[str, set[str]]:
     """
     Groups register types by name.
     """
@@ -57,11 +57,7 @@ class RegisterAllocatorLivenessBlockNaive(BlockNaiveAllocator):
                 f"Cannot register allocate func with {len(func.body.blocks)} blocks."
             )
 
-        preallocated = {
-            reg
-            for reg in RegisterAllocatableOperation.iter_all_used_registers(func.body)
-            if isinstance(reg, RISCVRegisterType)
-        }
+        preallocated = RegisterAllocatableOperation.all_used_registers(func.body)
 
         for pa_reg in preallocated:
             self.available_registers.exclude_register(pa_reg)

--- a/xdsl/backend/x86/register_allocation.py
+++ b/xdsl/backend/x86/register_allocation.py
@@ -25,11 +25,7 @@ class X86RegisterAllocator(BlockNaiveAllocator):
                 f"Cannot register allocate func with {len(func.body.blocks)} blocks."
             )
 
-        preallocated = {
-            reg
-            for reg in RegisterAllocatableOperation.iter_all_used_registers(func.body)
-            if isinstance(reg, registers.X86RegisterType)
-        }
+        preallocated = RegisterAllocatableOperation.all_used_registers(func.body)
 
         for pa_reg in preallocated:
             self.available_registers.exclude_register(pa_reg)

--- a/xdsl/transforms/riscv_allocate_infinite_registers.py
+++ b/xdsl/transforms/riscv_allocate_infinite_registers.py
@@ -22,9 +22,7 @@ class RISCVAllocateInfiniteRegistersPass(ModulePass):
             register_stack = RiscvRegisterStack.get()
 
             # remove registers from stack that are already used in body
-            for reg in RegisterAllocatableOperation.iter_all_used_registers(
-                func_op.body
-            ):
+            for reg in RegisterAllocatableOperation.all_used_registers(func_op.body):
                 register_stack.exclude_register(reg)
 
             phys_reg_by_inf_reg: dict[


### PR DESCRIPTION
We always create a set from this anyway, makes things a little bit easier to deal with.
