### PR TITLE
backend: add API to declare registers to exclude for regalloc

### DIFF
--- a/tests/dialects/test_riscv_snitch.py
+++ b/tests/dialects/test_riscv_snitch.py
@@ -3,7 +3,7 @@ import pytest
 from xdsl import ir, irdl
 from xdsl.backend.register_type import RegisterAllocatedMemoryEffect
 from xdsl.builder import ImplicitBuilder
-from xdsl.dialects import riscv, riscv_snitch
+from xdsl.dialects import riscv, riscv_snitch, snitch
 from xdsl.dialects.riscv import RISCVInstruction
 from xdsl.traits import (
     EffectInstance,
@@ -85,3 +85,26 @@ def test_frep_recursive_effects():
 
     assert get_effects(inner_op) == {EffectInstance(MemoryEffectKind.READ)}
     assert get_effects(frep_op) == {EffectInstance(MemoryEffectKind.READ)}
+
+
+def test_exclude_registers():
+    read_op = riscv_snitch.ReadOp(
+        create_ssa_value(snitch.ReadableStreamType(riscv.Registers.A0))
+    )
+    read_op.verify()
+    assert set(read_op.iter_excluded_registers()) == {
+        riscv.Registers.FT0,
+        riscv.Registers.FT1,
+        riscv.Registers.FT2,
+    }
+
+    write_op = riscv_snitch.WriteOp(
+        create_ssa_value(riscv.Registers.A0),
+        create_ssa_value(snitch.WritableStreamType(riscv.Registers.A0)),
+    )
+    read_op.verify()
+    assert set(write_op.iter_excluded_registers()) == {
+        riscv.Registers.FT0,
+        riscv.Registers.FT1,
+        riscv.Registers.FT2,
+    }

--- a/tests/dialects/test_riscv_snitch.py
+++ b/tests/dialects/test_riscv_snitch.py
@@ -102,7 +102,7 @@ def test_exclude_registers():
         create_ssa_value(riscv.Registers.A0),
         create_ssa_value(snitch.WritableStreamType(riscv.Registers.A0)),
     )
-    read_op.verify()
+    write_op.verify()
     assert set(write_op.iter_excluded_registers()) == {
         riscv.Registers.FT0,
         riscv.Registers.FT1,

--- a/tests/filecheck/backend/riscv/register-allocation/preallocated.mlir
+++ b/tests/filecheck/backend/riscv/register-allocation/preallocated.mlir
@@ -11,7 +11,7 @@ riscv_func.func @main() {
 }
 
 // LIVE-BNAIVE:       builtin.module {
-// LIVE-BNAIVE-NEXT:    riscv.comment {comment = "Regalloc stats: {\"preallocated_float\": [\"ft0\"], \"preallocated_int\": [\"t0\"], \"allocated_float\": [\"ft0\", \"ft1\"], \"allocated_int\": [\"t0\", \"t1\"]}"} : () -> ()
+// LIVE-BNAIVE-NEXT:    riscv.comment {comment = "Regalloc stats: {\"preallocated_float\": [\"ft0\"], \"preallocated_int\": [\"t0\"], \"excluded_float\": [], \"excluded_int\": [], \"allocated_float\": [\"ft0\", \"ft1\"], \"allocated_int\": [\"t0\", \"t1\"]}"} : () -> ()
 // LIVE-BNAIVE-NEXT:    riscv_func.func @main() {
 // LIVE-BNAIVE-NEXT:      %0 = rv32.li 6 : !riscv.reg<t1>
 // LIVE-BNAIVE-NEXT:      %1 = rv32.li 5 : !riscv.reg<t0>

--- a/tests/filecheck/projects/riscv-backend-paper/bottom_up_f32.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/bottom_up_f32.mlir
@@ -20,7 +20,7 @@ func.func public @ssum(
   func.return
 }
 
-// CHECK:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1", "ft2"], "preallocated_int": ["a0", "a1", "a2", "zero"], "allocated_float": ["ft0", "ft1", "ft2"], "allocated_int": ["a0", "a1", "a2", "t0", "t1", "t2", "t3", "zero"]}
+// CHECK:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1", "ft2"], "preallocated_int": ["a0", "a1", "a2", "zero"], "excluded_float": ["ft0", "ft1", "ft2"], "excluded_int": [], "allocated_float": ["ft0", "ft1", "ft2"], "allocated_int": ["a0", "a1", "a2", "t0", "t1", "t2", "t3", "zero"]}
 // CHECK-NEXT:  .text
 // CHECK-NEXT:  .globl ssum
 // CHECK-NEXT:  .p2align 2
@@ -79,7 +79,7 @@ func.func public @pooling_nchw_max_d1_s2_3x3(
     func.return
   }
 
-// CHECK-NEXT:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1", "ft2"], "preallocated_int": ["a0", "a1", "zero"], "allocated_float": ["ft0", "ft1", "ft3", "ft4", "ft5", "ft6", "ft7"], "allocated_int": ["a0", "a1", "t0", "t1", "t2", "t3", "t4", "t5", "t6", "zero"]}
+// CHECK-NEXT:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1"], "preallocated_int": ["a0", "a1", "zero"], "excluded_float": ["ft0", "ft1", "ft2"], "excluded_int": [], "allocated_float": ["ft0", "ft1", "ft3", "ft4", "ft5", "ft6", "ft7"], "allocated_int": ["a0", "a1", "t0", "t1", "t2", "t3", "t4", "t5", "t6", "zero"]}
 // CHECK-NEXT:  .globl pooling_nchw_max_d1_s2_3x3
 // CHECK-NEXT:  .p2align 2
 // CHECK-NEXT:  pooling_nchw_max_d1_s2_3x3:
@@ -182,7 +182,7 @@ func.func public @pooling_nchw_max_d1_s2_3x3(
     }
   }
 
