### PR TITLE
[Tracking branch] core: (Constraints) introduce constraint simplification

### DIFF
--- a/tests/filecheck/dialects/memref/invalid_ops.mlir
+++ b/tests/filecheck/dialects/memref/invalid_ops.mlir
@@ -4,7 +4,7 @@ builtin.module {
   "memref.global"() {"alignment" = 64 : i32, "sym_name" = "wrong_alignment_type", "type" = memref<1xindex>, "initial_value" = dense<0> : tensor<1xindex>, "sym_visibility" = "public"} : () -> ()
 }
 
-// CHECK: Invalid value 32, expected 64
+// CHECK: Expected attribute i64 but got i32
 
 // -----
 
@@ -40,7 +40,7 @@ builtin.module {
 
 
 
-// CHECK: Invalid value 32, expected 64
+// CHECK: Expected attribute i64 but got i32
 
 // -----
 
@@ -50,7 +50,7 @@ builtin.module {
     "func.return"() : () -> ()
 }) {function_type = () -> (), sym_name = "invalid_reassociation"} : () -> ()
 
-// CHECK: Invalid value 32, expected 64
+// CHECK: Expected attribute i64 but got i32
 
 
 // -----

--- a/tests/filecheck/dialects/snitch_runtime/snitch_runtime_invalid.mlir
+++ b/tests/filecheck/dialects/snitch_runtime/snitch_runtime_invalid.mlir
@@ -4,11 +4,11 @@
 %src_i64 = arith.constant 0 : i64
 %size = arith.constant 100 : i32
 %transfer_id = "snrt.dma_start_1d"(%dst_i64, %src_i64, %size) : (i64, i64, i32) -> i32
-// CHECK: Invalid value 64, expected 32
+// CHECK: Expected attribute i64 but got i32
 
 // -----
 %dst_i32 = arith.constant 100 : i32
 %src_i32 = arith.constant 0 : i32
 %size = arith.constant 100 : i32
 %transfer_id_1 = "snrt.dma_start_1d_wideptr"(%dst_i32, %src_i32, %size) : (i32, i32, i32) -> i32
-// CHECK: Invalid value 32, expected 64
+// CHECK: Expected attribute i64 but got i32

