### PR TITLE
backend: (x86) dce when converting arith and vector to x86

### DIFF
--- a/tests/filecheck/backend/x86/convert_arith_to_x86.mlir
+++ b/tests/filecheck/backend/x86/convert_arith_to_x86.mlir
@@ -3,6 +3,7 @@
 %i0 = "test.op"(): () -> i32
 %i1 = "test.op"(): () -> i32
 %i2 = arith.addi %i0, %i1: i32
+"test.op"(%i2) : (i32) -> ()
 
 // CHECK:      builtin.module {
 // CHECK-NEXT:   %i0 = "test.op"() : () -> i32
@@ -12,6 +13,7 @@
 // CHECK-NEXT:   %i2 = x86.ds.mov %i1_1 : (!x86.reg32) -> !x86.reg32
 // CHECK-NEXT:   %i2_1 = x86.rs.add %i2, %i0_1 : (!x86.reg32, !x86.reg32) -> !x86.reg32
 // CHECK-NEXT:   %i2_2 = builtin.unrealized_conversion_cast %i2_1 : !x86.reg32 to i32
+// CHECK-NEXT:   "test.op"(%i2_2) : (i32) -> ()
 // CHECK-NEXT: }
 
 // -----
@@ -20,12 +22,14 @@
 %i0 = "test.op"(): () -> tensor<2xi32>
 %i1 = "test.op"(): () -> tensor<2xi32>
 %i2 = arith.addi %i0, %i1: tensor<2xi32>
+"test.op"(%i2) : (tensor<2xi32>) -> ()
 
 // -----
 
 %i0 = "test.op"(): () -> i32
 %i1 = "test.op"(): () -> i32
 %i2 = arith.muli %i0, %i1: i32
+"test.op"(%i2) : (i32) -> ()
 
 // CHECK:      builtin.module {
 // CHECK-NEXT:   %i0 = "test.op"() : () -> i32
@@ -35,6 +39,7 @@
 // CHECK-NEXT:   %i2 = x86.ds.mov %i1_1 : (!x86.reg32) -> !x86.reg32
 // CHECK-NEXT:   %i2_1 = x86.rs.imul %i2, %i0_1 : (!x86.reg32, !x86.reg32) -> !x86.reg32
 // CHECK-NEXT:   %i2_2 = builtin.unrealized_conversion_cast %i2_1 : !x86.reg32 to i32
+// CHECK-NEXT:   "test.op"(%i2_2) : (i32) -> ()
 // CHECK-NEXT: }
 
 // -----
@@ -43,6 +48,7 @@
 %i0 = "test.op"(): () -> tensor<2xi32>
 %i1 = "test.op"(): () -> tensor<2xi32>
 %i2 = arith.muli %i0,%i1: tensor<2xi32>
+"test.op"(%i2) : (tensor<2xi32>) -> ()
 
 // -----
 
@@ -50,28 +56,34 @@
 %i0 = "test.op"(): () -> i128
 %i1 = "test.op"(): () -> i128
 %i2 = arith.addi %i0,%i1: i128
+"test.op"(%i2) : (i128) -> ()
 
 // -----
 
 // CHECK: Lowering of arith.constant is only implemented for integers
 %c = arith.constant 1.0: f32
+"test.op"(%c) : (f32) -> ()
 
 // -----
 
 %c = arith.constant 1: i32
+"test.op"(%c) : (i32) -> ()
 
 // CHECK:      builtin.module {
 // CHECK-NEXT:   %c = x86.di.mov 1 : () -> !x86.reg32
 // CHECK-NEXT:   %c_1 = builtin.unrealized_conversion_cast %c : !x86.reg32 to i32
+// CHECK-NEXT:   "test.op"(%c_1) : (i32) -> ()
 // CHECK-NEXT: }
 
 // -----
 
 %c = arith.constant 1: index
