### PR TITLE
dialects: (acc) Declare family of operations

### DIFF
--- a/tests/dialects/test_acc.py
+++ b/tests/dialects/test_acc.py
@@ -743,3 +743,28 @@ def test_update_init():
     assert op.if_cond is None
     assert len(op.async_operands) == 0
     assert len(op.wait_operands) == 0
+
+
+def test_declare_family_init_bodies():
+    """The three declare ops' `__init__` bodies are only reachable from
+    Python — the parser builds via IRDL `Operation.create()` and bypasses
+    them. Smoke-test all three to keep them covered. The non-trivial
+    branches: `DeclareExitOp` packing the optional `token` into a 0/1-list
+    (covered by both `token=...` and `token=None` calls), and `DeclareOp`
+    accepting the region keyword-only."""
+    var = create_ssa_value(MemRefType(f32, [10]))
+    copyin = acc.CopyinOp(var=var)
+
+    enter = acc.DeclareEnterOp(data_clause_operands=[copyin])
+    assert isinstance(enter.token.type, acc.DeclareTokenType)
+
+    exit_with_token = acc.DeclareExitOp(
+        token=enter.token, data_clause_operands=[copyin]
+    )
+    assert exit_with_token.token is enter.token
+
+    exit_no_token = acc.DeclareExitOp(data_clause_operands=[copyin])
+    assert exit_no_token.token is None
+
+    decl = acc.DeclareOp(region=Region(Block()), data_clause_operands=[copyin])
+    assert len(decl.region.blocks) == 1

