### PR TITLE
dialects: (riscv_func) add RiscvFunctionCallMemoryEffect

### DIFF
--- a/tests/dialects/test_riscv_func.py
+++ b/tests/dialects/test_riscv_func.py
@@ -1,6 +1,14 @@
+from xdsl.backend.register_type import RegisterAllocatedMemoryEffect
 from xdsl.dialects import riscv, riscv_func
 from xdsl.ir import Region
-from xdsl.traits import CallableOpInterface, MemoryEffect
+from xdsl.traits import (
+    CallableOpInterface,
+    MemoryAllocEffect,
+    MemoryEffect,
+    MemoryFreeEffect,
+    MemoryReadEffect,
+    MemoryWriteEffect,
+)
 
 
 def test_callable_interface():
@@ -28,8 +36,14 @@ def test_effect_traits():
     unknown_effects_ops = {op for op in operations if op not in effects_ops}
 
     # Sentinels to remind us to update this test when updating the dialect
-    assert len(effects_ops) == 0
-    assert len(unknown_effects_ops) == 4
+    assert effects_ops == {
+        riscv_func.CallOp,
+        riscv_func.ReturnOp,
+        riscv_func.SyscallOp,
+    }
+    assert unknown_effects_ops == {
+        riscv_func.FuncOp,
+    }
 
     all_effects_trait_types = {
         type(trait)
@@ -38,4 +52,33 @@ def test_effect_traits():
     }
 
     # Check below separately for each of these
-    assert not all_effects_trait_types
+    assert all_effects_trait_types == {
+        MemoryAllocEffect,
+        MemoryFreeEffect,
+        MemoryReadEffect,
+        MemoryWriteEffect,
+        RegisterAllocatedMemoryEffect,
+        riscv_func.RiscvFunctionCallMemoryEffect,
+    }
+
+    alloc_effects_ops = {op for op in effects_ops if op.has_trait(MemoryAllocEffect)}
+    free_effects_ops = {op for op in effects_ops if op.has_trait(MemoryFreeEffect)}
+    read_effects_ops = {op for op in effects_ops if op.has_trait(MemoryReadEffect)}
+    write_effects_ops = {op for op in effects_ops if op.has_trait(MemoryWriteEffect)}
+    riscv_func_call_effects_ops = {
+        op
+        for op in effects_ops
+        if op.has_trait(riscv_func.RiscvFunctionCallMemoryEffect)
+    }
+
+    register_allocated_memory_effects_ops = {
+        op for op in effects_ops if op.has_trait(RegisterAllocatedMemoryEffect)
+    }
+
+    assert alloc_effects_ops == {riscv_func.CallOp, riscv_func.SyscallOp}
+    assert free_effects_ops == {riscv_func.CallOp, riscv_func.SyscallOp}
+    assert read_effects_ops == {riscv_func.CallOp, riscv_func.SyscallOp}
+    assert write_effects_ops == {riscv_func.CallOp, riscv_func.SyscallOp}
+    assert riscv_func_call_effects_ops == {riscv_func.CallOp, riscv_func.SyscallOp}
+
+    assert register_allocated_memory_effects_ops == {riscv_func.ReturnOp}

--- a/xdsl/dialects/riscv_func.py
+++ b/xdsl/dialects/riscv_func.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
+import itertools
 from collections.abc import Generator, Sequence
 
 from xdsl.backend.assembly_printer import AssemblyPrintable, AssemblyPrinter
-from xdsl.backend.register_type import RegisterType
+from xdsl.backend.register_type import (
+    RegisterAllocatedMemoryEffect,
+    RegisterResource,
+    RegisterType,
+)
 from xdsl.dialects import riscv
 from xdsl.dialects.builtin import (
     I8,
@@ -36,13 +41,38 @@ from xdsl.parser import Parser
 from xdsl.printer import Printer
 from xdsl.traits import (
     CallableOpInterface,
+    EffectInstance,
     HasParent,
     IsolatedFromAbove,
     IsTerminator,
+    MemoryAllocEffect,
+    MemoryEffect,
+    MemoryEffectKind,
+    MemoryFreeEffect,
+    MemoryReadEffect,
+    MemoryWriteEffect,
     ReturnLike,
     SymbolOpInterface,
 )
 from xdsl.utils.exceptions import DiagnosticException, VerifyException
+
+_FUNCTION_CALL_EFFECTS = frozenset(
+    EffectInstance(MemoryEffectKind.WRITE, resource=RegisterResource(r))
+    for r in itertools.chain(
+        riscv.Registers.A, riscv.Registers.T, riscv.Registers.FA, riscv.Registers.FT
+    )
+)
+
+
+class RiscvFunctionCallMemoryEffect(MemoryEffect):
+    """
+    An assembly operation that corresponds to a function call in the RISC-V ABI,
+    overwwriting the A, T, FA, and FT registers.
+    """
+
+    @classmethod
+    def get_effects(cls, op: Operation) -> frozenset[EffectInstance]:
+        return _FUNCTION_CALL_EFFECTS
 
 
 @irdl_op_definition
@@ -51,6 +81,16 @@ class SyscallOp(IRDLOperation):
     args = var_operand_def(riscv.IntRegisterType)
     syscall_num = attr_def(IntegerAttr[I32])
     result = opt_result_def(riscv.IntRegisterType)
+
+    # Function calls can have arbitrary memory effects, and may overwrite the
+    # A, T, FA, and FT registers
+    traits = traits_def(
+        MemoryAllocEffect(),
+        MemoryFreeEffect(),
+        MemoryReadEffect(),
+        MemoryWriteEffect(),
+        RiscvFunctionCallMemoryEffect(),
+    )
 
     def __init__(
         self,
@@ -88,6 +128,16 @@ class CallOp(riscv.RISCVInstruction):
 
     assembly_format = (
         "$callee `(` $args `)` attr-dict `:` functional-type($args, $ress)"
+    )
+
+    # Function calls can have arbitrary memory effects, and may overwrite the
+    # A, T, FA, and FT registers
+    traits = traits_def(
+        MemoryAllocEffect(),
+        MemoryFreeEffect(),
+        MemoryReadEffect(),
+        MemoryWriteEffect(),
+        RiscvFunctionCallMemoryEffect(),
     )
 
     def __init__(
@@ -255,7 +305,14 @@ class ReturnOp(riscv.RISCVInstruction):
     values = var_operand_def(riscv.RISCVRegisterType)
     comment = opt_attr_def(StringAttr)
 
-    traits = traits_def(IsTerminator(), HasParent(FuncOp), ReturnLike())
+    traits = traits_def(
+        IsTerminator(),
+        HasParent(FuncOp),
+        ReturnLike(),
+        # https://github.com/xdslproject/xdsl/issues/5882
+        # Move to appropriate superclass in the future
+        RegisterAllocatedMemoryEffect(),
+    )
 
     assembly_format = "attr-dict ($values^ `:` type($values))?"
 


### PR DESCRIPTION
Also ReturnOp models an instruction with memory effects if the operands are allocated.