### PR TITLE
dialects: (riscv_snitch) add read/write effect traits

### DIFF
--- a/tests/dialects/test_riscv_snitch.py
+++ b/tests/dialects/test_riscv_snitch.py
@@ -123,8 +123,8 @@ def test_effect_traits():
     unknown_effects_ops = {op for op in operations if op not in effects_ops}
 
     # Sentinels to remind us to update this test when updating the dialect
-    assert len(effects_ops) == 14
-    assert len(unknown_effects_ops) == 12
+    assert len(effects_ops) == 26
+    assert not unknown_effects_ops
 
     all_effects_trait_types = {
         type(trait)
@@ -155,8 +155,21 @@ def test_effect_traits():
     }
     no_effects_ops = {op for op in effects_ops if op.has_trait(NoMemoryEffect)}
 
-    assert memory_read_effects_ops == {riscv_snitch.ReadOp}
+    assert memory_read_effects_ops == {
+        riscv_snitch.DMCopyImmOp,
+        riscv_snitch.DMCopyOp,
+        riscv_snitch.DMStatImmOp,
+        riscv_snitch.DMStatOp,
+        riscv_snitch.ReadOp,
+    }
     assert memory_write_effects_ops == {
+        riscv_snitch.DMCopyImmOp,
+        riscv_snitch.DMCopyOp,
+        riscv_snitch.DMDestinationOp,
+        riscv_snitch.DMDestinationOp,
+        riscv_snitch.DMRepOp,
+        riscv_snitch.DMSourceOp,
+        riscv_snitch.DMStrideOp,
         riscv_snitch.ReadOp,
         riscv_snitch.ScfgwiOp,
         riscv_snitch.ScfgwOp,
@@ -167,14 +180,23 @@ def test_effect_traits():
         riscv_snitch.FrepInnerOp,
     }
     assert register_allocated_memory_effects_ops == {
-        riscv_snitch.VFMulHOp,
-        riscv_snitch.VFSubHOp,
-        riscv_snitch.VFMulSOp,
-        riscv_snitch.VFMaxSOp,
+        riscv_snitch.DMCopyImmOp,
+        riscv_snitch.DMCopyOp,
+        riscv_snitch.DMStatImmOp,
+        riscv_snitch.DMStatOp,
         riscv_snitch.VFAddHOp,
         riscv_snitch.VFAddSOp,
+        riscv_snitch.VFCpkASSOp,
+        riscv_snitch.VFMacSOp,
+        riscv_snitch.VFMacSOp,
+        riscv_snitch.VFMaxSOp,
+        riscv_snitch.VFMulHOp,
+        riscv_snitch.VFMulSOp,
+        riscv_snitch.VFSubHOp,
         riscv_snitch.VFSubSOp,
+        riscv_snitch.VFSumSOp,
     }
     assert no_effects_ops == {
         riscv_snitch.FrepYieldOp,
+        riscv_snitch.GetStreamOp,
     }

--- a/tests/dialects/test_riscv_snitch.py
+++ b/tests/dialects/test_riscv_snitch.py
@@ -188,7 +188,6 @@ def test_effect_traits():
         riscv_snitch.VFAddSOp,
         riscv_snitch.VFCpkASSOp,
         riscv_snitch.VFMacSOp,
-        riscv_snitch.VFMacSOp,
         riscv_snitch.VFMaxSOp,
         riscv_snitch.VFMulHOp,
         riscv_snitch.VFMulSOp,

--- a/xdsl/dialects/riscv_snitch.py
+++ b/xdsl/dialects/riscv_snitch.py
@@ -8,7 +8,7 @@ from typing_extensions import Self, override
 
 from xdsl.backend.register_allocatable import RegisterConstraints
 from xdsl.backend.register_allocator import BlockAllocator
-from xdsl.backend.register_type import RegisterResource
+from xdsl.backend.register_type import RegisterAllocatedMemoryEffect, RegisterResource
 from xdsl.backend.riscv.traits import StaticInsnRepresentation
 from xdsl.dialects import riscv, snitch
 from xdsl.dialects.builtin import (
@@ -595,6 +595,8 @@ class GetStreamOp(RISCVAsmOperation, RISCVRegallocOperation):
         | snitch.WritableStreamType.constr(BaseAttr(riscv.FloatRegisterType))
     )
 
+    traits = traits_def(NoMemoryEffect())
+
     def __init__(self, result_type: Attribute):
         super().__init__(result_types=[result_type])
 