-// CHECK-NEXT:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1", "ft2"], "preallocated_int": ["a0", "a1", "zero"], "allocated_float": ["ft0", "ft1", "ft3"], "allocated_int": ["a0", "a1", "t0", "t1", "t2", "zero"]}
+// CHECK-NEXT:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1"], "preallocated_int": ["a0", "a1", "zero"], "excluded_float": ["ft0", "ft1", "ft2"], "excluded_int": [], "allocated_float": ["ft0", "ft1", "ft3"], "allocated_int": ["a0", "a1", "t0", "t1", "t2", "zero"]}
 // CHECK-NEXT:  .globl reluf32
 // CHECK-NEXT:  .p2align 2
 // CHECK-NEXT:  reluf32:

--- a/tests/filecheck/projects/riscv-backend-paper/bottom_up_f64.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/bottom_up_f64.mlir
@@ -34,7 +34,7 @@ func.func public @conv_2d_nchw_fchw_d1_s1_3x3(
   }
 
 
-// CHECK-NEXT:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1", "ft2"], "preallocated_int": ["a0", "a1", "a2", "zero"], "allocated_float": ["ft0", "ft1", "ft2", "ft3", "ft4", "ft5", "ft6", "ft7"], "allocated_int": ["a0", "a1", "a2", "a3", "a4", "t0", "t1", "t2", "t3", "t4", "t5", "t6", "zero"]}
+// CHECK-NEXT:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1", "ft2"], "preallocated_int": ["a0", "a1", "a2", "zero"], "excluded_float": ["ft0", "ft1", "ft2"], "excluded_int": [], "allocated_float": ["ft0", "ft1", "ft2", "ft3", "ft4", "ft5", "ft6", "ft7"], "allocated_int": ["a0", "a1", "a2", "a3", "a4", "t0", "t1", "t2", "t3", "t4", "t5", "t6", "zero"]}
 // CHECK:       .text
 // CHECK-NEXT:  .globl conv_2d_nchw_fchw_d1_s1_3x3
 // CHECK-NEXT:  .p2align 2
@@ -159,7 +159,7 @@ func.func public @conv_2d_nchw_fchw_d1_s1_3x3(
   }
 
 
-// CHECK-NEXT:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1", "ft2"], "preallocated_int": ["a0", "a1", "a2", "zero"], "allocated_float": ["ft0", "ft1", "ft3"], "allocated_int": ["a0", "a1", "a2", "t0", "t1", "t2", "t3", "zero"]}
+// CHECK-NEXT:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1"], "preallocated_int": ["a0", "a1", "a2", "zero"], "excluded_float": ["ft0", "ft1", "ft2"], "excluded_int": [], "allocated_float": ["ft0", "ft1", "ft3"], "allocated_int": ["a0", "a1", "a2", "t0", "t1", "t2", "t3", "zero"]}
 // CHECK-NEXT:  .globl ddot
 // CHECK-NEXT:  .p2align 2
 // CHECK-NEXT:  ddot:
@@ -205,7 +205,7 @@ func.func public @conv_2d_nchw_fchw_d1_s1_3x3(
     }
 
 
