### PR TITLE
core: Printing and parsing support for bf16

### DIFF
--- a/tests/dialects/test_builtin.py
+++ b/tests/dialects/test_builtin.py
@@ -140,9 +140,8 @@ def test_FloatType_packing():
     assert pi == math.pi
 
     # bf16 has no struct format code; pack/unpack are overridden directly.
-    bf16_nums = (-2.0, -1.0, 0.0, 1.0, 2.0)
-    bf16_buffer = bf16.pack(bf16_nums)
-    assert bf16.unpack(bf16_buffer, len(bf16_nums)) == bf16_nums
+    bf16_buffer = bf16.pack(nums)
+    assert bf16.unpack(bf16_buffer, len(nums)) == nums
 
 
 def test_bf16_attr_construction_roundtrips():

--- a/tests/dialects/test_builtin.py
+++ b/tests/dialects/test_builtin.py
@@ -144,12 +144,6 @@ def test_FloatType_packing():
     assert bf16.unpack(bf16_buffer, len(nums)) == nums
 
 
-def test_bf16_attr_construction_roundtrips():
-    # 1.5 is exactly representable in bf16.
-    a = FloatAttr(1.5, bf16)
-    assert a.value.data == 1.5
-
-
 @pytest.mark.parametrize(
     "value, expected_raw",
     [
@@ -185,19 +179,28 @@ def test_bf16_pack_rounds_to_nearest_even():
     assert bf16.pack((just_above,)) == (0x3F81).to_bytes(2, "little")
 
 
-def test_bf16_unpack_is_lossy():
-    # 0.1 is not exactly representable in bf16; round-trip is within ULP.
-    rt = bf16.unpack(bf16.pack((0.1,)), 1)[0]
-    assert rt != 0.1
-    assert abs(rt - 0.1) < 2**-6
-
-
-def test_FloatAttr_skips_normalisation_for_unsupported_widths():
-    # f80 and f128 have no precision-normalisation path (their format
-    # raises NotImplementedError). FloatAttr.__init__ must take the
-    # else-branch and store the Python float as-is.
-    assert FloatAttr(0.1, f80).value.data == 0.1
-    assert FloatAttr(0.1, f128).value.data == 0.1
+@pytest.mark.parametrize(
+    "value, type_, tolerance",
+    [
+        # f80 and f128 have no precision-normalisation path (their format
+        # raises NotImplementedError); FloatAttr stores the float as-is.
+        (0.1, f80, None),
+        (0.1, f128, None),
+        # bf16 normalises through pack/unpack; 1.5 is exactly representable.
+        (1.5, bf16, None),
+        # 0.1 is not exactly representable in bf16; round-trip is within ULP.
+        (0.1, bf16, 2**-6),
+    ],
+)
+def test_FloatAttr_normalisation(
+    value: float, type_: AnyFloat, tolerance: float | None
+):
+    data = FloatAttr(value, type_).value.data
+    if tolerance is None:
+        assert data == value
+    else:
+        assert data != value
+        assert abs(data - value) < tolerance
 
 
 def test_IntegerType_size():

--- a/tests/dialects/test_builtin.py
+++ b/tests/dialects/test_builtin.py
@@ -427,7 +427,7 @@ def test_IntegerType_packing():
     assert tuple(attr for attr in FloatAttr.iter_unpack(f16, buffer_f16)) == attrs_f16
 
     # f32
-    nums_f32 = (-3.140625, -1.0, 0.0, 1.0, 3.140625)
+    nums_f32 = (-3.140000104904175, -1.0, 0.0, 1.0, 3.140000104904175)
     buffer_f32 = f32.pack(nums_f32)
     unpacked_f32 = f32.unpack(buffer_f32, len(nums_f32))
     assert nums_f32 == unpacked_f32
@@ -436,7 +436,7 @@ def test_IntegerType_packing():
     assert tuple(attr for attr in FloatAttr.iter_unpack(f32, buffer_f32)) == attrs_f32
 
     # f64
-    nums_f64 = (-3.140625, -1.0, 0.0, 1.0, 3.140625)
+    nums_f64 = (-3.14159265359, -1.0, 0.0, 1.0, 3.14159265359)
     buffer_f64 = f64.pack(nums_f64)
     unpacked_f64 = f64.unpack(buffer_f64, len(nums_f64))
     assert nums_f64 == unpacked_f64

--- a/tests/dialects/test_builtin.py
+++ b/tests/dialects/test_builtin.py
@@ -1,5 +1,6 @@
 import math
 import re
+import struct
 from collections.abc import Sequence
 from io import StringIO
 
@@ -77,8 +78,8 @@ def test_FloatType_bitwidths():
 
 
 def test_FloatType_formats():
-    with pytest.raises(NotImplementedError):
-        bf16.format
+    # bf16 subclasses PackableType directly (no struct format string).
+    assert not hasattr(bf16, "format")
     assert f16.format == "<e"
     assert f32.format == "<f"
     assert f64.format == "<d"
@@ -137,6 +138,67 @@ def test_FloatType_packing():
 
     pi = f64.unpack(f64.pack((math.pi,)), 1)[0]
     assert pi == math.pi
+
+    # bf16 has no struct format code; pack/unpack are overridden directly.
+    bf16_nums = (-2.0, -1.0, 0.0, 1.0, 2.0)
+    bf16_buffer = bf16.pack(bf16_nums)
+    assert bf16.unpack(bf16_buffer, len(bf16_nums)) == bf16_nums
+
+
+def test_bf16_attr_construction_roundtrips():
+    # 1.5 is exactly representable in bf16.
+    a = FloatAttr(1.5, bf16)
+    assert a.value.data == 1.5
+
+
+@pytest.mark.parametrize(
+    "value, expected_raw",
+    [
+        (0.0, b"\x00\x00"),
+        (-0.0, b"\x00\x80"),
+        (1.0, b"\x80\x3f"),
+        (-1.0, b"\x80\xbf"),
+        (2.0, b"\x00\x40"),
+        (float("inf"), b"\x80\x7f"),
+        (float("-inf"), b"\x80\xff"),
+    ],
+)
+def test_bf16_pack_bit_patterns(value: float, expected_raw: bytes):
+    assert bf16.pack((value,)) == expected_raw
+    # Round-trip via struct so +0.0 and -0.0 stay distinguishable.
+    decoded = bf16.unpack(expected_raw, 1)[0]
+    assert struct.pack(">f", decoded) == struct.pack(">f", value)
+
+
+def test_bf16_pack_nan_stays_quiet():
+    raw = bf16.pack((float("nan"),))
+    bits = int.from_bytes(raw, "little")
+    assert (bits & 0x7F80) == 0x7F80  # exponent all-ones
+    assert (bits & 0x007F) != 0  # mantissa non-zero
+    assert bits & 0x0040  # quiet bit set
+
+
+def test_bf16_pack_rounds_to_nearest_even():
+    # Halfway between two bf16 values; ties go to even (mantissa LSB 0).
+    halfway = 1.0 + 2.0**-8
+    assert bf16.pack((halfway,)) == (0x3F80).to_bytes(2, "little")
+    just_above = 1.0 + 2.0**-8 + 2.0**-20
+    assert bf16.pack((just_above,)) == (0x3F81).to_bytes(2, "little")
+
+
+def test_bf16_unpack_is_lossy():
+    # 0.1 is not exactly representable in bf16; round-trip is within ULP.
+    rt = bf16.unpack(bf16.pack((0.1,)), 1)[0]
+    assert rt != 0.1
+    assert abs(rt - 0.1) < 2**-6
+
+
+def test_FloatAttr_skips_normalisation_for_unsupported_widths():
+    # f80 and f128 have no precision-normalisation path (their format
+    # raises NotImplementedError). FloatAttr.__init__ must take the
+    # else-branch and store the Python float as-is.
+    assert FloatAttr(0.1, f80).value.data == 0.1
+    assert FloatAttr(0.1, f128).value.data == 0.1
 
 
 def test_IntegerType_size():
@@ -339,6 +401,22 @@ def test_IntegerType_packing():
     assert attrs_i64 == tuple(IntegerAttr(n, i64) for n in nums_i64)
     assert tuple(attr for attr in IntegerAttr.iter_unpack(i64, buffer_i64)) == attrs_i64
 
+    # bf16
+    nums_bf16 = (-3.140625, -1.0, 0.0, 1.0, 3.140625)
+    buffer_bf16 = bf16.pack(nums_bf16)
+    unpacked_bf16 = bf16.unpack(buffer_bf16, len(nums_bf16))
+    assert nums_bf16 == unpacked_bf16
+    attrs_bf16 = FloatAttr.unpack(bf16, buffer_bf16, len(nums_bf16))
+    assert attrs_bf16 == tuple(FloatAttr(n, bf16) for n in nums_bf16)
+    assert (
+        tuple(attr for attr in FloatAttr.iter_unpack(bf16, buffer_bf16)) == attrs_bf16
+    )
+    # pack_into mirrors pack for the same values.
+    pack_into_buffer = bytearray(2 * len(nums_bf16))
+    for i, n in enumerate(nums_bf16):
+        bf16.pack_into(pack_into_buffer, 2 * i, n)
+    assert bytes(pack_into_buffer) == buffer_bf16
+
     # f16
     nums_f16 = (-3.140625, -1.0, 0.0, 1.0, 3.140625)
     buffer_f16 = f16.pack(nums_f16)
@@ -349,7 +427,7 @@ def test_IntegerType_packing():
     assert tuple(attr for attr in FloatAttr.iter_unpack(f16, buffer_f16)) == attrs_f16
 
     # f32
-    nums_f32 = (-3.140000104904175, -1.0, 0.0, 1.0, 3.140000104904175)
+    nums_f32 = (-3.140625, -1.0, 0.0, 1.0, 3.140625)
     buffer_f32 = f32.pack(nums_f32)
     unpacked_f32 = f32.unpack(buffer_f32, len(nums_f32))
     assert nums_f32 == unpacked_f32
@@ -358,7 +436,7 @@ def test_IntegerType_packing():
     assert tuple(attr for attr in FloatAttr.iter_unpack(f32, buffer_f32)) == attrs_f32
 
     # f64
-    nums_f64 = (-3.14159265359, -1.0, 0.0, 1.0, 3.14159265359)
+    nums_f64 = (-3.140625, -1.0, 0.0, 1.0, 3.140625)
     buffer_f64 = f64.pack(nums_f64)
     unpacked_f64 = f64.unpack(buffer_f64, len(nums_f64))
     assert nums_f64 == unpacked_f64

--- a/tests/filecheck/mlir-conversion/with-mlir/parser-printer/bfloat16.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/parser-printer/bfloat16.mlir
@@ -7,9 +7,26 @@
   "test.op"() {"value" = -2.0 : bf16} : () -> ()
   // CHECK-NEXT: "test.op"() {value = -2.000000e+00 : bf16} : () -> ()
 
-  "test.op"() {"weights" = dense<[1.0, 2.0, -1.5]> : tensor<3xbf16>} : () -> ()
-  // CHECK-NEXT: "test.op"() {weights = dense<[1.000000e+00, 2.000000e+00, -1.500000e+00]> : tensor<3xbf16>} : () -> ()
+  // 0.1 is not exactly representable in bf16; it must be quantised to
+  // its nearest bf16 value on parse and print as the rounded form.
+  "test.op"() {"value" = 0.1 : bf16} : () -> ()
+  // CHECK-NEXT: "test.op"() {value = 1.000980e-01 : bf16} : () -> ()
 
-  "test.op"() {"splat" = dense<3.0> : tensor<4xbf16>} : () -> ()
-  // CHECK-NEXT: "test.op"() {splat = dense<3.000000e+00> : tensor<4xbf16>} : () -> ()
+  "test.op"() {"value" = 0x7fc0 : bf16} : () -> ()
+  // CHECK-NEXT: "test.op"() {value = 0x7fc0 : bf16} : () -> ()
+
+  "test.op"() {"value" = 0x7f80 : bf16} : () -> ()
+  // CHECK-NEXT: "test.op"() {value = 0x7f80 : bf16} : () -> ()
+
+  "test.op"() {"value" = 0xff80 : bf16} : () -> ()
+  // CHECK-NEXT: "test.op"() {value = 0xff80 : bf16} : () -> ()
+
+  "test.op"() {"weights" = array<bf16: 1.0, 2.0, -1.5>} : () -> ()
+  // CHECK-NEXT: "test.op"() {weights = array<bf16: 1.000000e+00, 2.000000e+00, -1.500000e+00>} : () -> ()
+
+  "test.op"() {"t" = dense<[1.0, 2.0]> : tensor<2xbf16>} : () -> ()
+  // CHECK-NEXT: "test.op"() {t = dense<[1.000000e+00, 2.000000e+00]> : tensor<2xbf16>} : () -> ()
+
+  "test.op"() {"s" = dense<3.0> : tensor<4xbf16>} : () -> ()
+  // CHECK-NEXT: "test.op"() {s = dense<3.000000e+00> : tensor<4xbf16>} : () -> ()
 }) : () -> ()