--- a/tests/irdl/test_attr_constraint.py
+++ b/tests/irdl/test_attr_constraint.py
@@ -27,7 +27,7 @@ from xdsl.irdl import (
     BaseAttr,
     ConstraintContext,
     EqAttrConstraint,
-    EqIntConstraint,
+    IntSetConstraint,
     IntTypeVarConstraint,
     ParamAttrConstraint,
     VarConstraint,
@@ -371,7 +371,7 @@ def test_mapping_type_vars():
     _IntT = TypeVar("_IntT", bound=int, default=int)
     tv_constr = IntTypeVarConstraint(_IntT, AnyInt())
     int_attr_constr = IntAttrConstraint(tv_constr)
-    my_constr = EqIntConstraint(1)
+    my_constr = IntSetConstraint(frozenset((1, 2)))
     assert int_attr_constr.mapping_type_vars({_IntT: my_constr}) == IntAttrConstraint(
         my_constr
     )

--- a/tests/test_pyrdl.py
+++ b/tests/test_pyrdl.py
@@ -16,6 +16,7 @@ from xdsl.dialects.builtin import (
     IntegerType,
     Signedness,
     SignednessAttr,
+    i32,
 )
 from xdsl.ir import Attribute, Data, ParametrizedAttribute
 from xdsl.irdl import (
@@ -444,12 +445,11 @@ def test_irdl_to_attr_constraint():
     assert irdl_to_attr_constraint(IntAttr[int]) == IntAttrConstraint(
         int_constraint=AnyInt()
     )
-    assert irdl_to_attr_constraint(IntAttr[Literal[1]]) == IntAttrConstraint(
-        int_constraint=EqIntConstraint(value=1)
+    assert irdl_to_attr_constraint(IntAttr[Literal[1]]) == EqAttrConstraint(IntAttr(1))
+    assert irdl_to_attr_constraint(IntAttr[Literal[1, 2]]) == IntAttrConstraint(
+        int_constraint=IntSetConstraint(frozenset((1, 2)))
     )
-    assert irdl_to_attr_constraint(IntAttr[2]) == IntAttrConstraint(
-        int_constraint=EqIntConstraint(value=2)
-    )
+    assert irdl_to_attr_constraint(IntAttr[2]) == EqAttrConstraint(IntAttr(2))
 
     assert irdl_to_attr_constraint(IntegerType) == BaseAttr(IntegerType)
     # With one type arg, second default
@@ -464,7 +464,7 @@ def test_irdl_to_attr_constraint():
     )
     assert irdl_to_attr_constraint(IntegerType[32]) == ParamAttrConstraint(
         IntegerType,
-        (IntAttrConstraint(EqIntConstraint(32)), BaseAttr(SignednessAttr)),
+        (EqAttrConstraint(IntAttr(32)), BaseAttr(SignednessAttr)),
     )
     assert irdl_to_attr_constraint(IntegerType[Literal[32, 64]]) == ParamAttrConstraint(
         IntegerType,
@@ -473,6 +473,8 @@ def test_irdl_to_attr_constraint():
             BaseAttr(SignednessAttr),
         ),
     )
+
+    assert irdl_to_attr_constraint(I32) == EqAttrConstraint(i32)
 
     assert irdl_to_attr_constraint(Signedness.SIGNED) == EqAttrConstraint(
         SignednessAttr(Signedness.SIGNED)
@@ -488,13 +490,7 @@ def test_irdl_to_attr_constraint():
         IntegerAttr,
         (
             BaseAttr(IntAttr),
-            ParamAttrConstraint(
-                IntegerType,
-                (
-                    IntAttrConstraint(EqIntConstraint(32)),
-                    EqAttrConstraint(SignednessAttr(Signedness.SIGNLESS)),
-                ),
-            ),
+            EqAttrConstraint(i32),
         ),
     )
     assert irdl_to_attr_constraint(IntegerAttr[IntegerType[32]]) == ParamAttrConstraint(
@@ -503,7 +499,7 @@ def test_irdl_to_attr_constraint():
             BaseAttr(IntAttr),
             ParamAttrConstraint(
                 IntegerType,
-                (IntAttrConstraint(EqIntConstraint(32)), BaseAttr(SignednessAttr)),
+                (EqAttrConstraint(IntAttr(32)), BaseAttr(SignednessAttr)),
             ),
         ),
     )

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -55,6 +55,7 @@ from xdsl.irdl import (
     ConstraintContext,
     ConstraintConvertible,
     EqAttrConstraint,
+    EqIntConstraint,
     GenericData,
     IntConstraint,
     IntTypeVarConstraint,
@@ -421,9 +422,15 @@ class IntAttrConstraint(AttrConstraint[IntAttr]):
     def mapping_type_vars(
         self, type_var_mapping: Mapping[TypeVar, AttrConstraint | IntConstraint]
     ):
-        return IntAttrConstraint(
+        return IntAttrConstraint.create(
             self.int_constraint.mapping_type_vars(type_var_mapping)
         )
+
+    @staticmethod
+    def create(int_constraint: IntConstraint) -> AttrConstraint[IntAttr]:
+        if isinstance(int_constraint, EqIntConstraint):
+            return EqAttrConstraint(IntAttr(int_constraint.value))
+        return IntAttrConstraint(int_constraint)
 
 
 StaticDimensionConstr = MessageConstraint(

--- a/xdsl/irdl/attributes.py
+++ b/xdsl/irdl/attributes.py
@@ -596,19 +596,14 @@ def irdl_to_attr_constraint(
                     allow_type_var=allow_type_var,
                 )
             )
-        if len(constraints) > 1:
-            return cast(AttrConstraint[AttributeInvT], AnyOf(constraints))
-        return cast(AttrConstraint[AttributeInvT], constraints[0])
+        return cast(AttrConstraint[AttributeInvT], AnyOf.create(constraints))
 
     if isclass(irdl) and issubclass(irdl, ConstraintConvertible):
         attr_data = cast(type[ConstraintConvertible[AttributeInvT]], irdl)
         return attr_data.base_constr()
 
     if origin is Literal:
-        literal_args = get_args(irdl)
-        if len(literal_args) == 1:
-            return irdl_to_attr_constraint(literal_args[0])
-        return AnyOf(literal_args)
+        return AnyOf.create(get_args(irdl))
 
     # Better error messages for missing GenericData in Data definitions
     if isclass(origin) and issubclass(origin, Data):

--- a/xdsl/irdl/constraints.py
+++ b/xdsl/irdl/constraints.py
@@ -18,6 +18,7 @@ from typing_extensions import TypeVar, deprecated
 from xdsl.ir import (
     Attribute,
     AttributeCovT,
+    AttributeInvT,
     ParametrizedAttribute,
     TypedAttribute,
 )
@@ -544,10 +545,33 @@ class AnyOf(AttrConstraint[AttributeCovT], Generic[AttributeCovT]):
 
     def mapping_type_vars(
         self, type_var_mapping: Mapping[TypeVar, AttrConstraint | IntConstraint]
-    ) -> AnyOf[AttributeCovT]:
-        return AnyOf(
+    ) -> AttrConstraint[AttributeCovT]:
+        return AnyOf.create(
             tuple(c.mapping_type_vars(type_var_mapping) for c in self.attr_constrs)
         )
+
+    @staticmethod
+    def create(
+        attr_constrs: Sequence[
+            AttributeInvT | type[AttributeInvT] | AttrConstraint[AttributeInvT]
+        ],
+    ) -> AttrConstraint[AttributeInvT]:
+        from xdsl.irdl import irdl_to_attr_constraint
+
+        constrs: tuple[AttrConstraint[AttributeInvT], ...] = tuple(
+            irdl_to_attr_constraint(constr) for constr in attr_constrs
+        )
+        # Check for singleton AnyOf
+        if len(constrs) == 1:
+            return constrs[0]
+        # Check for AnyOf of AnyOf
+        constrs = tuple(
+            c
+            for constr in constrs
+            for c in (constr.attr_constrs if isinstance(constr, AnyOf) else (constr,))
+        )
+
+        return AnyOf(constrs)
 
 
 @dataclass(frozen=True)
@@ -696,8 +720,8 @@ class ParamAttrConstraint(
 
     def mapping_type_vars(
         self, type_var_mapping: Mapping[TypeVar, AttrConstraint | IntConstraint]
-    ) -> ParamAttrConstraint[ParametrizedAttributeCovT]:
-        return ParamAttrConstraint(
+    ) -> AttrConstraint[ParametrizedAttributeCovT]:
+        return ParamAttrConstraint.create(
             self.base_attr,
             tuple(c.mapping_type_vars(type_var_mapping) for c in self.param_constrs),
         )
@@ -715,6 +739,25 @@ class ParamAttrConstraint(
                 for l, r in zip(self.param_constrs, value.param_constrs, strict=True)
             ),
         )
+
+    @staticmethod
+    def create(
+        base_attr: type[ParametrizedAttributeT],
+        param_constrs: Sequence[IRDLAttrConstraint | None],
+    ) -> AttrConstraint[ParametrizedAttributeT]:
+        from xdsl.irdl import irdl_to_attr_constraint
+
+        constrs = tuple(
+            irdl_to_attr_constraint(constr) if constr is not None else AnyAttr()
+            for constr in param_constrs
+        )
+
+        if all(isinstance(c, EqAttrConstraint) for c in constrs):
+            return EqAttrConstraint(
+                base_attr(*(cast(EqAttrConstraint, c).attr for c in constrs))
+            )
+
+        return ParamAttrConstraint(base_attr, constrs)
 
 
 @dataclass(frozen=True, init=False)


### PR DESCRIPTION
Going to try the @superlopuh method of make a big PR and slowly split things off

Proposes to implement basic constraint simplification by adding `create` methods to various constraints that are drop ins for their `__init__` methods, but possibly perform some simplification. These can't just be the `__init__` methods as the types don't line up (e.g. an AnyOf.create of one constraint doesn't return an AnyOf). Further uses these `create` methods in `mapping_type_vars` and in `irdl_to_attr_constraint` to force simplification when converting python types.

Simplifications added in this PR:
- `AnyOf` 1 constraint returns just that constraint
- `AnyOf` of `AnyOf` is flattened to a single `AnyOf` (just does one "layer" of flattening at the moment which I think should be sufficient)
- `ParamAttrConstraint` of `EqAttrConstraints` becomes an `EqAttrConstraint`
- `IntAttrConstraint` of a `EqIntConstraint(X)` becomes a `EqAttrConstraint(IntAttr(X))`

The last two suffice to make `irdl_to_attr_constraint(I32) == EqAttrConstraint(i32)`
I have checked that this PR allows @hhkit 's type:
```python
ValType: TypeAlias = (
    I32 | I64 | I128 | Float32Type | Float64Type | FuncRefType | ExternRefType
)
```

I didn't implement @superlopuh 's suggested `AnyOf` of `ParamAttrConstraint` goes to `ParamAttrConstaint` of `AnyOf` as it didn't seem immediately necessary but it could be added.