### PR TITLE
dialects: (x86) only instructions have RegisterAllocatedMemoryEffect

### DIFF
--- a/tests/dialects/test_x86.py
+++ b/tests/dialects/test_x86.py
@@ -374,8 +374,11 @@ def test_effect_traits():
     unknown_effects_ops = {op for op in operations if op not in effects_ops}
 
     # Sentinels to remind us to update this test when updating the dialect
-    assert len(effects_ops) == 137
-    assert not unknown_effects_ops
+    assert len(effects_ops) == 135
+    assert unknown_effects_ops == {
+        x86.ops.LabelOp,
+        x86.ops.DirectiveOp,
+    }
 
     all_effects_trait_types = {
         type(trait)
@@ -387,6 +390,7 @@ def test_effect_traits():
     assert all_effects_trait_types == {
         MemoryReadEffect,
         MemoryWriteEffect,
+        NoMemoryEffect,
         RegisterAllocatedMemoryEffect,
     }
 
@@ -401,7 +405,7 @@ def test_effect_traits():
     }
     no_effects_ops = {op for op in effects_ops if op.has_trait(NoMemoryEffect)}
 
-    assert len(register_effects_ops) == 137
+    assert len(register_effects_ops) == 131
     assert memory_read_effects_ops == {
         x86.ops.DM_LeaOp,
         x86.ops.DM_MovOp,
@@ -482,4 +486,9 @@ def test_effect_traits():
         x86.ops.MSK_VmovupdOp,
         x86.ops.MSK_VmovupsOp,
     }
-    assert not no_effects_ops
+    assert no_effects_ops == {
+        x86.ops.FallthroughOp,
+        x86.ops.GetAVXRegisterOp,
+        x86.ops.GetMaskRegisterOp,
+        x86.ops.GetRegisterOp,
+    }

--- a/xdsl/dialects/x86/ops.py
+++ b/xdsl/dialects/x86/ops.py
@@ -90,6 +90,7 @@ from xdsl.traits import (
     IsTerminator,
     MemoryReadEffect,
     MemoryWriteEffect,
+    NoMemoryEffect,
 )
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.target import Target
@@ -141,8 +142,6 @@ class X86RegallocOperation(IRDLOperation, HasRegisterConstraints, ABC):
     """
     Base class for operations that can take part in register allocation.
     """
-
-    traits = traits_def(RegisterAllocatedMemoryEffect())
 
     def get_register_constraints(self) -> RegisterConstraints:
         # The default register constraints are that all operands are "in", and all
@@ -232,6 +231,8 @@ class X86Instruction(X86AsmOperation, X86RegallocOperation):
     represent an instruction in the x86 instruction set.
     The name of the operation will be used as the x86 assembly instruction name.
     """
+
+    traits = traits_def(RegisterAllocatedMemoryEffect())
 
     comment = opt_attr_def(StringAttr)
     """
@@ -2697,7 +2698,7 @@ class FallthroughOp(X86AsmOperation, X86RegallocOperation, X86CustomFormatOperat
 
     successor = successor_def()
 
-    traits = traits_def(IsTerminator())
+    traits = traits_def(IsTerminator(), NoMemoryEffect())
 
     def __init__(
         self,
@@ -3884,6 +3885,8 @@ class GetAnyRegisterOperation(
 
     assembly_format = "attr-dict `:` type($result)"
 
+    traits = traits_def(NoMemoryEffect())
+
     def __init__(
         self,
         register_type: R1InvT,
@@ -3918,6 +3921,8 @@ class ParallelMovOp(X86RegallocOperation):
 
     assembly_format = "$inputs attr-dict `:` functional-type($inputs, $outputs)"
     irdl_options = (ParsePropInAttrDict(),)
+
+    traits = traits_def(RegisterAllocatedMemoryEffect())
 
     def __init__(
         self,


### PR DESCRIPTION
I was too aggressive in #5510, adding the effects to all operations that participate in register allocation. There are many instructions that are present during register allocation, but don't have register effects, like x86_scf.yield, and x86.get_register. This moves the trait to the X86Instruction ABC, meaning to the set of operations that are actually expected to be present in the executable.
