### PR TITLE
dialects: (acc) Init and Shutdown OpenACC runtime operations

### DIFF
--- a/tests/dialects/test_acc.py
+++ b/tests/dialects/test_acc.py
@@ -867,10 +867,10 @@ def test_loop_unit_and_combined_shortcuts():
 
 
 def test_init_op_builder_branches():
-    """Exercises the InitOp `__init__` branches that the parser bypasses
-    (parsing goes through `Operation.create()`, not `__init__`): empty
-    ternaries, the `Sequence[DeviceTypeAttr] -> ArrayAttr` shortcut, and the
-    already-wrapped-ArrayAttr passthrough."""
+    """Exercises the InitOp `__init__` paths that the parser bypasses
+    (parsing goes through `Operation.create()`, not `__init__`): empty op
+    plus a fully-populated op with both operands and the `device_types`
+    property."""
     nvidia = acc.DeviceTypeAttr(acc.DeviceType.NVIDIA)
 
     empty = acc.InitOp()
@@ -879,18 +879,13 @@ def test_init_op_builder_branches():
     assert empty.if_cond is None
     assert empty.device_types is None
 
-    op_seq = acc.InitOp(
+    op = acc.InitOp(
         device_num=create_ssa_value(i64),
         if_cond=create_ssa_value(i1),
-        device_types=[nvidia],
+        device_types=ArrayAttr([nvidia]),
     )
-    op_seq.verify()
-    assert op_seq.device_types == ArrayAttr([nvidia])
-
-    arr = ArrayAttr([nvidia])
-    op_arr = acc.InitOp(device_types=arr)
-    op_arr.verify()
-    assert op_arr.device_types is arr
+    op.verify()
+    assert op.device_types == ArrayAttr([nvidia])
 
 
 def test_shutdown_op_builder_branches():
@@ -903,15 +898,10 @@ def test_shutdown_op_builder_branches():
     assert empty.if_cond is None
     assert empty.device_types is None
 
-    op_seq = acc.ShutdownOp(
+    op = acc.ShutdownOp(
         device_num=create_ssa_value(i64),
         if_cond=create_ssa_value(i1),
-        device_types=[default],
+        device_types=ArrayAttr([default]),
     )
-    op_seq.verify()
-    assert op_seq.device_types == ArrayAttr([default])
-
-    arr = ArrayAttr([default])
-    op_arr = acc.ShutdownOp(device_types=arr)
-    op_arr.verify()
-    assert op_arr.device_types is arr
+    op.verify()
+    assert op.device_types == ArrayAttr([default])

--- a/tests/dialects/test_acc.py
+++ b/tests/dialects/test_acc.py
@@ -864,3 +864,54 @@ def test_loop_unit_and_combined_shortcuts():
     assert op_explicit.combined == acc.CombinedConstructsTypeAttr(
         acc.CombinedConstructsType.KERNELS_LOOP
     )
+
+
+def test_init_op_builder_branches():
+    """Exercises the InitOp `__init__` branches that the parser bypasses
+    (parsing goes through `Operation.create()`, not `__init__`): empty
+    ternaries, the `Sequence[DeviceTypeAttr] -> ArrayAttr` shortcut, and the
+    already-wrapped-ArrayAttr passthrough."""
+    nvidia = acc.DeviceTypeAttr(acc.DeviceType.NVIDIA)
+
+    empty = acc.InitOp()
+    empty.verify()
+    assert empty.device_num is None
+    assert empty.if_cond is None
+    assert empty.device_types is None
+
+    op_seq = acc.InitOp(
+        device_num=create_ssa_value(i64),
+        if_cond=create_ssa_value(i1),
+        device_types=[nvidia],
+    )
+    op_seq.verify()
+    assert op_seq.device_types == ArrayAttr([nvidia])
+
+    arr = ArrayAttr([nvidia])
+    op_arr = acc.InitOp(device_types=arr)
+    op_arr.verify()
+    assert op_arr.device_types is arr
+
+
+def test_shutdown_op_builder_branches():
+    """Mirrors `test_init_op_builder_branches` for ShutdownOp."""
+    default = acc.DeviceTypeAttr(acc.DeviceType.DEFAULT)
+
+    empty = acc.ShutdownOp()
+    empty.verify()
+    assert empty.device_num is None
+    assert empty.if_cond is None
+    assert empty.device_types is None
+
+    op_seq = acc.ShutdownOp(
+        device_num=create_ssa_value(i64),
+        if_cond=create_ssa_value(i1),
+        device_types=[default],
+    )
+    op_seq.verify()
+    assert op_seq.device_types == ArrayAttr([default])
+
+    arr = ArrayAttr([default])
+    op_arr = acc.ShutdownOp(device_types=arr)
+    op_arr.verify()
+    assert op_arr.device_types is arr

--- a/tests/filecheck/dialects/acc/ops.mlir
+++ b/tests/filecheck/dialects/acc/ops.mlir
@@ -1952,4 +1952,85 @@ builtin.module {
   // CHECK:         acc.loop gang([#acc.device_type<nvidia>]) {
   // CHECK-NEXT:      acc.yield
   // CHECK-NEXT:    } attributes {seq = [#acc.device_type<none>]}
+
+  // -- Runtime executable ops: acc.init / acc.shutdown / acc.set / acc.wait --
+  // Each carries `AttrSizedOperandSegments` and shares a "cannot be nested
+  // in a compute operation" verifier; their pretty form is a fixed-order
+  // optional-clause sequence (the upstream `oilist(...)` is replaced by
+  // declarative `(...)?` groups).
+
+  func.func @init_empty() {
+    acc.init
+    func.return
+  }
+  // CHECK-LABEL: func.func @init_empty() {
+  // CHECK:         acc.init
+
+  func.func @init_device_num(%dn : i64) {
+    acc.init device_num(%dn : i64)
+    func.return
+  }
+  // CHECK-LABEL: func.func @init_device_num(
+  // CHECK:         acc.init device_num(%{{.*}} : i64)
+
+  func.func @init_if(%c : i1) {
+    acc.init if(%c)
+    func.return
+  }
+  // CHECK-LABEL: func.func @init_if(
+  // CHECK:         acc.init if(%{{.*}})
+
+  func.func @init_device_num_and_if(%dn : index, %c : i1) {
+    acc.init device_num(%dn : index) if(%c)
+    func.return
+  }
+  // CHECK-LABEL: func.func @init_device_num_and_if(
+  // CHECK:         acc.init device_num(%{{.*}} : index) if(%{{.*}})
+
+  // The inherent `device_types` property has no clause — it flows through
+  // `attr-dict-with-keyword`.
+  func.func @init_device_types() {
+    acc.init attributes {device_types = [#acc.device_type<nvidia>]}
+    func.return
+  }
+  // CHECK-LABEL: func.func @init_device_types() {
+  // CHECK:         acc.init attributes {device_types = [#acc.device_type<nvidia>]}
+
+  // Generic-form roundtrip insurance for acc.init — exercises the
+  // two-segment operand layout (device_num, if_cond).
+  func.func @init_generic_roundtrip(%dn : i64) {
+    "acc.init"(%dn) <{operandSegmentSizes = array<i32: 1, 0>}> : (i64) -> ()
+    func.return
+  }
+  // CHECK-LABEL: func.func @init_generic_roundtrip(
+  // CHECK:         acc.init device_num(%{{.*}} : i64)
+
+  func.func @shutdown_empty() {
+    acc.shutdown
+    func.return
+  }
+  // CHECK-LABEL: func.func @shutdown_empty() {
+  // CHECK:         acc.shutdown
+
+  func.func @shutdown_device_num_and_if(%dn : i64, %c : i1) {
+    acc.shutdown device_num(%dn : i64) if(%c)
+    func.return
+  }
+  // CHECK-LABEL: func.func @shutdown_device_num_and_if(
+  // CHECK:         acc.shutdown device_num(%{{.*}} : i64) if(%{{.*}})
+
+  func.func @shutdown_device_types() {
+    acc.shutdown attributes {device_types = [#acc.device_type<default>]}
+    func.return
+  }
+  // CHECK-LABEL: func.func @shutdown_device_types() {
+  // CHECK:         acc.shutdown attributes {device_types = [#acc.device_type<default>]}
+
+  // Generic-form roundtrip insurance for acc.shutdown.
+  func.func @shutdown_generic_roundtrip(%c : i1) {
+    "acc.shutdown"(%c) <{operandSegmentSizes = array<i32: 0, 1>}> : (i1) -> ()
+    func.return
+  }
+  // CHECK-LABEL: func.func @shutdown_generic_roundtrip(
+  // CHECK:         acc.shutdown if(%{{.*}})
 }

--- a/tests/filecheck/dialects/acc/ops_invalid.mlir
+++ b/tests/filecheck/dialects/acc/ops_invalid.mlir
@@ -809,3 +809,41 @@ func.func @loop_duplicate_collapse_dt() {
   func.return
 }
 // CHECK: duplicate device_type `none` found in collapseDeviceType attribute
+
+// -----
+
+// acc.init nested in acc.parallel — runtime ops cannot be nested in a
+// compute construct (parallel/serial/kernels/loop).
+func.func @init_in_parallel() {
+  acc.parallel {
+    acc.init
+    acc.yield
+  }
+  func.return
+}
+// CHECK: 'acc.init' op cannot be nested in a compute operation
+
+// -----
+
+// acc.init nested transitively (through acc.serial) — the parent walk
+// must traverse all ancestors, not just the direct parent.
+func.func @init_in_serial() {
+  acc.serial {
+    acc.init
+    acc.yield
+  }
+  func.return
+}
+// CHECK: 'acc.init' op cannot be nested in a compute operation
+
+// -----
+
+// acc.shutdown nested in acc.kernels.
+func.func @shutdown_in_kernels() {
+  acc.kernels {
+    acc.shutdown
+    acc.terminator
+  }
+  func.return
+}
+// CHECK: 'acc.shutdown' op cannot be nested in a compute operation

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/ops.mlir
@@ -1278,4 +1278,86 @@ builtin.module {
   // CHECK:       func.func @loop_cache(
   // CHECK:         acc.loop cache({{.*}} : memref<10xf32>) control(%{{.*}} : index)
 
+  // -- Runtime executable ops: acc.init / acc.shutdown --
+  // Both directives share `AttrSizedOperandSegments` and enforce "cannot be
+  // nested in a compute operation"; we test them at top level of `func.func`
+  // so the verifier passes. Each clause is exercised in isolation so that
+  // a regression in parsing or generic emission of one specific clause
+  // (device_num / if / device_types) fires a precise test rather than
+  // hiding behind an "everything together" case.
+
+  func.func @init_min() {
+    acc.init
+    func.return
+  }
+  // CHECK:       func.func @init_min() {
+  // CHECK-NEXT:    acc.init
+
+  func.func @init_device_num(%dn : i64) {
+    acc.init device_num(%dn : i64)
+    func.return
+  }
+  // CHECK:       func.func @init_device_num(
+  // CHECK:         acc.init device_num(%{{.*}} : i64)
+
+  func.func @init_if(%c : i1) {
+    acc.init if(%c)
+    func.return
+  }
+  // CHECK:       func.func @init_if(
+  // CHECK:         acc.init if(%{{.*}})
+
+  // `device_types` flows through `attr-dict-with-keyword`; covers the
+  // attr-dict path independent of the operand clauses.
+  func.func @init_device_types() {
+    acc.init attributes {device_types = [#acc.device_type<nvidia>]}
+    func.return
+  }
+  // CHECK:       func.func @init_device_types() {
+  // CHECK-NEXT:    acc.init attributes {device_types = [#acc.device_type<nvidia>]}
+
+  func.func @init_full(%dn : i64, %c : i1) {
+    acc.init device_num(%dn : i64) if(%c) attributes {device_types = [#acc.device_type<nvidia>]}
+    func.return
+  }
+  // CHECK:       func.func @init_full(
+  // CHECK:         acc.init device_num(%{{.*}} : i64) if(%{{.*}}) attributes {device_types = [#acc.device_type<nvidia>]}
+
+  func.func @shutdown_min() {
+    acc.shutdown
+    func.return
+  }
+  // CHECK:       func.func @shutdown_min() {
+  // CHECK-NEXT:    acc.shutdown
+
+  // device_num typed against `index` rather than `i64` to exercise the
+  // IntOrIndex polymorphism on the operand.
+  func.func @shutdown_device_num(%dn : index) {
+    acc.shutdown device_num(%dn : index)
+    func.return
+  }
+  // CHECK:       func.func @shutdown_device_num(
+  // CHECK:         acc.shutdown device_num(%{{.*}} : index)
+
+  func.func @shutdown_if(%c : i1) {
+    acc.shutdown if(%c)
+    func.return
+  }
+  // CHECK:       func.func @shutdown_if(
+  // CHECK:         acc.shutdown if(%{{.*}})
+
+  func.func @shutdown_device_types() {
+    acc.shutdown attributes {device_types = [#acc.device_type<default>]}
+    func.return
+  }
+  // CHECK:       func.func @shutdown_device_types() {
+  // CHECK-NEXT:    acc.shutdown attributes {device_types = [#acc.device_type<default>]}
+
+  func.func @shutdown_full(%dn : index, %c : i1) {
+    acc.shutdown device_num(%dn : index) if(%c) attributes {device_types = [#acc.device_type<default>]}
+    func.return
+  }
+  // CHECK:       func.func @shutdown_full(
+  // CHECK:         acc.shutdown device_num(%{{.*}} : index) if(%{{.*}}) attributes {device_types = [#acc.device_type<default>]}
+
 }

--- a/xdsl/dialects/acc.py
+++ b/xdsl/dialects/acc.py
@@ -4335,21 +4335,11 @@ class _RuntimeDeviceTypesOperation(IRDLOperation, ABC):
         *,
         device_num: SSAValue | Operation | None = None,
         if_cond: SSAValue | Operation | None = None,
-        device_types: ArrayAttr[DeviceTypeAttr]
-        | Sequence[DeviceTypeAttr]
-        | None = None,
+        device_types: ArrayAttr[DeviceTypeAttr] | None = None,
     ) -> None:
-        device_types_prop: ArrayAttr[DeviceTypeAttr] | None = (
-            ArrayAttr(device_types)
-            if device_types is not None and not isinstance(device_types, ArrayAttr)
-            else device_types
-        )
         super().__init__(
-            operands=[
-                [device_num] if device_num is not None else [],
-                [if_cond] if if_cond is not None else [],
-            ],
-            properties={"device_types": device_types_prop},
+            operands=[device_num, if_cond],
+            properties={"device_types": device_types},
         )
 
     def verify_(self) -> None:

--- a/xdsl/dialects/acc.py
+++ b/xdsl/dialects/acc.py
@@ -4283,6 +4283,100 @@ class ReductionRecipeOp(_RecipeOperation):
             )
 
 
+# ---------------------------------------------------------------------------
+# Runtime executable ops: acc.init, acc.shutdown
+# ---------------------------------------------------------------------------
+#
+# Upstream models acc.init / acc.shutdown with identical surface — same two
+# optional operands (device_num, if_cond), same `device_types` ArrayAttr
+# property, same assembly format, and the same "cannot be nested in a
+# compute operation" verifier (`mlir/lib/Dialect/OpenACC/IR/OpenACC.cpp`,
+# `isComputeOperation`; the set of compute ops is parallel / serial /
+# kernels / loop). The xDSL port factors that shape into the
+# `_RuntimeDeviceTypesOperation` mixin below; concrete leaves override only `name`.
+
+
+def _verify_not_in_compute_op(op: IRDLOperation) -> None:
+    """Mirrors upstream's `isComputeOperation` parent walk."""
+    parent = op.parent_op()
+    while parent is not None:
+        if isinstance(parent, (ParallelOp, SerialOp, KernelsOp, LoopOp)):
+            raise VerifyException(
+                f"'{op.name}' op cannot be nested in a compute operation"
+            )
+        parent = parent.parent_op()
+
+
+class _RuntimeDeviceTypesOperation(IRDLOperation, ABC):
+    """Base class for `acc.init` / `acc.shutdown`.
+
+    Concrete leaves inherit every IRDL field, the assembly format, the
+    `__init__`, and `verify_` — they only override `name`.
+    """
+
+    device_num = opt_operand_def(IntegerType | IndexType)
+    if_cond = opt_operand_def(I1)
+
+    device_types = opt_prop_def(ArrayAttr[DeviceTypeAttr], prop_name="device_types")
+
+    irdl_options = (
+        AttrSizedOperandSegments(as_property=True),
+        ParsePropInAttrDict(),
+    )
+
+    assembly_format = (
+        "(`device_num` `(` $device_num^ `:` type($device_num) `)`)?"
+        " (`if` `(` $if_cond^ `)`)?"
+        " attr-dict-with-keyword"
+    )
+
+    def __init__(
+        self,
+        *,
+        device_num: SSAValue | Operation | None = None,
+        if_cond: SSAValue | Operation | None = None,
+        device_types: ArrayAttr[DeviceTypeAttr]
+        | Sequence[DeviceTypeAttr]
+        | None = None,
+    ) -> None:
+        device_types_prop: ArrayAttr[DeviceTypeAttr] | None = (
+            ArrayAttr(device_types)
+            if device_types is not None and not isinstance(device_types, ArrayAttr)
+            else device_types
+        )
+        super().__init__(
+            operands=[
+                [device_num] if device_num is not None else [],
+                [if_cond] if if_cond is not None else [],
+            ],
+            properties={"device_types": device_types_prop},
+        )
+
+    def verify_(self) -> None:
+        _verify_not_in_compute_op(self)
+
+
+@irdl_op_definition
+class InitOp(_RuntimeDeviceTypesOperation):
+    """
+    Implementation of upstream acc.init — the OpenACC init executable directive.
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/OpenACCDialect/#accinit-accinitop).
+    """
+
+    name = "acc.init"
+
+
+@irdl_op_definition
+class ShutdownOp(_RuntimeDeviceTypesOperation):
+    """
+    Implementation of upstream acc.shutdown — the OpenACC shutdown executable
+    directive.
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/OpenACCDialect/#accshutdown-accshutdownop).
+    """
+
+    name = "acc.shutdown"
+
+
 @irdl_op_definition
 class TerminatorOp(IRDLOperation):
     """
@@ -4375,6 +4469,8 @@ ACC = Dialect(
         PrivateRecipeOp,
         FirstprivateRecipeOp,
         ReductionRecipeOp,
+        InitOp,
+        ShutdownOp,
         TerminatorOp,
         YieldOp,
     ],


### PR DESCRIPTION
This PR adds the Init and Shutdown OpenACC runtime operations, which are very similar and therefore extend the same base class. Note that the verification helper (_verify_not_in_compute_op) is at module level rather than in the base class, as in the next PR we add the other two runtime operations which are different (won't extend the same base class) but do share the same verification logic and-hence will also call into this helper method.
