### PR TITLE
dialects: (acc) Set and Wait OpenACC operations

### DIFF
--- a/tests/dialects/test_acc.py
+++ b/tests/dialects/test_acc.py
@@ -905,3 +905,27 @@ def test_shutdown_op_builder_branches():
     )
     op.verify()
     assert op.device_types == ArrayAttr([default])
+
+
+def test_set_op_init_smoke():
+    """Filecheck builds via `Operation.create()` and never calls `SetOp.__init__`,
+    leaving the constructor's `super().__init__(...)` line uncovered. A single
+    Python construction hits it (the body is branchless)."""
+    op = acc.SetOp(
+        default_async=create_ssa_value(i32),
+        device_num=create_ssa_value(i64),
+        if_cond=create_ssa_value(i1),
+        device_type=acc.DeviceTypeAttr(acc.DeviceType.NVIDIA),
+    )
+    op.verify()
+
+
+def test_wait_op_init_smoke():
+    """Mirrors `test_set_op_init_smoke` for WaitOp."""
+    op = acc.WaitOp(
+        wait_operands=[create_ssa_value(i64)],
+        async_operand=create_ssa_value(i32),
+        wait_devnum=create_ssa_value(i32),
+        if_cond=create_ssa_value(i1),
+    )
+    op.verify()

--- a/tests/filecheck/dialects/acc/ops.mlir
+++ b/tests/filecheck/dialects/acc/ops.mlir
@@ -2033,4 +2033,114 @@ builtin.module {
   }
   // CHECK-LABEL: func.func @shutdown_generic_roundtrip(
   // CHECK:         acc.shutdown if(%{{.*}})
