### PR TITLE
dialects: (llvm) add llvm.intr.fma op and use it in the LLVM backend

### DIFF
--- a/tests/backend/llvm/test_convert_op.py
+++ b/tests/backend/llvm/test_convert_op.py
@@ -44,6 +44,17 @@ def test_call_intrinsic_fastmath_raises():
         convert_op(op, MagicMock(), {arg: MagicMock()})
 
 
+def test_fma_fastmath_raises():
+    from xdsl.dialects.builtin import Float32Type
+
+    block = Block(arg_types=[Float32Type()])
+    arg = block.args[0]
+    op = llvm.FMAOp(arg, arg, arg, llvm.FastMathAttr([FastMathFlag.NO_NANS]))
+
+    with pytest.raises(NotImplementedError, match="Fast-math flags not supported"):
+        convert_op(op, MagicMock(), {arg: MagicMock()})
+
+
 def test_convert_zero():
     op = llvm.ZeroOp.create(result_types=[llvm.LLVMPointerType()])
     val_map: dict[SSAValue, Any] = {}

--- a/tests/filecheck/backend/llvm/convert_op.mlir
+++ b/tests/filecheck/backend/llvm/convert_op.mlir
@@ -870,8 +870,20 @@ builtin.module {
   // CHECK-NEXT:   ret i32 undef
   // CHECK-NEXT: }
 
+  llvm.func @fma_op_scalar_f32(%arg0: f32, %arg1: f32, %arg2: f32) -> f32 {
+    %0 = llvm.intr.fma(%arg0, %arg1, %arg2) : (f32, f32, f32) -> f32
+    llvm.return %0 : f32
+  }
+
+  // CHECK: define float @"fma_op_scalar_f32"(float %".1", float %".2", float %".3")
+  // CHECK-NEXT: {
+  // CHECK-NEXT: [[ENTRY:.\d+]]:
+  // CHECK-NEXT:   %"[[RES:.\d+]]" = call float @"llvm.fma.f32"(float %".1", float %".2", float %".3")
+  // CHECK-NEXT:   ret float %"[[RES]]"
+  // CHECK-NEXT: }
+
   llvm.func @fma_op_f32(%arg0: vector<4xf32>, %arg1: vector<4xf32>, %arg2: vector<4xf32>) -> vector<4xf32> {
-    %0 = vector.fma %arg0, %arg1, %arg2 : vector<4xf32>
+    %0 = llvm.intr.fma(%arg0, %arg1, %arg2) : (vector<4xf32>, vector<4xf32>, vector<4xf32>) -> vector<4xf32>
     llvm.return %0 : vector<4xf32>
   }
 
@@ -883,7 +895,7 @@ builtin.module {
   // CHECK-NEXT: }
 
   llvm.func @fma_op_f64(%arg0: vector<2xf64>, %arg1: vector<2xf64>, %arg2: vector<2xf64>) -> vector<2xf64> {
-    %0 = vector.fma %arg0, %arg1, %arg2 : vector<2xf64>
+    %0 = llvm.intr.fma(%arg0, %arg1, %arg2) : (vector<2xf64>, vector<2xf64>, vector<2xf64>) -> vector<2xf64>
     llvm.return %0 : vector<2xf64>
   }
 

--- a/tests/filecheck/dialects/llvm/llvm_intrinsics.mlir
+++ b/tests/filecheck/dialects/llvm/llvm_intrinsics.mlir
@@ -86,6 +86,15 @@
 %maxnum_vec = llvm.intr.maxnum(%vec_f32, %vec_f32) : (vector<4xf32>, vector<4xf32>) -> vector<4xf32>
 // CHECK-NEXT: %maxnum_vec = llvm.intr.maxnum(%vec_f32, %vec_f32) : (vector<4xf32>, vector<4xf32>) -> vector<4xf32>
 
+%fma_f32 = llvm.intr.fma(%f32, %f32, %f32) : (f32, f32, f32) -> f32
+// CHECK: %fma_f32 = llvm.intr.fma(%f32, %f32, %f32) : (f32, f32, f32) -> f32
+
+%fma_vec = llvm.intr.fma(%vec_f32, %vec_f32, %vec_f32) : (vector<4xf32>, vector<4xf32>, vector<4xf32>) -> vector<4xf32>
+// CHECK-NEXT: %fma_vec = llvm.intr.fma(%vec_f32, %vec_f32, %vec_f32) : (vector<4xf32>, vector<4xf32>, vector<4xf32>) -> vector<4xf32>
+
+%fma_fast = llvm.intr.fma(%f32, %f32, %f32) {fastmathFlags = #llvm.fastmath<fast>} : (f32, f32, f32) -> f32
+// CHECK-NEXT: %fma_fast = llvm.intr.fma(%f32, %f32, %f32) {fastmathFlags = #llvm.fastmath<fast>} : (f32, f32, f32) -> f32
+
 "test.op"() ({
 ^bb0(%br_arg: i32):
   llvm.br ^bb1(%br_arg : i32)

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/llvm_intrinsics.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/llvm_intrinsics.mlir
@@ -25,6 +25,15 @@
 %6 = llvm.fneg %arg0 {fastmathFlags = #llvm.fastmath<fast>} : f32
 // CHECK: llvm.fneg [[arg0]] {fastmathFlags = #llvm.fastmath<fast>} : f32
 
+%fma_f32 = llvm.intr.fma(%arg0, %arg0, %arg0) : (f32, f32, f32) -> f32
+// CHECK: llvm.intr.fma([[arg0]], [[arg0]], [[arg0]]) : (f32, f32, f32) -> f32
+
+%fma_vec = llvm.intr.fma(%arg2, %arg2, %arg2) : (vector<4xf32>, vector<4xf32>, vector<4xf32>) -> vector<4xf32>
+// CHECK: llvm.intr.fma([[arg2]], [[arg2]], [[arg2]]) : (vector<4xf32>, vector<4xf32>, vector<4xf32>) -> vector<4xf32>
+
+%fma_fast = llvm.intr.fma(%arg0, %arg0, %arg0) {fastmathFlags = #llvm.fastmath<fast>} : (f32, f32, f32) -> f32
+// CHECK: llvm.intr.fma([[arg0]], [[arg0]], [[arg0]]) {fastmathFlags = #llvm.fastmath<fast>} : (f32, f32, f32) -> f32
+
 %fcmp_lhs, %fcmp_rhs = "test.op"() : () -> (f32, f32)
 // CHECK: [[fcmp_lhs:%\d+]], [[fcmp_rhs:%\d+]]
 

--- a/xdsl/backend/llvm/convert_op.py
+++ b/xdsl/backend/llvm/convert_op.py
@@ -367,6 +367,8 @@ def _convert_fma(
     builder: ir.IRBuilder,
     val_map: dict[SSAValue, ir.Value],
 ):
+    if any(op.fastmathFlags.data):
+        raise NotImplementedError("Fast-math flags not supported")
     a = val_map[op.a]
     b = val_map[op.b]
     c = val_map[op.c]

--- a/xdsl/backend/llvm/convert_op.py
+++ b/xdsl/backend/llvm/convert_op.py
@@ -16,7 +16,6 @@ from xdsl.dialects.builtin import (
     FloatAttr,
     IntegerAttr,
 )
-from xdsl.dialects.vector import FMAOp
 from xdsl.ir import Attribute, Block, Operation, SSAValue
 from xdsl.utils.type import get_element_type_or_self
 
@@ -364,24 +363,27 @@ def _convert_masked_store(
 
 
 def _convert_fma(
-    op: FMAOp,
+    op: llvm.FMAOp,
     builder: ir.IRBuilder,
     val_map: dict[SSAValue, ir.Value],
 ):
-    lhs = val_map[op.lhs]
-    rhs = val_map[op.rhs]
-    acc = val_map[op.acc]
+    a = val_map[op.a]
+    b = val_map[op.b]
+    c = val_map[op.c]
     res_type = convert_type(op.res.type)
-    assert isinstance(res_type, ir.VectorType)
-    assert isinstance(res_type.element, (ir.HalfType, ir.FloatType, ir.DoubleType))
-    # declare_intrinsic doesn't support VectorType, build name manually
-    name = f"llvm.fma.v{res_type.count}{res_type.element.intrinsic_name}"
+    _float_types = (ir.HalfType, ir.FloatType, ir.DoubleType)
+    if isinstance(res_type, ir.VectorType):
+        assert isinstance(res_type.element, _float_types)
+        name = f"llvm.fma.v{res_type.count}{res_type.element.intrinsic_name}"
+    else:
+        assert isinstance(res_type, _float_types)
+        name = f"llvm.fma.{res_type.intrinsic_name}"
     fn_type = ir.FunctionType(res_type, [res_type, res_type, res_type])
     try:
         intrinsic = builder.module.get_global(name)
     except KeyError:
         intrinsic = ir.Function(builder.module, fn_type, name=name)
-    val_map[op.res] = builder.call(intrinsic, [lhs, rhs, acc])
+    val_map[op.res] = builder.call(intrinsic, [a, b, c])
 
 
 def _convert_return(
@@ -558,7 +560,7 @@ def convert_op(
             )
         case llvm.ShuffleVectorOp():
             _convert_shuffle_vector(op, builder, val_map)
-        case FMAOp():
+        case llvm.FMAOp():
             _convert_fma(op, builder, val_map)
         case vector.BroadcastOp():
             _convert_broadcast(op, builder, val_map)

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -3303,6 +3303,43 @@ class VectorFMaxOp(IRDLOperation):
 
 
 @irdl_op_definition
+class FMAOp(IRDLOperation):
+    T: ClassVar = VarConstraint("T", AnyFloatConstr | VectorType.constr(AnyFloatConstr))
+
+    name = "llvm.intr.fma"
+
+    a = operand_def(T)
+    b = operand_def(T)
+    c = operand_def(T)
+    res = result_def(T)
+
+    fastmathFlags = prop_def(FastMathAttr, default_value=FastMathAttr(None))
+
+    assembly_format = (
+        "`(` operands `)` attr-dict `:` functional-type(operands, results)"
+    )
+
+    irdl_options = (ParsePropInAttrDict(),)
+
+    traits = traits_def(Pure())
+
+    def __init__(
+        self,
+        a: Operation | SSAValue,
+        b: Operation | SSAValue,
+        c: Operation | SSAValue,
+        fast_math: FastMathAttr | FastMathFlag | None = None,
+    ):
+        if isinstance(fast_math, FastMathFlag | str | None):
+            fast_math = FastMathAttr(fast_math)
+        super().__init__(
+            operands=[a, b, c],
+            result_types=[SSAValue.get(a).type],
+            properties={"fastmathFlags": fast_math},
+        )
+
+
+@irdl_op_definition
 class UnreachableOp(IRDLOperation):
     name = "llvm.unreachable"
 
@@ -3331,6 +3368,7 @@ LLVM = Dialect(
         FCmpOp,
         FDivOp,
         FLogOp,
+        FMAOp,
         FMulOp,
         FNegOp,
         FPExtOp,


### PR DESCRIPTION
Replace vector.FMAOp with a native llvm.FMAOp in the LLVM backend converter. The new op supports both scalar and vector float types, and the backend now generates the correct intrinsic name for each case. Also adds a scalar f32 filecheck test.