### PR TITLE
dialects: (acc) exit_data and update OpenACC operations

### DIFF
--- a/tests/dialects/test_acc.py
+++ b/tests/dialects/test_acc.py
@@ -705,3 +705,41 @@ def test_enter_data_init_bool_shortcuts():
 
     assert isinstance(op.async_attr, UnitAttr)
     assert isinstance(op.wait_attr, UnitAttr)
+
+
+def test_exit_data_init_bool_shortcuts():
+    """Mirrors the EnterDataOp test for `ExitDataOp` plus its `finalize`
+    bool shortcut. Same parser-bypass story: bare-keyword UnitAttrs come
+    from the custom directive on parse, so the builder bool conversion
+    is only exercised from Python."""
+    devptr = acc.GetDevicePtrOp(var=create_ssa_value(MemRefType(f32, [10])))
+    op = acc.ExitDataOp(
+        data_clause_operands=[devptr],
+        async_attr=True,
+        wait_attr=True,
+        finalize=True,
+    )
+    op.verify()
+
+    assert isinstance(op.async_attr, UnitAttr)
+    assert isinstance(op.wait_attr, UnitAttr)
+    assert isinstance(op.finalize, UnitAttr)
+
+
+def test_update_init():
+    """Smoke test for `UpdateOp` — verifies operand wiring and the
+    `if_present` bool-shortcut branch (only reachable from Python; on
+    parse it lands as a UnitAttr in attr-dict)."""
+    update_dev = acc.UpdateDeviceOp(var=create_ssa_value(MemRefType(f32, [10])))
+    op = acc.UpdateOp(
+        data_clause_operands=[update_dev],
+        if_present=True,
+    )
+    op.verify()
+
+    assert len(op.data_clause_operands) == 1
+    assert op.data_clause_operands[0] is update_dev.acc_var
+    assert isinstance(op.if_present, UnitAttr)
+    assert op.if_cond is None
+    assert len(op.async_operands) == 0
+    assert len(op.wait_operands) == 0