+"test.op"(%c) : (index) -> ()
 
 // CHECK:      builtin.module {
 // CHECK-NEXT:   %c = x86.di.mov 1 : () -> !x86.reg64
 // CHECK-NEXT:   %c_1 = builtin.unrealized_conversion_cast %c : !x86.reg64 to index
+// CHECK-NEXT:   "test.op"(%c_1) : (index) -> ()
 // CHECK-NEXT: }
 
 // -----
@@ -90,3 +102,5 @@
 // CHECK-NEXT:    %mulf_1 = x86.rs.fmul %mulf, %f0_2 : (!x86.reg32, !x86.reg32) -> !x86.reg32
 // CHECK-NEXT:    %mulf_2 = builtin.unrealized_conversion_cast %mulf_1 : !x86.reg32 to f32
 %mulf = arith.mulf %f0, %f1: f32
+"test.op"(%addf, %mulf) : (f32, f32) -> ()
+// CHECK-NEXT:    "test.op"(%addf_2, %mulf_2) : (f32, f32) -> ()

--- a/tests/filecheck/backend/x86/convert_vector_to_x86.mlir
+++ b/tests/filecheck/backend/x86/convert_vector_to_x86.mlir
@@ -4,6 +4,7 @@
 %rhs = "test.op"(): () -> vector<8xf32>
 %acc = "test.op"(): () -> vector<8xf32>
 %fma = vector.fma %lhs,%rhs,%acc: vector<8xf32>
+"test.op"(%fma) : (vector<8xf32>) -> ()
 
 // CHECK:      builtin.module {
 // CHECK-NEXT:   %lhs = "test.op"() : () -> vector<8xf32>
@@ -14,6 +15,7 @@
 // CHECK-NEXT:   %acc_1 = builtin.unrealized_conversion_cast %acc : vector<8xf32> to !x86.avx2reg
 // CHECK-NEXT:   %fma = x86.rss.vfmadd231ps %acc_1, %lhs_1, %rhs_1 : (!x86.avx2reg, !x86.avx2reg, !x86.avx2reg) -> !x86.avx2reg
 // CHECK-NEXT:   %fma_1 = builtin.unrealized_conversion_cast %fma : !x86.avx2reg to vector<8xf32>
+// CHECK-NEXT:   "test.op"(%fma_1) : (vector<8xf32>) -> ()
 // CHECK-NEXT: }
 
 // -----
@@ -22,6 +24,7 @@
 %rhs = "test.op"(): () -> vector<4xf64>
 %acc = "test.op"(): () -> vector<4xf64>
 %fma = vector.fma %lhs,%rhs,%acc: vector<4xf64>
+"test.op"(%fma) : (vector<4xf64>) -> ()
 
 // CHECK:      builtin.module {
 // CHECK-NEXT:   %lhs = "test.op"() : () -> vector<4xf64>
@@ -32,6 +35,7 @@
 // CHECK-NEXT:   %acc_1 = builtin.unrealized_conversion_cast %acc : vector<4xf64> to !x86.avx2reg
 // CHECK-NEXT:   %fma = x86.rss.vfmadd231pd %acc_1, %lhs_1, %rhs_1 : (!x86.avx2reg, !x86.avx2reg, !x86.avx2reg) -> !x86.avx2reg
 // CHECK-NEXT:   %fma_1 = builtin.unrealized_conversion_cast %fma : !x86.avx2reg to vector<4xf64>
+// CHECK-NEXT:   "test.op"(%fma_1) : (vector<4xf64>) -> ()
 // CHECK-NEXT: }
 
 // -----
@@ -41,6 +45,7 @@
 %rhs = "test.op"(): () -> vector<8xf16>
 %acc = "test.op"(): () -> vector<8xf16>
 %fma = vector.fma %lhs,%rhs,%acc: vector<8xf16>
+"test.op"(%fma) : (vector<8xf16>) -> ()
 
 // -----
 
