### PR TITLE
dialects: (memref) Add memref subview result type inference

### DIFF
--- a/tests/dialects/test_memref.py
+++ b/tests/dialects/test_memref.py
@@ -334,6 +334,44 @@ def test_memref_subview_constant_parameters():
     assert subview.result.type.layout.offset.data == 222
 
 
+def test_memref_subview_identity_strides_for_shape():
+    assert SubviewOp.identity_strides_for_shape([2, 3, 4]) == (12, 4, 1)
+    assert SubviewOp.identity_strides_for_shape([2, DYNAMIC_INDEX, 4]) == (
+        None,
+        4,
+        1,
+    )
+
+
+def test_memref_subview_get_strides_and_offset_default_layout():
+    source_type = MemRefType(i32, [10, DYNAMIC_INDEX, 4])
+
+    strides, offset = SubviewOp.get_strides_and_offset(source_type)
+
+    assert strides == (None, 4, 1)
+    assert offset == 0
+
+
+def test_memref_subview_get_strides_and_offset_strided_layout():
+    source_type = MemRefType(i32, [10, 10], StridedLayoutAttr([None, 1], 5))
+
+    strides, offset = SubviewOp.get_strides_and_offset(source_type)
+
+    assert strides == (None, 1)
+    assert offset == 5
+
+
+def test_memref_subview_get_strides_and_offset_rejects_affine_map_layout():
+    source_type = MemRefType(
+        i32,
+        [10, 10],
+        AffineMapAttr(AffineMap.identity(2)),
+    )
+
+    with pytest.raises(ValueError, match="non-strided source type"):
+        SubviewOp.get_strides_and_offset(source_type)
+
+
 def test_memref_subview_infer_result_type_static():
     source_type = MemRefType(i32, [10, 10, 10])
 
@@ -453,7 +491,7 @@ def test_memref_subview_infer_result_type_rejects_affine_map_layout():
         AffineMapAttr(AffineMap.from_callable(lambda i, j: (i * 10 + j,))),
     )
 