--- a/tests/filecheck/dialects/acc/ops.mlir
+++ b/tests/filecheck/dialects/acc/ops.mlir
@@ -1562,6 +1562,115 @@ builtin.module {
   // CHECK-LABEL: func.func @enter_data_generic_roundtrip(
   // CHECK:         acc.enter_data dataOperands(%{{.*}} : memref<10xf32>)
 
+  // acc.exit_data — twin of enter_data plus a `finalize` UnitAttr. Same
+  // five-segment operand shape (if, async, wait_devnum, wait, dataOperands)
+  // and the same `OperandWithKeywordOnly` / `OperandsWithKeywordOnly`
+  // directives. `finalize` rides through `attr-dict-with-keyword`.
+  func.func @exit_data_minimal(%a : memref<10xf32>) {
+    %d = acc.getdeviceptr varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    acc.exit_data dataOperands(%d : memref<10xf32>)
+    func.return
+  }
+  // CHECK-LABEL: func.func @exit_data_minimal(
+  // CHECK:         acc.exit_data dataOperands(%{{.*}} : memref<10xf32>)
+
+  func.func @exit_data_async_finalize(%a : memref<10xf32>) {
+    %d = acc.getdeviceptr varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    acc.exit_data async dataOperands(%d : memref<10xf32>) attributes {finalize}
+    func.return
+  }
+  // CHECK-LABEL: func.func @exit_data_async_finalize(
+  // CHECK:         acc.exit_data async dataOperands(%{{.*}} : memref<10xf32>) attributes {finalize}
+
+  func.func @exit_data_async_operand(%a : memref<10xf32>, %v : i64) {
+    %d = acc.getdeviceptr varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    acc.exit_data async(%v : i64) dataOperands(%d : memref<10xf32>)
+    func.return
+  }
+  // CHECK-LABEL: func.func @exit_data_async_operand(
+  // CHECK:         acc.exit_data async(%{{.*}} : i64) dataOperands(%{{.*}} : memref<10xf32>)
+
+  func.func @exit_data_wait_bare(%a : memref<10xf32>) {
+    %d = acc.getdeviceptr varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    acc.exit_data wait dataOperands(%d : memref<10xf32>)
+    func.return
+  }
+  // CHECK-LABEL: func.func @exit_data_wait_bare(
+  // CHECK:         acc.exit_data wait dataOperands(%{{.*}} : memref<10xf32>)
+
+  func.func @exit_data_if_wait_devnum(%a : memref<10xf32>, %c : i1, %dn : i64, %w : i32) {
+    %d = acc.getdeviceptr varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    acc.exit_data if(%c) wait_devnum(%dn : i64) wait(%w : i32) dataOperands(%d : memref<10xf32>)
+    func.return
+  }
+  // CHECK-LABEL: func.func @exit_data_if_wait_devnum(
+  // CHECK:         acc.exit_data if(%{{.*}}) wait_devnum(%{{.*}} : i64) wait(%{{.*}} : i32) dataOperands(%{{.*}} : memref<10xf32>)
+
+  // Generic-form roundtrip insurance for `acc.exit_data` — same five-group
+  // operandSegmentSizes shape as enter_data plus the `finalize` UnitAttr.
+  func.func @exit_data_generic_roundtrip(%a : memref<10xf32>) {
+    %d = acc.getdeviceptr varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    "acc.exit_data"(%d) <{finalize, operandSegmentSizes = array<i32: 0, 0, 0, 0, 1>}> : (memref<10xf32>) -> ()
+    func.return
+  }
+  // CHECK-LABEL: func.func @exit_data_generic_roundtrip(
+  // CHECK:         acc.exit_data dataOperands(%{{.*}} : memref<10xf32>) attributes {finalize}
+
+  // acc.update — per-device-type async/wait shape mirroring `acc.parallel`,
+  // plus an `ifPresent` UnitAttr (no `async` / `wait` keyword-only attrs;
+  // those are encoded via `*Only` device-type arrays). Defining ops accepted
+  // for `dataOperands`: `acc.update_device`, `acc.update_host`,
+  // `acc.getdeviceptr`.
+  func.func @update_minimal(%a : memref<f32>) {
+    %d = acc.update_device varPtr(%a : memref<f32>) -> memref<f32>
+    acc.update dataOperands(%d : memref<f32>)
+    func.return
+  }
+  // CHECK-LABEL: func.func @update_minimal(
+  // CHECK:         acc.update dataOperands(%{{.*}} : memref<f32>)
+
+  func.func @update_async_bare(%a : memref<f32>) {
+    %d = acc.update_device varPtr(%a : memref<f32>) -> memref<f32>
+    acc.update async dataOperands(%d : memref<f32>)
+    func.return
+  }
+  // CHECK-LABEL: func.func @update_async_bare(
+  // CHECK:         acc.update async dataOperands(%{{.*}} : memref<f32>)
+
+  func.func @update_async_operand(%a : memref<f32>, %v : i64) {
+    %d = acc.update_device varPtr(%a : memref<f32>) -> memref<f32>
+    acc.update async(%v : i64) dataOperands(%d : memref<f32>)
+    func.return
+  }
+  // CHECK-LABEL: func.func @update_async_operand(
+  // CHECK:         acc.update async(%{{.*}} : i64) dataOperands(%{{.*}} : memref<f32>)
+
+  func.func @update_wait_devnum(%a : memref<f32>, %dn : i64, %w : i32) {
+    %d = acc.update_device varPtr(%a : memref<f32>) -> memref<f32>
+    acc.update wait({devnum: %dn : i64, %w : i32}) dataOperands(%d : memref<f32>)
+    func.return
+  }
+  // CHECK-LABEL: func.func @update_wait_devnum(
+  // CHECK:         acc.update wait({devnum: %{{.*}} : i64, %{{.*}} : i32}) dataOperands(%{{.*}} : memref<f32>)
+
+  func.func @update_if_present(%a : memref<f32>, %c : i1) {
+    %d = acc.update_device varPtr(%a : memref<f32>) -> memref<f32>
+    acc.update if(%c) dataOperands(%d : memref<f32>) attributes {ifPresent}
+    func.return
+  }
+  // CHECK-LABEL: func.func @update_if_present(
+  // CHECK:         acc.update if(%{{.*}}) dataOperands(%{{.*}} : memref<f32>) attributes {ifPresent}
+
+  // Generic-form roundtrip insurance for `acc.update` — four-segment
+  // operandSegmentSizes (if, async, wait, dataOperands).
+  func.func @update_generic_roundtrip(%a : memref<f32>) {
+    %d = acc.update_device varPtr(%a : memref<f32>) -> memref<f32>
+    "acc.update"(%d) <{operandSegmentSizes = array<i32: 0, 0, 0, 1>}> : (memref<f32>) -> ()
+    func.return
+  }
+  // CHECK-LABEL: func.func @update_generic_roundtrip(
+  // CHECK:         acc.update dataOperands(%{{.*}} : memref<f32>)
+
   // acc.terminator is the value-less generic terminator. It currently only
   // permits `acc.kernels` as a parent (per HasParent on TerminatorOp); other
   // region ops in the OpenACC dialect (acc.data, acc.host_data, …) will be

--- a/tests/filecheck/dialects/acc/ops_invalid.mlir
+++ b/tests/filecheck/dialects/acc/ops_invalid.mlir
@@ -376,3 +376,64 @@ func.func @enter_data_wait_devnum_alone(%a : memref<10xf32>, %dn : i64) {
   func.return
 }
 // CHECK: wait_devnum cannot appear without waitOperands
+
+// -----
+
+// acc.exit_data: 2.6.6 requires at least one copyout/delete/detach clause.
+func.func @exit_data_empty() {
+  acc.exit_data
+  func.return
+}
+// CHECK: at least one operand must be present in dataOperands on the exit data operation
+
+// -----
+
+// acc.exit_data: bare `async` UnitAttr and an `asyncOperand` are mutually
+// exclusive.
+func.func @exit_data_async_conflict(%a : memref<10xf32>, %v : i64) {
+  %d = acc.getdeviceptr varPtr(%a : memref<10xf32>) -> memref<10xf32>
+  "acc.exit_data"(%v, %d) <{async, operandSegmentSizes = array<i32: 0, 1, 0, 0, 1>}> : (i64, memref<10xf32>) -> ()
+  func.return
+}
+// CHECK: async attribute cannot appear with asyncOperand
+
+// -----
+
+// acc.exit_data: bare `wait` UnitAttr and `waitOperands` are mutually
+// exclusive.
+func.func @exit_data_wait_conflict(%a : memref<10xf32>, %w : i32) {
+  %d = acc.getdeviceptr varPtr(%a : memref<10xf32>) -> memref<10xf32>
+  "acc.exit_data"(%w, %d) <{wait, operandSegmentSizes = array<i32: 0, 0, 0, 1, 1>}> : (i32, memref<10xf32>) -> ()
+  func.return
+}
+// CHECK: wait attribute cannot appear with waitOperands
+
+// -----
+
+// acc.exit_data: `wait_devnum` requires `waitOperands` to be non-empty.
+func.func @exit_data_wait_devnum_alone(%a : memref<10xf32>, %dn : i64) {
+  %d = acc.getdeviceptr varPtr(%a : memref<10xf32>) -> memref<10xf32>
+  "acc.exit_data"(%dn, %d) <{operandSegmentSizes = array<i32: 0, 0, 1, 0, 1>}> : (i64, memref<10xf32>) -> ()
+  func.return
+}
+// CHECK: wait_devnum cannot appear without waitOperands
+
+// -----
+
+// acc.update: empty `dataOperands` fails the per-op verifier.
+func.func @update_empty() {
+  acc.update
+  func.return
+}
+// CHECK: at least one value must be present in dataOperands
+
+// -----
+
+// acc.update: every `dataOperands` value must be defined by an
+// `acc.update_device` / `acc.update_host` / `acc.getdeviceptr`. A bare
+// memref fails.
+func.func @update_wrong_defining_op(%a : memref<f32>) {
+  acc.update dataOperands(%a : memref<f32>)
+  func.return
+}
+// CHECK: expect data entry/exit operation or acc.getdeviceptr as defining op

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/ops.mlir
@@ -1023,4 +1023,108 @@ builtin.module {
   // CHECK:       func.func @enter_data_wait_devnum(
   // CHECK:         acc.enter_data wait_devnum(%{{.*}} : i64) wait(%{{.*}} : i32) dataOperands(%{{.*}} : memref<10xf32>)
 
+  // acc.exit_data — twin of enter_data plus a `finalize` UnitAttr. Both
+  // pretty and generic spellings round-trip through `mlir-opt`. Same
+  // five-segment operand layout (if, async, wait_devnum, wait, dataOperands).
+  func.func @exit_data_minimal(%a : memref<10xf32>) {
+    %d = acc.getdeviceptr varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    acc.exit_data dataOperands(%d : memref<10xf32>)
+    func.return
+  }
+  // CHECK:       func.func @exit_data_minimal(
+  // CHECK:         acc.exit_data dataOperands(%{{.*}} : memref<10xf32>)
+
+  func.func @exit_data_async_finalize(%a : memref<10xf32>) {
+    %d = acc.getdeviceptr varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    acc.exit_data async dataOperands(%d : memref<10xf32>) attributes {finalize}
+    func.return
+  }
+  // CHECK:       func.func @exit_data_async_finalize(
+  // CHECK:         acc.exit_data async dataOperands(%{{.*}} : memref<10xf32>) attributes {finalize}
+
+  func.func @exit_data_async_operand(%a : memref<10xf32>, %v : i64) {
+    %d = acc.getdeviceptr varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    acc.exit_data async(%v : i64) dataOperands(%d : memref<10xf32>)
+    func.return
+  }
+  // CHECK:       func.func @exit_data_async_operand(
+  // CHECK:         acc.exit_data async(%{{.*}} : i64) dataOperands(%{{.*}} : memref<10xf32>)
+
+  // Bare `wait` keyword (no operands) — UnitAttr code path through
+  // `OperandsWithKeywordOnly`. Distinct from the operand-bearing
+  // `wait_devnum`/`wait` form below.
+  func.func @exit_data_wait_bare(%a : memref<10xf32>) {
+    %d = acc.getdeviceptr varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    acc.exit_data wait dataOperands(%d : memref<10xf32>)
+    func.return
+  }
+  // CHECK:       func.func @exit_data_wait_bare(
+  // CHECK:         acc.exit_data wait dataOperands(%{{.*}} : memref<10xf32>)
+
+  func.func @exit_data_if(%a : memref<10xf32>, %c : i1) {
+    %d = acc.getdeviceptr varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    acc.exit_data if(%c) dataOperands(%d : memref<10xf32>)
+    func.return
+  }
+  // CHECK:       func.func @exit_data_if(
+  // CHECK:         acc.exit_data if(%{{.*}}) dataOperands(%{{.*}} : memref<10xf32>)
+
+  func.func @exit_data_wait_devnum(%a : memref<10xf32>, %dn : i64, %w : i32) {
+    %d = acc.getdeviceptr varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    acc.exit_data wait_devnum(%dn : i64) wait(%w : i32) dataOperands(%d : memref<10xf32>)
+    func.return
+  }
+  // CHECK:       func.func @exit_data_wait_devnum(
+  // CHECK:         acc.exit_data wait_devnum(%{{.*}} : i64) wait(%{{.*}} : i32) dataOperands(%{{.*}} : memref<10xf32>)
+
+  // acc.update — per-device-type async/wait shape mirroring `acc.parallel`,
+  // plus an `ifPresent` UnitAttr. Defining ops accepted: `acc.update_device`,
+  // `acc.update_host`, `acc.getdeviceptr`. Note that `mlir-opt`'s
+  // `verifyDeviceTypeCountMatch` segfaults if `asyncOperandsDeviceType` is
+  // not populated when there are async operands — xDSL's
+  // `DeviceTypeOperandsWithKeywordOnly` directive auto-populates it.
+  func.func @update_minimal(%a : memref<f32>) {
+    %d = acc.update_device varPtr(%a : memref<f32>) -> memref<f32>
+    acc.update dataOperands(%d : memref<f32>)
+    func.return
+  }
+  // CHECK:       func.func @update_minimal(
+  // CHECK:         acc.update dataOperands(%{{.*}} : memref<f32>)
+
+  // Bare `async` keyword on `acc.update` — distinct from `acc.exit_data async`:
+  // it lands as `asyncOnly = [#acc.device_type<none>]` (an array attr) via
+  // `DeviceTypeOperandsWithKeywordOnly`, *not* as a `UnitAttr`. This is the
+  // op-specific keyword-only path on the per-device-type async/wait shape.
+  func.func @update_async_bare(%a : memref<f32>) {
+    %d = acc.update_device varPtr(%a : memref<f32>) -> memref<f32>
+    acc.update async dataOperands(%d : memref<f32>)
+    func.return
+  }
+  // CHECK:       func.func @update_async_bare(
+  // CHECK:         acc.update async dataOperands(%{{.*}} : memref<f32>)
+
+  func.func @update_async_operand(%a : memref<f32>, %v : i64) {
+    %d = acc.update_device varPtr(%a : memref<f32>) -> memref<f32>
+    acc.update async(%v : i64) dataOperands(%d : memref<f32>)
+    func.return
+  }
+  // CHECK:       func.func @update_async_operand(
+  // CHECK:         acc.update async(%{{.*}} : i64) dataOperands(%{{.*}} : memref<f32>)
+
+  func.func @update_wait_devnum(%a : memref<f32>, %dn : i64, %w : i32) {
+    %d = acc.update_device varPtr(%a : memref<f32>) -> memref<f32>
+    acc.update wait({devnum: %dn : i64, %w : i32}) dataOperands(%d : memref<f32>)
+    func.return
+  }
+  // CHECK:       func.func @update_wait_devnum(
+  // CHECK:         acc.update wait({devnum: %{{.*}} : i64, %{{.*}} : i32}) dataOperands(%{{.*}} : memref<f32>)
+
+  func.func @update_if_present(%a : memref<f32>, %c : i1) {
+    %d = acc.update_device varPtr(%a : memref<f32>) -> memref<f32>
+    acc.update if(%c) dataOperands(%d : memref<f32>) attributes {ifPresent}
+    func.return
+  }
+  // CHECK:       func.func @update_if_present(
+  // CHECK:         acc.update if(%{{.*}}) dataOperands(%{{.*}} : memref<f32>) attributes {ifPresent}
+
 }

--- a/xdsl/dialects/acc.py
+++ b/xdsl/dialects/acc.py
@@ -2461,13 +2461,19 @@ class DetachOp(_DataExitOperationNoVarPtr):
 
 
 # ---------------------------------------------------------------------------
-# Standalone unstructured data-movement ops: acc.enter_data.
+# Standalone unstructured data-movement ops: acc.enter_data, acc.exit_data,
+# acc.update.
 # ---------------------------------------------------------------------------
 #
-# `enter_data` has no region. It carries a single optional `asyncOperand` (no
-# per-device-type array), a single optional `waitDevnum`, variadic
-# `waitOperands`, and `dataClauseOperands`, plus `async` / `wait` UnitAttrs
-# that mirror the bare-keyword spellings.
+# None of the three carry a region. `enter_data` and `exit_data` share the
+# same operand shape: a single optional `asyncOperand` (no per-device-type
+# array), a single optional `waitDevnum`, variadic `waitOperands`, and
+# `dataClauseOperands`, plus `async` / `wait` UnitAttrs that mirror the
+# bare-keyword spellings; `exit_data` additionally carries a `finalize`
+# UnitAttr. `acc.update` instead matches the per-device-type async/wait
+# shape used by `acc.parallel` (variadic `asyncOperands` /
+# `waitOperands` paired with `*DeviceType` / `*Segments` / `hasWaitDevnum` /
+# `*Only` arrays) and carries an `ifPresent` UnitAttr.
 
 
 @irdl_op_definition
@@ -2561,6 +2567,218 @@ class EnterDataOp(IRDLOperation):
         for operand in self.data_clause_operands:
             if not isinstance(operand.owner, (AttachOp, CreateOp, CopyinOp)):
                 raise VerifyException("expect data entry operation as defining op")
+
+
+@irdl_op_definition
+class ExitDataOp(IRDLOperation):
+    """
+    Implementation of upstream acc.exit_data — the OpenACC exit data directive.
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/OpenACCDialect/#accexit_data-accexitdataop).
+    """
+
+    name = "acc.exit_data"
+
+    if_cond = opt_operand_def(I1)
+    async_operand = opt_operand_def(IntegerType | IndexType)
+    wait_devnum = opt_operand_def(IntegerType | IndexType)
+    wait_operands = var_operand_def(IntegerType | IndexType)
+    data_clause_operands = var_operand_def()
+
+    async_attr = opt_prop_def(UnitAttr, prop_name="async")
+    wait_attr = opt_prop_def(UnitAttr, prop_name="wait")
+    finalize = opt_prop_def(UnitAttr, prop_name="finalize")
+
+    irdl_options = (
+        AttrSizedOperandSegments(as_property=True),
+        ParsePropInAttrDict(),
+    )
+
+    custom_directives = (
+        OperandWithKeywordOnly,
+        OperandsWithKeywordOnly,
+    )
+
+    assembly_format = (
+        "(`if` `(` $if_cond^ `)`)?"
+        " (`async` custom<OperandWithKeywordOnly>($async_operand,"
+        " type($async_operand), $async)^)?"
+        " (`wait_devnum` `(` $wait_devnum^ `:` type($wait_devnum) `)`)?"
+        " (`wait` custom<OperandsWithKeywordOnly>($wait_operands,"
+        " type($wait_operands), $wait)^)?"
+        " (`dataOperands` `(` $data_clause_operands^ `:`"
+        " type($data_clause_operands) `)`)?"
+        " attr-dict-with-keyword"
+    )
+
+    def __init__(
+        self,
+        *,
+        if_cond: SSAValue | Operation | None = None,
+        async_operand: SSAValue | Operation | None = None,
+        wait_devnum: SSAValue | Operation | None = None,
+        wait_operands: Sequence[SSAValue | Operation] = (),
+        data_clause_operands: Sequence[SSAValue | Operation] = (),
+        async_attr: UnitAttr | bool = False,
+        wait_attr: UnitAttr | bool = False,
+        finalize: UnitAttr | bool = False,
+    ) -> None:
+        async_prop: UnitAttr | None = (
+            (UnitAttr() if async_attr else None)
+            if isinstance(async_attr, bool)
+            else async_attr
+        )
+        wait_prop: UnitAttr | None = (
+            (UnitAttr() if wait_attr else None)
+            if isinstance(wait_attr, bool)
+            else wait_attr
+        )
+        finalize_prop: UnitAttr | None = (
+            (UnitAttr() if finalize else None)
+            if isinstance(finalize, bool)
+            else finalize
+        )
+        super().__init__(
+            operands=[
+                [if_cond] if if_cond is not None else [],
+                [async_operand] if async_operand is not None else [],
+                [wait_devnum] if wait_devnum is not None else [],
+                wait_operands,
+                data_clause_operands,
+            ],
+            properties={
+                "async": async_prop,
+                "wait": wait_prop,
+                "finalize": finalize_prop,
+            },
+        )
+
+    def verify_(self) -> None:
+        # Mirrors `acc::ExitDataOp::verify` (2.6.6 Data Exit Directive).
+        # Note that, unlike `EnterDataOp`, upstream does *not* restrict the
+        # set of defining ops for `dataClauseOperands` here — the data-exit
+        # family is more permissive (copyout / delete / detach / update_host
+        # / getdeviceptr all flow in).
+        if not self.data_clause_operands:
+            raise VerifyException(
+                "at least one operand must be present in dataOperands on "
+                "the exit data operation"
+            )
+        if self.async_operand is not None and self.async_attr is not None:
+            raise VerifyException("async attribute cannot appear with asyncOperand")
+        if self.wait_operands and self.wait_attr is not None:
+            raise VerifyException("wait attribute cannot appear with waitOperands")
+        if self.wait_devnum is not None and not self.wait_operands:
+            raise VerifyException("wait_devnum cannot appear without waitOperands")
+
+
+@irdl_op_definition
+class UpdateOp(IRDLOperation):
+    """
+    Implementation of upstream acc.update — the OpenACC update executable
+    directive.
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/OpenACCDialect/#accupdate-accupdateop).
+
+    Unlike `acc.enter_data` / `acc.exit_data`, `acc.update` carries the same
+    per-device-type async/wait operand+attribute shape as `acc.parallel`
+    (variadic `asyncOperands`/`waitOperands` paired with `*DeviceType`,
+    `*Segments`, `hasWaitDevnum`, and `*Only` arrays). It additionally
+    carries an `ifPresent` UnitAttr but no `async` / `wait` keyword-only
+    UnitAttrs (those are encoded via the `*Only` device-type arrays).
+    """
+
+    name = "acc.update"
+
+    if_cond = opt_operand_def(I1)
+    async_operands = var_operand_def(IntegerType | IndexType)
+    wait_operands = var_operand_def(IntegerType | IndexType)
+    data_clause_operands = var_operand_def()
+
+    async_operands_device_type = opt_prop_def(
+        ArrayAttr[DeviceTypeAttr], prop_name="asyncOperandsDeviceType"
+    )
+    async_only = opt_prop_def(ArrayAttr[DeviceTypeAttr], prop_name="asyncOnly")
+    wait_operands_device_type = opt_prop_def(
+        ArrayAttr[DeviceTypeAttr], prop_name="waitOperandsDeviceType"
+    )
+    wait_operands_segments = opt_prop_def(
+        DenseArrayBase.constr(IntegerType(32)), prop_name="waitOperandsSegments"
+    )
+    has_wait_devnum = opt_prop_def(ArrayAttr[BoolAttr], prop_name="hasWaitDevnum")
+    wait_only = opt_prop_def(ArrayAttr[DeviceTypeAttr], prop_name="waitOnly")
+    if_present = opt_prop_def(UnitAttr, prop_name="ifPresent")
+
+    irdl_options = (
+        AttrSizedOperandSegments(as_property=True),
+        ParsePropInAttrDict(),
+    )
+
+    custom_directives = (
+        DeviceTypeOperandsWithKeywordOnly,
+        WaitClause,
+    )
+
+    assembly_format = (
+        "(`if` `(` $if_cond^ `)`)?"
+        " (`async` custom<DeviceTypeOperandsWithKeywordOnly>($async_operands,"
+        " type($async_operands), $asyncOperandsDeviceType, $asyncOnly)^)?"
+        " (`wait` custom<WaitClause>($wait_operands, type($wait_operands),"
+        " $waitOperandsDeviceType, $waitOperandsSegments, $hasWaitDevnum,"
+        " $waitOnly)^)?"
+        " (`dataOperands` `(` $data_clause_operands^ `:`"
+        " type($data_clause_operands) `)`)?"
+        " attr-dict-with-keyword"
+    )
+
+    def __init__(
+        self,
+        *,
+        if_cond: SSAValue | Operation | None = None,
+        async_operands: Sequence[SSAValue | Operation] = (),
+        wait_operands: Sequence[SSAValue | Operation] = (),
+        data_clause_operands: Sequence[SSAValue | Operation] = (),
+        async_operands_device_type: ArrayAttr[DeviceTypeAttr] | None = None,
+        async_only: ArrayAttr[DeviceTypeAttr] | None = None,
+        wait_operands_device_type: ArrayAttr[DeviceTypeAttr] | None = None,
+        wait_operands_segments: DenseArrayBase | None = None,
+        has_wait_devnum: ArrayAttr[BoolAttr] | None = None,
+        wait_only: ArrayAttr[DeviceTypeAttr] | None = None,
+        if_present: UnitAttr | bool = False,
+    ) -> None:
+        if_present_prop: UnitAttr | None = (
+            (UnitAttr() if if_present else None)
+            if isinstance(if_present, bool)
+            else if_present
+        )
+        super().__init__(
+            operands=[
+                [if_cond] if if_cond is not None else [],
+                async_operands,
+                wait_operands,
+                data_clause_operands,
+            ],
+            properties={
+                "asyncOperandsDeviceType": async_operands_device_type,
+                "asyncOnly": async_only,
+                "waitOperandsDeviceType": wait_operands_device_type,
+                "waitOperandsSegments": wait_operands_segments,
+                "hasWaitDevnum": has_wait_devnum,
+                "waitOnly": wait_only,
+                "ifPresent": if_present_prop,
+            },
+        )
+
+    def verify_(self) -> None:
+        # Mirrors `acc::UpdateOp::verify`.
+        if not self.data_clause_operands:
+            raise VerifyException("at least one value must be present in dataOperands")
+        for operand in self.data_clause_operands:
+            if not isinstance(
+                operand.owner, (UpdateDeviceOp, UpdateHostOp, GetDevicePtrOp)
+            ):
+                raise VerifyException(
+                    "expect data entry/exit operation or acc.getdeviceptr "
+                    "as defining op"
+                )
 
 
 @irdl_op_definition
@@ -3036,6 +3254,8 @@ ACC = Dialect(
         DeleteOp,
         DetachOp,
         EnterDataOp,
+        ExitDataOp,
+        UpdateOp,
         PrivateRecipeOp,
         FirstprivateRecipeOp,
         ReductionRecipeOp,


### PR DESCRIPTION
This PR adds the exit_data and update OpenACC operations, which completes support in the dialect for unstructured data movement. It leverages the custom assembly syntax added in the previous PR.