--- a/tests/filecheck/mlir-conversion/with-mlir/parser-printer/bfloat16.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/parser-printer/bfloat16.mlir
@@ -1,0 +1,15 @@
+// RUN: MLIR_GENERIC_ROUNDTRIP
+
+"builtin.module"() ({
+  "test.op"() {"value" = 1.5 : bf16} : () -> ()
+  // CHECK:      "test.op"() {value = 1.500000e+00 : bf16} : () -> ()
+
+  "test.op"() {"value" = -2.0 : bf16} : () -> ()
+  // CHECK-NEXT: "test.op"() {value = -2.000000e+00 : bf16} : () -> ()
+
+  "test.op"() {"weights" = dense<[1.0, 2.0, -1.5]> : tensor<3xbf16>} : () -> ()
+  // CHECK-NEXT: "test.op"() {weights = dense<[1.000000e+00, 2.000000e+00, -1.500000e+00]> : tensor<3xbf16>} : () -> ()
+
+  "test.op"() {"splat" = dense<3.0> : tensor<4xbf16>} : () -> ()
+  // CHECK-NEXT: "test.op"() {splat = dense<3.000000e+00> : tensor<4xbf16>} : () -> ()
+}) : () -> ()

--- a/tests/filecheck/parser-printer/bfloat16_parsing.mlir
+++ b/tests/filecheck/parser-printer/bfloat16_parsing.mlir
@@ -1,0 +1,33 @@
+// RUN: XDSL_ROUNDTRIP
+
+
+"builtin.module"() ({
+  "test.op"() {"value" = 1.5 : bf16} : () -> ()
+  // CHECK:      "test.op"() {value = 1.500000e+00 : bf16} : () -> ()
+
+  "test.op"() {"value" = -2.0 : bf16} : () -> ()
+  // CHECK-NEXT: "test.op"() {value = -2.000000e+00 : bf16} : () -> ()
+
+  // 0.1 is not exactly representable in bf16; it must be quantised to
+  // its nearest bf16 value on parse and print as the rounded form.
+  "test.op"() {"value" = 0.1 : bf16} : () -> ()
+  // CHECK-NEXT: "test.op"() {value = 1.000980e-01 : bf16} : () -> ()
+
+  "test.op"() {"value" = 0x7fc0 : bf16} : () -> ()
+  // CHECK-NEXT: "test.op"() {value = 0x7fc0 : bf16} : () -> ()
+
+  "test.op"() {"value" = 0x7f80 : bf16} : () -> ()
+  // CHECK-NEXT: "test.op"() {value = 0x7f80 : bf16} : () -> ()
+
+  "test.op"() {"value" = 0xff80 : bf16} : () -> ()
+  // CHECK-NEXT: "test.op"() {value = 0xff80 : bf16} : () -> ()
+
+  "test.op"() {"weights" = array<bf16: 1.0, 2.0, -1.5>} : () -> ()
+  // CHECK-NEXT: "test.op"() {weights = array<bf16: 1.000000e+00, 2.000000e+00, -1.500000e+00>} : () -> ()
+
+  "test.op"() {"t" = dense<[1.0, 2.0]> : tensor<2xbf16>} : () -> ()
+  // CHECK-NEXT: "test.op"() {t = dense<[1.000000e+00, 2.000000e+00]> : tensor<2xbf16>} : () -> ()
+
+  "test.op"() {"s" = dense<3.0> : tensor<4xbf16>} : () -> ()
+  // CHECK-NEXT: "test.op"() {s = dense<3.000000e+00> : tensor<4xbf16>} : () -> ()
+}) : () -> ()

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -25,6 +25,7 @@ from xdsl.dialects.builtin import (
     StringAttr,
     SymbolRefAttr,
     UnknownLoc,
+    bf16,
     i32,
 )
 from xdsl.dialects.func import Func, FuncOp