+
+  // acc.set requires at least one of default_async/device_num/device_type.
+  // Three optional operand clauses + a single (non-array) device_type
+  // property that flows through `attr-dict-with-keyword`.
+  func.func @set_device_type_only() {
+    acc.set attributes {device_type = #acc.device_type<nvidia>}
+    func.return
+  }
+  // CHECK-LABEL: func.func @set_device_type_only() {
+  // CHECK:         acc.set attributes {device_type = #acc.device_type<nvidia>}
+
+  func.func @set_device_num(%dn : i32) {
+    acc.set device_num(%dn : i32)
+    func.return
+  }
+  // CHECK-LABEL: func.func @set_device_num(
+  // CHECK:         acc.set device_num(%{{.*}} : i32)
+
+  func.func @set_default_async(%da : i32) {
+    acc.set default_async(%da : i32)
+    func.return
+  }
+  // CHECK-LABEL: func.func @set_default_async(
+  // CHECK:         acc.set default_async(%{{.*}} : i32)
+
+  func.func @set_full(%da : i32, %dn : index, %c : i1) {
+    acc.set default_async(%da : i32) device_num(%dn : index) if(%c) attributes {device_type = #acc.device_type<host>}
+    func.return
+  }
+  // CHECK-LABEL: func.func @set_full(
+  // CHECK:         acc.set default_async(%{{.*}} : i32) device_num(%{{.*}} : index) if(%{{.*}}) attributes {device_type = #acc.device_type<host>}
+
+  // Generic-form roundtrip insurance for acc.set — three operand groups
+  // (default_async, device_num, if_cond).
+  func.func @set_generic_roundtrip(%dn : i64) {
+    "acc.set"(%dn) <{operandSegmentSizes = array<i32: 0, 1, 0>}> : (i64) -> ()
+    func.return
+  }
+  // CHECK-LABEL: func.func @set_generic_roundtrip(
+  // CHECK:         acc.set device_num(%{{.*}} : i64)
+
+  // acc.wait — the only runtime op with a leading parenthesised variadic
+  // operand list (no keyword), plus the same `OperandWithKeywordOnly`
+  // directive used by enter_data/exit_data for the `async` clause. Note:
+  // unlike init/shutdown/set, `acc.wait` does *not* forbid nesting in a
+  // compute op.
+  func.func @wait_empty() {
+    acc.wait
+    func.return
+  }
+  // CHECK-LABEL: func.func @wait_empty() {
+  // CHECK:         acc.wait
+
+  func.func @wait_one_operand(%w : i64) {
+    acc.wait(%w : i64)
+    func.return
+  }
+  // CHECK-LABEL: func.func @wait_one_operand(
+  // CHECK:         acc.wait(%{{.*}} : i64)
+
+  func.func @wait_multiple_operands(%w1 : i32, %w2 : index) {
+    acc.wait(%w1, %w2 : i32, index)
+    func.return
+  }
+  // CHECK-LABEL: func.func @wait_multiple_operands(
+  // CHECK:         acc.wait(%{{.*}}, %{{.*}} : i32, index)
+
+  func.func @wait_async_bare() {
+    acc.wait async
+    func.return
+  }
+  // CHECK-LABEL: func.func @wait_async_bare() {
+  // CHECK:         acc.wait async
+
+  func.func @wait_async_operand(%a : i32) {
+    acc.wait async(%a : i32)
+    func.return
+  }
+  // CHECK-LABEL: func.func @wait_async_operand(
+  // CHECK:         acc.wait async(%{{.*}} : i32)
+
+  func.func @wait_wait_devnum(%w : i64, %dn : i32) {
+    acc.wait(%w : i64) wait_devnum(%dn : i32)
+    func.return
+  }
+  // CHECK-LABEL: func.func @wait_wait_devnum(
+  // CHECK:         acc.wait(%{{.*}} : i64) wait_devnum(%{{.*}} : i32)
+
+  func.func @wait_if(%c : i1) {
+    acc.wait if(%c)
+    func.return
+  }
+  // CHECK-LABEL: func.func @wait_if(
+  // CHECK:         acc.wait if(%{{.*}})
+
+  func.func @wait_full(%w : i64, %a : index, %dn : i32, %c : i1) {
+    acc.wait(%w : i64) async(%a : index) wait_devnum(%dn : i32) if(%c)
+    func.return
+  }
+  // CHECK-LABEL: func.func @wait_full(
+  // CHECK:         acc.wait(%{{.*}} : i64) async(%{{.*}} : index) wait_devnum(%{{.*}} : i32) if(%{{.*}})
+
+  // Generic-form roundtrip insurance for acc.wait — four operand groups
+  // (waitOperands, asyncOperand, waitDevnum, ifCond).
+  func.func @wait_generic_roundtrip(%w : i64) {
+    "acc.wait"(%w) <{operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (i64) -> ()
+    func.return
+  }
+  // CHECK-LABEL: func.func @wait_generic_roundtrip(
+  // CHECK:         acc.wait(%{{.*}} : i64)
 }

--- a/tests/filecheck/dialects/acc/ops_invalid.mlir
+++ b/tests/filecheck/dialects/acc/ops_invalid.mlir
@@ -847,3 +847,45 @@ func.func @shutdown_in_kernels() {
   func.return
 }
 // CHECK: 'acc.shutdown' op cannot be nested in a compute operation
+
+// -----
+
+// acc.set nested in acc.loop.
+func.func @set_in_loop(%lb : index, %ub : index, %st : index) {
+  acc.loop control(%iv : index) = (%lb : index) to (%ub : index) step (%st : index) {
+    acc.set attributes {device_type = #acc.device_type<nvidia>}
+    acc.yield
+  } attributes {independent = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true>}
+  func.return
+}
+// CHECK: 'acc.set' op cannot be nested in a compute operation
+
+// -----
+
+// acc.set with no operands and no device_type — at least one of
+// default_async/device_num/device_type must appear.
+func.func @set_empty() {
+  acc.set
+  func.return
+}
+// CHECK: at least one default_async, device_num, or device_type operand must appear
+
+// -----
+
+// acc.wait: the bare `async` UnitAttr and an `asyncOperand` cannot both be
+// set. The pretty form can only emit one or the other, so build the
+// conflicting state via generic form.
+func.func @wait_async_conflict(%v : i32) {
+  "acc.wait"(%v) <{async, operandSegmentSizes = array<i32: 0, 1, 0, 0>}> : (i32) -> ()
+  func.return
+}
+// CHECK: async attribute cannot appear with asyncOperand
+
+// -----
+
+// acc.wait: `wait_devnum` requires `waitOperands` to be non-empty.
+func.func @wait_devnum_alone(%dn : i32) {
+  acc.wait wait_devnum(%dn : i32)
+  func.return
+}
+// CHECK: wait_devnum cannot appear without waitOperands

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/ops.mlir
@@ -1360,4 +1360,104 @@ builtin.module {
   // CHECK:       func.func @shutdown_full(
   // CHECK:         acc.shutdown device_num(%{{.*}} : index) if(%{{.*}}) attributes {device_types = [#acc.device_type<default>]}
 
+  // acc.set — three optional operand clauses (default_async, device_num,
+  // if_cond) plus a single (non-array) `device_type` property routed
+  // through `attr-dict-with-keyword`.
+  func.func @set_dt() {
+    acc.set attributes {device_type = #acc.device_type<nvidia>}
+    func.return
+  }
+  // CHECK:       func.func @set_dt() {
+  // CHECK-NEXT:    acc.set attributes {device_type = #acc.device_type<nvidia>}
+
+  func.func @set_default_async(%da : i32) {
+    acc.set default_async(%da : i32)
+    func.return
+  }
+  // CHECK:       func.func @set_default_async(
+  // CHECK:         acc.set default_async(%{{.*}} : i32)
+
+  func.func @set_device_num(%dn : i64) {
+    acc.set device_num(%dn : i64)
+    func.return
+  }
+  // CHECK:       func.func @set_device_num(
+  // CHECK:         acc.set device_num(%{{.*}} : i64)
+
+  func.func @set_if(%da : i32, %c : i1) {
+    acc.set default_async(%da : i32) if(%c)
+    func.return
+  }
+  // CHECK:       func.func @set_if(
+  // CHECK:         acc.set default_async(%{{.*}} : i32) if(%{{.*}})
+
+  // `set_full` uses `index` for `device_num` so the interop file covers the
+  // `IntOrIndex` polymorphism on SetOp (InitOp / WaitOp already exercise
+  // `index` elsewhere; this fills the gap for SetOp).
+  func.func @set_full(%da : i32, %dn : index, %c : i1) {
+    acc.set default_async(%da : i32) device_num(%dn : index) if(%c) attributes {device_type = #acc.device_type<host>}
+    func.return
+  }
+  // CHECK:       func.func @set_full(
+  // CHECK:         acc.set default_async(%{{.*}} : i32) device_num(%{{.*}} : index) if(%{{.*}}) attributes {device_type = #acc.device_type<host>}
+
+  // acc.wait — leading `( $waitOperands : type )` group plus
+  // `OperandWithKeywordOnly` for `async`. Each clause covered in
+  // isolation so a regression in any one fires precisely.
+  func.func @wait_min() {
+    acc.wait
+    func.return
+  }
+  // CHECK:       func.func @wait_min() {
+  // CHECK-NEXT:    acc.wait
+
+  func.func @wait_one_operand(%w : i64) {
+    acc.wait(%w : i64)
+    func.return
+  }
+  // CHECK:       func.func @wait_one_operand(
+  // CHECK:         acc.wait(%{{.*}} : i64)
+
+  func.func @wait_multiple_operands(%w1 : i32, %w2 : index) {
+    acc.wait(%w1, %w2 : i32, index)
+    func.return
+  }
+  // CHECK:       func.func @wait_multiple_operands(
+  // CHECK:         acc.wait(%{{.*}}, %{{.*}} : i32, index)
+
+  func.func @wait_async_bare() {
+    acc.wait async
+    func.return
+  }
+  // CHECK:       func.func @wait_async_bare() {
+  // CHECK-NEXT:    acc.wait async
+
+  func.func @wait_async_operand(%a : i32) {
+    acc.wait async(%a : i32)
+    func.return
+  }
+  // CHECK:       func.func @wait_async_operand(
+  // CHECK:         acc.wait async(%{{.*}} : i32)
+
+  func.func @wait_wait_devnum(%w : i64, %dn : i32) {
+    acc.wait(%w : i64) wait_devnum(%dn : i32)
+    func.return
+  }
+  // CHECK:       func.func @wait_wait_devnum(
+  // CHECK:         acc.wait(%{{.*}} : i64) wait_devnum(%{{.*}} : i32)
+
+  func.func @wait_if(%c : i1) {
+    acc.wait if(%c)
+    func.return
+  }
+  // CHECK:       func.func @wait_if(
+  // CHECK:         acc.wait if(%{{.*}})
+
+  func.func @wait_full(%w : i64, %a : index, %dn : i32, %c : i1) {
+    acc.wait(%w : i64) async(%a : index) wait_devnum(%dn : i32) if(%c)
+    func.return
+  }
+  // CHECK:       func.func @wait_full(
+  // CHECK:         acc.wait(%{{.*}} : i64) async(%{{.*}} : index) wait_devnum(%{{.*}} : i32) if(%{{.*}})
+
 }

--- a/xdsl/dialects/acc.py
+++ b/xdsl/dialects/acc.py
@@ -4284,7 +4284,7 @@ class ReductionRecipeOp(_RecipeOperation):
 
 
 # ---------------------------------------------------------------------------
-# Runtime executable ops: acc.init, acc.shutdown
+# Runtime executable ops: acc.init, acc.shutdown, acc.set, acc.wait
 # ---------------------------------------------------------------------------
 #
 # Upstream models acc.init / acc.shutdown with identical surface — same two
@@ -4294,6 +4294,12 @@ class ReductionRecipeOp(_RecipeOperation):
 # `isComputeOperation`; the set of compute ops is parallel / serial /
 # kernels / loop). The xDSL port factors that shape into the
 # `_RuntimeDeviceTypesOperation` mixin below; concrete leaves override only `name`.
+#
+# `acc.set` and `acc.wait` diverge from that shape (different operand
+# counts, different property names/types, different assembly formats) so
+# they're written as standalone IRDL ops. Both still share the
+# `_verify_not_in_compute_op` parent walk — except `acc.wait`, which
+# upstream explicitly leaves unrestricted (see `acc::WaitOp::verify`).
 
 
 def _verify_not_in_compute_op(op: IRDLOperation) -> None:
@@ -4365,6 +4371,115 @@ class ShutdownOp(_RuntimeDeviceTypesOperation):
     """
 
     name = "acc.shutdown"
+
+
+@irdl_op_definition
+class SetOp(IRDLOperation):
+    """
+    Implementation of upstream acc.set — the OpenACC set executable directive.
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/OpenACCDialect/#accset-accsetop).
+    """
+
+    name = "acc.set"
+
+    default_async = opt_operand_def(IntegerType | IndexType)
+    device_num = opt_operand_def(IntegerType | IndexType)
+    if_cond = opt_operand_def(I1)
+
+    device_type = opt_prop_def(DeviceTypeAttr, prop_name="device_type")
+
+    irdl_options = (
+        AttrSizedOperandSegments(as_property=True),
+        ParsePropInAttrDict(),
+    )
+
+    assembly_format = (
+        "(`default_async` `(` $default_async^ `:` type($default_async) `)`)?"
+        " (`device_num` `(` $device_num^ `:` type($device_num) `)`)?"
+        " (`if` `(` $if_cond^ `)`)?"
+        " attr-dict-with-keyword"
+    )
+
+    def __init__(
+        self,
+        *,
+        default_async: SSAValue | Operation | None = None,
+        device_num: SSAValue | Operation | None = None,
+        if_cond: SSAValue | Operation | None = None,
+        device_type: DeviceTypeAttr | None = None,
+    ) -> None:
+        super().__init__(
+            operands=[default_async, device_num, if_cond],
+            properties={"device_type": device_type},
+        )
+
+    def verify_(self) -> None:
+        _verify_not_in_compute_op(self)
+        if (
+            self.device_type is None
+            and self.default_async is None
+            and self.device_num is None
+        ):
+            raise VerifyException(
+                "at least one default_async, device_num, or device_type "
+                "operand must appear"
+            )
+
+
+@irdl_op_definition
+class WaitOp(IRDLOperation):
+    """
+    Implementation of upstream acc.wait — the OpenACC wait executable directive.
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/OpenACCDialect/#accwait-accwaitop).
+    """
+
+    name = "acc.wait"
+
+    wait_operands = var_operand_def(IntegerType | IndexType)
+    async_operand = opt_operand_def(IntegerType | IndexType)
+    wait_devnum = opt_operand_def(IntegerType | IndexType)
+    if_cond = opt_operand_def(I1)
+
+    async_attr = opt_prop_def(UnitAttr, prop_name="async")
+
+    irdl_options = (
+        AttrSizedOperandSegments(as_property=True),
+        ParsePropInAttrDict(),
+    )
+
+    custom_directives = (OperandWithKeywordOnly,)
+
+    assembly_format = (
+        "( `(` $wait_operands^ `:` type($wait_operands) `)` )?"
+        " (`async` custom<OperandWithKeywordOnly>($async_operand,"
+        " type($async_operand), $async)^)?"
+        " (`wait_devnum` `(` $wait_devnum^ `:` type($wait_devnum) `)`)?"
+        " (`if` `(` $if_cond^ `)`)?"
+        " attr-dict-with-keyword"
+    )
+
+    def __init__(
+        self,
+        *,
+        wait_operands: Sequence[SSAValue | Operation] = (),
+        async_operand: SSAValue | Operation | None = None,
+        wait_devnum: SSAValue | Operation | None = None,
+        if_cond: SSAValue | Operation | None = None,
+        async_attr: UnitAttr | None = None,
+    ) -> None:
+        super().__init__(
+            operands=[wait_operands, async_operand, wait_devnum, if_cond],
+            properties={"async": async_attr},
+        )
+
+    def verify_(self) -> None:
+        # Mirrors upstream `acc::WaitOp::verify`. Note that — unlike
+        # init/shutdown/set — `acc.wait` does *not* forbid nesting inside a
+        # compute construct.
+        if self.async_operand is not None and self.async_attr is not None:
+            raise VerifyException("async attribute cannot appear with asyncOperand")
+        if self.wait_devnum is not None and not self.wait_operands:
+            raise VerifyException("wait_devnum cannot appear without waitOperands")
 
 
 @irdl_op_definition
@@ -4461,6 +4576,8 @@ ACC = Dialect(
         ReductionRecipeOp,
         InitOp,
         ShutdownOp,
+        SetOp,
+        WaitOp,
         TerminatorOp,
         YieldOp,
     ],


### PR DESCRIPTION
The other two OpenACC runtime operations, set and wait. Set leverages the verification method added in the previous PR, wait does not as it's verification is looser