@@ -629,7 +631,8 @@ class DMSourceOp(RISCVInstruction):
     assembly_format = "$ptrlo `,` $ptrhi attr-dict `:` `(` type($ptrlo) `,` type($ptrhi) `)` `->` `(` `)`"
 
     traits = traits_def(
-        StaticInsnRepresentation(insn=".insn r 0x2b, 0, 0, x0, {0}, {1}")
+        StaticInsnRepresentation(insn=".insn r 0x2b, 0, 0, x0, {0}, {1}"),
+        MemoryWriteEffect(),
     )
 
     def __init__(self, ptrlo: SSAValue | Operation, ptrhi: SSAValue | Operation):
@@ -649,7 +652,8 @@ class DMDestinationOp(RISCVInstruction):
     assembly_format = "$ptrlo `,` $ptrhi attr-dict `:` `(` type($ptrlo) `,` type($ptrhi) `)` `->` `(` `)`"
 
     traits = traits_def(
-        StaticInsnRepresentation(insn=".insn r 0x2b, 0, 1, x0, {0}, {1}")
+        StaticInsnRepresentation(insn=".insn r 0x2b, 0, 1, x0, {0}, {1}"),
+        MemoryWriteEffect(),
     )
 
     def __init__(self, ptrlo: SSAValue | Operation, ptrhi: SSAValue | Operation):
@@ -669,7 +673,8 @@ class DMStrideOp(RISCVInstruction):
     assembly_format = "$srcstrd `,` $dststrd attr-dict `:` `(` type($srcstrd) `,` type($dststrd) `)` `->` `(` `)`"
 
     traits = traits_def(
-        StaticInsnRepresentation(insn=".insn r 0x2b, 0, 6, x0, {0}, {1}")
+        StaticInsnRepresentation(insn=".insn r 0x2b, 0, 6, x0, {0}, {1}"),
+        MemoryWriteEffect(),
     )
 
     def __init__(self, srcstrd: SSAValue | Operation, dststrd: SSAValue | Operation):
@@ -688,7 +693,8 @@ class DMRepOp(RISCVInstruction):
     assembly_format = "$reps attr-dict `:` `(` type($reps) `)` `->` `(` `)`"
 
     traits = traits_def(
-        StaticInsnRepresentation(insn=".insn r 0x2b, 0, 7, x0, {0}, x0")
+        StaticInsnRepresentation(insn=".insn r 0x2b, 0, 7, x0, {0}, x0"),
+        MemoryWriteEffect(),
     )
 
     def __init__(self, reps: SSAValue | Operation):
@@ -700,18 +706,41 @@ class DMRepOp(RISCVInstruction):
 
 @irdl_op_definition
 class DMCopyOp(RISCVInstruction):
+    """
+    DMCPY and DMCPYI initiate an asynchronous data movement with the parameters
+    configured by the previous DM instructions. A transfer id is placed in register rd,
+    which is necessary to later check for transfer completion. size contains the number
+    of consecutive bytes to transfer. For multi-dimensional transfers this is the size
+    of the innermost dimension.
+    """
+
     name = "riscv_snitch.dmcpy"
 
     dest = result_def(riscv.IntRegisterType)
     size = operand_def(riscv.IntRegisterType)
     config = operand_def(riscv.IntRegisterType)
