### PR TITLE
dialects: (riscv) all instructions have RegisterAllocatedMemoryEffect

### DIFF
--- a/tests/dialects/test_riscv.py
+++ b/tests/dialects/test_riscv.py
@@ -375,8 +375,14 @@ def test_effect_traits():
     unknown_effects_ops = {op for op in operations if op not in effects_ops}
 
     # Sentinels to remind us to update this test when updating the dialect
-    assert len(effects_ops) == 90
-    assert len(unknown_effects_ops) == 68
+    assert len(effects_ops) == 153
+    assert unknown_effects_ops == {
+        riscv.ops.CommentOp,
+        riscv.ops.AssemblySectionOp,
+        riscv.ops.DirectiveOp,
+        riscv.ops.ParallelMovOp,
+        riscv.ops.LabelOp,
+    }
 
     all_effects_trait_types = {
         type(trait)
@@ -400,7 +406,7 @@ def test_effect_traits():
 
     no_effects_ops = {op for op in effects_ops if op.has_trait(NoMemoryEffect)}
 
-    assert len(register_effects_ops) == 18
+    assert len(register_effects_ops) == 152
     assert read_effects_ops == {
         riscv.CsrrciOp,
         riscv.CsrrcOp,
@@ -429,4 +435,4 @@ def test_effect_traits():
         riscv.ShOp,
         riscv.SwOp,
     }
-    assert len(no_effects_ops) == 54
+    assert no_effects_ops == {riscv.ops.GetFloatRegisterOp}

--- a/tests/dialects/test_riscv_debug.py
+++ b/tests/dialects/test_riscv_debug.py
@@ -1,3 +1,4 @@
+from xdsl.backend.register_type import RegisterAllocatedMemoryEffect
 from xdsl.dialects import riscv_debug
 from xdsl.traits import (
     EffectInstance,
@@ -33,4 +34,15 @@ def test_effect_traits():
     }
 
     # Check below separately for each of these
-    assert all_effects_trait_types == {MemoryWriteEffect}
+    assert all_effects_trait_types == {
+        MemoryWriteEffect,
+        RegisterAllocatedMemoryEffect,
+    }
+
+    register_effects_ops = {
+        op for op in effects_ops if op.has_trait(RegisterAllocatedMemoryEffect)
+    }
+    write_effects_ops = {op for op in effects_ops if op.has_trait(MemoryWriteEffect)}
+
+    assert register_effects_ops == {riscv_debug.PrintfOp}
+    assert write_effects_ops == {riscv_debug.PrintfOp}

--- a/tests/dialects/test_riscv_func.py
+++ b/tests/dialects/test_riscv_func.py
@@ -81,4 +81,7 @@ def test_effect_traits():
     assert write_effects_ops == {riscv_func.CallOp, riscv_func.SyscallOp}
     assert riscv_func_call_effects_ops == {riscv_func.CallOp, riscv_func.SyscallOp}
 
-    assert register_allocated_memory_effects_ops == {riscv_func.ReturnOp}
+    assert register_allocated_memory_effects_ops == {
+        riscv_func.CallOp,
+        riscv_func.ReturnOp,
+    }

--- a/tests/dialects/test_riscv_snitch.py
+++ b/tests/dialects/test_riscv_snitch.py
@@ -179,22 +179,7 @@ def test_effect_traits():
         riscv_snitch.FrepOuterOp,
         riscv_snitch.FrepInnerOp,
     }