-// CHECK-NEXT:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1", "ft2"], "preallocated_int": ["a0", "a1", "a2", "zero"], "allocated_float": ["ft0", "ft1", "ft2"], "allocated_int": ["a0", "a1", "a2", "t0", "t1", "t2", "t3", "zero"]}
+// CHECK-NEXT:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1", "ft2"], "preallocated_int": ["a0", "a1", "a2", "zero"], "excluded_float": ["ft0", "ft1", "ft2"], "excluded_int": [], "allocated_float": ["ft0", "ft1", "ft2"], "allocated_int": ["a0", "a1", "a2", "t0", "t1", "t2", "t3", "zero"]}
 // CHECK-NEXT:  .globl dsum
 // CHECK-NEXT:  .p2align 2
 // CHECK-NEXT:  dsum:
@@ -248,7 +248,7 @@ func.func public @conv_2d_nchw_fchw_d1_s1_3x3(
   }
 
 
-// CHECK-NEXT:  # Regalloc stats: {"preallocated_float": ["fa0", "ft0", "ft1", "ft2"], "preallocated_int": ["a0", "zero"], "allocated_float": ["fa0", "ft0", "ft3"], "allocated_int": ["a0", "t0", "t1", "zero"]}
+// CHECK-NEXT:  # Regalloc stats: {"preallocated_float": ["fa0", "ft0"], "preallocated_int": ["a0", "zero"], "excluded_float": ["ft0", "ft1", "ft2"], "excluded_int": [], "allocated_float": ["fa0", "ft0", "ft3"], "allocated_int": ["a0", "t0", "t1", "zero"]}
 // CHECK-NEXT:  .globl fill
 // CHECK-NEXT:  .p2align 2
 // CHECK-NEXT:  fill:
@@ -304,7 +304,7 @@ func.func public @conv_2d_nchw_fchw_d1_s1_3x3(
     func.return
 }
 
-// CHECK-NEXT:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1", "ft2"], "preallocated_int": ["a0", "a1", "a2", "zero"], "allocated_float": ["ft0", "ft1", "ft2", "ft3", "ft4", "ft5", "ft6", "ft7"], "allocated_int": ["a0", "a1", "a2", "t0", "t1", "t2", "t3", "zero"]}
+// CHECK-NEXT:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1", "ft2"], "preallocated_int": ["a0", "a1", "a2", "zero"], "excluded_float": ["ft0", "ft1", "ft2"], "excluded_int": [], "allocated_float": ["ft0", "ft1", "ft2", "ft3", "ft4", "ft5", "ft6", "ft7"], "allocated_int": ["a0", "a1", "a2", "t0", "t1", "t2", "t3", "zero"]}
 // CHECK-NEXT:  .globl matmul
 // CHECK-NEXT:  .p2align 2
 // CHECK-NEXT:  matmul:
@@ -413,7 +413,7 @@ func.func public @pooling_nchw_max_d1_s2_3x3(
   }
 
 
-// CHECK-NEXT:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1", "ft2"], "preallocated_int": ["a0", "a1", "zero"], "allocated_float": ["ft0", "ft1", "ft3", "ft4", "ft5", "ft6", "ft7"], "allocated_int": ["a0", "a1", "t0", "t1", "t2", "t3", "t4", "t5", "t6", "zero"]}
+// CHECK-NEXT:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1"], "preallocated_int": ["a0", "a1", "zero"], "excluded_float": ["ft0", "ft1", "ft2"], "excluded_int": [], "allocated_float": ["ft0", "ft1", "ft3", "ft4", "ft5", "ft6", "ft7"], "allocated_int": ["a0", "a1", "t0", "t1", "t2", "t3", "t4", "t5", "t6", "zero"]}
 // CHECK-NEXT:  .globl pooling_nchw_max_d1_s2_3x3
 // CHECK-NEXT:  .p2align 2
 // CHECK-NEXT:  pooling_nchw_max_d1_s2_3x3:
@@ -508,7 +508,7 @@ func.func public @pooling_nchw_max_d1_s2_3x3(
   }
 
 
-// CHECK-NEXT:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1", "ft2"], "preallocated_int": ["a0", "a1", "zero"], "allocated_float": ["ft0", "ft1", "ft3"], "allocated_int": ["a0", "a1", "t0", "t1", "t2", "zero"]}
+// CHECK-NEXT:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1"], "preallocated_int": ["a0", "a1", "zero"], "excluded_float": ["ft0", "ft1", "ft2"], "excluded_int": [], "allocated_float": ["ft0", "ft1", "ft3"], "allocated_int": ["a0", "a1", "t0", "t1", "t2", "zero"]}
 // CHECK-NEXT:  .globl reluf64
 // CHECK-NEXT:  .p2align 2
 // CHECK-NEXT:  reluf64:
@@ -566,7 +566,7 @@ func.func public @pooling_nchw_sum_d1_s2_3x3(
   }
 
 
