### PR TITLE
dialects: (acc) Loop operation

### DIFF
--- a/tests/dialects/test_acc.py
+++ b/tests/dialects/test_acc.py
@@ -768,3 +768,99 @@ def test_declare_family_init_bodies():
 
     decl = acc.DeclareOp(region=Region(Block()), data_clause_operands=[copyin])
     assert len(decl.region.blocks) == 1
+
+
+def _empty_loop(*, default_independent: bool = True) -> acc.LoopOp:
+    """`acc.loop` with an empty single-block body holding just an `acc.yield`.
+
+    Defaults `independent = [#acc.device_type<none>]` so the verifier's
+    "at least one of auto/independent/seq" check is satisfied.
+    """
+    independent = (
+        ArrayAttr([acc.DeviceTypeAttr(acc.DeviceType.NONE)])
+        if default_independent
+        else None
+    )
+    return acc.LoopOp(
+        region=Region(Block([acc.YieldOp()])),
+        independent=independent,
+    )
+
+
+def test_loop_par_mode_shortcut():
+    """The `par_mode=` keyword argument fills in the matching seq /
+    independent / auto array. This is a builder-only path: the parser only
+    sees the already-built `ArrayAttr[DeviceTypeAttr]`, so the conversion
+    branch is unreachable from filecheck."""
+    op_seq = acc.LoopOp(
+        region=Region(Block([acc.YieldOp()])),
+        par_mode=acc.LoopParMode.SEQ,
+    )
+    op_seq.verify()
+    assert op_seq.seq == ArrayAttr([acc.DeviceTypeAttr(acc.DeviceType.NONE)])
+    assert op_seq.independent is None
+    assert op_seq.auto_ is None
+
+    op_auto = acc.LoopOp(
+        region=Region(Block([acc.YieldOp()])),
+        par_mode=acc.LoopParMode.AUTO,
+    )
+    op_auto.verify()
+    assert op_auto.auto_ == ArrayAttr([acc.DeviceTypeAttr(acc.DeviceType.NONE)])
+    assert op_auto.independent is None
+    assert op_auto.seq is None
+
+    op_indep = acc.LoopOp(
+        region=Region(Block([acc.YieldOp()])),
+        par_mode=acc.LoopParMode.INDEPENDENT,
+    )
+    op_indep.verify()
+    assert op_indep.independent == ArrayAttr([acc.DeviceTypeAttr(acc.DeviceType.NONE)])
+    assert op_indep.seq is None
+    assert op_indep.auto_ is None
+
+    # An explicit `seq=` argument wins over `par_mode=...`. Builder-only
+    # branch; the parser would never pass both.
+    nvidia = acc.DeviceTypeAttr(acc.DeviceType.NVIDIA)
+    op_explicit = acc.LoopOp(
+        region=Region(Block([acc.YieldOp()])),
+        par_mode=acc.LoopParMode.SEQ,
+        seq=ArrayAttr([nvidia]),
+        independent=ArrayAttr([acc.DeviceTypeAttr(acc.DeviceType.NONE)]),
+    )
+    op_explicit.verify()
+    assert op_explicit.seq == ArrayAttr([nvidia])
+
+
+def test_loop_unit_and_combined_shortcuts():
+    """`unstructured` accepts a bool shortcut; `combined` accepts a
+    `CombinedConstructsType` value as well as the wrapped attribute."""
+    op = acc.LoopOp(
+        region=Region(Block([acc.YieldOp()])),
+        independent=ArrayAttr([acc.DeviceTypeAttr(acc.DeviceType.NONE)]),
+        unstructured=True,
+        combined=acc.CombinedConstructsType.PARALLEL_LOOP,
+    )
+    op.verify()
+
+    assert isinstance(op.unstructured, UnitAttr)
+    assert op.combined == acc.CombinedConstructsTypeAttr(
+        acc.CombinedConstructsType.PARALLEL_LOOP
+    )
+
+    op_off = _empty_loop()
+    assert op_off.unstructured is None
+    assert op_off.combined is None
+
+    op_explicit = acc.LoopOp(
+        region=Region(Block([acc.YieldOp()])),
+        independent=ArrayAttr([acc.DeviceTypeAttr(acc.DeviceType.NONE)]),
+        unstructured=UnitAttr(),
+        combined=acc.CombinedConstructsTypeAttr(
+            acc.CombinedConstructsType.KERNELS_LOOP
+        ),
+    )
+    assert isinstance(op_explicit.unstructured, UnitAttr)
+    assert op_explicit.combined == acc.CombinedConstructsTypeAttr(
+        acc.CombinedConstructsType.KERNELS_LOOP
+    )