-    assert register_allocated_memory_effects_ops == {
-        riscv_snitch.DMCopyImmOp,
-        riscv_snitch.DMCopyOp,
-        riscv_snitch.DMStatImmOp,
-        riscv_snitch.DMStatOp,
-        riscv_snitch.VFAddHOp,
-        riscv_snitch.VFAddSOp,
-        riscv_snitch.VFCpkASSOp,
-        riscv_snitch.VFMacSOp,
-        riscv_snitch.VFMaxSOp,
-        riscv_snitch.VFMulHOp,
-        riscv_snitch.VFMulSOp,
-        riscv_snitch.VFSubHOp,
-        riscv_snitch.VFSubSOp,
-        riscv_snitch.VFSumSOp,
-    }
+    assert len(register_allocated_memory_effects_ops) == 22
     assert no_effects_ops == {
         riscv_snitch.FrepYieldOp,
         riscv_snitch.GetStreamOp,

--- a/tests/dialects/test_rv32.py
+++ b/tests/dialects/test_rv32.py
@@ -64,6 +64,7 @@ def test_effect_traits():
     # Check below separately for each of these
     assert all_effects_trait_types == {
         Pure,
+        RegisterAllocatedMemoryEffect,
     }
 
     register_effects_ops = {
@@ -71,8 +72,9 @@ def test_effect_traits():
     }
     no_effects_ops = {op for op in effects_ops if op.has_trait(NoMemoryEffect)}
 
-    assert not register_effects_ops
+    assert register_effects_ops == {
+        rv32.LiOp,
+    }
     assert no_effects_ops == {
-        rv32.LiOp,  # This is a bug, will fix in an upcoming PR
         rv32.GetRegisterOp,
     }

--- a/tests/dialects/test_rv64.py
+++ b/tests/dialects/test_rv64.py
@@ -64,6 +64,7 @@ def test_effect_traits():
     # Check below separately for each of these
     assert all_effects_trait_types == {
         Pure,
+        RegisterAllocatedMemoryEffect,
     }
 
     register_effects_ops = {
@@ -71,8 +72,5 @@ def test_effect_traits():
     }
     no_effects_ops = {op for op in effects_ops if op.has_trait(NoMemoryEffect)}
 
-    assert not register_effects_ops
-    assert no_effects_ops == {
-        rv64.LiOp,  # This is a bug, will fix in an upcoming PR
-        rv64.GetRegisterOp,
-    }
+    assert register_effects_ops == {rv64.LiOp}
+    assert no_effects_ops == {rv64.GetRegisterOp}

--- a/xdsl/dialects/riscv/abstract_ops.py
+++ b/xdsl/dialects/riscv/abstract_ops.py
@@ -197,6 +197,8 @@ class RISCVInstruction(RISCVAsmOperation, RISCVRegallocOperation, ABC):
     An optional comment that will be printed along with the instruction.
     """
 
+    traits = traits_def(RegisterAllocatedMemoryEffect())
+
     @abstractmethod
     def assembly_line_args(self) -> tuple[AssemblyInstructionArg | None, ...]:
         """
@@ -440,8 +442,6 @@ class RdRsRsRsFloatOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC):
     rs2 = operand_def(FloatRegisterType)
     rs3 = operand_def(FloatRegisterType)
 