--- a/tests/filecheck/dialects/acc/ops.mlir
+++ b/tests/filecheck/dialects/acc/ops.mlir
@@ -1697,4 +1697,89 @@ builtin.module {
   // CHECK-NEXT:    acc.kernels {
   // CHECK-NEXT:      acc.terminator
   // CHECK-NEXT:    }
+
+  // acc.declare_enter — entry to an implicit declare data region. Yields
+  // an `!acc.declare_token` that may be threaded into the matching
+  // `acc.declare_exit`. Defining ops accepted for `dataOperands`: any of
+  // copyin / copyout / create / deviceptr / getdeviceptr / present /
+  // declare_device_resident / declare_link (per upstream's
+  // `checkDeclareOperands` helper).
+  func.func @declare_enter_basic(%a : memref<f32>) {
+    %0 = acc.copyin varPtr(%a : memref<f32>) -> memref<f32>
+    %t = acc.declare_enter dataOperands(%0 : memref<f32>)
+    acc.declare_exit token(%t) dataOperands(%0 : memref<f32>)
+    func.return
+  }
+  // CHECK-LABEL: func.func @declare_enter_basic(
+  // CHECK:         %{{.*}} = acc.copyin varPtr(%{{.*}} : memref<f32>) -> memref<f32>
+  // CHECK-NEXT:    %{{.*}} = acc.declare_enter dataOperands(%{{.*}} : memref<f32>)
+  // CHECK-NEXT:    acc.declare_exit token(%{{.*}}) dataOperands(%{{.*}} : memref<f32>)
+
+  // acc.declare_exit — when a `token` is present, `dataOperands` may be
+  // empty (mirrors upstream's `requireAtLeastOneOperand=false` branch).
+  func.func @declare_exit_token_only(%a : memref<f32>) {
+    %0 = acc.create varPtr(%a : memref<f32>) -> memref<f32>
+    %t = acc.declare_enter dataOperands(%0 : memref<f32>)
+    acc.declare_exit token(%t)
+    func.return
+  }
+  // CHECK-LABEL: func.func @declare_exit_token_only(
+  // CHECK:         acc.declare_exit token(%{{.*}})
+
+  // acc.declare_exit — without a `token`, only `dataOperands` is given.
+  // Defining ops accepted include `acc.getdeviceptr` for device-resident
+  // tear-down (per upstream's example).
+  func.func @declare_exit_no_token(%a : memref<f32>) {
+    %0 = acc.getdeviceptr varPtr(%a : memref<f32>) -> memref<f32>
+    acc.declare_exit dataOperands(%0 : memref<f32>)
+    func.return
+  }
+  // CHECK-LABEL: func.func @declare_exit_no_token(
+  // CHECK:         acc.declare_exit dataOperands(%{{.*}} : memref<f32>)
+
+  // acc.declare — structured declare region (no implicit terminator). The
+  // body is just the implicit data region's lifetime; here it's empty.
+  func.func @declare_region(%a : memref<f32>) {
+    %0 = acc.create varPtr(%a : memref<f32>) -> memref<f32>
+    acc.declare dataOperands(%0 : memref<f32>) {
+    }
+    func.return
+  }
+  // CHECK-LABEL: func.func @declare_region(
+  // CHECK:         acc.declare dataOperands(%{{.*}} : memref<f32>) {
+  // CHECK-NEXT:    }
+
+  // Generic-form roundtrip insurance for `acc.declare_enter` plus its
+  // typed token result.
+  func.func @declare_enter_generic_roundtrip_retained(%a : memref<f32>) {
+    %0 = "acc.copyin"(%a) <{varType = f32, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (memref<f32>) -> memref<f32>
+    %t = "acc.declare_enter"(%0) : (memref<f32>) -> !acc.declare_token
+    "acc.declare_exit"(%t) <{operandSegmentSizes = array<i32: 1, 0>}> : (!acc.declare_token) -> ()
+    func.return
+  }
+  // CHECK-LABEL: func.func @declare_enter_generic_roundtrip_retained(
+  // CHECK:         %{{.*}} = acc.declare_enter dataOperands(%{{.*}} : memref<f32>)
+  // CHECK-NEXT:    acc.declare_exit token(%{{.*}})
+
+  // Generic-form roundtrip insurance for `acc.declare_exit`'s
+  // AttrSizedOperandSegments — the [0, 1] segments shape (no token,
+  // single dataOperand).
+  func.func @declare_exit_generic_roundtrip_retained(%a : memref<f32>) {
+    %0 = acc.getdeviceptr varPtr(%a : memref<f32>) -> memref<f32>
+    "acc.declare_exit"(%0) <{operandSegmentSizes = array<i32: 0, 1>}> : (memref<f32>) -> ()
+    func.return
+  }
+  // CHECK-LABEL: func.func @declare_exit_generic_roundtrip_retained(
+  // CHECK:         acc.declare_exit dataOperands(%{{.*}} : memref<f32>)
+
+  // Generic-form roundtrip insurance for `acc.declare`.
+  func.func @declare_generic_roundtrip_retained(%a : memref<f32>) {
+    %0 = acc.create varPtr(%a : memref<f32>) -> memref<f32>
+    "acc.declare"(%0) ({
+    }) : (memref<f32>) -> ()
+    func.return
+  }
+  // CHECK-LABEL: func.func @declare_generic_roundtrip_retained(
+  // CHECK:         acc.declare dataOperands(%{{.*}} : memref<f32>) {
+  // CHECK-NEXT:    }
 }

--- a/tests/filecheck/dialects/acc/ops_invalid.mlir
+++ b/tests/filecheck/dialects/acc/ops_invalid.mlir
@@ -437,3 +437,59 @@ func.func @update_wrong_defining_op(%a : memref<f32>) {
   func.return
 }
 // CHECK: expect data entry/exit operation or acc.getdeviceptr as defining op
+
+// -----
+
+// acc.declare_enter: empty `dataOperands` fails the per-op verifier
+// (mirrors upstream's `checkDeclareOperands(requireAtLeastOneOperand=true)`).
+func.func @declare_enter_empty() {
+  %t = acc.declare_enter
+  acc.declare_exit token(%t)
+  func.return
+}
+// CHECK: at least one operand must appear on the declare operation
+
+// -----
+
+// acc.declare_enter: every `dataOperands` value must be defined by one
+// of the eight allowed data-clause ops (per `checkDeclareOperands`). A
+// bare block argument fails.
+func.func @declare_enter_wrong_defining_op(%a : memref<f32>) {
+  %t = acc.declare_enter dataOperands(%a : memref<f32>)
+  acc.declare_exit token(%t) dataOperands(%a : memref<f32>)
+  func.return
+}
+// CHECK: expect valid declare data entry operation or acc.getdeviceptr as defining op
+
+// -----
+
+// acc.declare_exit without a `token`: empty `dataOperands` fails. The
+// `token`-bearing form would relax this — covered by the positive
+// roundtrip `declare_exit_token_only` in `ops.mlir`.
+func.func @declare_exit_empty_no_token() {
+  acc.declare_exit
+  func.return
+}
+// CHECK: at least one operand must appear on the declare operation
+
+// -----
+
+// acc.declare: empty `dataOperands` fails (the structured declare always
+// requires at least one data operand to scope the implicit data region).
+func.func @declare_empty() {
+  acc.declare {
+  }
+  func.return
+}
+// CHECK: at least one operand must appear on the declare operation
+
+// -----
+
+// acc.declare: every `dataOperands` value must be defined by one of the
+// eight allowed data-clause ops; a bare block-argument memref fails.
+func.func @declare_wrong_defining_op(%a : memref<f32>) {
+  acc.declare dataOperands(%a : memref<f32>) {
+  }
+  func.return
+}
+// CHECK: expect valid declare data entry operation or acc.getdeviceptr as defining op

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/ops.mlir
@@ -1127,4 +1127,54 @@ builtin.module {
   // CHECK:       func.func @update_if_present(
   // CHECK:         acc.update if(%{{.*}}) dataOperands(%{{.*}} : memref<f32>) attributes {ifPresent}
 
+  // acc.declare_enter / acc.declare_exit / acc.declare — declare family.
+  // Defining ops accepted for `dataOperands`: copyin / copyout / create /
+  // deviceptr / getdeviceptr / present / declare_device_resident /
+  // declare_link (per upstream's `checkDeclareOperands` helper).
+  func.func @declare_enter_basic(%a : memref<f32>) {
+    %0 = acc.copyin varPtr(%a : memref<f32>) -> memref<f32>
+    %t = acc.declare_enter dataOperands(%0 : memref<f32>)
+    acc.declare_exit token(%t) dataOperands(%0 : memref<f32>)
+    func.return
+  }
+  // CHECK:       func.func @declare_enter_basic(
+  // CHECK:         %[[CI:.*]] = acc.copyin varPtr(%{{.*}} : memref<f32>) -> memref<f32>
+  // CHECK-NEXT:    %[[T:.*]] = acc.declare_enter dataOperands(%[[CI]] : memref<f32>)
+  // CHECK-NEXT:    acc.declare_exit token(%[[T]]) dataOperands(%[[CI]] : memref<f32>)
+
+  // acc.declare_exit's `token`-bearing form relaxes the at-least-one
+  // operand requirement — proves the optional-operand AttrSizedOperandSegments
+  // round-trips cleanly through mlir-opt's parser.
+  func.func @declare_exit_token_only(%a : memref<f32>) {
+    %0 = acc.create varPtr(%a : memref<f32>) -> memref<f32>
+    %t = acc.declare_enter dataOperands(%0 : memref<f32>)
+    acc.declare_exit token(%t)
+    func.return
+  }
+  // CHECK:       func.func @declare_exit_token_only(
+  // CHECK:         acc.declare_exit token(%{{.*}})
+
+  // acc.declare_exit without a `token`: only `dataOperands`. Mirrors
+  // upstream's `getdeviceptr` example for device-resident tear-down.
+  func.func @declare_exit_no_token(%a : memref<f32>) {
+    %0 = acc.getdeviceptr varPtr(%a : memref<f32>) -> memref<f32>
+    acc.declare_exit dataOperands(%0 : memref<f32>)
+    func.return
+  }
+  // CHECK:       func.func @declare_exit_no_token(
+  // CHECK:         acc.declare_exit dataOperands(%{{.*}} : memref<f32>)
+
+  // acc.declare — structured declare region. The body is the implicit
+  // data region's lifetime (here empty; AnyRegion has no implicit
+  // terminator).
+  func.func @declare_region(%a : memref<f32>) {
+    %0 = acc.create varPtr(%a : memref<f32>) -> memref<f32>
+    acc.declare dataOperands(%0 : memref<f32>) {
+    }
+    func.return
+  }
+  // CHECK:       func.func @declare_region(
+  // CHECK:         acc.declare dataOperands(%{{.*}} : memref<f32>) {
+  // CHECK-NEXT:    }
+
 }

--- a/xdsl/dialects/acc.py
+++ b/xdsl/dialects/acc.py
@@ -75,6 +75,7 @@ from xdsl.traits import (
     IsolatedFromAbove,
     IsTerminator,
     NoMemoryEffect,
+    NoTerminator,
     RecursiveMemoryEffect,
     SingleBlockImplicitTerminator,
     SymbolOpInterface,
@@ -294,6 +295,17 @@ class DataBoundsType(ParametrizedAttribute, TypeAttribute):
     """
 
     name = "acc.data_bounds_ty"
+
+
+@irdl_attr_definition
+class DeclareTokenType(ParametrizedAttribute, TypeAttribute):
+    """
+    Type returned by `acc.declare_enter` and consumed by `acc.declare_exit`
+    to represent an implicit OpenACC data region. See upstream
+    `!acc.declare_token`.
+    """
+
+    name = "acc.declare_token"
 
 
 def _parse_device_type_attr(parser: Parser) -> DeviceTypeAttr:
@@ -2781,6 +2793,174 @@ class UpdateOp(IRDLOperation):
                 )
 
 
+# ---------------------------------------------------------------------------
+# Declare family
+# ---------------------------------------------------------------------------
+#
+# `acc.declare_enter`, `acc.declare_exit`, and `acc.declare` all carry a
+# variadic `dataClauseOperands` and validate it the same way: every operand
+# must be defined by one of the eight data ops listed in upstream's
+# `checkDeclareOperands` helper. The diagnostic strings ("at least one
+# operand must appear on the declare operation" / "expect valid declare data
+# entry operation or acc.getdeviceptr as defining op") are copied verbatim
+# from `mlir/lib/Dialect/OpenACC/IR/OpenACC.cpp` so external tooling and
+# upstream tests round-trip identically.
+
+
+def _verify_declare_operands(
+    operands: Sequence[SSAValue], *, require_at_least_one: bool = True
+) -> None:
+    """Mirror of upstream's `checkDeclareOperands` template helper.
+
+    `acc.declare_exit` passes ``require_at_least_one=False`` when a `token`
+    is present (the token already pins the implicit data region — operands
+    are then redundant); every other caller requires at least one operand.
+    """
+    if not operands and require_at_least_one:
+        raise VerifyException(
+            "at least one operand must appear on the declare operation"
+        )
+    for operand in operands:
+        if not isinstance(
+            operand.owner,
+            (
+                CopyinOp,
+                CopyoutOp,
+                CreateOp,
+                DevicePtrOp,
+                GetDevicePtrOp,
+                PresentOp,
+                DeclareDeviceResidentOp,
+                DeclareLinkOp,
+            ),
+        ):
+            raise VerifyException(
+                "expect valid declare data entry operation or "
+                "acc.getdeviceptr as defining op"
+            )
+
+
+@irdl_op_definition
+class DeclareEnterOp(IRDLOperation):
+    """
+    Implementation of upstream acc.declare_enter — entry to an implicit
+    OpenACC declare data region. Yields an `!acc.declare_token` that can
+    optionally be threaded into the matching `acc.declare_exit`.
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/OpenACCDialect/#accdeclare_enter-accdeclareenterop).
+    """
+
+    name = "acc.declare_enter"
+
+    data_clause_operands = var_operand_def()
+
+    token = result_def(DeclareTokenType)
+
+    assembly_format = (
+        "(`dataOperands` `(` $data_clause_operands^ `:`"
+        " type($data_clause_operands) `)`)?"
+        " attr-dict-with-keyword"
+    )
+
+    def __init__(
+        self,
+        *,
+        data_clause_operands: Sequence[SSAValue | Operation] = (),
+    ) -> None:
+        super().__init__(
+            operands=[data_clause_operands],
+            result_types=[DeclareTokenType()],
+        )
+
+    def verify_(self) -> None:
+        _verify_declare_operands(self.data_clause_operands)
+
+
+@irdl_op_definition
+class DeclareExitOp(IRDLOperation):
+    """
+    Implementation of upstream acc.declare_exit — exit from an implicit
+    OpenACC declare data region, optionally consuming the
+    `!acc.declare_token` produced by the matching `acc.declare_enter`.
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/OpenACCDialect/#accdeclare_exit-accdeclareexitop).
+    """
+
+    name = "acc.declare_exit"
+
+    token = opt_operand_def(DeclareTokenType)
+    data_clause_operands = var_operand_def()
+
+    irdl_options = (
+        AttrSizedOperandSegments(as_property=True),
+        ParsePropInAttrDict(),
+    )
+
+    assembly_format = (
+        "(`token` `(` $token^ `)`)?"
+        " (`dataOperands` `(` $data_clause_operands^ `:`"
+        " type($data_clause_operands) `)`)?"
+        " attr-dict-with-keyword"
+    )
+
+    def __init__(
+        self,
+        *,
+        token: SSAValue | Operation | None = None,
+        data_clause_operands: Sequence[SSAValue | Operation] = (),
+    ) -> None:
+        super().__init__(
+            operands=[
+                [token] if token is not None else [],
+                data_clause_operands,
+            ],
+        )
+
+    def verify_(self) -> None:
+        # Upstream `acc::DeclareExitOp::verify`: the `token`-bearing form
+        # relaxes the at-least-one operand requirement.
+        _verify_declare_operands(
+            self.data_clause_operands,
+            require_at_least_one=self.token is None,
+        )
+
+
+@irdl_op_definition
+class DeclareOp(IRDLOperation):
+    """
+    Implementation of upstream acc.declare — the structured declare region
+    inside a function/subroutine. Body is an arbitrary single-block region
+    (no terminator) holding the implicit data region's lifetime.
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/OpenACCDialect/#accdeclare-accdeclareop).
+    """
+
+    name = "acc.declare"
+
+    data_clause_operands = var_operand_def()
+
+    region = region_def()
+
+    assembly_format = (
+        "(`dataOperands` `(` $data_clause_operands^ `:`"
+        " type($data_clause_operands) `)`)?"
+        " $region attr-dict-with-keyword"
+    )
+
+    traits = traits_def(NoTerminator(), RecursiveMemoryEffect())
+
+    def __init__(
+        self,
+        *,
+        region: Region,
+        data_clause_operands: Sequence[SSAValue | Operation] = (),
+    ) -> None:
+        super().__init__(
+            operands=[data_clause_operands],
+            regions=[region],
+        )
+
+    def verify_(self) -> None:
+        _verify_declare_operands(self.data_clause_operands)
+
+
 @irdl_op_definition
 class DataBoundsOp(IRDLOperation):
     """
@@ -3256,6 +3436,9 @@ ACC = Dialect(
         EnterDataOp,
         ExitDataOp,
         UpdateOp,
+        DeclareEnterOp,
+        DeclareExitOp,
+        DeclareOp,
         PrivateRecipeOp,
         FirstprivateRecipeOp,
         ReductionRecipeOp,
@@ -3270,5 +3453,6 @@ ACC = Dialect(
         VariableTypeCategoryAttr,
         ReductionOpKindAttr,
         DataBoundsType,
+        DeclareTokenType,
     ],
 )


### PR DESCRIPTION
This PR adds the declare family of OpenACC operations, declare, declare_enter and declare_exit along with the token attribute (used to track declarations). These operations are all very similar and all share the same verification logic which I break out into a separate function