### PR TITLE
dialects: (acc) Global constructor and destructor operations

### DIFF
--- a/tests/dialects/test_acc.py
+++ b/tests/dialects/test_acc.py
@@ -1015,3 +1015,21 @@ def test_routine_op_full_population():
     assert op.worker == ArrayAttr([radeon])
     assert op.vector == ArrayAttr([host])
     assert op.seq == ArrayAttr([multicore])
+
+
+def test_global_ctor_dtor_builder_shortcuts():
+    """`GlobalConstructorOp` / `GlobalDestructorOp` accept both a `str` and a
+    `StringAttr` for `sym_name`. The filecheck parser bypasses `__init__`
+    (it goes through IRDL's generic constructor), so the str → StringAttr
+    branch and the StringAttr-passthrough branch are only exercised here."""
+    ctor = acc.GlobalConstructorOp(
+        sym_name="acc_constructor",
+        region=Region(Block([acc.TerminatorOp()])),
+    )
+    assert ctor.sym_name == StringAttr("acc_constructor")
+
+    dtor = acc.GlobalDestructorOp(
+        sym_name=StringAttr("acc_destructor"),
+        region=Region(Block([acc.TerminatorOp()])),
+    )
+    assert dtor.sym_name == StringAttr("acc_destructor")

--- a/tests/filecheck/dialects/acc/ops.mlir
+++ b/tests/filecheck/dialects/acc/ops.mlir
@@ -2219,4 +2219,37 @@ builtin.module {
   // bypasses the custom directives entirely.
   "acc.routine"() <{func_name = @acc_func, sym_name = "rt_generic", gang = [#acc.device_type<nvidia>]}> : () -> ()
   // CHECK-LABEL: acc.routine @rt_generic func(@acc_func) gang([#acc.device_type<nvidia>])
+
+  // acc.global_ctor / acc.global_dtor — Symbol + IsolatedFromAbove module-level
+  // ops carrying just a sym_name and an unrestricted region. The body
+  // typically holds data-clause / declare ops terminated by acc.terminator.
+  acc.global_ctor @acc_ctor_empty {
+    acc.terminator
+  }
+  // CHECK-LABEL: acc.global_ctor @acc_ctor_empty {
+  // CHECK-NEXT:    acc.terminator
+  // CHECK-NEXT:  }
+
+  acc.global_dtor @acc_dtor_empty {
+    acc.terminator
+  }
+  // CHECK-LABEL: acc.global_dtor @acc_dtor_empty {
+  // CHECK-NEXT:    acc.terminator
+  // CHECK-NEXT:  }
+
+  // Generic-form roundtrip insurance for both ops — covers the parser path
+  // that bypasses the declarative custom assembly format.
+  "acc.global_ctor"() <{sym_name = "acc_ctor_generic"}> ({
+    "acc.terminator"() : () -> ()
+  }) : () -> ()
+  // CHECK-LABEL: acc.global_ctor @acc_ctor_generic {
+  // CHECK-NEXT:    acc.terminator
+  // CHECK-NEXT:  }
+
+  "acc.global_dtor"() <{sym_name = "acc_dtor_generic"}> ({
+    "acc.terminator"() : () -> ()
+  }) : () -> ()
+  // CHECK-LABEL: acc.global_dtor @acc_dtor_generic {
+  // CHECK-NEXT:    acc.terminator
+  // CHECK-NEXT:  }
 }

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/ops.mlir
@@ -1519,4 +1519,37 @@ builtin.module {
   acc.routine @rt_full func(@rt_func) bind("name") gang([#acc.device_type<nvidia>], dim: 1 : i64 [#acc.device_type<nvidia>]) worker([#acc.device_type<radeon>]) vector([#acc.device_type<host>]) seq([#acc.device_type<multicore>]) nohost implicit
   // CHECK:       acc.routine @rt_full func(@rt_func) bind("name") gang([#acc.device_type<nvidia>], dim: 1 : i64 [#acc.device_type<nvidia>]) worker([#acc.device_type<radeon>]) vector([#acc.device_type<host>]) seq([#acc.device_type<multicore>]) nohost implicit
 
+  // acc.global_ctor / acc.global_dtor — Symbol + IsolatedFromAbove module-level
+  // ops. Body typically holds data-clause + declare ops terminated by
+  // acc.terminator (the assembly format is `$sym_name $region attr-dict-with-keyword`).
+  acc.global_ctor @acc_ctor {
+    acc.terminator
+  }
+  // CHECK:       acc.global_ctor @acc_ctor {
+  // CHECK-NEXT:    acc.terminator
+  // CHECK-NEXT:  }
+
+  acc.global_dtor @acc_dtor {
+    acc.terminator
+  }
+  // CHECK:       acc.global_dtor @acc_dtor {
+  // CHECK-NEXT:    acc.terminator
+  // CHECK-NEXT:  }
+
+  // Generic-form input — proves a hand-written generic spelling survives the
+  // xdsl ↔ mlir-opt round-trip in both directions.
+  "acc.global_ctor"() <{sym_name = "acc_ctor_generic"}> ({
+    "acc.terminator"() : () -> ()
+  }) : () -> ()
+  // CHECK:       acc.global_ctor @acc_ctor_generic {
+  // CHECK-NEXT:    acc.terminator
+  // CHECK-NEXT:  }
+
+  "acc.global_dtor"() <{sym_name = "acc_dtor_generic"}> ({
+    "acc.terminator"() : () -> ()
+  }) : () -> ()
+  // CHECK:       acc.global_dtor @acc_dtor_generic {
+  // CHECK-NEXT:    acc.terminator
+  // CHECK-NEXT:  }
+
 }

--- a/xdsl/dialects/acc.py
+++ b/xdsl/dialects/acc.py
@@ -4889,7 +4889,7 @@ class GlobalConstructorOp(_GlobalCtorDtorOperation):
 
     name = "acc.global_ctor"
 
-    traits = lazy_traits_def(lambda: (IsolatedFromAbove(), SymbolOpInterface()))
+    traits = traits_def(IsolatedFromAbove(), SymbolOpInterface())
 
 
 @irdl_op_definition
@@ -4903,7 +4903,7 @@ class GlobalDestructorOp(_GlobalCtorDtorOperation):
 
     name = "acc.global_dtor"
 
-    traits = lazy_traits_def(lambda: (IsolatedFromAbove(), SymbolOpInterface()))
+    traits = traits_def(IsolatedFromAbove(), SymbolOpInterface())
 
 
 @irdl_op_definition

--- a/xdsl/dialects/acc.py
+++ b/xdsl/dialects/acc.py
@@ -4855,6 +4855,57 @@ class RoutineOp(IRDLOperation):
                 )
 
 
+class _GlobalCtorDtorOperation(IRDLOperation, ABC):
+    """Shared shape for `acc.global_ctor` / `acc.global_dtor`.
+
+    Mirrors upstream's `OpenACC_GlobalConstructorOp` / `OpenACC_GlobalDestructorOp`
+    — both are module-level `IsolatedFromAbove` + `Symbol` ops carrying just a
+    `sym_name` and an unrestricted region. Concrete leaves override only `name`.
+    """
+
+    sym_name = prop_def(SymbolNameConstraint())
+    region = region_def()
+
+    assembly_format = "$sym_name $region attr-dict-with-keyword"
+
+    def __init__(self, *, sym_name: StringAttr | str, region: Region) -> None:
+        sym_name_attr: StringAttr = (
+            StringAttr(sym_name) if isinstance(sym_name, str) else sym_name
+        )
+        super().__init__(
+            properties={"sym_name": sym_name_attr},
+            regions=[region],
+        )
+
+
+@irdl_op_definition
+class GlobalConstructorOp(_GlobalCtorDtorOperation):
+    """
+    Implementation of upstream acc.global_ctor — captures OpenACC actions
+    (e.g. `declare create`) to apply to globals at the entry to the implicit
+    data region. Module-level, isolated, named via Symbol.
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/OpenACCDialect/#accglobal_ctor-accglobalconstructorop).
+    """
+
+    name = "acc.global_ctor"
+
+    traits = lazy_traits_def(lambda: (IsolatedFromAbove(), SymbolOpInterface()))
+
+
+@irdl_op_definition
+class GlobalDestructorOp(_GlobalCtorDtorOperation):
+    """
+    Implementation of upstream acc.global_dtor — captures OpenACC actions
+    (e.g. matching `delete` for a `declare create`) to apply to globals at the
+    exit from the implicit data region. Module-level, isolated, named via Symbol.
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/OpenACCDialect/#accglobal_dtor-accglobaldestructorop).
+    """
+
+    name = "acc.global_dtor"
+
+    traits = lazy_traits_def(lambda: (IsolatedFromAbove(), SymbolOpInterface()))
+
+
 @irdl_op_definition
 class TerminatorOp(IRDLOperation):
     """
@@ -4871,7 +4922,13 @@ class TerminatorOp(IRDLOperation):
         lambda: (
             IsTerminator(),
             NoMemoryEffect(),
-            HasParent(KernelsOp, DataOp, HostDataOp),
+            HasParent(
+                KernelsOp,
+                DataOp,
+                HostDataOp,
+                GlobalConstructorOp,
+                GlobalDestructorOp,
+            ),
         )
     )
 
@@ -4952,6 +5009,8 @@ ACC = Dialect(
         SetOp,
         WaitOp,
         RoutineOp,
+        GlobalConstructorOp,
+        GlobalDestructorOp,
         TerminatorOp,
         YieldOp,
     ],


### PR DESCRIPTION
This PR adds the OpenACC global constructor and destructor operations which are very similar and both extend the same base class. Tests included, but no invalid tests as there are no operation specific invalid things to test based on the operations