--- a/tests/filecheck/dialects/acc/ops.mlir
+++ b/tests/filecheck/dialects/acc/ops.mlir
@@ -1782,4 +1782,174 @@ builtin.module {
   // CHECK-LABEL: func.func @declare_generic_roundtrip_retained(
   // CHECK:         acc.declare dataOperands(%{{.*}} : memref<f32>) {
   // CHECK-NEXT:    }
+
+  // ===========================================================================
+  // acc.loop
+  // ===========================================================================
+
+  // Container-like loop (no induction variables) — the `independent` /
+  // `seq` / `auto` device-`none` entry is required by the verifier.
+  func.func @loop_empty() {
+    acc.loop {
+      acc.yield
+    } attributes {independent = [#acc.device_type<none>]}
+    func.return
+  }
+  // CHECK-LABEL: func.func @loop_empty() {
+  // CHECK-NEXT:    acc.loop {
+  // CHECK-NEXT:      acc.yield
+  // CHECK-NEXT:    } attributes {independent = [#acc.device_type<none>]}
+
+  // Loop with induction variables — the `control(...) = (...) to (...)
+  // step (...)` header is parsed/printed by the LoopControl directive.
+  func.func @loop_control(%lb : index, %ub : index, %st : index) {
+    acc.loop control(%iv : index) = (%lb : index) to (%ub : index) step (%st : index) {
+      acc.yield
+    } attributes {independent = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true>}
+    func.return
+  }
+  // CHECK-LABEL: func.func @loop_control(
+  // CHECK:         acc.loop control(%{{.*}} : index) = (%{{.*}} : index) to (%{{.*}} : index) step (%{{.*}} : index) {
+  // CHECK-NEXT:      acc.yield
+  // CHECK-NEXT:    } attributes {independent = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true>}
+
+  // Bare gang/worker/vector keywords land as device-`none` arrays.
+  func.func @loop_bare_par_keywords(%lb : index, %ub : index, %st : index) {
+    acc.loop gang worker vector control(%iv : index) = (%lb : index) to (%ub : index) step (%st : index) {
+      acc.yield
+    } attributes {independent = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true>}
+    func.return
+  }
+  // CHECK-LABEL: func.func @loop_bare_par_keywords(
+  // CHECK:         acc.loop gang worker vector control(%{{.*}} : index) = (%{{.*}} : index) to (%{{.*}} : index) step (%{{.*}} : index) {
+  // CHECK-NEXT:      acc.yield
+  // CHECK-NEXT:    } attributes {independent = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true>}
+
+  // gang clause with `num=` / `static=` / `dim=` operand groups.
+  func.func @loop_gang_operands(%v : i64, %lb : index, %ub : index, %st : index) {
+    acc.loop gang({num=%v : i64, static=%v : i64}) worker(%v : i64) vector(%v : i64) control(%iv : index) = (%lb : index) to (%ub : index) step (%st : index) {
+      acc.yield
+    } attributes {independent = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true>}
+    func.return
+  }
+  // CHECK-LABEL: func.func @loop_gang_operands(
+  // CHECK:         acc.loop gang({num=%{{.*}} : i64, static=%{{.*}} : i64}) worker(%{{.*}} : i64) vector(%{{.*}} : i64) control(%{{.*}} : index)
+
+  // tile clause with brace-grouped operands.
+  func.func @loop_tile(%v : i64, %lb : index, %ub : index, %st : index) {
+    acc.loop tile({%v : i64, %v : i64}) control(%iv : index) = (%lb : index) to (%ub : index) step (%st : index) {
+      acc.yield
+    } attributes {independent = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true>}
+    func.return
+  }
+  // CHECK-LABEL: func.func @loop_tile(
+  // CHECK:         acc.loop tile({%{{.*}} : i64, %{{.*}} : i64}) control(%{{.*}} : index)
+
+  // Combined construct keyword — `combined(parallel)` decomposes a
+  // `parallel loop` directive.
+  func.func @loop_combined(%lb : index, %ub : index, %st : index) {
+    acc.loop combined(parallel) control(%iv : index) = (%lb : index) to (%ub : index) step (%st : index) {
+      acc.yield
+    } attributes {independent = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true>}
+    func.return
+  }
+  // CHECK-LABEL: func.func @loop_combined(
+  // CHECK:         acc.loop combined(parallel) control(%{{.*}} : index)
+
+  // private / firstprivate / reduction operand groups.
+  func.func @loop_data_clauses(%a : memref<10xf32>, %lb : index, %ub : index, %st : index) {
+    %p = acc.private varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    %f = acc.firstprivate varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    %r = acc.reduction varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    acc.loop private(%p : memref<10xf32>) firstprivate(%f : memref<10xf32>) reduction(%r : memref<10xf32>) control(%iv : index) = (%lb : index) to (%ub : index) step (%st : index) {
+      acc.yield
+    } attributes {independent = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true>}
+    func.return
+  }
+  // CHECK-LABEL: func.func @loop_data_clauses(
+  // CHECK:         acc.loop private(%{{.*}} : memref<10xf32>) firstprivate(%{{.*}} : memref<10xf32>) reduction(%{{.*}} : memref<10xf32>) control(%{{.*}} : index)
+
+  // cache operand list.
+  func.func @loop_cache(%a : memref<10xf32>, %lb : index, %ub : index, %st : index) {
+    %b = acc.cache varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    acc.loop cache(%b : memref<10xf32>) control(%iv : index) = (%lb : index) to (%ub : index) step (%st : index) {
+      acc.yield
+    } attributes {independent = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true>}
+    func.return
+  }
+  // CHECK-LABEL: func.func @loop_cache(
+  // CHECK:         acc.loop cache(%{{.*}} : memref<10xf32>) control(%{{.*}} : index)
+
+  // Generic-form roundtrip insurance for `acc.loop` — proves the bare
+  // generic surface (operandSegmentSizes + properties) still parses.
+  func.func @loop_generic_roundtrip_retained(%lb : index, %ub : index, %st : index) {
+    "acc.loop"(%lb, %ub, %st) <{independent = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true>, operandSegmentSizes = array<i32: 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0>}> ({
+    ^bb0(%iv: index):
+      "acc.yield"() : () -> ()
+    }) : (index, index, index) -> ()
+    func.return
+  }
+  // CHECK-LABEL: func.func @loop_generic_roundtrip_retained(
+  // CHECK:         acc.loop control(%{{.*}} : index) = (%{{.*}} : index) to (%{{.*}} : index) step (%{{.*}} : index) {
+  // CHECK-NEXT:      acc.yield
+  // CHECK-NEXT:    } attributes {independent = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true>}
+
+  // gang clause with a keyword-only `[#dt]` device-type list (no operands).
+  func.func @loop_gang_kw_only_dts(%lb : index, %ub : index, %st : index) {
+    acc.loop gang([#acc.device_type<nvidia>]) control(%iv : index) = (%lb : index) to (%ub : index) step (%st : index) {
+      acc.yield
+    } attributes {independent = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true>}
+    func.return
+  }
+  // CHECK-LABEL: func.func @loop_gang_kw_only_dts(
+  // CHECK:         acc.loop gang([#acc.device_type<nvidia>]) control(%{{.*}} : index)
+
+  // gang clause mixing keyword-only DT list and operand groups.
+  func.func @loop_gang_mixed(%v : i64, %lb : index, %ub : index, %st : index) {
+    acc.loop gang([#acc.device_type<nvidia>], {num=%v : i64} [#acc.device_type<default>]) control(%iv : index) = (%lb : index) to (%ub : index) step (%st : index) {
+      acc.yield
+    } attributes {independent = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true>}
+    func.return
+  }
+  // CHECK-LABEL: func.func @loop_gang_mixed(
+  // CHECK:         acc.loop gang([#acc.device_type<nvidia>], {num=%{{.*}} : i64} [#acc.device_type<default>]) control(%{{.*}} : index)
+
+  // Multiple gang operand groups — exercises the `, ` separator between
+  // groups in GangClause's printer.
+  func.func @loop_gang_multi_group(%v : i64, %lb : index, %ub : index, %st : index) {
+    acc.loop gang({num=%v : i64} [#acc.device_type<nvidia>], {dim=%v : i64} [#acc.device_type<default>]) control(%iv : index) = (%lb : index) to (%ub : index) step (%st : index) {
+      acc.yield
+    } attributes {independent = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true>}
+    func.return
+  }
+  // CHECK-LABEL: func.func @loop_gang_multi_group(
+  // CHECK:         acc.loop gang({num=%{{.*}} : i64} [#acc.device_type<nvidia>], {dim=%{{.*}} : i64} [#acc.device_type<default>]) control(%{{.*}} : index)
+
+  // collapse with matching counts (1 entry each) — exercises the verifier
+  // path past the collapse-count check on the happy path.
+  func.func @loop_collapse() {
+    acc.loop {
+      acc.yield
+    } attributes {collapse = [2 : i64], collapseDeviceType = [#acc.device_type<none>], independent = [#acc.device_type<none>]}
+    func.return
+  }
+  // CHECK-LABEL: func.func @loop_collapse() {
+  // CHECK:         acc.loop {
+  // CHECK-NEXT:      acc.yield
+  // CHECK-NEXT:    } attributes {collapse = [2 : i64], collapseDeviceType = [#acc.device_type<none>], independent = [#acc.device_type<none>]}
+
+  // seq + gang with non-overlapping device types — exercises the
+  // gang/worker/vector incompatibility check's no-conflict branch. The
+  // round-trip prints `gang([#nvidia])` via the GangClause directive's
+  // keyword-only DT spelling (since `gang`'s sole entry isn't `#none`).
+  func.func @loop_seq_gang_disjoint() {
+    acc.loop {
+      acc.yield
+    } attributes {seq = [#acc.device_type<none>], gang = [#acc.device_type<nvidia>]}
+    func.return
+  }
+  // CHECK-LABEL: func.func @loop_seq_gang_disjoint() {
+  // CHECK:         acc.loop gang([#acc.device_type<nvidia>]) {
+  // CHECK-NEXT:      acc.yield
+  // CHECK-NEXT:    } attributes {seq = [#acc.device_type<none>]}
 }

--- a/tests/filecheck/dialects/acc/ops.mlir
+++ b/tests/filecheck/dialects/acc/ops.mlir
@@ -1940,12 +1940,12 @@ builtin.module {
 
   // seq + gang with non-overlapping device types — exercises the
   // gang/worker/vector incompatibility check's no-conflict branch. The
-  // round-trip prints `gang([#nvidia])` via the GangClause directive's
-  // keyword-only DT spelling (since `gang`'s sole entry isn't `#none`).
+  // `gang([#nvidia])` keyword-only DT spelling writes to the `gang`
+  // property via GangClause.
   func.func @loop_seq_gang_disjoint() {
-    acc.loop {
+    acc.loop gang([#acc.device_type<nvidia>]) {
       acc.yield
-    } attributes {seq = [#acc.device_type<none>], gang = [#acc.device_type<nvidia>]}
+    } attributes {seq = [#acc.device_type<none>]}
     func.return
   }
   // CHECK-LABEL: func.func @loop_seq_gang_disjoint() {

--- a/tests/filecheck/dialects/acc/ops_invalid.mlir
+++ b/tests/filecheck/dialects/acc/ops_invalid.mlir
@@ -510,11 +510,13 @@ func.func @loop_missing_par_mode() {
 // -----
 
 // acc.loop: gang / worker / vector cannot coexist with seq for the same
-// device type — the verifier catches `seq + gang` on `#none`.
+// device type — the verifier catches `seq + gang` on `#none`. The bare
+// `gang` keyword writes to the `gang` property directly via GangClause,
+// matching how a real source emits it.
 func.func @loop_seq_with_gang() {
-  acc.loop {
+  acc.loop gang {
     acc.yield
-  } attributes {seq = [#acc.device_type<none>], gang = [#acc.device_type<none>]}
+  } attributes {seq = [#acc.device_type<none>]}
   func.return
 }
 // CHECK: gang, worker or vector cannot appear with seq
@@ -534,11 +536,13 @@ func.func @loop_auto_seq_same_dt() {
 // -----
 
 // acc.loop: duplicate device type in the gang attribute fires a verifier
-// error (mirrors upstream's `checkDeviceTypes` helper).
+// error (mirrors upstream's `checkDeviceTypes` helper). The
+// `gang([#dt, #dt])` keyword-only DT spelling writes the array directly
+// to the `gang` property via GangClause.
 func.func @loop_duplicate_gang_dt() {
-  acc.loop {
+  acc.loop gang([#acc.device_type<none>, #acc.device_type<none>]) {
     acc.yield
-  } attributes {gang = [#acc.device_type<none>, #acc.device_type<none>], independent = [#acc.device_type<none>]}
+  } attributes {independent = [#acc.device_type<none>]}
   func.return
 }
 // CHECK: duplicate device_type `none` found in gang attribute
@@ -750,11 +754,12 @@ func.func @loop_control_too_few_lb_types(%lb : index, %ub : index, %st : index) 
 // -----
 
 // acc.loop: duplicate device_type in `worker` attribute fires the
-// duplicate-DT verifier.
+// duplicate-DT verifier. `worker([#dt, #dt])` is the keyword-only DT
+// spelling that writes the array directly to the `worker` property.
 func.func @loop_duplicate_worker_dt() {
-  acc.loop {
+  acc.loop worker([#acc.device_type<none>, #acc.device_type<none>]) {
     acc.yield
-  } attributes {worker = [#acc.device_type<none>, #acc.device_type<none>], independent = [#acc.device_type<none>]}
+  } attributes {independent = [#acc.device_type<none>]}
   func.return
 }
 // CHECK: duplicate device_type `none` found in worker attribute
@@ -764,9 +769,9 @@ func.func @loop_duplicate_worker_dt() {
 // acc.loop: duplicate device_type in `vector` attribute fires the
 // duplicate-DT verifier.
 func.func @loop_duplicate_vector_dt() {
-  acc.loop {
+  acc.loop vector([#acc.device_type<none>, #acc.device_type<none>]) {
     acc.yield
-  } attributes {vector = [#acc.device_type<none>, #acc.device_type<none>], independent = [#acc.device_type<none>]}
+  } attributes {independent = [#acc.device_type<none>]}
   func.return
 }
 // CHECK: duplicate device_type `none` found in vector attribute

--- a/tests/filecheck/dialects/acc/ops_invalid.mlir
+++ b/tests/filecheck/dialects/acc/ops_invalid.mlir
@@ -493,3 +493,314 @@ func.func @declare_wrong_defining_op(%a : memref<f32>) {
   func.return
 }
 // CHECK: expect valid declare data entry operation or acc.getdeviceptr as defining op
+
+// -----
+
+// acc.loop: at least one of auto / independent / seq must apply to the
+// device-`none` (default) device type. A bare loop with no parallelism
+// markers fails this check.
+func.func @loop_missing_par_mode() {
+  acc.loop {
+    acc.yield
+  }
+  func.return
+}
+// CHECK: at least one of auto, independent, seq must be present
+
+// -----
+
+// acc.loop: gang / worker / vector cannot coexist with seq for the same
+// device type — the verifier catches `seq + gang` on `#none`.
+func.func @loop_seq_with_gang() {
+  acc.loop {
+    acc.yield
+  } attributes {seq = [#acc.device_type<none>], gang = [#acc.device_type<none>]}
+  func.return
+}
+// CHECK: gang, worker or vector cannot appear with seq
+
+// -----
+
+// acc.loop: the same device type cannot appear twice across auto /
+// independent / seq.
+func.func @loop_auto_seq_same_dt() {
+  acc.loop {
+    acc.yield
+  } attributes {auto_ = [#acc.device_type<none>], seq = [#acc.device_type<none>]}
+  func.return
+}
+// CHECK: only one of auto, independent, seq can be present at the same time
+
+// -----
+
+// acc.loop: duplicate device type in the gang attribute fires a verifier
+// error (mirrors upstream's `checkDeviceTypes` helper).
+func.func @loop_duplicate_gang_dt() {
+  acc.loop {
+    acc.yield
+  } attributes {gang = [#acc.device_type<none>, #acc.device_type<none>], independent = [#acc.device_type<none>]}
+  func.return
+}
+// CHECK: duplicate device_type `none` found in gang attribute
+
+// -----
+
+// acc.loop: an `unstructured` loop carries no induction variables — pairing
+// it with a `control(...)` clause is rejected.
+func.func @loop_unstructured_with_control(%lb : index, %ub : index, %st : index) {
+  acc.loop control(%iv : index) = (%lb : index) to (%ub : index) step (%st : index) {
+    acc.yield
+  } attributes {independent = [#acc.device_type<none>], unstructured}
+  func.return
+}
+// CHECK: unstructured acc.loop must not have induction variables
+
+// -----
+
+// acc.loop: lowerbound / upperbound / step counts must match each other.
+// Generic-form input is the only way to land mismatched counts; the
+// declarative parser only accepts equal-length lists.
+func.func @loop_unequal_counts(%lb : index, %ub : index, %st : index) {
+  "acc.loop"(%lb, %ub) <{independent = [#acc.device_type<none>], operandSegmentSizes = array<i32: 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0>}> ({
+  ^bb0(%iv: index):
+    "acc.yield"() : () -> ()
+  }) : (index, index) -> ()
+  func.return
+}
+// CHECK: number of upperbounds expected to be the same as number of steps
+
+// -----
+
+// acc.loop: lowerbound count must match upperbound count. Generic-form
+// input is the only way to reach this check (the declarative parser uses
+// the same induction-var count for all three lists). Pick segment sizes
+// where upperbound == step but lowerbound differs, so the upperbound/step
+// check passes and the lowerbound check fires.
+func.func @loop_lb_ub_mismatch(%lb : index, %ub : index, %st : index) {
+  "acc.loop"(%lb, %ub, %ub, %st, %st) <{independent = [#acc.device_type<none>], operandSegmentSizes = array<i32: 1, 2, 2, 0, 0, 0, 0, 0, 0, 0, 0>}> ({
+  ^bb0(%iv: index, %iv2: index):
+    "acc.yield"() : () -> ()
+  }) : (index, index, index, index, index) -> ()
+  func.return
+}
+// CHECK: number of upperbounds expected to be the same as number of lowerbounds
+
+// -----
+
+// acc.loop: inclusiveUpperbound array size must match upperbound count.
+func.func @loop_inclusive_size_mismatch(%lb : index, %ub : index, %st : index) {
+  "acc.loop"(%lb, %ub, %st) <{independent = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true, false>, operandSegmentSizes = array<i32: 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0>}> ({
+  ^bb0(%iv: index):
+    "acc.yield"() : () -> ()
+  }) : (index, index, index) -> ()
+  func.return
+}
+// CHECK: inclusiveUpperbound size is expected to be the same as upperbound size
+
+// -----
+
+// acc.loop: a `collapse` attribute requires `collapseDeviceType` too.
+func.func @loop_collapse_no_dt() {
+  acc.loop {
+    acc.yield
+  } attributes {collapse = [1 : i64], independent = [#acc.device_type<none>]}
+  func.return
+}
+// CHECK: collapse device_type attr must be define when collapse attr is present
+
+// -----
+
+// acc.loop: collapse and collapseDeviceType arrays must have matching counts.
+func.func @loop_collapse_count_mismatch() {
+  acc.loop {
+    acc.yield
+  } attributes {collapse = [1 : i64, 2 : i64], collapseDeviceType = [#acc.device_type<none>], independent = [#acc.device_type<none>]}
+  func.return
+}
+// CHECK: collapse attribute count must match collapse device_type count
+
+// -----
+
+// acc.loop: gang_operands present without `gangOperandsArgType` fails.
+func.func @loop_gang_no_arg_type(%v : i64) {
+  "acc.loop"(%v) <{independent = [#acc.device_type<none>], operandSegmentSizes = array<i32: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0>}> ({
+    "acc.yield"() : () -> ()
+  }) : (i64) -> ()
+  func.return
+}
+// CHECK: gangOperandsArgType attribute must be defined when gang operands are present
+
+// -----
+
+// acc.loop: gangOperandsArgType count must match gang_operands count.
+func.func @loop_gang_arg_type_mismatch(%v : i64) {
+  "acc.loop"(%v, %v) <{independent = [#acc.device_type<none>], gangOperandsArgType = [#acc.gang_arg_type<Num>], gangOperandsDeviceType = [#acc.device_type<none>], gangOperandsSegments = array<i32: 2>, operandSegmentSizes = array<i32: 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0>}> ({
+    "acc.yield"() : () -> ()
+  }) : (i64, i64) -> ()
+  func.return
+}
+// CHECK: gangOperandsArgType attribute count must match gangOperands count
+
+// -----
+
+// acc.loop: worker_num_operands count must match worker_num_operands_device_type
+// count. Generic-form bypasses the declarative parser, which would always
+// populate one DT entry per operand.
+func.func @loop_worker_dt_mismatch(%v : i64) {
+  "acc.loop"(%v, %v) <{independent = [#acc.device_type<none>], workerNumOperandsDeviceType = [#acc.device_type<none>], operandSegmentSizes = array<i32: 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0>}> ({
+    "acc.yield"() : () -> ()
+  }) : (i64, i64) -> ()
+  func.return
+}
+// CHECK: worker operands count must match worker device_type count
+
+// -----
+
+// acc.loop: vector_operands count must match vector_operands_device_type
+// count.
+func.func @loop_vector_dt_mismatch(%v : i64) {
+  "acc.loop"(%v, %v) <{independent = [#acc.device_type<none>], vectorOperandsDeviceType = [#acc.device_type<none>], operandSegmentSizes = array<i32: 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0>}> ({
+    "acc.yield"() : () -> ()
+  }) : (i64, i64) -> ()
+  func.return
+}
+// CHECK: vector operands count must match vector device_type count
+
+// -----
+
+// acc.loop: tile operand count must match the sum of tileOperandsSegments.
+func.func @loop_tile_segment_count_mismatch(%v : i64) {
+  "acc.loop"(%v, %v) <{independent = [#acc.device_type<none>], tileOperandsDeviceType = [#acc.device_type<none>], tileOperandsSegments = array<i32: 1>, operandSegmentSizes = array<i32: 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0>}> ({
+    "acc.yield"() : () -> ()
+  }) : (i64, i64) -> ()
+  func.return
+}
+// CHECK: tile operand count does not match count in segments
+
+// -----
+
+// acc.loop: tileOperandsSegments count must match tileOperandsDeviceType count.
+func.func @loop_tile_segment_dt_mismatch(%v : i64) {
+  "acc.loop"(%v, %v) <{independent = [#acc.device_type<none>], tileOperandsDeviceType = [#acc.device_type<none>, #acc.device_type<nvidia>], tileOperandsSegments = array<i32: 2>, operandSegmentSizes = array<i32: 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0>}> ({
+    "acc.yield"() : () -> ()
+  }) : (i64, i64) -> ()
+  func.return
+}
+// CHECK: tile segment count does not match device_type count
+
+// -----
+
+// acc.loop: parser rejects `combined(...)` with an unknown construct keyword.
+func.func @loop_combined_bad_keyword(%lb : index, %ub : index, %st : index) {
+  acc.loop combined(banana) control(%iv : index) = (%lb : index) to (%ub : index) step (%st : index) {
+    acc.yield
+  } attributes {independent = [#acc.device_type<none>]}
+  func.return
+}
+// CHECK: expected compute construct name
+
+// -----
+
+// acc.loop: gang clause with empty group `{}` is rejected.
+func.func @loop_gang_empty_group(%lb : index, %ub : index, %st : index) {
+  acc.loop gang({}) control(%iv : index) = (%lb : index) to (%ub : index) step (%st : index) {
+    acc.yield
+  } attributes {independent = [#acc.device_type<none>]}
+  func.return
+}
+// CHECK: expect at least one of num, dim or static values
+
+// -----
+
+// acc.loop: trailing comma inside a gang group fires the parser's
+// "new value expected after comma" error.
+func.func @loop_gang_trailing_comma(%v : i64, %lb : index, %ub : index, %st : index) {
+  acc.loop gang({num=%v : i64,}) control(%iv : index) = (%lb : index) to (%ub : index) step (%st : index) {
+    acc.yield
+  } attributes {independent = [#acc.device_type<none>]}
+  func.return
+}
+// CHECK: new value expected after comma
+
+// -----
+
+// acc.loop: `control(...)` with too few lower-bound operands raises a
+// parse error. The declarative parser uses the induction-var count to
+// bound the operand list.
+func.func @loop_control_too_few_lb(%lb : index, %ub : index, %st : index) {
+  acc.loop control(%iv : index, %iv2 : index) = (%lb : index) to (%ub, %ub : index, index) step (%st, %st : index, index) {
+    acc.yield
+  } attributes {independent = [#acc.device_type<none>]}
+  func.return
+}
+// CHECK: expected 2 operands
+
+// -----
+
+// acc.loop: `control(...)` with too few lower-bound types raises a parse
+// error.
+func.func @loop_control_too_few_lb_types(%lb : index, %ub : index, %st : index) {
+  acc.loop control(%iv : index, %iv2 : index) = (%lb, %lb : index) to (%ub, %ub : index, index) step (%st, %st : index, index) {
+    acc.yield
+  } attributes {independent = [#acc.device_type<none>]}
+  func.return
+}
+// CHECK: expected 2 types
+
+// -----
+
+// acc.loop: duplicate device_type in `worker` attribute fires the
+// duplicate-DT verifier.
+func.func @loop_duplicate_worker_dt() {
+  acc.loop {
+    acc.yield
+  } attributes {worker = [#acc.device_type<none>, #acc.device_type<none>], independent = [#acc.device_type<none>]}
+  func.return
+}
+// CHECK: duplicate device_type `none` found in worker attribute
+
+// -----
+
+// acc.loop: duplicate device_type in `vector` attribute fires the
+// duplicate-DT verifier.
+func.func @loop_duplicate_vector_dt() {
+  acc.loop {
+    acc.yield
+  } attributes {vector = [#acc.device_type<none>, #acc.device_type<none>], independent = [#acc.device_type<none>]}
+  func.return
+}
+// CHECK: duplicate device_type `none` found in vector attribute
+
+// -----
+
+// acc.loop: duplicate device_type in `workerNumOperandsDeviceType`
+// (generic form — declarative parser would never produce duplicates).
+func.func @loop_duplicate_worker_num_operands_dt(%v : i64) {
+  "acc.loop"(%v, %v) <{independent = [#acc.device_type<none>], workerNumOperandsDeviceType = [#acc.device_type<none>, #acc.device_type<none>], operandSegmentSizes = array<i32: 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0>}> ({
+    "acc.yield"() : () -> ()
+  }) : (i64, i64) -> ()
+  func.return
+}
+// CHECK: duplicate device_type `none` found in workerNumOperandsDeviceType attribute
+
+// -----
+
+// acc.loop: duplicate device_type in `vectorOperandsDeviceType`.
+func.func @loop_duplicate_vector_operands_dt(%v : i64) {
+  "acc.loop"(%v, %v) <{independent = [#acc.device_type<none>], vectorOperandsDeviceType = [#acc.device_type<none>, #acc.device_type<none>], operandSegmentSizes = array<i32: 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0>}> ({
+    "acc.yield"() : () -> ()
+  }) : (i64, i64) -> ()
+  func.return
+}
+// CHECK: duplicate device_type `none` found in vectorOperandsDeviceType attribute
+
+// -----
+
+// acc.loop: duplicate device_type in `collapseDeviceType` attribute.
+func.func @loop_duplicate_collapse_dt() {
+  acc.loop {
+    acc.yield
+  } attributes {collapse = [1 : i64, 1 : i64], collapseDeviceType = [#acc.device_type<none>, #acc.device_type<none>], independent = [#acc.device_type<none>]}
+  func.return
+}
+// CHECK: duplicate device_type `none` found in collapseDeviceType attribute

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/ops.mlir
@@ -1177,4 +1177,105 @@ builtin.module {
   // CHECK:         acc.declare dataOperands(%{{.*}} : memref<f32>) {
   // CHECK-NEXT:    }
 
+  // ===========================================================================
+  // acc.loop — interop tests. The `independent = [#acc.device_type<none>]`
+  // attribute satisfies upstream's "at least one of auto/independent/seq"
+  // verifier check. Container-like loops (no induction variables) need an
+  // inner loop to satisfy upstream's `LoopLikeOpInterface` walk; these
+  // cases all use `control(...)` so the loop holds its own induction
+  // variables.
+  // ===========================================================================
+
+  func.func @loop_control(%lb : index, %ub : index, %st : index) {
+    acc.loop control(%iv : index) = (%lb : index) to (%ub : index) step (%st : index) {
+      acc.yield
+    } attributes {independent = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true>}
+    func.return
+  }
+  // CHECK:       func.func @loop_control(
+  // CHECK:         acc.loop control(%{{.*}} : index) = (%{{.*}} : index) to (%{{.*}} : index){{[ ]*}}step (%{{.*}} : index) {
+  // CHECK-NEXT:      acc.yield
+  // CHECK-NEXT:    } attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+
+  func.func @loop_bare_par_keywords(%lb : index, %ub : index, %st : index) {
+    acc.loop gang worker vector control(%iv : index) = (%lb : index) to (%ub : index) step (%st : index) {
+      acc.yield
+    } attributes {independent = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true>}
+    func.return
+  }
+  // CHECK:       func.func @loop_bare_par_keywords(
+  // CHECK:         acc.loop gang worker vector control(%{{.*}} : index)
+  // CHECK:           acc.yield
+
+  func.func @loop_gang_operands(%v : i64, %lb : index, %ub : index, %st : index) {
+    acc.loop gang({num=%v : i64, static=%v : i64}) worker(%v : i64) vector(%v : i64) control(%iv : index) = (%lb : index) to (%ub : index) step (%st : index) {
+      acc.yield
+    } attributes {independent = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true>}
+    func.return
+  }
+  // CHECK:       func.func @loop_gang_operands(
+  // CHECK:         acc.loop gang({num={{.*}} : i64, static={{.*}} : i64}) worker({{.*}} : i64) vector({{.*}} : i64) control(%{{.*}} : index)
+
+  func.func @loop_tile(%v : i64, %lb : index, %ub : index, %st : index) {
+    acc.loop tile({%v : i64, %v : i64}) control(%iv : index) = (%lb : index) to (%ub : index) step (%st : index) {
+      acc.yield
+    } attributes {independent = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true>}
+    func.return
+  }
+  // CHECK:       func.func @loop_tile(
+  // CHECK:         acc.loop tile({{{.*}} : i64, {{.*}} : i64}) control(%{{.*}} : index)
+
+  func.func @loop_combined(%lb : index, %ub : index, %st : index) {
+    acc.loop combined(parallel) control(%iv : index) = (%lb : index) to (%ub : index) step (%st : index) {
+      acc.yield
+    } attributes {independent = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true>}
+    func.return
+  }
+  // CHECK:       func.func @loop_combined(
+  // CHECK:         acc.loop combined(parallel) control(%{{.*}} : index)
+
+  // Upstream `acc.private` / `acc.firstprivate` / `acc.reduction` verifiers
+  // require a `recipe(@...)` symbol reference, so the loop's data-clause
+  // case carries pre-declared recipes (matching upstream's
+  // `mlir/test/Dialect/OpenACC/ops.mlir` shape).
+  acc.private.recipe @priv_loop : memref<10xf32> init {
+  ^bb0(%arg0: memref<10xf32>):
+    acc.yield %arg0 : memref<10xf32>
+  }
+  acc.firstprivate.recipe @fp_loop : memref<10xf32> init {
+  ^bb0(%arg0: memref<10xf32>):
+    acc.yield %arg0 : memref<10xf32>
+  } copy {
+  ^bb0(%arg0: memref<10xf32>, %arg1: memref<10xf32>):
+    acc.yield
+  }
+  acc.reduction.recipe @red_loop : memref<10xf32> reduction_operator <add> init {
+  ^bb0(%arg0: memref<10xf32>):
+    acc.yield %arg0 : memref<10xf32>
+  } combiner {
+  ^bb0(%arg0: memref<10xf32>, %arg1: memref<10xf32>):
+    acc.yield %arg0 : memref<10xf32>
+  }
+  func.func @loop_data_clauses(%a : memref<10xf32>, %lb : index, %ub : index, %st : index) {
+    %p = acc.private varPtr(%a : memref<10xf32>) recipe(@priv_loop) -> memref<10xf32>
+    %f = acc.firstprivate varPtr(%a : memref<10xf32>) recipe(@fp_loop) -> memref<10xf32>
+    %r = acc.reduction varPtr(%a : memref<10xf32>) recipe(@red_loop) -> memref<10xf32>
+    acc.loop private(%p : memref<10xf32>) firstprivate(%f : memref<10xf32>) reduction(%r : memref<10xf32>) control(%iv : index) = (%lb : index) to (%ub : index) step (%st : index) {
+      acc.yield
+    } attributes {independent = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true>}
+    func.return
+  }
+  // CHECK:       func.func @loop_data_clauses(
+  // CHECK:         acc.loop private({{.*}} : memref<10xf32>) firstprivate({{.*}} : memref<10xf32>) reduction({{.*}} : memref<10xf32>) control(%{{.*}} : index)
+
+  func.func @loop_cache(%a : memref<10xf32>, %lb : index, %ub : index, %st : index) {
+    %b = acc.cache varPtr(%a : memref<10xf32>) -> memref<10xf32>
+    acc.loop cache(%b : memref<10xf32>) control(%iv : index) = (%lb : index) to (%ub : index) step (%st : index) {
+      acc.yield
+    } attributes {independent = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true>}
+    func.return
+  }
+  // CHECK:       func.func @loop_cache(
+  // CHECK:         acc.loop cache({{.*}} : memref<10xf32>) control(%{{.*}} : index)
+
 }

--- a/xdsl/dialects/acc.py
+++ b/xdsl/dialects/acc.py
@@ -2551,17 +2551,12 @@ def _verify_dt_count_match(
 
 def _verify_dt_and_segment_count_match(
     operands: Sequence[SSAValue],
-    segments: DenseArrayBase | None,
+    segments: DenseArrayBase[IntegerType] | None,
     device_types: ArrayAttr[DeviceTypeAttr] | None,
     keyword: str,
 ) -> None:
     """Mirror of upstream's `verifyDeviceTypeAndSegmentCountMatch`."""
-    seg_values: tuple[int, ...] = ()
-    if segments is not None:
-        # `segments` is always built from an `i32` element type by the parser
-        # / our own builders — narrow for the typed `get_values` overload.
-        assert isa(segments, DenseArrayBase[IntegerType])
-        seg_values = segments.get_values()
+    seg_values = segments.get_values() if segments is not None else ()
     num_in_segments = sum(seg_values)
     nb_segments = len(seg_values)
     if num_in_segments != len(operands) or (device_types is None and operands):

--- a/xdsl/dialects/acc.py
+++ b/xdsl/dialects/acc.py
@@ -2295,13 +2295,12 @@ class LoopOp(IRDLOperation):
         # entry on the matching seq/independent/auto array. Explicit
         # `seq=` / `independent=` / `auto_=` arguments win if also given.
         if par_mode is not None:
-            none_array = ArrayAttr([DeviceTypeAttr(DeviceType.NONE)])
             if par_mode is LoopParMode.SEQ and seq is None:
-                seq = none_array
+                seq = _DEVICE_TYPE_ONLY_NONE
             elif par_mode is LoopParMode.INDEPENDENT and independent is None:
-                independent = none_array
+                independent = _DEVICE_TYPE_ONLY_NONE
             elif par_mode is LoopParMode.AUTO and auto_ is None:
-                auto_ = none_array
+                auto_ = _DEVICE_TYPE_ONLY_NONE
 
         super().__init__(
             operands=[

--- a/xdsl/dialects/acc.py
+++ b/xdsl/dialects/acc.py
@@ -1315,9 +1315,10 @@ class DeviceTypeOperandsWithSegment(CustomDirective):
         return True
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
+        # `is_present = bool(self.operands.get(op))` — when this `print` is
+        # called the operand list is guaranteed non-empty by the framework's
+        # anchor mechanism, so no empty-list early-return guard is needed.
         operands = self.operands.get(op)
-        if not operands:
-            return
         dts = (
             attr.data
             if isa(attr := self.device_types.get(op), ArrayAttr)

--- a/xdsl/dialects/acc.py
+++ b/xdsl/dialects/acc.py
@@ -10,7 +10,7 @@ See external [documentation](https://mlir.llvm.org/docs/Dialects/OpenACCDialect/
 """
 
 from abc import ABC
-from collections.abc import Hashable, Sequence
+from collections.abc import Hashable, Iterable, Sequence
 from typing import cast
 
 from typing_extensions import TypeVar
@@ -2380,7 +2380,7 @@ class LoopOp(IRDLOperation):
             self.collapse_device_type is not None
             and (
                 dup := _first_duplicate(
-                    [dt.data for dt in self.collapse_device_type.data]
+                    dt.data for dt in self.collapse_device_type.data
                 )
             )
             is not None
@@ -2402,8 +2402,7 @@ class LoopOp(IRDLOperation):
                 )
         if (
             self.gang is not None
-            and (dup := _first_duplicate([dt.data for dt in self.gang.data]))
-            is not None
+            and (dup := _first_duplicate(dt.data for dt in self.gang.data)) is not None
         ):
             raise VerifyException(
                 f"duplicate device_type `{dup.value}` found in gang attribute"
@@ -2417,7 +2416,7 @@ class LoopOp(IRDLOperation):
 
         if (
             self.worker is not None
-            and (dup := _first_duplicate([dt.data for dt in self.worker.data]))
+            and (dup := _first_duplicate(dt.data for dt in self.worker.data))
             is not None
         ):
             raise VerifyException(
@@ -2427,7 +2426,7 @@ class LoopOp(IRDLOperation):
             self.worker_num_operands_device_type is not None
             and (
                 dup := _first_duplicate(
-                    [dt.data for dt in self.worker_num_operands_device_type.data]
+                    dt.data for dt in self.worker_num_operands_device_type.data
                 )
             )
             is not None
@@ -2444,7 +2443,7 @@ class LoopOp(IRDLOperation):
 
         if (
             self.vector is not None
-            and (dup := _first_duplicate([dt.data for dt in self.vector.data]))
+            and (dup := _first_duplicate(dt.data for dt in self.vector.data))
             is not None
         ):
             raise VerifyException(
@@ -2454,7 +2453,7 @@ class LoopOp(IRDLOperation):
             self.vector_operands_device_type is not None
             and (
                 dup := _first_duplicate(
-                    [dt.data for dt in self.vector_operands_device_type.data]
+                    dt.data for dt in self.vector_operands_device_type.data
                 )
             )
             is not None
@@ -2520,7 +2519,7 @@ class LoopOp(IRDLOperation):
 _T = TypeVar("_T", bound=Hashable)
 
 
-def _first_duplicate(els: Sequence[_T]) -> _T | None:
+def _first_duplicate(els: Iterable[_T]) -> _T | None:
     """Return the first duplicate `el` in `els`, `None` if there are no duplicates."""
     seen: set[_T] = set()
     for el in els:

--- a/xdsl/dialects/acc.py
+++ b/xdsl/dialects/acc.py
@@ -56,6 +56,7 @@ from xdsl.irdl import (
     result_def,
     traits_def,
     var_operand_def,
+    var_result_def,
 )
 from xdsl.irdl.declarative_assembly_format import (
     AttributeVariable,
@@ -64,6 +65,7 @@ from xdsl.irdl.declarative_assembly_format import (
     OptionalOperandVariable,
     ParsingState,
     PrintingState,
+    RegionVariable,
     TypeDirective,
     VariadicOperandVariable,
     irdl_custom_directive,
@@ -184,6 +186,19 @@ class ReductionOpKind(StrEnum):
     NEQV = "neqv"
     LAND = "land"
     LOR = "lor"
+
+
+class LoopParMode(StrEnum):
+    """Loop parallelism determination mode for `acc.loop` builders.
+
+    See upstream `mlir::acc::LoopParMode`. Used by Python builders to pick
+    between the `seq` / `independent` / `auto` attributes; the enum itself
+    is not stored on the op.
+    """
+
+    SEQ = "loop_seq"
+    AUTO = "loop_auto"
+    INDEPENDENT = "loop_independent"
 
 
 class GangArgType(StrEnum):
@@ -1222,6 +1237,416 @@ class DataEntryOilist(CustomDirective):
             state.last_was_punctuation = False
 
 
+@irdl_custom_directive
+class CombinedConstructsLoop(CustomDirective):
+    """Port of upstream `custom<CombinedConstructsLoop>($combined)`.
+
+    Sits inside `acc.loop`'s `combined ( ... )` group: parses one of the
+    bare keywords `kernels` / `parallel` / `serial` and produces a
+    `CombinedConstructsTypeAttr`. On print, emits the matching keyword.
+    """
+
+    combined: AttributeVariable
+
+    _KEYWORDS = ("kernels", "parallel", "serial")
+    _BY_KEYWORD = {
+        "kernels": CombinedConstructsType.KERNELS_LOOP,
+        "parallel": CombinedConstructsType.PARALLEL_LOOP,
+        "serial": CombinedConstructsType.SERIAL_LOOP,
+    }
+    _BY_VALUE = {v: k for k, v in _BY_KEYWORD.items()}
+
+    def is_anchorable(self) -> bool:
+        return True
+
+    def is_present(self, op: IRDLOperation) -> bool:
+        return self.combined.get(op) is not None
+
+    def parse(self, parser: Parser, state: ParsingState) -> bool:
+        for kw in self._KEYWORDS:
+            if parser.parse_optional_keyword(kw) is not None:
+                self.combined.set(
+                    state, CombinedConstructsTypeAttr(self._BY_KEYWORD[kw])
+                )
+                return True
+        parser.raise_error("expected compute construct name")
+
+    def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
+        attr = self.combined.get(op)
+        assert isinstance(attr, CombinedConstructsTypeAttr)
+        printer.print_string(self._BY_VALUE[attr.data])
+
+
+@irdl_custom_directive
+class DeviceTypeOperandsWithSegment(CustomDirective):
+    """Port of upstream `custom<DeviceTypeOperandsWithSegment>`.
+
+    Used by `acc.loop` for the `tile(...)` clause. Groups operands inside
+    `{...}`, with an optional per-group `[#acc.device_type<...>]` suffix
+    and a `DenseI32ArrayAttr` segments array. Syntax inside the enclosing
+    `( ... )`:
+      `{` op:type (`,` op:type)* `}` (`[` dt `]`)?  (`,` ...)*
+    """
+
+    operands: VariadicOperandVariable
+    operand_types: TypeDirective
+    device_types: AttributeVariable
+    segments: AttributeVariable
+
+    def is_anchorable(self) -> bool:
+        return True
+
+    def is_present(self, op: IRDLOperation) -> bool:
+        return bool(self.operands.get(op))
+
+    def set_empty(self, state: ParsingState) -> None:
+        self.operands.set(state, ())
+        self.operand_types.set(state, ())
+
+    def parse(self, parser: Parser, state: ParsingState) -> bool:
+        groups = parser.parse_comma_separated_list(
+            parser.Delimiter.NONE, lambda: _parse_num_gangs_group(parser)
+        )
+        operands, types, dts, segs = _flatten_groups(groups)
+        self.operands.set(state, operands)
+        self.operand_types.set(state, types)
+        self.device_types.set(state, ArrayAttr(dts))
+        self.segments.set(state, DenseArrayBase.from_list(i32, segs))
+        return True
+
+    def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
+        operands = self.operands.get(op)
+        if not operands:
+            return
+        dts = (
+            attr.data
+            if isa(attr := self.device_types.get(op), ArrayAttr)
+            else (DeviceTypeAttr(DeviceType.NONE),)
+        )
+        seg_values: Sequence[int] = (
+            segments.get_values()
+            if isinstance(segments := self.segments.get(op), DenseArrayBase)
+            else (len(operands),)
+        )
+        _print_groups(printer, operands, dts, seg_values)
+        state.should_emit_space = True
+        state.last_was_punctuation = False
+
+
+_GANG_KEYWORDS: tuple[tuple[str, GangArgType], ...] = (
+    ("num", GangArgType.NUM),
+    ("dim", GangArgType.DIM),
+    ("static", GangArgType.STATIC),
+)
+"""`(keyword, GangArgType)` pairs in upstream's parse-attempt order."""
+
+_GANG_KEYWORD_BY_TYPE = {ty: kw for kw, ty in _GANG_KEYWORDS}
+
+
+def _parse_gang_value_group(
+    parser: Parser,
+) -> tuple[
+    tuple[UnresolvedOperand, ...],
+    tuple[Attribute, ...],
+    tuple[GangArgTypeAttr, ...],
+    DeviceTypeAttr,
+]:
+    """Parse `{ kw=%v:T (`,` kw=%v:T)* }` plus an optional `[#dt]` suffix.
+
+    Returns `(operands, types, gang_arg_types, device_type)`. Mirrors the
+    inner loop of upstream's `parseGangClause`, which retries each
+    `num=` / `dim=` / `static=` keyword in order; raises on an empty group
+    matching upstream's "expect at least one of num, dim or static values"
+    diagnostic.
+    """
+    with parser.in_braces():
+        operands: list[UnresolvedOperand] = []
+        types: list[Attribute] = []
+        arg_types: list[GangArgTypeAttr] = []
+        need_comma = False
+        while True:
+            if need_comma and parser.parse_optional_punctuation(",") is None:
+                break
+            matched = False
+            for keyword, gang_arg_ty in _GANG_KEYWORDS:
+                if parser.parse_optional_keyword(keyword) is None:
+                    continue
+                parser.parse_punctuation("=")
+                operand, ty = _parse_typed_operand(parser)
+                operands.append(operand)
+                types.append(ty)
+                arg_types.append(GangArgTypeAttr(gang_arg_ty))
+                matched = True
+                need_comma = True
+                break
+            if not matched:
+                if need_comma:
+                    parser.raise_error("new value expected after comma")
+                break
+        if not operands:
+            parser.raise_error("expect at least one of num, dim or static values")
+    dt = _parse_optional_device_type_suffix(parser)
+    return tuple(operands), tuple(types), tuple(arg_types), dt
+
+
+@irdl_custom_directive
+class GangClause(CustomDirective):
+    """Port of upstream `custom<GangClause>`.
+
+    Follows a bare `gang` keyword in `acc.loop`'s format. The directive
+    owns the optional surrounding parentheses. Syntax options after the
+    keyword:
+      bare                                     → `gang_only` = [#none]
+      `(` `[` dts `]` `)`                      → keyword-only DT list, no operands
+      `(` group (`,` group)* `)`               → gang operand groups
+      `(` `[` dts `]` `,` group (`,` group)* `)` → mix of keyword-only and groups
+    where each group is `{ kw=%v:T (`,` kw=%v:T)* }` (`[` dt `]`)? and
+    `kw` ∈ {`num`, `dim`, `static`}.
+    """
+
+    operands: VariadicOperandVariable
+    operand_types: TypeDirective
+    gang_arg_types: AttributeVariable
+    device_types: AttributeVariable
+    segments: AttributeVariable
+    gang_only: AttributeVariable
+
+    def is_anchorable(self) -> bool:
+        return True
+
+    def is_present(self, op: IRDLOperation) -> bool:
+        return (
+            bool(self.operands.get(op))
+            or self.gang_only.get(op) is not None
+            or self.device_types.get(op) is not None
+        )
+
+    def set_empty(self, state: ParsingState) -> None:
+        self.operands.set(state, ())
+        self.operand_types.set(state, ())
+
+    def parse(self, parser: Parser, state: ParsingState) -> bool:
+        if not parser.parse_optional_punctuation("("):
+            self.gang_only.set(state, ArrayAttr([DeviceTypeAttr(DeviceType.NONE)]))
+            self.operands.set(state, ())
+            self.operand_types.set(state, ())
+            return True
+
+        kw_only = parser.parse_optional_comma_separated_list(
+            parser.Delimiter.SQUARE, lambda: _parse_device_type_attr(parser)
+        )
+        if kw_only is not None:
+            self.gang_only.set(state, ArrayAttr(kw_only))
+
+        if parser.parse_optional_punctuation(")"):
+            self.operands.set(state, ())
+            self.operand_types.set(state, ())
+            return True
+
+        if kw_only is not None:
+            parser.parse_punctuation(",")
+
+        groups = parser.parse_comma_separated_list(
+            parser.Delimiter.NONE, lambda: _parse_gang_value_group(parser)
+        )
+        parser.parse_punctuation(")")
+
+        all_operands: list[UnresolvedOperand] = []
+        all_types: list[Attribute] = []
+        arg_types: list[GangArgTypeAttr] = []
+        dts: list[DeviceTypeAttr] = []
+        segs: list[int] = []
+        for group_operands, group_types, group_arg_types, dt in groups:
+            all_operands.extend(group_operands)
+            all_types.extend(group_types)
+            arg_types.extend(group_arg_types)
+            dts.append(dt)
+            segs.append(len(group_operands))
+
+        self.operands.set(state, tuple(all_operands))
+        self.operand_types.set(state, tuple(all_types))
+        self.gang_arg_types.set(state, ArrayAttr(arg_types))
+        self.device_types.set(state, ArrayAttr(dts))
+        self.segments.set(state, DenseArrayBase.from_list(i32, segs))
+        return True
+
+    def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
+        operands = self.operands.get(op)
+        gang_only = self.gang_only.get(op)
+
+        if not operands and gang_only == _DEVICE_TYPE_ONLY_NONE:
+            return
+
+        printer.print_string("(")
+        if (
+            isa(gang_only, ArrayAttr)
+            and gang_only.data
+            and gang_only != _DEVICE_TYPE_ONLY_NONE
+        ):
+            printer.print_string("[")
+            printer.print_list(gang_only.data, printer.print_attribute)
+            printer.print_string("]")
+            if operands:
+                printer.print_string(", ")
+
+        if operands:
+            dts = (
+                attr.data
+                if isa(attr := self.device_types.get(op), ArrayAttr)
+                else (DeviceTypeAttr(DeviceType.NONE),)
+            )
+            seg_values: Sequence[int] = (
+                segments.get_values()
+                if isinstance(segments := self.segments.get(op), DenseArrayBase)
+                else (len(operands),)
+            )
+            arg_type_values: Sequence[Attribute] = (
+                arg_attrs.data
+                if isa(arg_attrs := self.gang_arg_types.get(op), ArrayAttr)
+                else ()
+            )
+            idx = 0
+            for group_idx, (size, dt) in enumerate(zip(seg_values, dts, strict=True)):
+                if group_idx:
+                    printer.print_string(", ")
+                printer.print_string("{")
+                for i in range(size):
+                    if i:
+                        printer.print_string(", ")
+                    arg_ty_attr = (
+                        arg_type_values[idx]
+                        if idx < len(arg_type_values)
+                        else GangArgTypeAttr(GangArgType.NUM)
+                    )
+                    keyword = (
+                        _GANG_KEYWORD_BY_TYPE[arg_ty_attr.data]
+                        if isinstance(arg_ty_attr, GangArgTypeAttr)
+                        else "num"
+                    )
+                    printer.print_string(keyword)
+                    printer.print_string("=")
+                    _print_typed_operand(printer, operands[idx])
+                    idx += 1
+                printer.print_string("}")
+                _print_device_type_suffix(printer, dt)
+        printer.print_string(")")
+        state.should_emit_space = True
+        state.last_was_punctuation = False
+
+
+@irdl_custom_directive
+class LoopControl(CustomDirective):
+    """Port of upstream `custom<LoopControl>`.
+
+    Owns `acc.loop`'s region and the optional `control(...) = (...) to (...)
+    step (...)` header. Syntax:
+      `control` `(` arg `:` T (`,` arg `:` T)* `)` `=`
+        `(` lb (`,` lb)* `:` T (`,` T)* `)` `to`
+        `(` ub (`,` ub)* `:` T (`,` T)* `)` `step`
+        `(` st (`,` st)* `:` T (`,` T)* `)`
+        region
+      | region
+
+    The first form provides induction variables to the region's entry
+    block (matching upstream's `parseRegion(region, inductionVars)`); the
+    second form is the container-like loop, which has no induction
+    variables.
+    """
+
+    region: RegionVariable
+    lowerbound: VariadicOperandVariable
+    lowerbound_types: TypeDirective
+    upperbound: VariadicOperandVariable
+    upperbound_types: TypeDirective
+    step: VariadicOperandVariable
+    step_types: TypeDirective
+
+    def parse(self, parser: Parser, state: ParsingState) -> bool:
+        if parser.parse_optional_keyword("control") is None:
+            self.lowerbound.set(state, ())
+            self.lowerbound_types.set(state, ())
+            self.upperbound.set(state, ())
+            self.upperbound_types.set(state, ())
+            self.step.set(state, ())
+            self.step_types.set(state, ())
+            self.region.set(state, parser.parse_region())
+            return True
+
+        with parser.in_parens():
+            args = parser.parse_comma_separated_list(
+                parser.Delimiter.NONE, parser.parse_argument
+            )
+        parser.parse_punctuation("=")
+        lb_ops, lb_types = _parse_loop_bound_group(parser, len(args))
+        parser.parse_keyword("to")
+        ub_ops, ub_types = _parse_loop_bound_group(parser, len(args))
+        parser.parse_keyword("step")
+        st_ops, st_types = _parse_loop_bound_group(parser, len(args))
+
+        self.lowerbound.set(state, lb_ops)
+        self.lowerbound_types.set(state, lb_types)
+        self.upperbound.set(state, ub_ops)
+        self.upperbound_types.set(state, ub_types)
+        self.step.set(state, st_ops)
+        self.step_types.set(state, st_types)
+        self.region.set(state, parser.parse_region(args))
+        return True
+
+    def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
+        region = self.region.get(op)
+        entry_args: Sequence[SSAValue] = region.block.args if region.blocks else ()
+        lb_ops = self.lowerbound.get(op)
+        ub_ops = self.upperbound.get(op)
+        st_ops = self.step.get(op)
+
+        state.print_whitespace(printer)
+        if entry_args:
+            printer.print_string("control(")
+            printer.print_list(
+                entry_args,
+                lambda arg: _print_typed_operand(printer, arg),
+            )
+            printer.print_string(") = (")
+            _print_loop_bound_group(printer, lb_ops)
+            printer.print_string(") to (")
+            _print_loop_bound_group(printer, ub_ops)
+            printer.print_string(") step (")
+            _print_loop_bound_group(printer, st_ops)
+            printer.print_string(") ")
+
+        printer.print_region(region, print_entry_block_args=False)
+        state.should_emit_space = True
+        state.last_was_punctuation = False
+
+
+def _parse_loop_bound_group(
+    parser: Parser, count: int
+) -> tuple[tuple[UnresolvedOperand, ...], tuple[Attribute, ...]]:
+    """Parse `(%a (`,` %a)* `:` T (`,` T)*)` with exactly `count` operands and types."""
+    with parser.in_parens():
+        operands = tuple(
+            parser.parse_comma_separated_list(
+                parser.Delimiter.NONE, parser.parse_unresolved_operand
+            )
+        )
+        if len(operands) != count:
+            parser.raise_error(f"expected {count} operands")
+        parser.parse_punctuation(":")
+        types = tuple(
+            parser.parse_comma_separated_list(parser.Delimiter.NONE, parser.parse_type)
+        )
+        if len(types) != count:
+            parser.raise_error(f"expected {count} types")
+    return operands, types
+
+
+def _print_loop_bound_group(printer: Printer, operands: Sequence[SSAValue]) -> None:
+    """Print `%a (`,` %a)* `:` T (`,` T)*` for a loop control bound group."""
+    printer.print_list(operands, printer.print_ssa_value)
+    printer.print_string(" : ")
+    printer.print_list((operand.type for operand in operands), printer.print_attribute)
+
+
 @irdl_op_definition
 class ParallelOp(IRDLOperation):
     """
@@ -1701,6 +2126,451 @@ class KernelsOp(IRDLOperation):
                 "combined": combined_prop,
             },
             regions=[region],
+        )
+
+
+@irdl_op_definition
+class LoopOp(IRDLOperation):
+    """
+    Implementation of upstream acc.loop — the OpenACC loop construct.
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/OpenACCDialect/#accloop-accloopop).
+
+    Carries the loop's induction variables (`lowerbound` / `upperbound` /
+    `step`) plus per-device-type clauses for `gang` / `worker` / `vector`,
+    `private` / `firstprivate` / `reduction` data ops, `tile` / `cache`
+    operands, `collapse` group sizes, and `seq` / `independent` / `auto`
+    parallelism mode markers. The body is an arbitrary region terminated
+    by `acc.yield`.
+
+    The container-like loop count check from upstream's verifier (which
+    uses `LoopLikeOpInterface` to enumerate loop ops) is intentionally
+    skipped here — xDSL has no equivalent interface yet, so PR 17 of the
+    OpenACC roadmap will wire it up alongside the other interface-driven
+    traits.
+    """
+
+    name = "acc.loop"
+
+    lowerbound = var_operand_def(IntegerType | IndexType)
+    upperbound = var_operand_def(IntegerType | IndexType)
+    step = var_operand_def(IntegerType | IndexType)
+    gang_operands = var_operand_def(IntegerType | IndexType)
+    worker_num_operands = var_operand_def(IntegerType | IndexType)
+    vector_operands = var_operand_def(IntegerType | IndexType)
+    tile_operands = var_operand_def(IntegerType | IndexType)
+    cache_operands = var_operand_def()
+    private_operands = var_operand_def()
+    firstprivate_operands = var_operand_def()
+    reduction_operands = var_operand_def()
+
+    inclusive_upperbound = opt_prop_def(
+        DenseArrayBase.constr(IntegerType(1)), prop_name="inclusiveUpperbound"
+    )
+    collapse = opt_prop_def(ArrayAttr[IntegerAttr])
+    collapse_device_type = opt_prop_def(
+        ArrayAttr[DeviceTypeAttr], prop_name="collapseDeviceType"
+    )
+    gang_operands_arg_type = opt_prop_def(
+        ArrayAttr[GangArgTypeAttr], prop_name="gangOperandsArgType"
+    )
+    gang_operands_segments = opt_prop_def(
+        DenseArrayBase.constr(IntegerType(32)), prop_name="gangOperandsSegments"
+    )
+    gang_operands_device_type = opt_prop_def(
+        ArrayAttr[DeviceTypeAttr], prop_name="gangOperandsDeviceType"
+    )
+    worker_num_operands_device_type = opt_prop_def(
+        ArrayAttr[DeviceTypeAttr], prop_name="workerNumOperandsDeviceType"
+    )
+    vector_operands_device_type = opt_prop_def(
+        ArrayAttr[DeviceTypeAttr], prop_name="vectorOperandsDeviceType"
+    )
+    seq = opt_prop_def(ArrayAttr[DeviceTypeAttr])
+    independent = opt_prop_def(ArrayAttr[DeviceTypeAttr])
+    auto_ = opt_prop_def(ArrayAttr[DeviceTypeAttr], prop_name="auto_")
+    gang = opt_prop_def(ArrayAttr[DeviceTypeAttr])
+    worker = opt_prop_def(ArrayAttr[DeviceTypeAttr])
+    vector = opt_prop_def(ArrayAttr[DeviceTypeAttr])
+    tile_operands_segments = opt_prop_def(
+        DenseArrayBase.constr(IntegerType(32)), prop_name="tileOperandsSegments"
+    )
+    tile_operands_device_type = opt_prop_def(
+        ArrayAttr[DeviceTypeAttr], prop_name="tileOperandsDeviceType"
+    )
+    combined = opt_prop_def(CombinedConstructsTypeAttr)
+    unstructured = opt_prop_def(UnitAttr)
+
+    results_ = var_result_def()
+
+    region = region_def()
+
+    irdl_options = (
+        AttrSizedOperandSegments(as_property=True),
+        ParsePropInAttrDict(),
+    )
+
+    custom_directives = (
+        CombinedConstructsLoop,
+        GangClause,
+        DeviceTypeOperandsWithKeywordOnly,
+        DeviceTypeOperandsWithSegment,
+        LoopControl,
+    )
+
+    assembly_format = (
+        "(`combined` `(` custom<CombinedConstructsLoop>($combined)^ `)`)?"
+        " (`gang` custom<GangClause>($gang_operands, type($gang_operands),"
+        " $gangOperandsArgType, $gangOperandsDeviceType,"
+        " $gangOperandsSegments, $gang)^)?"
+        " (`worker` custom<DeviceTypeOperandsWithKeywordOnly>("
+        "$worker_num_operands, type($worker_num_operands),"
+        " $workerNumOperandsDeviceType, $worker)^)?"
+        " (`vector` custom<DeviceTypeOperandsWithKeywordOnly>($vector_operands,"
+        " type($vector_operands), $vectorOperandsDeviceType, $vector)^)?"
+        " (`private` `(` $private_operands^ `:` type($private_operands) `)`)?"
+        " (`firstprivate` `(` $firstprivate_operands^ `:`"
+        " type($firstprivate_operands) `)`)?"
+        " (`tile` `(` custom<DeviceTypeOperandsWithSegment>($tile_operands,"
+        " type($tile_operands), $tileOperandsDeviceType,"
+        " $tileOperandsSegments)^ `)`)?"
+        " (`reduction` `(` $reduction_operands^ `:`"
+        " type($reduction_operands) `)`)?"
+        " (`cache` `(` $cache_operands^ `:` type($cache_operands) `)`)?"
+        " custom<LoopControl>($region, $lowerbound, type($lowerbound),"
+        " $upperbound, type($upperbound), $step, type($step))"
+        " (`(` type($results_)^ `)`)?"
+        " attr-dict-with-keyword"
+    )
+
+    traits = lazy_traits_def(lambda: (RecursiveMemoryEffect(),))
+
+    def __init__(
+        self,
+        *,
+        region: Region,
+        lowerbound: Sequence[SSAValue | Operation] = (),
+        upperbound: Sequence[SSAValue | Operation] = (),
+        step: Sequence[SSAValue | Operation] = (),
+        gang_operands: Sequence[SSAValue | Operation] = (),
+        worker_num_operands: Sequence[SSAValue | Operation] = (),
+        vector_operands: Sequence[SSAValue | Operation] = (),
+        tile_operands: Sequence[SSAValue | Operation] = (),
+        cache_operands: Sequence[SSAValue | Operation] = (),
+        private_operands: Sequence[SSAValue | Operation] = (),
+        firstprivate_operands: Sequence[SSAValue | Operation] = (),
+        reduction_operands: Sequence[SSAValue | Operation] = (),
+        result_types: Sequence[Attribute] = (),
+        inclusive_upperbound: DenseArrayBase | None = None,
+        collapse: ArrayAttr[IntegerAttr] | None = None,
+        collapse_device_type: ArrayAttr[DeviceTypeAttr] | None = None,
+        gang_operands_arg_type: ArrayAttr[GangArgTypeAttr] | None = None,
+        gang_operands_segments: DenseArrayBase | None = None,
+        gang_operands_device_type: ArrayAttr[DeviceTypeAttr] | None = None,
+        worker_num_operands_device_type: ArrayAttr[DeviceTypeAttr] | None = None,
+        vector_operands_device_type: ArrayAttr[DeviceTypeAttr] | None = None,
+        seq: ArrayAttr[DeviceTypeAttr] | None = None,
+        independent: ArrayAttr[DeviceTypeAttr] | None = None,
+        auto_: ArrayAttr[DeviceTypeAttr] | None = None,
+        gang: ArrayAttr[DeviceTypeAttr] | None = None,
+        worker: ArrayAttr[DeviceTypeAttr] | None = None,
+        vector: ArrayAttr[DeviceTypeAttr] | None = None,
+        tile_operands_segments: DenseArrayBase | None = None,
+        tile_operands_device_type: ArrayAttr[DeviceTypeAttr] | None = None,
+        combined: CombinedConstructsTypeAttr | CombinedConstructsType | None = None,
+        unstructured: UnitAttr | bool = False,
+        par_mode: LoopParMode | None = None,
+    ) -> None:
+        unstructured_prop: UnitAttr | None = (
+            (UnitAttr() if unstructured else None)
+            if isinstance(unstructured, bool)
+            else unstructured
+        )
+        combined_prop: CombinedConstructsTypeAttr | None = (
+            CombinedConstructsTypeAttr(combined)
+            if isinstance(combined, CombinedConstructsType)
+            else combined
+        )
+        # Mirror upstream's `LoopParMode`-driven builder: a single device-`none`
+        # entry on the matching seq/independent/auto array. Explicit
+        # `seq=` / `independent=` / `auto_=` arguments win if also given.
+        if par_mode is not None:
+            none_array = ArrayAttr([DeviceTypeAttr(DeviceType.NONE)])
+            if par_mode is LoopParMode.SEQ and seq is None:
+                seq = none_array
+            elif par_mode is LoopParMode.INDEPENDENT and independent is None:
+                independent = none_array
+            elif par_mode is LoopParMode.AUTO and auto_ is None:
+                auto_ = none_array
+
+        super().__init__(
+            operands=[
+                lowerbound,
+                upperbound,
+                step,
+                gang_operands,
+                worker_num_operands,
+                vector_operands,
+                tile_operands,
+                cache_operands,
+                private_operands,
+                firstprivate_operands,
+                reduction_operands,
+            ],
+            properties={
+                "inclusiveUpperbound": inclusive_upperbound,
+                "collapse": collapse,
+                "collapseDeviceType": collapse_device_type,
+                "gangOperandsArgType": gang_operands_arg_type,
+                "gangOperandsSegments": gang_operands_segments,
+                "gangOperandsDeviceType": gang_operands_device_type,
+                "workerNumOperandsDeviceType": worker_num_operands_device_type,
+                "vectorOperandsDeviceType": vector_operands_device_type,
+                "seq": seq,
+                "independent": independent,
+                "auto_": auto_,
+                "gang": gang,
+                "worker": worker,
+                "vector": vector,
+                "tileOperandsSegments": tile_operands_segments,
+                "tileOperandsDeviceType": tile_operands_device_type,
+                "combined": combined_prop,
+                "unstructured": unstructured_prop,
+            },
+            regions=[region],
+            result_types=[result_types],
+        )
+
+    def verify_(self) -> None:
+        # Mirrors `acc::LoopOp::verify`. The container-like loop checks
+        # (sibling loops / collapse-count satisfaction) require a
+        # `LoopLikeOpInterface`-style enumeration that xDSL doesn't have
+        # yet — those land in PR 17 of the OpenACC roadmap.
+        #
+        # The DT array attrs (`gang` / `worker` / `vector` / `seq` /
+        # `independent` / `auto_`) are referenced by name in the assembly
+        # format, so xDSL routes attr-dict-form spellings into
+        # `op.attributes` rather than `op.properties`. The
+        # `_get_attr_or_prop` helper lets the verifier read both surfaces
+        # — matching MLIR's behavior, where TableGen-declared properties
+        # are looked up from one storage regardless of how the user wrote
+        # them.
+        gang = _get_attr_or_prop(self, "gang")
+        worker = _get_attr_or_prop(self, "worker")
+        vector = _get_attr_or_prop(self, "vector")
+        seq = _get_attr_or_prop(self, "seq")
+        independent = _get_attr_or_prop(self, "independent")
+        auto_ = _get_attr_or_prop(self, "auto_")
+
+        if len(self.upperbound) != len(self.step):
+            raise VerifyException(
+                "number of upperbounds expected to be the same as number of steps"
+            )
+        if len(self.upperbound) != len(self.lowerbound):
+            raise VerifyException(
+                "number of upperbounds expected to be the same as number of lowerbounds"
+            )
+        if (
+            self.upperbound
+            and self.inclusive_upperbound is not None
+            and len(self.inclusive_upperbound.get_values()) != len(self.upperbound)
+        ):
+            raise VerifyException(
+                "inclusiveUpperbound size is expected to be the same as upperbound size"
+            )
+
+        if self.collapse is not None and self.collapse_device_type is None:
+            raise VerifyException(
+                "collapse device_type attr must be define when collapse attr is present"
+            )
+        if (
+            self.collapse is not None
+            and self.collapse_device_type is not None
+            and len(self.collapse) != len(self.collapse_device_type)
+        ):
+            raise VerifyException(
+                "collapse attribute count must match collapse device_type count"
+            )
+        if (dup := _duplicate_device_type(self.collapse_device_type)) is not None:
+            raise VerifyException(
+                f"duplicate device_type `{dup.value}` found in "
+                "collapseDeviceType attribute"
+            )
+
+        if self.gang_operands:
+            if self.gang_operands_arg_type is None:
+                raise VerifyException(
+                    "gangOperandsArgType attribute must be defined when gang "
+                    "operands are present"
+                )
+            if len(self.gang_operands) != len(self.gang_operands_arg_type):
+                raise VerifyException(
+                    "gangOperandsArgType attribute count must match gangOperands count"
+                )
+        if (dup := _duplicate_device_type(gang)) is not None:
+            raise VerifyException(
+                f"duplicate device_type `{dup.value}` found in gang attribute"
+            )
+        _verify_dt_and_segment_count_match(
+            self.gang_operands,
+            self.gang_operands_segments,
+            self.gang_operands_device_type,
+            "gang",
+        )
+
+        if (dup := _duplicate_device_type(worker)) is not None:
+            raise VerifyException(
+                f"duplicate device_type `{dup.value}` found in worker attribute"
+            )
+        if (
+            dup := _duplicate_device_type(self.worker_num_operands_device_type)
+        ) is not None:
+            raise VerifyException(
+                f"duplicate device_type `{dup.value}` found in "
+                "workerNumOperandsDeviceType attribute"
+            )
+        _verify_dt_count_match(
+            self.worker_num_operands,
+            self.worker_num_operands_device_type,
+            "worker",
+        )
+
+        if (dup := _duplicate_device_type(vector)) is not None:
+            raise VerifyException(
+                f"duplicate device_type `{dup.value}` found in vector attribute"
+            )
+        if (
+            dup := _duplicate_device_type(self.vector_operands_device_type)
+        ) is not None:
+            raise VerifyException(
+                f"duplicate device_type `{dup.value}` found in "
+                "vectorOperandsDeviceType attribute"
+            )
+        _verify_dt_count_match(
+            self.vector_operands, self.vector_operands_device_type, "vector"
+        )
+
+        _verify_dt_and_segment_count_match(
+            self.tile_operands,
+            self.tile_operands_segments,
+            self.tile_operands_device_type,
+            "tile",
+        )
+
+        # auto / independent / seq must not specify the same device type more
+        # than once across all three.
+        seen_device_types: set[DeviceType] = set()
+        for attr in (auto_, independent, seq):
+            if attr is None:
+                continue
+            for dt in attr.data:
+                if dt.data in seen_device_types:
+                    raise VerifyException(
+                        "only one of auto, independent, seq can be present at "
+                        "the same time"
+                    )
+                seen_device_types.add(dt.data)
+
+        # At least one of auto / independent / seq must apply to the
+        # device-`none` (default) device type.
+        has_default = any(
+            attr is not None and any(dt.data is DeviceType.NONE for dt in attr.data)
+            for attr in (seq, independent, auto_)
+        )
+        if not has_default:
+            raise VerifyException(
+                "at least one of auto, independent, seq must be present"
+            )
+
+        # `gang` / `worker` / `vector` cannot coexist with `seq` for the same
+        # device type.
+        if seq is not None:
+            seq_device_types = {dt.data for dt in seq.data}
+            for attr in (gang, worker, vector):
+                if attr is None:
+                    continue
+                if any(dt.data in seq_device_types for dt in attr.data):
+                    raise VerifyException(
+                        "gang, worker or vector cannot appear with seq"
+                    )
+
+        if self.unstructured is not None and self.lowerbound:
+            raise VerifyException(
+                "unstructured acc.loop must not have induction variables"
+            )
+
+
+def _get_attr_or_prop(op: IRDLOperation, name: str) -> ArrayAttr[DeviceTypeAttr] | None:
+    """Read a `gang` / `worker` / `vector` / `seq` / `independent` / `auto_`
+    DT array from either the op's properties or its attributes dict.
+
+    These six properties are referenced by name in `acc.loop`'s assembly
+    format (as the `^` keyword anchor for the corresponding clause), so the
+    declarative-format parser routes attr-dict-form spellings into
+    `op.attributes` rather than `op.properties`. The verifier must consult
+    both surfaces to mirror MLIR — where TableGen-declared properties are
+    looked up from one storage regardless of how the user wrote them.
+
+    The IRDL framework enforces the `ArrayAttr[DeviceTypeAttr]` type on the
+    underlying `opt_prop_def` before `verify_` runs (rejecting wrong-typed
+    inputs like `attributes {gang = 42}` upstream of this lookup), so the
+    `assert isa(...)` here documents the invariant rather than guarding
+    against a reachable case.
+    """
+    attr = op.properties.get(name) or op.attributes.get(name)
+    if attr is None:
+        return None
+    assert isa(attr, ArrayAttr[DeviceTypeAttr])
+    return attr
+
+
+def _duplicate_device_type(
+    attr: ArrayAttr[DeviceTypeAttr] | None,
+) -> DeviceType | None:
+    """Return the first duplicate device type in ``attr``, or `None` if none."""
+    if attr is None:
+        return None
+    seen: set[DeviceType] = set()
+    for dt in attr.data:
+        if dt.data in seen:
+            return dt.data
+        seen.add(dt.data)
+    return None
+
+
+def _verify_dt_count_match(
+    operands: Sequence[SSAValue],
+    device_types: ArrayAttr[DeviceTypeAttr] | None,
+    keyword: str,
+) -> None:
+    """Mirror of upstream's `verifyDeviceTypeCountMatch`."""
+    if operands and (device_types is None or len(device_types) != len(operands)):
+        raise VerifyException(
+            f"{keyword} operands count must match {keyword} device_type count"
+        )
+
+
+def _verify_dt_and_segment_count_match(
+    operands: Sequence[SSAValue],
+    segments: DenseArrayBase | None,
+    device_types: ArrayAttr[DeviceTypeAttr] | None,
+    keyword: str,
+) -> None:
+    """Mirror of upstream's `verifyDeviceTypeAndSegmentCountMatch`."""
+    seg_values: tuple[int, ...] = ()
+    if segments is not None:
+        # `segments` is always built from an `i32` element type by the parser
+        # / our own builders — narrow for the typed `get_values` overload.
+        assert isa(segments, DenseArrayBase[IntegerType])
+        seg_values = segments.get_values()
+    num_in_segments = sum(seg_values)
+    nb_segments = len(seg_values)
+    if num_in_segments != len(operands) or (device_types is None and operands):
+        raise VerifyException(
+            f"{keyword} operand count does not match count in segments"
+        )
+    if device_types is not None and len(device_types) != nb_segments:
+        raise VerifyException(
+            f"{keyword} segment count does not match device_type count"
         )
 
 
@@ -3467,6 +4337,7 @@ class YieldOp(AbstractYieldOperation[Attribute]):
             HasParent(
                 ParallelOp,
                 SerialOp,
+                LoopOp,
                 PrivateRecipeOp,
                 FirstprivateRecipeOp,
                 ReductionRecipeOp,
@@ -3481,6 +4352,7 @@ ACC = Dialect(
         ParallelOp,
         SerialOp,
         KernelsOp,
+        LoopOp,
         DataOp,
         HostDataOp,
         DataBoundsOp,

--- a/xdsl/dialects/acc.py
+++ b/xdsl/dialects/acc.py
@@ -10,8 +10,10 @@ See external [documentation](https://mlir.llvm.org/docs/Dialects/OpenACCDialect/
 """
 
 from abc import ABC
-from collections.abc import Sequence
+from collections.abc import Hashable, Sequence
 from typing import cast
+
+from typing_extensions import TypeVar
 
 from xdsl.dialects.builtin import (
     I1,
@@ -2374,7 +2376,15 @@ class LoopOp(IRDLOperation):
             raise VerifyException(
                 "collapse attribute count must match collapse device_type count"
             )
-        if (dup := _duplicate_device_type(self.collapse_device_type)) is not None:
+        if (
+            self.collapse_device_type is not None
+            and (
+                dup := _first_duplicate(
+                    [dt.data for dt in self.collapse_device_type.data]
+                )
+            )
+            is not None
+        ):
             raise VerifyException(
                 f"duplicate device_type `{dup.value}` found in "
                 "collapseDeviceType attribute"
@@ -2390,7 +2400,11 @@ class LoopOp(IRDLOperation):
                 raise VerifyException(
                     "gangOperandsArgType attribute count must match gangOperands count"
                 )
-        if (dup := _duplicate_device_type(self.gang)) is not None:
+        if (
+            self.gang is not None
+            and (dup := _first_duplicate([dt.data for dt in self.gang.data]))
+            is not None
+        ):
             raise VerifyException(
                 f"duplicate device_type `{dup.value}` found in gang attribute"
             )
@@ -2401,13 +2415,23 @@ class LoopOp(IRDLOperation):
             "gang",
         )
 
-        if (dup := _duplicate_device_type(self.worker)) is not None:
+        if (
+            self.worker is not None
+            and (dup := _first_duplicate([dt.data for dt in self.worker.data]))
+            is not None
+        ):
             raise VerifyException(
                 f"duplicate device_type `{dup.value}` found in worker attribute"
             )
         if (
-            dup := _duplicate_device_type(self.worker_num_operands_device_type)
-        ) is not None:
+            self.worker_num_operands_device_type is not None
+            and (
+                dup := _first_duplicate(
+                    [dt.data for dt in self.worker_num_operands_device_type.data]
+                )
+            )
+            is not None
+        ):
             raise VerifyException(
                 f"duplicate device_type `{dup.value}` found in "
                 "workerNumOperandsDeviceType attribute"
@@ -2418,13 +2442,23 @@ class LoopOp(IRDLOperation):
             "worker",
         )
 
-        if (dup := _duplicate_device_type(self.vector)) is not None:
+        if (
+            self.vector is not None
+            and (dup := _first_duplicate([dt.data for dt in self.vector.data]))
+            is not None
+        ):
             raise VerifyException(
                 f"duplicate device_type `{dup.value}` found in vector attribute"
             )
         if (
-            dup := _duplicate_device_type(self.vector_operands_device_type)
-        ) is not None:
+            self.vector_operands_device_type is not None
+            and (
+                dup := _first_duplicate(
+                    [dt.data for dt in self.vector_operands_device_type.data]
+                )
+            )
+            is not None
+        ):
             raise VerifyException(
                 f"duplicate device_type `{dup.value}` found in "
                 "vectorOperandsDeviceType attribute"
@@ -2483,18 +2517,16 @@ class LoopOp(IRDLOperation):
             )
 
 
-def _duplicate_device_type(
-    attr: ArrayAttr[DeviceTypeAttr] | None,
-) -> DeviceType | None:
-    """Return the first duplicate device type in ``attr``, or `None` if none."""
-    if attr is None:
-        return None
-    seen: set[DeviceType] = set()
-    for dt in attr.data:
-        if dt.data in seen:
-            return dt.data
-        seen.add(dt.data)
-    return None
+_T = TypeVar("_T", bound=Hashable)
+
+
+def _first_duplicate(els: Sequence[_T]) -> _T | None:
+    """Return the first duplicate `el` in `els`, `None` if there are no duplicates."""
+    seen: set[_T] = set()
+    for el in els:
+        if el in seen:
+            return el
+        seen.add(el)
 
 
 def _verify_dt_count_match(

--- a/xdsl/dialects/acc.py
+++ b/xdsl/dialects/acc.py
@@ -2345,22 +2345,6 @@ class LoopOp(IRDLOperation):
         # (sibling loops / collapse-count satisfaction) require a
         # `LoopLikeOpInterface`-style enumeration that xDSL doesn't have
         # yet — those land in PR 17 of the OpenACC roadmap.
-        #
-        # The DT array attrs (`gang` / `worker` / `vector` / `seq` /
-        # `independent` / `auto_`) are referenced by name in the assembly
-        # format, so xDSL routes attr-dict-form spellings into
-        # `op.attributes` rather than `op.properties`. The
-        # `_get_attr_or_prop` helper lets the verifier read both surfaces
-        # — matching MLIR's behavior, where TableGen-declared properties
-        # are looked up from one storage regardless of how the user wrote
-        # them.
-        gang = _get_attr_or_prop(self, "gang")
-        worker = _get_attr_or_prop(self, "worker")
-        vector = _get_attr_or_prop(self, "vector")
-        seq = _get_attr_or_prop(self, "seq")
-        independent = _get_attr_or_prop(self, "independent")
-        auto_ = _get_attr_or_prop(self, "auto_")
-
         if len(self.upperbound) != len(self.step):
             raise VerifyException(
                 "number of upperbounds expected to be the same as number of steps"
@@ -2406,7 +2390,7 @@ class LoopOp(IRDLOperation):
                 raise VerifyException(
                     "gangOperandsArgType attribute count must match gangOperands count"
                 )
-        if (dup := _duplicate_device_type(gang)) is not None:
+        if (dup := _duplicate_device_type(self.gang)) is not None:
             raise VerifyException(
                 f"duplicate device_type `{dup.value}` found in gang attribute"
             )
@@ -2417,7 +2401,7 @@ class LoopOp(IRDLOperation):
             "gang",
         )
 
-        if (dup := _duplicate_device_type(worker)) is not None:
+        if (dup := _duplicate_device_type(self.worker)) is not None:
             raise VerifyException(
                 f"duplicate device_type `{dup.value}` found in worker attribute"
             )
@@ -2434,7 +2418,7 @@ class LoopOp(IRDLOperation):
             "worker",
         )
 
-        if (dup := _duplicate_device_type(vector)) is not None:
+        if (dup := _duplicate_device_type(self.vector)) is not None:
             raise VerifyException(
                 f"duplicate device_type `{dup.value}` found in vector attribute"
             )
@@ -2459,7 +2443,7 @@ class LoopOp(IRDLOperation):
         # auto / independent / seq must not specify the same device type more
         # than once across all three.
         seen_device_types: set[DeviceType] = set()
-        for attr in (auto_, independent, seq):
+        for attr in (self.auto_, self.independent, self.seq):
             if attr is None:
                 continue
             for dt in attr.data:
@@ -2474,7 +2458,7 @@ class LoopOp(IRDLOperation):
         # device-`none` (default) device type.
         has_default = any(
             attr is not None and any(dt.data is DeviceType.NONE for dt in attr.data)
-            for attr in (seq, independent, auto_)
+            for attr in (self.seq, self.independent, self.auto_)
         )
         if not has_default:
             raise VerifyException(
@@ -2483,9 +2467,9 @@ class LoopOp(IRDLOperation):
 
         # `gang` / `worker` / `vector` cannot coexist with `seq` for the same
         # device type.
-        if seq is not None:
-            seq_device_types = {dt.data for dt in seq.data}
-            for attr in (gang, worker, vector):
+        if self.seq is not None:
+            seq_device_types = {dt.data for dt in self.seq.data}
+            for attr in (self.gang, self.worker, self.vector):
                 if attr is None:
                     continue
                 if any(dt.data in seq_device_types for dt in attr.data):
@@ -2497,30 +2481,6 @@ class LoopOp(IRDLOperation):
             raise VerifyException(
                 "unstructured acc.loop must not have induction variables"
             )
-
-
-def _get_attr_or_prop(op: IRDLOperation, name: str) -> ArrayAttr[DeviceTypeAttr] | None:
-    """Read a `gang` / `worker` / `vector` / `seq` / `independent` / `auto_`
-    DT array from either the op's properties or its attributes dict.
-
-    These six properties are referenced by name in `acc.loop`'s assembly
-    format (as the `^` keyword anchor for the corresponding clause), so the
-    declarative-format parser routes attr-dict-form spellings into
-    `op.attributes` rather than `op.properties`. The verifier must consult
-    both surfaces to mirror MLIR — where TableGen-declared properties are
-    looked up from one storage regardless of how the user wrote them.
-
-    The IRDL framework enforces the `ArrayAttr[DeviceTypeAttr]` type on the
-    underlying `opt_prop_def` before `verify_` runs (rejecting wrong-typed
-    inputs like `attributes {gang = 42}` upstream of this lookup), so the
-    `assert isa(...)` here documents the invariant rather than guarding
-    against a reachable case.
-    """
-    attr = op.properties.get(name) or op.attributes.get(name)
-    if attr is None:
-        return None
-    assert isa(attr, ArrayAttr[DeviceTypeAttr])
-    return attr
 
 
 def _duplicate_device_type(


### PR DESCRIPTION
Adds the OpenACC loop operation to the dialect, this is a single operation but still a pretty big PR (the largest one for the dialect) as there is quite a bit of custom assembly syntax here but logically all fits into the one unit as is all driven by a single operation and-so from a testing PoV makes sense to have it as one PR. The operation leverages the previous PR's loop attributes, as those were easier to split apart as a logical testable unit.