@@ -928,6 +929,10 @@ def test_parse_number(
         ("0x7ff8000000000000 : f64", FloatAttr(float("nan"), 64)),
         ("0x7ff0000000000000 : f64", FloatAttr(float("inf"), 64)),
         ("0xfff0000000000000 : f64", FloatAttr(float("-inf"), 64)),
+        ("-1.5: bf16", FloatAttr(-1.5, bf16)),
+        ("0x7fc0 : bf16", FloatAttr(float("nan"), bf16)),
+        ("0x7f80 : bf16", FloatAttr(float("inf"), bf16)),
+        ("0xff80 : bf16", FloatAttr(float("-inf"), bf16)),
         # ("3 : f64", None),  # todo this fails in mlir-opt but not in xdsl
     ],
 )

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -29,6 +29,7 @@ from xdsl.dialects.builtin import (
     SymbolRefAttr,
     UnitAttr,
     UnknownLoc,
+    bf16,
     f32,
     i1,
     i32,
@@ -1007,6 +1008,10 @@ def test_float_attr_specials():
     _test_attr_print("0x7e00 : f16", FloatAttr(float("nan"), 16))
     _test_attr_print("0x7c00 : f16", FloatAttr(float("inf"), 16))
     _test_attr_print("0xfc00 : f16", FloatAttr(float("-inf"), 16))
+
+    _test_attr_print("0x7fc0 : bf16", FloatAttr(float("nan"), bf16))
+    _test_attr_print("0x7f80 : bf16", FloatAttr(float("inf"), bf16))
+    _test_attr_print("0xff80 : bf16", FloatAttr(float("-inf"), bf16))
 
     _test_attr_print("0x7fc00000 : f32", FloatAttr(float("nan"), 32))
     _test_attr_print("0x7f800000 : f32", FloatAttr(float("inf"), 32))

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -1160,8 +1160,7 @@ class BFloat16Type(ParametrizedAttribute, _FloatType):
             yield self._decode(bytes(mv[i : i + 2]))
 
     def unpack(self, buffer: ReadableBuffer, num: int, /) -> tuple[float, ...]:
-        mv = memoryview(buffer)
-        return tuple(self._decode(bytes(mv[i * 2 : i * 2 + 2])) for i in range(num))
+        return tuple(res for _, res in zip(range(num), self.iter_unpack(buffer)))
 
     def pack_into(self, buffer: WriteableBuffer, offset: int, value: float) -> None:
         memoryview(buffer)[offset : offset + 2] = self._encode(value)

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -1107,7 +1107,7 @@ class IntegerAttr(
 BoolAttr: TypeAlias = IntegerAttr[Annotated[IntegerType, IntegerType(1)]]
 
 
-class _FloatType(StructPackableType[float], FixedBitwidthType, BuiltinAttribute, ABC):
+class _FloatType(PackableType[float], FixedBitwidthType, BuiltinAttribute, ABC):
     @property
     @abstractmethod
     def bitwidth(self) -> int:
@@ -1127,12 +1127,51 @@ class BFloat16Type(ParametrizedAttribute, _FloatType):
         return 16
 
     @property
-    def format(self) -> str:
-        raise NotImplementedError()
+    def compile_time_size(self) -> int:
+        return 2
+
+    @staticmethod
+    def _encode(value: float) -> bytes:
+        """
+        Encode a Python float (IEEE 754 binary32 after Python's f64 -> f32
+        narrowing) as bf16 bytes, little-endian. Round-to-nearest-even,
+        quiet-NaN preservation; matches LLVM APFloat semantics.
+        """
+        f32_bits = struct.unpack("<I", struct.pack("<f", value))[0]
+        # NaN must remain a NaN after truncation; force the quiet bit on so a
+        # signaling NaN with mantissa entirely in the truncated bits doesn't
+        # become inf.
+        if (f32_bits & 0x7FFFFFFF) > 0x7F800000:
+            bits = ((f32_bits >> 16) | 0x0040) & 0xFFFF
+        else:
+            rounding_bias = 0x7FFF + ((f32_bits >> 16) & 1)
+            bits = ((f32_bits + rounding_bias) >> 16) & 0xFFFF
+        return bits.to_bytes(2, "little")
+
+    @staticmethod
+    def _decode(raw: bytes) -> float:
+        # bf16 is the high 16 bits of an f32 with the low 16 truncated; the
+        # inverse is to zero-extend with two low bytes in little-endian.
+        return struct.unpack("<f", b"\x00\x00" + raw)[0]
+
+    def iter_unpack(self, buffer: ReadableBuffer, /) -> Iterator[float]:
+        mv = memoryview(buffer)
+        for i in range(0, len(mv), 2):
+            yield self._decode(bytes(mv[i : i + 2]))
+
+    def unpack(self, buffer: ReadableBuffer, num: int, /) -> tuple[float, ...]:
+        mv = memoryview(buffer)
+        return tuple(self._decode(bytes(mv[i * 2 : i * 2 + 2])) for i in range(num))
+
+    def pack_into(self, buffer: WriteableBuffer, offset: int, value: float) -> None:
+        memoryview(buffer)[offset : offset + 2] = self._encode(value)
+
+    def pack(self, values: Sequence[float]) -> bytes:
+        return b"".join(self._encode(v) for v in values)
 
 
 @irdl_attr_definition
-class Float16Type(ParametrizedAttribute, _FloatType):
+class Float16Type(ParametrizedAttribute, _FloatType, StructPackableType[float]):
     name = "f16"
 
     @property
@@ -1145,7 +1184,7 @@ class Float16Type(ParametrizedAttribute, _FloatType):
 
 
 @irdl_attr_definition
-class Float32Type(ParametrizedAttribute, _FloatType):
+class Float32Type(ParametrizedAttribute, _FloatType, StructPackableType[float]):
     name = "f32"
 
     @property
@@ -1158,7 +1197,7 @@ class Float32Type(ParametrizedAttribute, _FloatType):
 
 
 @irdl_attr_definition
-class Float64Type(ParametrizedAttribute, _FloatType):
+class Float64Type(ParametrizedAttribute, _FloatType, StructPackableType[float]):
     name = "f64"
 
     @property
@@ -1171,7 +1210,7 @@ class Float64Type(ParametrizedAttribute, _FloatType):
 
 
 @irdl_attr_definition
-class Float80Type(ParametrizedAttribute, _FloatType):
+class Float80Type(ParametrizedAttribute, _FloatType, StructPackableType[float]):
     name = "f80"
 
     @property
@@ -1184,7 +1223,7 @@ class Float80Type(ParametrizedAttribute, _FloatType):
 
 
 @irdl_attr_definition
-class Float128Type(ParametrizedAttribute, _FloatType):
+class Float128Type(ParametrizedAttribute, _FloatType, StructPackableType[float]):
     name = "f128"
 
     @property
@@ -1272,7 +1311,7 @@ class FloatAttr(BuiltinAttribute, TypedAttribute, Generic[_FloatAttrType]):
         value: float = data.data if isinstance(data, FloatData) else data
         # for supported types, constrain value to precision of floating point type
         # else, allow full python float precision
-        if isinstance(type, Float64Type | Float32Type | Float16Type):
+        if isinstance(type, Float64Type | Float32Type | Float16Type | BFloat16Type):
             value = type.unpack(type.pack((value,)), 1)[0]
 
         data_attr = FloatData(value)


### PR DESCRIPTION
This PR adds support for printing and parsing of bf16 number format. It reads in bf16 and then bit converts this to fp32 for storage as a Python float internally, and the opposite (converting back out to bf16) for printing. This maintains compatibility with MLIR and the correct number representation externally, but using Python's float storage as the internal representation whilst maintaining correctness of the bf16 number itself. Therefore this avoids needing to pull in any specialist numeric libraries for bf16 and interface them with the rest of xDSL which I felt would be a pain and a bit messy. This PR also updates the builtin dialect to hook this in, removing the NotImplementedError from the Bfloat16 type. 

Ultimately, this PR adds support for working with bf16 numbers now into xDSL.