-    with pytest.raises(VerifyException, match="non-strided source type"):
+    with pytest.raises(ValueError, match="non-strided source type"):
         SubviewOp.infer_result_type(
             source_type,
             [0, 0],

--- a/tests/dialects/test_memref.py
+++ b/tests/dialects/test_memref.py
@@ -340,70 +340,88 @@ def test_memref_subview_constant_parameters():
         "offsets",
         "sizes",
         "strides",
+        "reduce_rank",
         "expected_shape",
         "expected_strides",
         "expected_offset",
     ),
     [
-        (
-            # static
+        pytest.param(
             MemRefType(i32, [10, 10, 10]),
             [2, 2, 2],
             [2, 2, 2],
             [3, 3, 3],
+            False,
             (2, 2, 2),
             (300, 30, 3),
             222,
+            id="Static",
         ),
-        (
-            # dynamic-source-shape-static-result-offset
+        pytest.param(
             MemRefType(i32, [2, DYNAMIC_INDEX, 4]),
             [0, 1, 0],
             [2, 3, 4],
             [1, 1, 1],
+            False,
             (2, 3, 4),
             (None, 4, 1),
             4,
+            id="Dynamic source shape, static result offset",
         ),
-        (
-            # dynamic-source-shape-dynamic-result-offset
+        pytest.param(
             MemRefType(i32, [2, DYNAMIC_INDEX, 4]),
             [1, 0, 0],
             [2, 3, 4],
             [1, 1, 1],
+            False,
             (2, 3, 4),
             (None, 4, 1),
             None,
+            id="Dynamic source shape, dynamic result offset",
         ),
-        (
-            # dynamic-source-stride-dynamic-result-offset
+        pytest.param(
             MemRefType(i32, [10, 10], StridedLayoutAttr([None, 1], 5)),
             [1, 2],
             [4, 4],
             [2, 3],
+            False,
             (4, 4),
             (None, 3),
             None,
+            id="Dynamic source stride, dynamic result offset",
         ),
-        (
-            # dynamic-source-stride-static-result-offset
+        pytest.param(
             MemRefType(i32, [10, 10], StridedLayoutAttr([None, 1], 5)),
             [0, 2],
             [4, 4],
             [1, 1],
+            False,
             (4, 4),
             (None, 1),
             7,
+            id="Dynamic source stride, static result offset",
         ),
-        (
-            # dynamic-source-offset
+        pytest.param(
             MemRefType(i32, [10, 10], StridedLayoutAttr([10, 1], None)),
             [1, 2],
             [4, 4],
             [2, 3],
+            False,
             (4, 4),
             (20, 3),
             None,
+            id="Dynamic source offset",
+        ),
+        pytest.param(
+            MemRefType(i32, [4, 5, 6]),
+            [0, 1, 2],
+            [1, 3, 1],
+            [1, 2, 1],
+            True,
+            (3,),
+            (12,),
+            8,
+            id="Reduce rank",
         ),
     ],
 )
@@ -412,6 +430,7 @@ def test_memref_subview_infer_result_type(
     offsets: list[int],
     sizes: list[int],
     strides: list[int],
+    reduce_rank: bool,
     expected_shape: tuple[int, ...],
     expected_strides: tuple[int | None, ...],
     expected_offset: int | None,
@@ -421,6 +440,7 @@ def test_memref_subview_infer_result_type(
         offsets,
         sizes,
         strides,
+        reduce_rank=reduce_rank,
     )
 
     assert result_type.get_shape() == expected_shape
@@ -429,15 +449,27 @@ def test_memref_subview_infer_result_type(
     assert result_type.layout.get_offset() == expected_offset
 
 
-def test_memref_subview_infer_result_type_rejects_rank_mismatch():
+@pytest.mark.parametrize(
+    "offsets, sizes, strides",
+    [
+        pytest.param([0], [1, 1], [1, 1], id="Wrong offsets rank"),
+        pytest.param([0, 0], [1], [1, 1], id="Wrong sizes rank"),
+        pytest.param([0, 0], [1, 1], [1], id="Wrong strides rank"),
+    ],
+)
+def test_memref_subview_infer_result_type_rejects_rank_mismatch(
+    offsets: list[int],
+    sizes: list[int],
+    strides: list[int],
+):
     source_type = MemRefType(i32, [4, 5])
 
     with pytest.raises(ValueError, match="match source rank"):
         SubviewOp.infer_result_type(
             source_type,
-            [0],
-            [1, 1],
-            [1, 1],
+            offsets,
+            sizes,
+            strides,
         )
 
 
@@ -455,23 +487,6 @@ def test_memref_subview_infer_result_type_rejects_affine_map_layout():
             [4, 4],
             [1, 1],
         )
-
-
-def test_memref_subview_infer_result_type_reduce_rank():
-    source_type = MemRefType(i32, [4, 5, 6])
-
-    result_type = SubviewOp.infer_result_type(
-        source_type,
-        [0, 1, 2],
-        [1, 3, 1],
-        [1, 2, 1],
-        reduce_rank=True,
-    )
-
-    assert result_type.get_shape() == (3,)
-    assert isinstance(result_type.layout, StridedLayoutAttr)
-    assert result_type.layout.get_strides() == (12,)
-    assert result_type.layout.get_offset() == 8
 
 
 def test_memref_subview_infer_result_type_reduce_rank_rejects_dynamic_size():

--- a/tests/dialects/test_memref.py
+++ b/tests/dialects/test_memref.py
@@ -334,52 +334,127 @@ def test_memref_subview_constant_parameters():
     assert subview.result.type.layout.offset.data == 222
 
 
-def test_memref_subview_infer_result_type_static():
-    source_type = MemRefType(i32, [10, 10, 10])
-
+@pytest.mark.parametrize(
+    (
+        "source_type",
+        "offsets",
+        "sizes",
+        "strides",
+        "expected_shape",
+        "expected_strides",
+        "expected_offset",
+    ),
+    [
+        (
+            # static
+            MemRefType(i32, [10, 10, 10]),
+            [2, 2, 2],
+            [2, 2, 2],
+            [3, 3, 3],
+            (2, 2, 2),
+            (300, 30, 3),
+            222,
+        ),
+        (
+            # dynamic-source-shape-static-result-offset
+            MemRefType(i32, [2, DYNAMIC_INDEX, 4]),
+            [0, 1, 0],
+            [2, 3, 4],
+            [1, 1, 1],
+            (2, 3, 4),
+            (None, 4, 1),
+            4,
+        ),
+        (
+            # dynamic-source-shape-dynamic-result-offset
+            MemRefType(i32, [2, DYNAMIC_INDEX, 4]),
+            [1, 0, 0],
+            [2, 3, 4],
+            [1, 1, 1],
+            (2, 3, 4),
+            (None, 4, 1),
+            None,
+        ),
+        (
+            # dynamic-source-stride-dynamic-result-offset
+            MemRefType(i32, [10, 10], StridedLayoutAttr([None, 1], 5)),
+            [1, 2],
+            [4, 4],
+            [2, 3],
+            (4, 4),
+            (None, 3),
+            None,
+        ),
+        (
+            # dynamic-source-stride-static-result-offset
+            MemRefType(i32, [10, 10], StridedLayoutAttr([None, 1], 5)),
+            [0, 2],
+            [4, 4],
+            [1, 1],
+            (4, 4),
+            (None, 1),
+            7,
+        ),
+        (
+            # dynamic-source-offset
+            MemRefType(i32, [10, 10], StridedLayoutAttr([10, 1], None)),
+            [1, 2],
+            [4, 4],
+            [2, 3],
+            (4, 4),
+            (20, 3),
+            None,
+        ),
+    ],
+)
+def test_memref_subview_infer_result_type(
+    source_type: MemRefType,
+    offsets: list[int],
+    sizes: list[int],
+    strides: list[int],
+    expected_shape: tuple[int, ...],
+    expected_strides: tuple[int | None, ...],
+    expected_offset: int | None,
+):
     result_type = SubviewOp.infer_result_type(
         source_type,
-        [2, 2, 2],
-        [2, 2, 2],
-        [3, 3, 3],
+        offsets,
+        sizes,
+        strides,
     )
 
-    assert result_type.get_shape() == (2, 2, 2)
+    assert result_type.get_shape() == expected_shape
     assert isinstance(result_type.layout, StridedLayoutAttr)
-    assert result_type.layout.get_strides() == (300, 30, 3)
-    assert result_type.layout.get_offset() == 222
+    assert result_type.layout.get_strides() == expected_strides
+    assert result_type.layout.get_offset() == expected_offset
 
 
-def test_memref_subview_infer_result_type_dynamic_source_shape():
-    source_type = MemRefType(i32, [2, DYNAMIC_INDEX, 4])
+def test_memref_subview_infer_result_type_rejects_rank_mismatch():
+    source_type = MemRefType(i32, [4, 5])
 
-    result_type = SubviewOp.infer_result_type(
-        source_type,
-        [0, 1, 0],
-        [2, 3, 4],
-        [1, 1, 1],
+    with pytest.raises(ValueError, match="match source rank"):
+        SubviewOp.infer_result_type(
+            source_type,
+            [0],
+            [1, 1],
+            [1, 1],
+        )
+
+
+def test_memref_subview_infer_result_type_rejects_affine_map_layout():
+    source_type = MemRefType(
+        i32,
+        [10, 10],
+        AffineMapAttr(AffineMap.from_callable(lambda i, j: (i * 10 + j,))),
     )
 
-    assert result_type.get_shape() == (2, 3, 4)
-    assert isinstance(result_type.layout, StridedLayoutAttr)
-    assert result_type.layout.get_strides() == (None, 4, 1)
-    assert result_type.layout.get_offset() == 4
-
-
-def test_memref_subview_infer_result_type_dynamic_source_shape_dynamic_offset():
-    source_type = MemRefType(i32, [2, DYNAMIC_INDEX, 4])
-
-    result_type = SubviewOp.infer_result_type(
-        source_type,
-        [1, 0, 0],
-        [2, 3, 4],
-        [1, 1, 1],
-    )
-
-    assert result_type.get_shape() == (2, 3, 4)
-    assert isinstance(result_type.layout, StridedLayoutAttr)
-    assert result_type.layout.get_strides() == (None, 4, 1)
-    assert result_type.layout.get_offset() is None
+    with pytest.raises(ValueError, match="non-strided source type"):
+        SubviewOp.infer_result_type(
+            source_type,
+            [0, 0],
+            [4, 4],
+            [1, 1],
+        )
 
 
 def test_memref_subview_infer_result_type_reduce_rank():
@@ -403,7 +478,7 @@ def test_memref_subview_infer_result_type_reduce_rank_rejects_dynamic_size():
     dynamic_index = create_ssa_value(IndexType())
     source_type = MemRefType(i32, [4, 5])
 
-    with pytest.raises(VerifyException, match="dynamic sizes"):
+    with pytest.raises(ValueError, match="dynamic sizes"):
         SubviewOp.infer_result_type(
             source_type,
             [0, 0],
@@ -428,70 +503,6 @@ def test_memref_subview_infer_result_type_dynamic_operands():
     assert isinstance(result_type.layout, StridedLayoutAttr)
     assert result_type.layout.get_strides() == (20, None)
     assert result_type.layout.get_offset() is None
-
-
-def test_memref_subview_infer_result_type_dynamic_source_stride():
-    source_type = MemRefType(i32, [10, 10], StridedLayoutAttr([None, 1], 5))
-
-    result_type = SubviewOp.infer_result_type(
-        source_type,
-        [1, 2],
-        [4, 4],
-        [2, 3],
-    )
-
-    assert result_type.get_shape() == (4, 4)
-    assert isinstance(result_type.layout, StridedLayoutAttr)
-    assert result_type.layout.get_strides() == (None, 3)
-    assert result_type.layout.get_offset() is None
-
-
-def test_memref_subview_infer_result_type_dynamic_source_stride_zero_offset():
-    source_type = MemRefType(i32, [10, 10], StridedLayoutAttr([None, 1], 5))
-
-    result_type = SubviewOp.infer_result_type(
-        source_type,
-        [0, 2],
-        [4, 4],
-        [1, 1],
-    )
-
-    assert result_type.get_shape() == (4, 4)
-    assert isinstance(result_type.layout, StridedLayoutAttr)
-    assert result_type.layout.get_strides() == (None, 1)
-    assert result_type.layout.get_offset() == 7
-
-
-def test_memref_subview_infer_result_type_dynamic_source_offset():
-    source_type = MemRefType(i32, [10, 10], StridedLayoutAttr([10, 1], None))
-
-    result_type = SubviewOp.infer_result_type(
-        source_type,
-        [1, 2],
-        [4, 4],
-        [2, 3],
-    )
-
-    assert result_type.get_shape() == (4, 4)
-    assert isinstance(result_type.layout, StridedLayoutAttr)
-    assert result_type.layout.get_strides() == (20, 3)
-    assert result_type.layout.get_offset() is None
-
-
-def test_memref_subview_infer_result_type_rejects_affine_map_layout():
-    source_type = MemRefType(
-        i32,
-        [10, 10],
-        AffineMapAttr(AffineMap.from_callable(lambda i, j: (i * 10 + j,))),
-    )
-
-    with pytest.raises(ValueError, match="non-strided source type"):
-        SubviewOp.infer_result_type(
-            source_type,
-            [0, 0],
-            [4, 4],
-            [1, 1],
-        )
 
 
 def test_memref_cast():

--- a/tests/dialects/test_memref.py
+++ b/tests/dialects/test_memref.py
@@ -334,44 +334,6 @@ def test_memref_subview_constant_parameters():
     assert subview.result.type.layout.offset.data == 222
 
 
-def test_memref_subview_identity_strides_for_shape():
-    assert SubviewOp.identity_strides_for_shape([2, 3, 4]) == (12, 4, 1)
-    assert SubviewOp.identity_strides_for_shape([2, DYNAMIC_INDEX, 4]) == (
-        None,
-        4,
-        1,
-    )
-
-
-def test_memref_subview_get_strides_and_offset_default_layout():
-    source_type = MemRefType(i32, [10, DYNAMIC_INDEX, 4])
-
-    strides, offset = SubviewOp.get_strides_and_offset(source_type)
-
-    assert strides == (None, 4, 1)
-    assert offset == 0
-
-
-def test_memref_subview_get_strides_and_offset_strided_layout():
-    source_type = MemRefType(i32, [10, 10], StridedLayoutAttr([None, 1], 5))
-
-    strides, offset = SubviewOp.get_strides_and_offset(source_type)
-
-    assert strides == (None, 1)
-    assert offset == 5
-
-
-def test_memref_subview_get_strides_and_offset_rejects_affine_map_layout():
-    source_type = MemRefType(
-        i32,
-        [10, 10],
-        AffineMapAttr(AffineMap.identity(2)),
-    )
-
-    with pytest.raises(ValueError, match="non-strided source type"):
-        SubviewOp.get_strides_and_offset(source_type)
-
-
 def test_memref_subview_infer_result_type_static():
     source_type = MemRefType(i32, [10, 10, 10])
 
@@ -386,6 +348,38 @@ def test_memref_subview_infer_result_type_static():
     assert isinstance(result_type.layout, StridedLayoutAttr)
     assert result_type.layout.get_strides() == (300, 30, 3)
     assert result_type.layout.get_offset() == 222
+
+
+def test_memref_subview_infer_result_type_dynamic_source_shape():
+    source_type = MemRefType(i32, [2, DYNAMIC_INDEX, 4])
+
+    result_type = SubviewOp.infer_result_type(
+        source_type,
+        [0, 1, 0],
+        [2, 3, 4],
+        [1, 1, 1],
+    )
+
+    assert result_type.get_shape() == (2, 3, 4)
+    assert isinstance(result_type.layout, StridedLayoutAttr)
+    assert result_type.layout.get_strides() == (None, 4, 1)
+    assert result_type.layout.get_offset() == 4
+
+
+def test_memref_subview_infer_result_type_dynamic_source_shape_dynamic_offset():
+    source_type = MemRefType(i32, [2, DYNAMIC_INDEX, 4])
+
+    result_type = SubviewOp.infer_result_type(
+        source_type,
+        [1, 0, 0],
+        [2, 3, 4],
+        [1, 1, 1],
+    )
+
+    assert result_type.get_shape() == (2, 3, 4)
+    assert isinstance(result_type.layout, StridedLayoutAttr)
+    assert result_type.layout.get_strides() == (None, 4, 1)
+    assert result_type.layout.get_offset() is None
 
 
 def test_memref_subview_infer_result_type_reduce_rank():

--- a/tests/dialects/test_memref.py
+++ b/tests/dialects/test_memref.py
@@ -334,6 +334,134 @@ def test_memref_subview_constant_parameters():
     assert subview.result.type.layout.offset.data == 222
 
 
+def test_memref_subview_infer_result_type_static():
+    source_type = MemRefType(i32, [10, 10, 10])
+
+    result_type = SubviewOp.infer_result_type(
+        source_type,
+        [2, 2, 2],
+        [2, 2, 2],
+        [3, 3, 3],
+    )
+
+    assert result_type.get_shape() == (2, 2, 2)
+    assert isinstance(result_type.layout, StridedLayoutAttr)
+    assert result_type.layout.get_strides() == (300, 30, 3)
+    assert result_type.layout.get_offset() == 222
+
+
+def test_memref_subview_infer_result_type_reduce_rank():
+    source_type = MemRefType(i32, [4, 5, 6])
+
+    result_type = SubviewOp.infer_result_type(
+        source_type,
+        [0, 1, 2],
+        [1, 3, 1],
+        [1, 2, 1],
+        reduce_rank=True,
+    )
+
+    assert result_type.get_shape() == (3,)
+    assert isinstance(result_type.layout, StridedLayoutAttr)
+    assert result_type.layout.get_strides() == (12,)
+    assert result_type.layout.get_offset() == 8
+
+
+def test_memref_subview_infer_result_type_reduce_rank_rejects_dynamic_size():
+    dynamic_index = create_ssa_value(IndexType())
+    source_type = MemRefType(i32, [4, 5])
+
+    with pytest.raises(VerifyException, match="dynamic sizes"):
+        SubviewOp.infer_result_type(
+            source_type,
+            [0, 0],
+            [dynamic_index, 1],
+            [1, 1],
+            reduce_rank=True,
+        )
+
+
+def test_memref_subview_infer_result_type_dynamic_operands():
+    dynamic_index = create_ssa_value(IndexType())
+    source_type = MemRefType(i32, [10, 10])
+
+    result_type = SubviewOp.infer_result_type(
+        source_type,
+        [dynamic_index, 1],
+        [4, dynamic_index],
+        [2, dynamic_index],
+    )
+
+    assert result_type.get_shape() == (4, DYNAMIC_INDEX)
+    assert isinstance(result_type.layout, StridedLayoutAttr)
+    assert result_type.layout.get_strides() == (20, None)
+    assert result_type.layout.get_offset() is None
+
+
+def test_memref_subview_infer_result_type_dynamic_source_stride():
+    source_type = MemRefType(i32, [10, 10], StridedLayoutAttr([None, 1], 5))
+
+    result_type = SubviewOp.infer_result_type(
+        source_type,
+        [1, 2],
+        [4, 4],
+        [2, 3],
+    )
+
+    assert result_type.get_shape() == (4, 4)
+    assert isinstance(result_type.layout, StridedLayoutAttr)
+    assert result_type.layout.get_strides() == (None, 3)
+    assert result_type.layout.get_offset() is None
+
+
+def test_memref_subview_infer_result_type_dynamic_source_stride_zero_offset():
+    source_type = MemRefType(i32, [10, 10], StridedLayoutAttr([None, 1], 5))
+
+    result_type = SubviewOp.infer_result_type(
+        source_type,
+        [0, 2],
+        [4, 4],
+        [1, 1],
+    )
+
+    assert result_type.get_shape() == (4, 4)
+    assert isinstance(result_type.layout, StridedLayoutAttr)
+    assert result_type.layout.get_strides() == (None, 1)
+    assert result_type.layout.get_offset() == 7
+
+
+def test_memref_subview_infer_result_type_dynamic_source_offset():
+    source_type = MemRefType(i32, [10, 10], StridedLayoutAttr([10, 1], None))
+
+    result_type = SubviewOp.infer_result_type(
+        source_type,
+        [1, 2],
+        [4, 4],
+        [2, 3],
+    )
+
+    assert result_type.get_shape() == (4, 4)
+    assert isinstance(result_type.layout, StridedLayoutAttr)
+    assert result_type.layout.get_strides() == (20, 3)
+    assert result_type.layout.get_offset() is None
+
+
+def test_memref_subview_infer_result_type_rejects_affine_map_layout():
+    source_type = MemRefType(
+        i32,
+        [10, 10],
+        AffineMapAttr(AffineMap.from_callable(lambda i, j: (i * 10 + j,))),
+    )
+
+    with pytest.raises(VerifyException, match="non-strided source type"):
+        SubviewOp.infer_result_type(
+            source_type,
+            [0, 0],
+            [4, 4],
+            [1, 1],
+        )
+
+
 def test_memref_cast():
     i32_memref_type = MemRefType(i32, [10, 2])
     memref_ssa_value = create_ssa_value(i32_memref_type)

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -719,7 +719,7 @@ class SubviewOp(IRDLOperation):
         )
 
     @staticmethod
-    def _identity_strides_for_shape(shape: Sequence[int]) -> tuple[int | None, ...]:
+    def identity_strides_for_shape(shape: Sequence[int]) -> tuple[int | None, ...]:
         """
         Return row-major strides for a memref without an explicit layout.
         """
@@ -734,19 +734,20 @@ class SubviewOp(IRDLOperation):
         return tuple(strides)
 
     @staticmethod
-    def _get_strides_and_offset(
+    def get_strides_and_offset(
         source_type: MemRefType[Attribute],
     ) -> tuple[tuple[int | None, ...], int | None]:
         """
-        Return source strides and offset when the layout is strided-like.
+        Return source strides and offset when the layout is strided-like,
+        otherwise raises `ValueError`.
         """
         match source_type.layout:
             case NoneAttr():
-                return SubviewOp._identity_strides_for_shape(source_type.get_shape()), 0
+                return SubviewOp.identity_strides_for_shape(source_type.get_shape()), 0
             case StridedLayoutAttr() as layout:
                 strides = source_type.get_strides()
                 if strides is None:
-                    raise VerifyException(
+                    raise ValueError(
                         "cannot infer memref.subview result type from non-strided "
                         f"source type {source_type}"
                     )
@@ -754,7 +755,7 @@ class SubviewOp(IRDLOperation):
             case _:
                 strides = source_type.get_strides()
                 if strides is None:
-                    raise VerifyException(
+                    raise ValueError(
                         "cannot infer memref.subview result type from non-strided "
                         f"source type {source_type}"
                     )
@@ -782,7 +783,7 @@ class SubviewOp(IRDLOperation):
         static_offsets, _ = split_dynamic_index_list(offsets, DYNAMIC_INDEX)
         static_sizes, _ = split_dynamic_index_list(sizes, DYNAMIC_INDEX)
         static_strides, _ = split_dynamic_index_list(strides, DYNAMIC_INDEX)
-        source_strides, source_offset = SubviewOp._get_strides_and_offset(source_type)
+        source_strides, source_offset = SubviewOp.get_strides_and_offset(source_type)
 
         result_shape = tuple(static_sizes)
         result_strides = tuple(

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -10,7 +10,6 @@ from xdsl.dialects.builtin import (
     DYNAMIC_INDEX,
     I64,
     AnyFloatConstr,
-    ArrayAttr,
     BoolAttr,
     DenseArrayBase,
     DenseIntOrFPElementsAttr,
@@ -720,6 +719,118 @@ class SubviewOp(IRDLOperation):
         )
 
     @staticmethod
+    def _identity_strides_for_shape(shape: Sequence[int]) -> tuple[int | None, ...]:
+        """
+        Return row-major strides for a memref without an explicit layout.
+        """
+        strides: list[int | None] = []
+        stride: int | None = 1
+        for dim in reversed(shape):
+            strides.insert(0, stride)
+            if dim == DYNAMIC_INDEX or stride is None:
+                stride = None
+            else:
+                stride *= dim
+        return tuple(strides)
+
+    @staticmethod
+    def _get_strides_and_offset(
+        source_type: MemRefType[Attribute],
+    ) -> tuple[tuple[int | None, ...], int | None]:
+        """
+        Return source strides and offset when the layout is strided-like.
+        """
+        match source_type.layout:
+            case NoneAttr():
+                return SubviewOp._identity_strides_for_shape(source_type.get_shape()), 0
+            case StridedLayoutAttr() as layout:
+                strides = source_type.get_strides()
+                if strides is None:
+                    raise VerifyException(
+                        "cannot infer memref.subview result type from non-strided "
+                        f"source type {source_type}"
+                    )
+                return tuple(strides), layout.get_offset()
+            case _:
+                strides = source_type.get_strides()
+                if strides is None:
+                    raise VerifyException(
+                        "cannot infer memref.subview result type from non-strided "
+                        f"source type {source_type}"
+                    )
+                return tuple(strides), None
+
+    @staticmethod
+    def infer_result_type(
+        source_type: MemRefType[Attribute],
+        offsets: Sequence[SSAValue | int],
+        sizes: Sequence[SSAValue | int],
+        strides: Sequence[SSAValue | int],
+        *,
+        reduce_rank: bool = False,
+    ) -> MemRefType[Attribute]:
+        """
+        Infer the result type of a memref.subview from its source type and
+        offsets/sizes/strides.
+        """
+        rank = source_type.get_num_dims()
+        if not (len(offsets) == len(sizes) == len(strides) == rank):
+            raise VerifyException(
+                "expected offsets, sizes, and strides to match source rank"
+            )
+
+        static_offsets, _ = split_dynamic_index_list(offsets, DYNAMIC_INDEX)
+        static_sizes, _ = split_dynamic_index_list(sizes, DYNAMIC_INDEX)
+        static_strides, _ = split_dynamic_index_list(strides, DYNAMIC_INDEX)
+        source_strides, source_offset = SubviewOp._get_strides_and_offset(source_type)
+
+        result_shape = tuple(static_sizes)
+        result_strides = tuple(
+            None
+            if source_stride is None or static_stride == DYNAMIC_INDEX
+            else source_stride * static_stride
+            for source_stride, static_stride in zip(
+                source_strides, static_strides, strict=True
+            )
+        )
+
+        result_offset = source_offset
+        if result_offset is not None:
+            for static_offset, source_stride in zip(
+                static_offsets, source_strides, strict=True
+            ):
+                if static_offset == 0:
+                    continue
+                if static_offset == DYNAMIC_INDEX or source_stride is None:
+                    result_offset = None
+                    break
+                result_offset += static_offset * source_stride
+
+        if reduce_rank:
+            if any(size == DYNAMIC_INDEX for size in result_shape):
+                raise VerifyException(
+                    "cannot infer rank-reduced memref.subview result type with "
+                    "dynamic sizes"
+                )
+
+            reduced_shape: list[int] = []
+            reduced_strides: list[int | None] = []
+            for size, stride in zip(result_shape, result_strides, strict=True):
+                if size == 1:
+                    continue
+                reduced_shape.append(size)
+                reduced_strides.append(stride)
+            result_shape = tuple(reduced_shape)
+            result_strides = tuple(reduced_strides)
+
+        return MemRefType(
+            source_type.element_type,
+            result_shape,
+            StridedLayoutAttr(result_strides, result_offset),
+            source_type.memory_space,
+        )
+
+    @staticmethod
     def from_static_parameters(
         source: SSAValue | Operation,
         source_type: MemRefType,
@@ -730,55 +841,19 @@ class SubviewOp(IRDLOperation):
     ) -> SubviewOp:
         source = SSAValue.get(source)
 
-        source_shape = source_type.get_shape()
-        source_offset = 0
-        source_strides = [1]
-        for input_size in reversed(source_shape[1:]):
-            source_strides.insert(0, source_strides[0] * input_size)
-        if isinstance(source_type.layout, StridedLayoutAttr):
-            if isinstance(source_type.layout.offset, IntAttr):
-                source_offset = source_type.layout.offset.data
-            if isa(source_type.layout.strides, ArrayAttr[IntAttr]):
-                source_strides = [s.data for s in source_type.layout.strides]
-
-        layout_strides = [a * b for (a, b) in zip(strides, source_strides)]
-
-        layout_offset = (
-            sum(stride * offset for stride, offset in zip(source_strides, offsets))
-            + source_offset
+        return_type = SubviewOp.infer_result_type(
+            source_type,
+            offsets,
+            sizes,
+            strides,
+            reduce_rank=reduce_rank,
         )
 
-        if reduce_rank:
-            composed_strides = layout_strides
-            layout_strides: list[int] = []
-            result_sizes: list[int] = []
-
-            for stride, size in zip(composed_strides, sizes):
-                if size == 1:
-                    continue
-                layout_strides.append(stride)
-                result_sizes.append(size)
-
-        else:
-            result_sizes = list(sizes)
-
-        layout = StridedLayoutAttr(layout_strides, layout_offset)
-
-        return_type = MemRefType(
-            source_type.element_type,
-            result_sizes,
-            layout,
-            source_type.memory_space,
-        )
-
-        return SubviewOp(
+        return SubviewOp.get(
             source,
-            (),
-            (),
-            (),
-            DenseArrayBase.from_list(i64, offsets),
-            DenseArrayBase.from_list(i64, sizes),
-            DenseArrayBase.from_list(i64, strides),
+            offsets,
+            sizes,
+            strides,
             return_type,
         )
 

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -730,10 +730,15 @@ class SubviewOp(IRDLOperation):
         """
         Infer the result type of a memref.subview from its source type and
         offsets/sizes/strides.
+
+        Raises:
+            ValueError: If offsets, sizes, and strides do not match the source rank,
+                if the source layout is not strided-like, or if rank reduction is
+                requested with dynamic sizes.
         """
         rank = source_type.get_num_dims()
         if not (len(offsets) == len(sizes) == len(strides) == rank):
-            raise VerifyException(
+            raise ValueError(
                 "expected offsets, sizes, and strides to match source rank"
             )
 
@@ -782,7 +787,7 @@ class SubviewOp(IRDLOperation):
 
         if reduce_rank:
             if any(size is None for size in static_sizes):
-                raise VerifyException(
+                raise ValueError(
                     "cannot infer rank-reduced memref.subview result type with "
                     "dynamic sizes"
                 )
@@ -814,6 +819,15 @@ class SubviewOp(IRDLOperation):
         strides: Sequence[int],
         reduce_rank: bool = False,
     ) -> SubviewOp:
+        """
+        Build a memref.subview from static offsets, sizes, and strides.
+
+        Raises:
+            ValueError: If offsets, sizes, and strides do not match the source rank,
+                if the source layout is not strided-like, or if rank reduction is
+                requested with dynamic sizes.
+        """
+
         source = SSAValue.get(source)
 
         return_type = SubviewOp.infer_result_type(

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -719,49 +719,6 @@ class SubviewOp(IRDLOperation):
         )
 
     @staticmethod
-    def identity_strides_for_shape(shape: Sequence[int]) -> tuple[int | None, ...]:
-        """
-        Return row-major strides for a memref without an explicit layout.
-        """
-        strides: list[int | None] = []
-        stride: int | None = 1
-        for dim in reversed(shape):
-            strides.insert(0, stride)
-            if dim == DYNAMIC_INDEX or stride is None:
-                stride = None
-            else:
-                stride *= dim
-        return tuple(strides)
-
-    @staticmethod
-    def get_strides_and_offset(
-        source_type: MemRefType[Attribute],
-    ) -> tuple[tuple[int | None, ...], int | None]:
-        """
-        Return source strides and offset when the layout is strided-like,
-        otherwise raises `ValueError`.
-        """
-        match source_type.layout:
-            case NoneAttr():
-                return SubviewOp.identity_strides_for_shape(source_type.get_shape()), 0
-            case StridedLayoutAttr() as layout:
-                strides = source_type.get_strides()
-                if strides is None:
-                    raise ValueError(
-                        "cannot infer memref.subview result type from non-strided "
-                        f"source type {source_type}"
-                    )
-                return tuple(strides), layout.get_offset()
-            case _:
-                strides = source_type.get_strides()
-                if strides is None:
-                    raise ValueError(
-                        "cannot infer memref.subview result type from non-strided "
-                        f"source type {source_type}"
-                    )
-                return tuple(strides), None
-
-    @staticmethod
     def infer_result_type(
         source_type: MemRefType[Attribute],
         offsets: Sequence[SSAValue | int],
@@ -780,15 +737,31 @@ class SubviewOp(IRDLOperation):
                 "expected offsets, sizes, and strides to match source rank"
             )
 
-        static_offsets, _ = split_dynamic_index_list(offsets, DYNAMIC_INDEX)
-        static_sizes, _ = split_dynamic_index_list(sizes, DYNAMIC_INDEX)
-        static_strides, _ = split_dynamic_index_list(strides, DYNAMIC_INDEX)
-        source_strides, source_offset = SubviewOp.get_strides_and_offset(source_type)
+        static_offsets = tuple(
+            value if isinstance(value, int) else None for value in offsets
+        )
+        static_sizes = tuple(
+            value if isinstance(value, int) else None for value in sizes
+        )
+        static_strides = tuple(
+            value if isinstance(value, int) else None for value in strides
+        )
 
-        result_shape = tuple(static_sizes)
+        source_strides = source_type.get_strides()
+        if source_strides is None:
+            raise ValueError(
+                "cannot infer memref.subview result type from non-strided "
+                f"source type {source_type}"
+            )
+        source_offset = source_type.get_offset()
+
+        result_shape = tuple(
+            DYNAMIC_INDEX if size is None else size for size in static_sizes
+        )
+
         result_strides = tuple(
             None
-            if source_stride is None or static_stride == DYNAMIC_INDEX
+            if source_stride is None or static_stride is None
             else source_stride * static_stride
             for source_stride, static_stride in zip(
                 source_strides, static_strides, strict=True
@@ -802,13 +775,13 @@ class SubviewOp(IRDLOperation):
             ):
                 if static_offset == 0:
                     continue
-                if static_offset == DYNAMIC_INDEX or source_stride is None:
+                if static_offset is None or source_stride is None:
                     result_offset = None
                     break
                 result_offset += static_offset * source_stride
 
         if reduce_rank:
-            if any(size == DYNAMIC_INDEX for size in result_shape):
+            if any(size is None for size in static_sizes):
                 raise VerifyException(
                     "cannot infer rank-reduced memref.subview result type with "
                     "dynamic sizes"
@@ -816,7 +789,8 @@ class SubviewOp(IRDLOperation):
 
             reduced_shape: list[int] = []
             reduced_strides: list[int | None] = []
-            for size, stride in zip(result_shape, result_strides, strict=True):
+            for size, stride in zip(static_sizes, result_strides, strict=True):
+                assert size is not None
                 if size == 1:
                     continue
                 reduced_shape.append(size)


### PR DESCRIPTION
Add SubviewOp.infer_result_type to infer the result memref type from a source type and subview offsets, sizes, and strides.

The helper supports static and dynamic offsets, sizes, and strides, as well as dynamic source strides and offsets for strided memref layouts.

This does not add tensor support or AffineMapAttr layout inference.