### PR TITLE
dialects: (x86, riscv) fix clashing memory effects declarations

### DIFF
--- a/tests/dialects/test_dialects.py
+++ b/tests/dialects/test_dialects.py
@@ -27,13 +27,12 @@ def test_no_memory_effects_exclusive():
 
     for dialect_factory in all_dialects.values():
         for op in dialect_factory().operations:
-            effects_traits = tuple(
-                trait for trait in op.traits.traits if isinstance(trait, MemoryEffect)
-            )
-            if any(isinstance(t, NoMemoryEffect) for t in (effects_traits)):
-                if other_traits := tuple(
+            effects_traits = op.get_traits_of_type(MemoryEffect)
+            if effects_traits and op.has_trait(NoMemoryEffect):
+                other_traits = tuple(
                     trait
                     for trait in effects_traits
                     if not isinstance(trait, NoMemoryEffect)
-                ):
+                )
+                if other_traits:
                     assert not other_traits, op.name

--- a/tests/dialects/test_dialects.py
+++ b/tests/dialects/test_dialects.py
@@ -1,4 +1,5 @@
 from xdsl.dialects import get_all_dialects
+from xdsl.traits import MemoryEffect, NoMemoryEffect
 
 
 def test_op_class_names():
@@ -15,3 +16,24 @@ def test_op_class_names():
     )
 
     assert not malformed_op_names
+
+
+def test_no_memory_effects_exclusive():
+    """
+    Make sure that ops that declare NoMemoryEffects don't also have other traits that
+    may have memory effects.
+    """
+    all_dialects = get_all_dialects()
+
+    for dialect_factory in all_dialects.values():
+        for op in dialect_factory().operations:
+            effects_traits = tuple(
+                trait for trait in op.traits.traits if isinstance(trait, MemoryEffect)
+            )
+            if any(isinstance(t, NoMemoryEffect) for t in (effects_traits)):
+                if other_traits := tuple(
+                    trait
+                    for trait in effects_traits
+                    if not isinstance(trait, NoMemoryEffect)
+                ):
+                    assert not other_traits, op.name

--- a/xdsl/dialects/riscv/ops.py
+++ b/xdsl/dialects/riscv/ops.py
@@ -44,6 +44,7 @@ from xdsl.parser import Parser
 from xdsl.pattern_rewriter import RewritePattern
 from xdsl.printer import Printer
 from xdsl.traits import (
+    AlwaysSpeculatable,
     HasCanonicalizationPatternsTrait,
     IsolatedFromAbove,
     IsTerminator,
@@ -2560,7 +2561,7 @@ class FAddSOp(RdRsRsFloatOperationWithFastMath):
 
     name = "riscv.fadd.s"
 
-    traits = traits_def(Pure())
+    traits = traits_def(AlwaysSpeculatable())
 
 
 @irdl_op_definition
@@ -2947,7 +2948,7 @@ class FMAddDOp(RdRsRsRsFloatOperation):
 
     name = "riscv.fmadd.d"
 
-    traits = traits_def(Pure())
+    traits = traits_def(AlwaysSpeculatable())
 
 
 @irdl_op_definition
@@ -2962,7 +2963,7 @@ class FMSubDOp(RdRsRsRsFloatOperation):
 
     name = "riscv.fmsub.d"
 
-    traits = traits_def(Pure())
+    traits = traits_def(AlwaysSpeculatable())
 
 
 class FuseMultiplyAddDCanonicalizationPatternTrait(HasCanonicalizationPatternsTrait):
@@ -2988,7 +2989,7 @@ class FAddDOp(RdRsRsFloatOperationWithFastMath):
     name = "riscv.fadd.d"
 
     traits = traits_def(
-        Pure(),
+        AlwaysSpeculatable(),
         FuseMultiplyAddDCanonicalizationPatternTrait(),
     )
 
@@ -3005,7 +3006,7 @@ class FSubDOp(RdRsRsFloatOperationWithFastMath):
 
     name = "riscv.fsub.d"
 
-    traits = traits_def(Pure())
+    traits = traits_def(AlwaysSpeculatable())
 
 
 @irdl_op_definition
@@ -3020,7 +3021,7 @@ class FMulDOp(RdRsRsFloatOperationWithFastMath):
 
     name = "riscv.fmul.d"
 
-    traits = traits_def(Pure())
+    traits = traits_def(AlwaysSpeculatable())
 
 
 @irdl_op_definition
@@ -3058,7 +3059,7 @@ class FMinDOp(RdRsRsFloatOperationWithFastMath):
 
     name = "riscv.fmin.d"
 
-    traits = traits_def(Pure())
+    traits = traits_def(AlwaysSpeculatable())
 
 
 @irdl_op_definition
@@ -3073,7 +3074,7 @@ class FMaxDOp(RdRsRsFloatOperationWithFastMath):
 
     name = "riscv.fmax.d"
 
-    traits = traits_def(Pure())
+    traits = traits_def(AlwaysSpeculatable())
 
 
 @irdl_op_definition

--- a/xdsl/dialects/x86/ops.py
+++ b/xdsl/dialects/x86/ops.py
@@ -85,11 +85,11 @@ from xdsl.parser import Parser, UnresolvedOperand
 from xdsl.pattern_rewriter import RewritePattern
 from xdsl.printer import Printer
 from xdsl.traits import (
+    AlwaysSpeculatable,
     HasCanonicalizationPatternsTrait,
     IsTerminator,
     MemoryReadEffect,
     MemoryWriteEffect,
-    Pure,
 )
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.target import Target
@@ -1465,7 +1465,7 @@ class RS_AddOp(RS_Operation[GeneralRegisterType, GeneralRegisterType]):
 
     name = "x86.rs.add"
 
-    traits = traits_def(Pure(), RS_AddOpHasCanonicalizationPatterns())
+    traits = traits_def(AlwaysSpeculatable(), RS_AddOpHasCanonicalizationPatterns())
 
 
 @irdl_op_definition
@@ -1588,7 +1588,7 @@ class DS_MovOp(DS_Operation[X86RegisterType, GeneralRegisterType]):
 
     name = "x86.ds.mov"
 
-    traits = traits_def(Pure(), DS_MovOpHasCanonicalizationPatterns())
+    traits = traits_def(AlwaysSpeculatable(), DS_MovOpHasCanonicalizationPatterns())
 
 
 @irdl_op_definition
@@ -2054,7 +2054,7 @@ class DI_MovOp(DI_Operation[GeneralRegisterType]):
 
     name = "x86.di.mov"
 
-    traits = traits_def(Pure())
+    traits = traits_def(AlwaysSpeculatable())
 
 
 @irdl_op_definition


### PR DESCRIPTION
Some ops currently declare both that they don't have memory effects and that they have some. This PR adds a test to detect it for all dialects in xDSL, and fixes the ops.