-    traits = traits_def(RegisterAllocatedMemoryEffect())
-
     def __init__(
         self,
         rs1: Operation | SSAValue,
@@ -535,10 +535,6 @@ class RdRsRsFloatOperationWithFastMath(
     rs1 = operand_def(FloatRegisterType)
     rs2 = operand_def(FloatRegisterType)
     fastmath = opt_attr_def(FastMathFlagsAttr)
-
-    # https://github.com/xdslproject/xdsl/issues/5882
-    # Move to appropriate superclass in the future
-    traits = traits_def(RegisterAllocatedMemoryEffect())
 
     def __init__(
         self,

--- a/xdsl/dialects/riscv/ops.py
+++ b/xdsl/dialects/riscv/ops.py
@@ -51,7 +51,6 @@ from xdsl.traits import (
     MemoryReadEffect,
     MemoryWriteEffect,
     NoTerminator,
-    Pure,
 )
 from xdsl.utils.exceptions import VerifyException
 
@@ -130,7 +129,7 @@ class AddiOp(RdRsImmIntegerOperation):
 
     name = "riscv.addi"
 
-    traits = traits_def(Pure(), AddiOpHasCanonicalizationPatternsTrait())
+    traits = traits_def(AlwaysSpeculatable(), AddiOpHasCanonicalizationPatternsTrait())
 
 
 @irdl_op_definition
@@ -309,7 +308,7 @@ class AddiwOp(RdRsImmIntegerOperation):
 
     name = "riscv.addiw"
 
-    traits = traits_def(Pure())
+    traits = traits_def(AlwaysSpeculatable())
 
 
 @irdl_op_definition
@@ -325,7 +324,7 @@ class SlliwOp(RdRsImmShiftOperation):
 
     name = "riscv.slliw"
 
-    traits = traits_def(Pure())
+    traits = traits_def(AlwaysSpeculatable())
 
 
 @irdl_op_definition
@@ -342,7 +341,7 @@ class SrliwOp(RdRsImmShiftOperation):
 
     name = "riscv.srliw"
 
-    traits = traits_def(Pure())
+    traits = traits_def(AlwaysSpeculatable())
 
 
 @irdl_op_definition
@@ -359,7 +358,7 @@ class SraiwOp(RdRsImmIntegerOperation):
 
     name = "riscv.sraiw"
 
-    traits = traits_def(Pure())
+    traits = traits_def(AlwaysSpeculatable())
 
 
 @irdl_op_definition
@@ -377,7 +376,7 @@ class AddwOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
 
     name = "riscv.addw"
 
-    traits = traits_def(Pure())
+    traits = traits_def(AlwaysSpeculatable())
 
 
 @irdl_op_definition
@@ -395,7 +394,7 @@ class SubwOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
 
     name = "riscv.subw"
 
-    traits = traits_def(Pure())
+    traits = traits_def(AlwaysSpeculatable())
 
 
 @irdl_op_definition
@@ -412,7 +411,7 @@ class SllwOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
 
     name = "riscv.sllw"
 
-    traits = traits_def(Pure())
+    traits = traits_def(AlwaysSpeculatable())
 
 
 @irdl_op_definition
@@ -430,7 +429,7 @@ class SrlwOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
 
     name = "riscv.srlw"
 
-    traits = traits_def(Pure())
+    traits = traits_def(AlwaysSpeculatable())
 
 
 @irdl_op_definition
@@ -447,7 +446,7 @@ class SrawOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
 
     name = "riscv.sraw"
 
-    traits = traits_def(Pure())
+    traits = traits_def(AlwaysSpeculatable())
 
 
 @irdl_op_definition
@@ -500,7 +499,7 @@ class MVOp(RdRsIntegerOperation[IntRegisterType]):
     name = "riscv.mv"
 
     traits = traits_def(
-        Pure(),
+        AlwaysSpeculatable(),
         MVHasCanonicalizationPatternsTrait(),
     )
 
@@ -538,7 +537,7 @@ class ZextBOp(RdRsIntegerOperation[IntRegisterType]):
 
     name = "riscv.zext.b"
 
-    traits = traits_def(Pure())
+    traits = traits_def(AlwaysSpeculatable())
 
 
 @irdl_op_definition
@@ -554,7 +553,7 @@ class ZextWOp(RdRsIntegerOperation[IntRegisterType]):
 
     name = "riscv.zext.w"
 
-    traits = traits_def(Pure())
+    traits = traits_def(AlwaysSpeculatable())
 
 
 @irdl_op_definition
@@ -569,7 +568,7 @@ class SextWOp(RdRsIntegerOperation[IntRegisterType]):
 
     name = "riscv.sext.w"
 
-    traits = traits_def(Pure())
+    traits = traits_def(AlwaysSpeculatable())
 
 
 class FMVHasCanonicalizationPatternsTrait(HasCanonicalizationPatternsTrait):
@@ -595,7 +594,7 @@ class FMVOp(RdRsFloatOperation[FloatRegisterType]):
     name = "riscv.fmv.s"
 
     traits = traits_def(
-        Pure(),
+        AlwaysSpeculatable(),
         FMVHasCanonicalizationPatternsTrait(),
     )
 
@@ -630,7 +629,7 @@ class AddOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
     name = "riscv.add"
 
     traits = traits_def(
-        Pure(),
+        AlwaysSpeculatable(),
         AddOpHasCanonicalizationPatternsTrait(),
     )
 
@@ -1335,7 +1334,7 @@ class MulOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
 
     name = "riscv.mul"
 
-    traits = traits_def(MulOpHasCanonicalizationPatternsTrait(), Pure())
+    traits = traits_def(MulOpHasCanonicalizationPatternsTrait(), AlwaysSpeculatable())
 
 
 @irdl_op_definition
@@ -1413,7 +1412,7 @@ class DivOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
     """
 
     name = "riscv.div"
-    traits = traits_def(DivOpHasCanonicalizationPatternsTrait(), Pure())
+    traits = traits_def(DivOpHasCanonicalizationPatternsTrait(), AlwaysSpeculatable())
 
 
 @irdl_op_definition
@@ -1530,7 +1529,7 @@ class RolOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
 
     name = "riscv.rol"
 
-    traits = traits_def(Pure())
+    traits = traits_def(AlwaysSpeculatable())
 
 
 @irdl_op_definition
@@ -1549,7 +1548,7 @@ class RorOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
 
     name = "riscv.ror"
 
-    traits = traits_def(Pure())
+    traits = traits_def(AlwaysSpeculatable())
 
 
 @irdl_op_definition
@@ -1565,7 +1564,7 @@ class SextHOp(RdRsIntegerOperation[IntRegisterType]):
 
     name = "riscv.sext.h"
 
-    traits = traits_def(Pure())
+    traits = traits_def(AlwaysSpeculatable())
 
 
 @irdl_op_definition
@@ -1581,7 +1580,7 @@ class ZextHOp(RdRsIntegerOperation[IntRegisterType]):
 
     name = "riscv.zext.h"
 
-    traits = traits_def(Pure())
+    traits = traits_def(AlwaysSpeculatable())
 
 
 @irdl_op_definition
@@ -1597,7 +1596,7 @@ class SextBOp(RdRsIntegerOperation[IntRegisterType]):
 
     name = "riscv.sext.b"
 
-    traits = traits_def(Pure())
+    traits = traits_def(AlwaysSpeculatable())
 
 
 @irdl_op_definition
@@ -1614,7 +1613,7 @@ class BclrOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
 
     name = "riscv.bclr"
 
-    traits = traits_def(Pure())
+    traits = traits_def(AlwaysSpeculatable())
 
 
 @irdl_op_definition
@@ -1632,7 +1631,7 @@ class BclrIOp(RdRsImmBitManipOperation):
 
     name = "riscv.bclri"
 
-    traits = traits_def(Pure())
+    traits = traits_def(AlwaysSpeculatable())
 
 
 @irdl_op_definition
@@ -1649,7 +1648,7 @@ class BextOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
 
     name = "riscv.bext"
 
-    traits = traits_def(Pure())
+    traits = traits_def(AlwaysSpeculatable())
 
 
 @irdl_op_definition
@@ -1667,7 +1666,7 @@ class BextIOp(RdRsImmBitManipOperation):
 
     name = "riscv.bexti"
 
-    traits = traits_def(Pure())
+    traits = traits_def(AlwaysSpeculatable())
 
 
 @irdl_op_definition
@@ -1685,7 +1684,7 @@ class BinvOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
 
     name = "riscv.binv"
 
-    traits = traits_def(Pure())
+    traits = traits_def(AlwaysSpeculatable())
 
 
 @irdl_op_definition
@@ -1703,7 +1702,7 @@ class BinvIOp(RdRsImmBitManipOperation):
 
     name = "riscv.binvi"
 
-    traits = traits_def(Pure())
+    traits = traits_def(AlwaysSpeculatable())
 
 
 @irdl_op_definition
@@ -1720,7 +1719,7 @@ class BsetOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
 
     name = "riscv.bset"
 
-    traits = traits_def(Pure())
+    traits = traits_def(AlwaysSpeculatable())
 
 
 @irdl_op_definition
@@ -1738,7 +1737,7 @@ class BsetIOp(RdRsImmBitManipOperation):
 
     name = "riscv.bseti"
 
-    traits = traits_def(Pure())
+    traits = traits_def(AlwaysSpeculatable())
 
 
 @irdl_op_definition
@@ -1758,7 +1757,7 @@ class RolwOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
 
     name = "riscv.rolw"
 
-    traits = traits_def(Pure())
+    traits = traits_def(AlwaysSpeculatable())
 
 
 @irdl_op_definition
@@ -1778,7 +1777,7 @@ class RorwOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
 
     name = "riscv.rorw"
 
-    traits = traits_def(Pure())
+    traits = traits_def(AlwaysSpeculatable())
 
 
 @irdl_op_definition
@@ -1798,7 +1797,7 @@ class RoriOp(RdRsImmBitManipOperation):
 
     name = "riscv.rori"
 
-    traits = traits_def(Pure())
+    traits = traits_def(AlwaysSpeculatable())
 
 
 @irdl_op_definition
@@ -1817,7 +1816,7 @@ class RoriwOp(RdRsImmBitManipOperation):
 
     name = "riscv.roriw"
 
-    traits = traits_def(Pure())
+    traits = traits_def(AlwaysSpeculatable())
 
 
 @irdl_op_definition
@@ -1835,7 +1834,7 @@ class AddUwOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
 
     name = "riscv.add.uw"
 
-    traits = traits_def(Pure())
+    traits = traits_def(AlwaysSpeculatable())
 
 
 @irdl_op_definition
@@ -1850,7 +1849,7 @@ class Sh1addOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
 
     name = "riscv.sh1add"
 
-    traits = traits_def(Pure())
+    traits = traits_def(AlwaysSpeculatable())
 
 
 @irdl_op_definition
@@ -1865,7 +1864,7 @@ class Sh2addOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
 
     name = "riscv.sh2add"
 
-    traits = traits_def(Pure())
+    traits = traits_def(AlwaysSpeculatable())
 
 
 @irdl_op_definition
@@ -1880,7 +1879,7 @@ class Sh3addOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
 
     name = "riscv.sh3add"
 
-    traits = traits_def(Pure())
+    traits = traits_def(AlwaysSpeculatable())
 
 
 @irdl_op_definition
@@ -1900,7 +1899,7 @@ class Sh1addUwOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
 
     name = "riscv.sh1add.uw"
 
-    traits = traits_def(Pure())
+    traits = traits_def(AlwaysSpeculatable())
 
 
 @irdl_op_definition
@@ -1919,7 +1918,7 @@ class Sh2addUwOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
 
     name = "riscv.sh2add.uw"
 
-    traits = traits_def(Pure())
+    traits = traits_def(AlwaysSpeculatable())
 
 
 @irdl_op_definition
@@ -1939,7 +1938,7 @@ class Sh3addUwOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
 
     name = "riscv.sh3add.uw"
 
-    traits = traits_def(Pure())
+    traits = traits_def(AlwaysSpeculatable())
 
 
 @irdl_op_definition
@@ -1955,7 +1954,7 @@ class SlliUwOp(RdRsImmBitManipOperation):
 
     name = "riscv.slli.uw"
 
-    traits = traits_def(Pure())
+    traits = traits_def(AlwaysSpeculatable())
 
 
 @irdl_op_definition
@@ -1970,7 +1969,7 @@ class AndnOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
 
     name = "riscv.andn"
 
-    traits = traits_def(Pure())
+    traits = traits_def(AlwaysSpeculatable())
 
 
 @irdl_op_definition
@@ -1985,7 +1984,7 @@ class OrnOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
 
     name = "riscv.orn"
 
-    traits = traits_def(Pure())
+    traits = traits_def(AlwaysSpeculatable())
 
 
 @irdl_op_definition
@@ -2000,7 +1999,7 @@ class XnorOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
 
     name = "riscv.xnor"
 
-    traits = traits_def(Pure())
+    traits = traits_def(AlwaysSpeculatable())
 
 
 @irdl_op_definition
@@ -2021,7 +2020,7 @@ class MaxOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
 
     name = "riscv.max"
 
-    traits = traits_def(Pure())
+    traits = traits_def(AlwaysSpeculatable())
 
 
 @irdl_op_definition
@@ -2041,7 +2040,7 @@ class MaxUOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
 
     name = "riscv.maxu"
 
-    traits = traits_def(Pure())
+    traits = traits_def(AlwaysSpeculatable())
 
 
 @irdl_op_definition
@@ -2061,7 +2060,7 @@ class MinOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
 
     name = "riscv.min"
 
-    traits = traits_def(Pure())
+    traits = traits_def(AlwaysSpeculatable())
 
 
 @irdl_op_definition
@@ -2081,7 +2080,7 @@ class MinUOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
 
     name = "riscv.minu"
 
-    traits = traits_def(Pure())
+    traits = traits_def(AlwaysSpeculatable())
 
 
 # endregion
@@ -3100,7 +3099,7 @@ class FCvtDWOp(RdRsFloatOperation[IntRegisterType]):
 
     name = "riscv.fcvt.d.w"
 
-    traits = traits_def(Pure())
+    traits = traits_def(AlwaysSpeculatable())
 
 
 @irdl_op_definition
@@ -3116,7 +3115,7 @@ class FCvtDWuOp(RdRsFloatOperation[IntRegisterType]):
 
     name = "riscv.fcvt.d.wu"
 
-    traits = traits_def(Pure())
+    traits = traits_def(AlwaysSpeculatable())
 
 
 @irdl_op_definition
@@ -3203,7 +3202,7 @@ class FMvDOp(RdRsFloatOperation[FloatRegisterType]):
     name = "riscv.fmv.d"
 
     traits = traits_def(
-        Pure(),
+        AlwaysSpeculatable(),
         FMvDHasCanonicalizationPatternsTrait(),
     )
 
@@ -3232,7 +3231,7 @@ class VFAddSOp(RdRsRsFloatOperation[FloatRegisterType, FloatRegisterType]):
 
     name = "riscv.vfadd.s"
 
-    traits = traits_def(Pure())
+    traits = traits_def(AlwaysSpeculatable())
 
 
 @irdl_op_definition
@@ -3246,7 +3245,7 @@ class VFMulSOp(RdRsRsFloatOperation[FloatRegisterType, FloatRegisterType]):
 
     name = "riscv.vfmul.s"
 
-    traits = traits_def(Pure())
+    traits = traits_def(AlwaysSpeculatable())
 
 
 # endregion

--- a/xdsl/dialects/riscv_func.py
+++ b/xdsl/dialects/riscv_func.py
@@ -4,11 +4,7 @@ import itertools
 from collections.abc import Generator, Sequence
 
 from xdsl.backend.assembly_printer import AssemblyPrintable, AssemblyPrinter
-from xdsl.backend.register_type import (
-    RegisterAllocatedMemoryEffect,
-    RegisterResource,
-    RegisterType,
-)
+from xdsl.backend.register_type import RegisterResource, RegisterType
 from xdsl.dialects import riscv
 from xdsl.dialects.builtin import (
     I8,
@@ -309,9 +305,6 @@ class ReturnOp(riscv.RISCVInstruction):
         IsTerminator(),
         HasParent(FuncOp),
         ReturnLike(),
-        # https://github.com/xdslproject/xdsl/issues/5882
-        # Move to appropriate superclass in the future
-        RegisterAllocatedMemoryEffect(),
     )
 
     assembly_format = "attr-dict ($values^ `:` type($values))?"

--- a/xdsl/dialects/riscv_snitch.py
+++ b/xdsl/dialects/riscv_snitch.py
@@ -8,7 +8,7 @@ from typing_extensions import Self, override
 
 from xdsl.backend.register_allocatable import RegisterConstraints
 from xdsl.backend.register_allocator import BlockAllocator
-from xdsl.backend.register_type import RegisterAllocatedMemoryEffect, RegisterResource
+from xdsl.backend.register_type import RegisterResource
 from xdsl.backend.riscv.traits import StaticInsnRepresentation
 from xdsl.dialects import riscv, snitch
 from xdsl.dialects.builtin import (
@@ -738,9 +738,6 @@ class DMCopyOp(RISCVInstruction):
         StaticInsnRepresentation(insn=".insn r 0x2b, 0, 3, {0}, {1}, {2}"),
         MemoryReadEffect(),
         MemoryWriteEffect(),
-        # https://github.com/xdslproject/xdsl/issues/5882
-        # Move to appropriate superclass in the future
-        RegisterAllocatedMemoryEffect(),
     )
 
     def __init__(
@@ -767,9 +764,6 @@ class DMStatOp(RISCVInstruction):
     traits = traits_def(
         StaticInsnRepresentation(insn=".insn r 0x2b, 0, 5, {0}, {1}, {2}"),
         MemoryReadEffect(),
-        # https://github.com/xdslproject/xdsl/issues/5882
-        # Move to appropriate superclass in the future
-        RegisterAllocatedMemoryEffect(),
     )
 
     def __init__(
@@ -817,9 +811,6 @@ class DMCopyImmOp(RISCVInstruction):
         StaticInsnRepresentation(insn=".insn r 0x2b, 0, 2, {0}, {1}, {2}"),
         MemoryReadEffect(),
         MemoryWriteEffect(),
-        # https://github.com/xdslproject/xdsl/issues/5882
-        # Move to appropriate superclass in the future
-        RegisterAllocatedMemoryEffect(),
     )
 
     def __init__(
@@ -852,9 +843,6 @@ class DMStatImmOp(RISCVInstruction):
     traits = traits_def(
         StaticInsnRepresentation(insn=".insn r 0x2b, 0, 4, {0}, {1}, {2}"),
         MemoryReadEffect(),
-        # https://github.com/xdslproject/xdsl/issues/5882
-        # Move to appropriate superclass in the future
-        RegisterAllocatedMemoryEffect(),
     )
 
     def __init__(
@@ -903,9 +891,7 @@ class VFCpkASSOp(
 
     name = "riscv_snitch.vfcpka.s.s"
 
-    # https://github.com/xdslproject/xdsl/issues/5882
-    # Move to appropriate superclass in the future
-    traits = traits_def(AlwaysSpeculatable(), RegisterAllocatedMemoryEffect())
+    traits = traits_def(AlwaysSpeculatable())
 
 
 @irdl_op_definition
@@ -1060,9 +1046,7 @@ class RdRsRsAccumulatingFloatOperationWithFastMath(
 
     fastmath = opt_attr_def(FastMathFlagsAttr)
 
-    # https://github.com/xdslproject/xdsl/issues/5882
-    # Move to appropriate superclass in the future
-    traits = traits_def(AlwaysSpeculatable(), RegisterAllocatedMemoryEffect())
+    traits = traits_def(AlwaysSpeculatable())
 
     def __init__(
         self,
@@ -1125,9 +1109,7 @@ class RdRsAccumulatingFloatOperation(RISCVCustomFormatOperation, RISCVInstructio
     rd_in = operand_def(SAME_FLOAT_REGISTER_TYPE)
     rs = operand_def(FloatRegisterType)
 
-    # https://github.com/xdslproject/xdsl/issues/5882
-    # Move to appropriate superclass in the future
-    traits = traits_def(AlwaysSpeculatable(), RegisterAllocatedMemoryEffect())
+    traits = traits_def(AlwaysSpeculatable())
 
     def __init__(
         self,

--- a/xdsl/dialects/rv32.py
+++ b/xdsl/dialects/rv32.py
@@ -37,10 +37,7 @@ from xdsl.irdl import (
 )
 from xdsl.parser import Parser
 from xdsl.printer import Printer
-from xdsl.traits import (
-    ConstantLike,
-    Pure,
-)
+from xdsl.traits import ConstantLike
 
 
 @irdl_op_definition
@@ -58,7 +55,7 @@ class LiOp(RISCVCustomFormatOperation, RISCVInstruction, HasFolderInterface, ABC
     rd = result_def(IntRegisterType)
     immediate = attr_def(IntegerAttr[I32] | LabelAttr)
 
-    traits = traits_def(Pure(), LiOpHasCanonicalizationPatternTrait(), ConstantLike())
+    traits = traits_def(LiOpHasCanonicalizationPatternTrait(), ConstantLike())
 
     def __init__(
         self,

--- a/xdsl/dialects/rv64.py
+++ b/xdsl/dialects/rv64.py
@@ -37,10 +37,7 @@ from xdsl.irdl import (
 )
 from xdsl.parser import Parser
 from xdsl.printer import Printer
-from xdsl.traits import (
-    ConstantLike,
-    Pure,
-)
+from xdsl.traits import ConstantLike
 
 
 @irdl_op_definition
@@ -58,7 +55,7 @@ class LiOp(RISCVCustomFormatOperation, RISCVInstruction, HasFolderInterface, ABC
     rd = result_def(IntRegisterType)
     immediate = attr_def(IntegerAttr[I64] | LabelAttr)
 
-    traits = traits_def(Pure(), LiOpHasCanonicalizationPatternTrait(), ConstantLike())
+    traits = traits_def(LiOpHasCanonicalizationPatternTrait(), ConstantLike())
 
     def __init__(
         self,


### PR DESCRIPTION
Another step towards #5882, this time making sure that we correctly communicate the registers being read from and written to by each op in the riscv dialects.