-// CHECK-NEXT:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1", "ft2"], "preallocated_int": ["a0", "a1", "zero"], "allocated_float": ["ft0", "ft1", "ft3", "ft4", "ft5", "ft6", "ft7"], "allocated_int": ["a0", "a1", "t0", "t1", "t2", "t3", "t4", "t5", "t6", "zero"]}
+// CHECK-NEXT:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1"], "preallocated_int": ["a0", "a1", "zero"], "excluded_float": ["ft0", "ft1", "ft2"], "excluded_int": [], "allocated_float": ["ft0", "ft1", "ft3", "ft4", "ft5", "ft6", "ft7"], "allocated_int": ["a0", "a1", "t0", "t1", "t2", "t3", "t4", "t5", "t6", "zero"]}
 // CHECK-NEXT:  .globl pooling_nchw_sum_d1_s2_3x3
 // CHECK-NEXT:  .p2align 2
 // CHECK-NEXT:  pooling_nchw_sum_d1_s2_3x3:

--- a/tests/filecheck/projects/riscv-backend-paper/exp_f64.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/exp_f64.mlir
@@ -18,7 +18,7 @@ func.func public @exp_f64(
   func.return
 }
 
-// CHECK:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1", "ft2"], "preallocated_int": ["a0", "a1", "sp", "zero"], "allocated_float": ["ft0", "ft1", "ft3", "ft4", "ft5", "ft6"], "allocated_int": ["a0", "a1", "sp", "t0", "t1", "t2", "zero"]}
+// CHECK:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1"], "preallocated_int": ["a0", "a1", "sp", "zero"], "excluded_float": ["ft0", "ft1", "ft2"], "excluded_int": [], "allocated_float": ["ft0", "ft1", "ft3", "ft4", "ft5", "ft6"], "allocated_int": ["a0", "a1", "sp", "t0", "t1", "t2", "zero"]}
 // CHECK-NEXT:  .text
 // CHECK-NEXT:  .globl exp_f64
 // CHECK-NEXT:  .p2align 2

--- a/tests/filecheck/projects/riscv-backend-paper/nsnet.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/nsnet.mlir
@@ -10,7 +10,7 @@ func.func @main$async_dispatch_0_matmul_transpose_b_1x400x161_f64$xdsl_kernel1(%
   return
 }
 
-// CHECK:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1", "ft2"], "preallocated_int": ["a0", "a1", "a2", "zero"], "allocated_float": ["ft0", "ft1", "ft3", "ft4", "ft5", "ft6", "ft7"], "allocated_int": ["a0", "a1", "a2", "t0", "t1", "t2", "t3", "zero"]}
+// CHECK:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1"], "preallocated_int": ["a0", "a1", "a2", "zero"], "excluded_float": ["ft0", "ft1", "ft2"], "excluded_int": [], "allocated_float": ["ft0", "ft1", "ft3", "ft4", "ft5", "ft6", "ft7"], "allocated_int": ["a0", "a1", "a2", "t0", "t1", "t2", "t3", "zero"]}
 // CHECK-NEXT:  .text
 // CHECK-NEXT:  .globl main$async_dispatch_0_matmul_transpose_b_1x400x161_f64$xdsl_kernel1
 // CHECK-NEXT:  .p2align 2

--- a/xdsl/backend/register_allocatable.py
+++ b/xdsl/backend/register_allocatable.py
@@ -30,6 +30,12 @@ class RegisterAllocatableOperation(Operation, abc.ABC):
             if isinstance(val.type, RegisterType) and val.type.is_allocated
         )
 