+    """
+    config* determines the following parameters of the
+    transfer:
+
+    | Bit(s)     | Field         | Description                                            |
+    |------------|---------------|--------------------------------------------------------|
+    | config[0]  | decouple_rw   | Decouple the handshakes of the read and write channels |
+    | config[1]  | enable_2d     | Enable two-dimensional transfer                        |
+    | config[4:2]| channel_sel   | Selects the DMA backend if a multi-channel DMA is used |
+    """
 
     assembly_format = (
         "$size `,` $config attr-dict `:` functional-type(operands, results)"
     )
 
     traits = traits_def(
-        StaticInsnRepresentation(insn=".insn r 0x2b, 0, 3, {0}, {1}, {2}")
+        StaticInsnRepresentation(insn=".insn r 0x2b, 0, 3, {0}, {1}, {2}"),
+        MemoryReadEffect(),
+        MemoryWriteEffect(),
+        # https://github.com/xdslproject/xdsl/issues/5882
+        # Move to appropriate superclass in the future
+        RegisterAllocatedMemoryEffect(),
     )
 
     def __init__(
@@ -736,7 +765,11 @@ class DMStatOp(RISCVInstruction):
     assembly_format = "$status attr-dict `:` functional-type(operands, results)"
 
     traits = traits_def(
-        StaticInsnRepresentation(insn=".insn r 0x2b, 0, 5, {0}, {1}, {2}")
+        StaticInsnRepresentation(insn=".insn r 0x2b, 0, 5, {0}, {1}, {2}"),
+        MemoryReadEffect(),
+        # https://github.com/xdslproject/xdsl/issues/5882
+        # Move to appropriate superclass in the future
+        RegisterAllocatedMemoryEffect(),
     )
 
     def __init__(
@@ -752,18 +785,41 @@ class DMStatOp(RISCVInstruction):
 
 @irdl_op_definition
 class DMCopyImmOp(RISCVInstruction):
+    """
+    DMCPY and DMCPYI initiate an asynchronous data movement with the parameters
+    configured by the previous DM instructions. A transfer id is placed in register rd,
+    which is necessary to later check for transfer completion. size contains the number
+    of consecutive bytes to transfer. For multi-dimensional transfers this is the size
+    of the innermost dimension.
+    """
+
     name = "riscv_snitch.dmcpyi"
 
     dest = result_def(riscv.IntRegisterType)
     size = operand_def(riscv.IntRegisterType)
     config = prop_def(IntegerAttr[UI5])
+    """
+    config* determines the following parameters of the
+    transfer:
+
+    | Bit(s)     | Field         | Description                                            |
+    |------------|---------------|--------------------------------------------------------|
+    | config[0]  | decouple_rw   | Decouple the handshakes of the read and write channels |
+    | config[1]  | enable_2d     | Enable two-dimensional transfer                        |
+    | config[4:2]| channel_sel   | Selects the DMA backend if a multi-channel DMA is used |
+    """
 
     assembly_format = (
         "$size `,` $config attr-dict `:` functional-type(operands, results)"
     )
 
     traits = traits_def(
-        StaticInsnRepresentation(insn=".insn r 0x2b, 0, 2, {0}, {1}, {2}")
+        StaticInsnRepresentation(insn=".insn r 0x2b, 0, 2, {0}, {1}, {2}"),
+        MemoryReadEffect(),
+        MemoryWriteEffect(),
+        # https://github.com/xdslproject/xdsl/issues/5882
+        # Move to appropriate superclass in the future
+        RegisterAllocatedMemoryEffect(),
     )
 
     def __init__(
@@ -794,7 +850,11 @@ class DMStatImmOp(RISCVInstruction):
     assembly_format = "$status attr-dict `:` `(` `)` `->` type($dest)"
 
     traits = traits_def(
-        StaticInsnRepresentation(insn=".insn r 0x2b, 0, 4, {0}, {1}, {2}")
+        StaticInsnRepresentation(insn=".insn r 0x2b, 0, 4, {0}, {1}, {2}"),
+        MemoryReadEffect(),
+        # https://github.com/xdslproject/xdsl/issues/5882
+        # Move to appropriate superclass in the future
+        RegisterAllocatedMemoryEffect(),
     )
 
     def __init__(
@@ -843,7 +903,9 @@ class VFCpkASSOp(
 
     name = "riscv_snitch.vfcpka.s.s"
 
-    traits = traits_def(AlwaysSpeculatable())
+    # https://github.com/xdslproject/xdsl/issues/5882
+    # Move to appropriate superclass in the future
+    traits = traits_def(AlwaysSpeculatable(), RegisterAllocatedMemoryEffect())
 
 
 @irdl_op_definition
@@ -998,7 +1060,9 @@ class RdRsRsAccumulatingFloatOperationWithFastMath(
 
     fastmath = opt_attr_def(FastMathFlagsAttr)
 
-    traits = traits_def(AlwaysSpeculatable())
+    # https://github.com/xdslproject/xdsl/issues/5882
+    # Move to appropriate superclass in the future
+    traits = traits_def(AlwaysSpeculatable(), RegisterAllocatedMemoryEffect())
 
     def __init__(
         self,
@@ -1061,7 +1125,9 @@ class RdRsAccumulatingFloatOperation(RISCVCustomFormatOperation, RISCVInstructio
     rd_in = operand_def(SAME_FLOAT_REGISTER_TYPE)
     rs = operand_def(FloatRegisterType)
 
-    traits = traits_def(AlwaysSpeculatable())
+    # https://github.com/xdslproject/xdsl/issues/5882
+    # Move to appropriate superclass in the future
+    traits = traits_def(AlwaysSpeculatable(), RegisterAllocatedMemoryEffect())
 
     def __init__(
         self,


### PR DESCRIPTION
We currently don't track reads or writes to csr registers, main, or accelerator memory, this PR fixes all of these.