### PR TITLE
transformations: (convert-func-to-x86-func) don't insert directives

### DIFF
--- a/tests/filecheck/backend/x86/convert_func_to_x86.mlir
+++ b/tests/filecheck/backend/x86/convert_func_to_x86.mlir
@@ -40,7 +40,6 @@ func.func public @foo_int(%0: i32, %1: i32, %2: i32, %3: i32, %4: i32, %5: i32, 
 }
 
 // CHECK:      builtin.module {
-// CHECK-NEXT:   x86.directive ".global" "foo_int"
 // CHECK-NEXT:   x86_func.func public @foo_int(%0: !x86.reg32<edi>, %1: !x86.reg32<esi>, %2: !x86.reg32<edx>, %3: !x86.reg32<ecx>, %4: !x86.reg32<r8d>, %5: !x86.reg32<r9d>, %6: !x86.reg64<rsp>) -> !x86.reg32<eax> {
 // CHECK-NEXT:     %7 = x86.ds.mov %0 : (!x86.reg32<edi>) -> !x86.reg32
 // CHECK-NEXT:     %8 = builtin.unrealized_conversion_cast %7 : !x86.reg32 to i32

--- a/xdsl/backend/x86/lowering/convert_func_to_x86_func.py
+++ b/xdsl/backend/x86/lowering/convert_func_to_x86_func.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from xdsl.backend.x86.lowering.helpers import Arch
 from xdsl.context import Context
 from xdsl.dialects import builtin, func, x86, x86_func
-from xdsl.dialects.builtin import ModuleOp, StringAttr
+from xdsl.dialects.builtin import ModuleOp
 from xdsl.dialects.x86.registers import GeneralRegisterType
 from xdsl.ir import Attribute, Block
 from xdsl.passes import ModulePass
@@ -67,10 +67,6 @@ class LowerFuncOp(RewritePattern):
                 raise DiagnosticException(
                     "Cannot lower function parameters bigger than 64 bits (not implemented)"
                 )
-
-        if op.sym_visibility == StringAttr("public"):
-            directive_op = x86.DirectiveOp(".global", op.sym_name)
-            rewriter.insert_op(directive_op)
 
         num_inputs = len(op.function_type.inputs.data)
         new_region = rewriter.move_region_contents_to_new_regions(op.body)


### PR DESCRIPTION
These are printed anyway as part of assembly emission:

https://github.com/xdslproject/xdsl/blob/22d6a64361005b2387b58850264be99f37adc5e6/tests/filecheck/dialects/x86_func/x86_func_asm.mlir

https://github.com/xdslproject/xdsl/blob/22d6a64361005b2387b58850264be99f37adc5e6/tests/filecheck/projects/libxsmm/integration_test_matmul.mlir