+    def iter_excluded_registers(self) -> Iterator[RegisterType]:
+        """
+        The registers that should not be used when this operation is present.
+        """
+        yield from ()
+
     @abc.abstractmethod
     def allocate_registers(self, allocator: BlockAllocator) -> None:
         """
@@ -48,6 +54,20 @@ class RegisterAllocatableOperation(Operation, abc.ABC):
             for op in region.walk()
             if isinstance(op, RegisterAllocatableOperation)
             for reg in op.iter_used_registers()
+        }
+
+    @staticmethod
+    def all_excluded_registers(
+        region: Region,
+    ) -> AbstractSet[RegisterType]:
+        """
+        All excluded registers as declared by all operations within a region.
+        """
+        return {
+            reg
+            for op in region.walk()
+            if isinstance(op, RegisterAllocatableOperation)
+            for reg in op.iter_excluded_registers()
         }
 
 

--- a/xdsl/backend/riscv/register_allocation.py
+++ b/xdsl/backend/riscv/register_allocation.py
@@ -58,8 +58,9 @@ class RegisterAllocatorLivenessBlockNaive(BlockNaiveAllocator):
             )
 
         preallocated = RegisterAllocatableOperation.all_used_registers(func.body)
+        excluded = RegisterAllocatableOperation.all_excluded_registers(func.body)
 
-        for pa_reg in preallocated:
+        for pa_reg in preallocated | excluded:
             self.available_registers.exclude_register(pa_reg)
 
         block = func.body.block
@@ -71,6 +72,7 @@ class RegisterAllocatorLivenessBlockNaive(BlockNaiveAllocator):
 
         if add_regalloc_stats:
             preallocated_stats = reg_types_by_name(preallocated)
+            excluded_stats = reg_types_by_name(excluded)
             allocated_stats = reg_types_by_name(
                 val.type
                 for op in block.walk()
@@ -81,6 +83,8 @@ class RegisterAllocatorLivenessBlockNaive(BlockNaiveAllocator):
             stats = {
                 "preallocated_float": sorted(preallocated_stats["riscv.freg"]),
                 "preallocated_int": sorted(preallocated_stats["riscv.reg"]),
+                "excluded_float": sorted(excluded_stats["riscv.freg"]),
+                "excluded_int": sorted(excluded_stats["riscv.reg"]),
                 "allocated_float": sorted(allocated_stats["riscv.freg"]),
                 "allocated_int": sorted(allocated_stats["riscv.reg"]),
             }

--- a/xdsl/backend/x86/register_allocation.py
+++ b/xdsl/backend/x86/register_allocation.py
@@ -26,8 +26,9 @@ class X86RegisterAllocator(BlockNaiveAllocator):
             )
 
         preallocated = RegisterAllocatableOperation.all_used_registers(func.body)
+        excluded = RegisterAllocatableOperation.all_excluded_registers(func.body)
 
-        for pa_reg in preallocated:
+        for pa_reg in preallocated | excluded:
             self.available_registers.exclude_register(pa_reg)
 
         block = func.body.block

--- a/xdsl/dialects/riscv_snitch.py
+++ b/xdsl/dialects/riscv_snitch.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from abc import ABC
 from collections.abc import Sequence
-from typing import ClassVar, Literal, TypeAlias, cast, override
+from typing import ClassVar, Literal, TypeAlias, cast
 
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from xdsl.backend.register_allocatable import RegisterConstraints
 from xdsl.backend.register_allocator import BlockAllocator

--- a/xdsl/dialects/riscv_snitch.py
+++ b/xdsl/dialects/riscv_snitch.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from abc import ABC
 from collections.abc import Sequence
-from typing import ClassVar, Literal, TypeAlias, cast
+from typing import ClassVar, Literal, TypeAlias, cast, override
 
 from typing_extensions import Self
 
@@ -196,7 +196,8 @@ class ReadOp(RISCVAsmOperation, RISCVRegallocOperation):
     def assembly_line(self) -> str | None:
         return None
 
-    def iter_used_registers(self):
+    @override
+    def iter_excluded_registers(self):
         # When streaming, FT0, FT1, and FT2 cannot be used as general-purpose float
         # registers
         yield riscv.Registers.FT0
@@ -224,7 +225,8 @@ class WriteOp(RISCVAsmOperation, RISCVRegallocOperation):
     def assembly_line(self) -> str | None:
         return None
 
-    def iter_used_registers(self):
+    @override
+    def iter_excluded_registers(self):
         # When streaming, FT0, FT1, and FT2 cannot be used as general-purpose float
         # registers
         yield riscv.Registers.FT0

--- a/xdsl/transforms/riscv_allocate_infinite_registers.py
+++ b/xdsl/transforms/riscv_allocate_infinite_registers.py
@@ -22,7 +22,10 @@ class RISCVAllocateInfiniteRegistersPass(ModulePass):
             register_stack = RiscvRegisterStack.get()
 
             # remove registers from stack that are already used in body
-            for reg in RegisterAllocatableOperation.all_used_registers(func_op.body):
+            preallocated = RegisterAllocatableOperation.all_used_registers(func_op.body)
+            excluded = RegisterAllocatableOperation.all_excluded_registers(func_op.body)
+
+            for reg in preallocated | excluded:
                 register_stack.exclude_register(reg)
 
             phys_reg_by_inf_reg: dict[


### PR DESCRIPTION
This is currently conflated with the preallocated registers. Our current register allocation strategy is conservative, and removes from allocation all registers that are mentioned anywhere in a function. When adding support for Snitch, we used the same API to say that registers ft0, ft1, and ft2 were off-limits. This PR addresses this hack by adding a separate API for excluded registers. It also adds the excluded registers separately to the allocation stats.