@@ -49,27 +54,32 @@
 %rhs = "test.op"(): () -> vector<2xf128>
 %acc = "test.op"(): () -> vector<2xf128>
 %fma = vector.fma %lhs,%rhs,%acc: vector<2xf128>
+"test.op"(%fma) : (vector<2xf128>) -> ()
 
 // -----
 
 %s = "test.op"(): () -> f64
 %broadcast = vector.broadcast %s: f64 to vector<4xf64>
+"test.op"(%broadcast) : (vector<4xf64>) -> ()
 // CHECK:      builtin.module {
 // CHECK-NEXT:   %s = "test.op"() : () -> f64
 // CHECK-NEXT:   %s_1 = builtin.unrealized_conversion_cast %s : f64 to !x86.reg64
 // CHECK-NEXT:   %broadcast = x86.ds.vpbroadcastq %s_1 : (!x86.reg64) -> !x86.avx2reg
 // CHECK-NEXT:   %broadcast_1 = builtin.unrealized_conversion_cast %broadcast : !x86.avx2reg to vector<4xf64>
+// CHECK-NEXT:   "test.op"(%broadcast_1) : (vector<4xf64>) -> ()
 // CHECK-NEXT: }
 
 // -----
 
 %s = "test.op"(): () -> f32
 %broadcast = vector.broadcast %s: f32 to vector<8xf32>
+"test.op"(%broadcast) : (vector<8xf32>) -> ()
 // CHECK:      builtin.module {
 // CHECK-NEXT:   %s = "test.op"() : () -> f32
 // CHECK-NEXT:   %s_1 = builtin.unrealized_conversion_cast %s : f32 to !x86.reg32
 // CHECK-NEXT:   %broadcast = x86.ds.vpbroadcastd %s_1 : (!x86.reg32) -> !x86.avx2reg
 // CHECK-NEXT:   %broadcast_1 = builtin.unrealized_conversion_cast %broadcast : !x86.avx2reg to vector<8xf32>
+// CHECK-NEXT:   "test.op"(%broadcast_1) : (vector<8xf32>) -> ()
 // CHECK-NEXT: }
 
 // -----
@@ -78,6 +88,7 @@
 %ptr = "test.op"(): () -> !ptr_xdsl.ptr
 %s = ptr_xdsl.load %ptr : !ptr_xdsl.ptr -> f16
 %broadcast = vector.broadcast %s: f16 to vector<16xf16>
+"test.op"(%broadcast) : (vector<16xf16>) -> ()
 
 // -----
 
@@ -85,3 +96,4 @@
 %ptr = "test.op"(): () -> !ptr_xdsl.ptr
 %s = ptr_xdsl.load %ptr : !ptr_xdsl.ptr -> f128
 %broadcast = vector.broadcast %s: f128 to vector<2xf128>
+"test.op"(%broadcast) : (vector<2xf128>) -> ()

--- a/xdsl/backend/x86/lowering/convert_arith_to_x86.py
+++ b/xdsl/backend/x86/lowering/convert_arith_to_x86.py
@@ -90,7 +90,6 @@ class ConvertArithToX86Pass(ModulePass):
                     ArithBinaryToX86(arch),
                     ArithConstantToX86(arch),
                 ],
-                dce_enabled=False,
             ),
             apply_recursively=False,
         ).rewrite_module(op)

--- a/xdsl/backend/x86/lowering/convert_vector_to_x86.py
+++ b/xdsl/backend/x86/lowering/convert_vector_to_x86.py
@@ -116,7 +116,6 @@ class ConvertVectorToX86Pass(ModulePass):
                     VectorFMAToX86(arch),
                     VectorBroadcastToX86(arch),
                 ],
-                dce_enabled=False,
             ),
             apply_recursively=False,
         ).rewrite_module(op)


### PR DESCRIPTION
We deferred this change when merging #5485, it's now time to address this. This PR touches the x86 backend, will soon do the same for RISC-V.