### PR TITLE
core: Printing and parsing simplified/generalised across float types

### DIFF
--- a/tests/utils/test_bf16_float.py
+++ b/tests/utils/test_bf16_float.py
@@ -100,18 +100,3 @@ def test_bf16_hash_matches_eq():
     a = BF16Float.from_value(1.5)
     b = BF16Float.from_value(1.5)
     assert hash(a) == hash(b)
-
-
-def test_bf16_hex_is_zero_padded():
-    assert BF16Float.from_value(1.0).hex() == "0x3f80"
-    assert BF16Float.from_value(0.0).hex() == "0x0000"
-    assert BF16Float.from_value(float("inf")).hex() == "0x7f80"
-
-
-def test_bf16_repr():
-    assert repr(BF16Float.from_value(1.0)) == "BF16Float(0x3f80)"
-
-
-def test_bf16_str_is_float_str():
-    assert str(BF16Float.from_value(1.0)) == "1.0"
-    assert str(BF16Float.from_value(2.5)) == "2.5"

--- a/xdsl/parser/attribute_parser.py
+++ b/xdsl/parser/attribute_parser.py
@@ -21,7 +21,6 @@ from xdsl.dialects.builtin import (
     AnyUnrankedTensorType,
     AnyVectorType,
     ArrayAttr,
-    BFloat16Type,
     BoolAttr,
     BytesAttr,
     CallSiteLoc,
@@ -71,12 +70,6 @@ from xdsl.dialects.builtin import (
 from xdsl.ir import Attribute, Data, ParametrizedAttribute, TypeAttribute
 from xdsl.ir.affine import AffineMap, AffineSet
 from xdsl.irdl import base
-from xdsl.utils.bf16_float import BF16Float
-from xdsl.utils.bitwise_casts import (
-    convert_u16_to_f16,
-    convert_u32_to_f32,
-    convert_u64_to_f64,
-)
 from xdsl.utils.exceptions import ParseError, VerifyException
 from xdsl.utils.hints import isa
 from xdsl.utils.lexer import Position, Span
@@ -1451,19 +1444,8 @@ class AttrParser(BaseParser):
         if isinstance(type, AnyFloat):
             if is_hexadecimal_token:
                 assert isinstance(value, int)
-                match type:
-                    case Float16Type():
-                        return FloatAttr(convert_u16_to_f16(value), type)
-                    case BFloat16Type():
-                        return FloatAttr(float(BF16Float.from_value(value)), type)
-                    case Float32Type():
-                        return FloatAttr(convert_u32_to_f32(value), type)
-                    case Float64Type():
-                        return FloatAttr(convert_u64_to_f64(value), type)
-                    case _:
-                        raise NotImplementedError(
-                            f"Cannot parse hexadecimal literal for float type of bit width {type}"
-                        )
+                raw = value.to_bytes(type.compile_time_size, "little")
+                return FloatAttr(next(type.iter_unpack(raw)), type)
             return FloatAttr(float(value), type)
 
         if isa(type, IntegerType | IndexType):

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -14,10 +14,8 @@ from xdsl.dialect_interfaces.op_asm import OpAsmDialectInterface
 from xdsl.dialects.builtin import (
     DYNAMIC_INDEX,
     AnyFloat,
-    BFloat16Type,
     BuiltinAttribute,
     ComplexType,
-    Float16Type,
     Float32Type,
     Float64Type,
     FunctionType,
@@ -43,9 +41,7 @@ from xdsl.ir import (
 )
 from xdsl.traits import IsolatedFromAbove, IsTerminator
 from xdsl.utils.base_printer import BasePrinter
-from xdsl.utils.bf16_float import BF16Float
 from xdsl.utils.bitwise_casts import (
-    convert_f16_to_u16,
     convert_f32_to_u32,
     convert_f64_to_u64,
 )
@@ -361,18 +357,8 @@ class Printer(BasePrinter):
 
     def print_float(self, value: float, type: AnyFloat):
         if math.isnan(value) or math.isinf(value):
-            if isinstance(type, Float16Type):
-                self.print_string(hex(convert_f16_to_u16(value)))
-            elif isinstance(type, BFloat16Type):
-                self.print_string(BF16Float.from_value(value).hex())
-            elif isinstance(type, Float32Type):
-                self.print_string(hex(convert_f32_to_u32(value)))
-            elif isinstance(type, Float64Type):
-                self.print_string(hex(convert_f64_to_u64(value)))
-            else:
-                raise NotImplementedError(
-                    f"Cannot print '{value}' value for float type {type!s}"
-                )
+            raw = type.pack((value,))
+            self.print_string(f"0x{raw[::-1].hex()}")
         else:
             # to mirror mlir-opt, attempt to print scientific notation iff the value parses losslessly
             float_str = f"{value:.5e}"

--- a/xdsl/utils/bf16_float.py
+++ b/xdsl/utils/bf16_float.py
@@ -21,8 +21,7 @@ class BF16Float:
 
     Construct from raw bytes (``BF16Float(b"\\x80\\x3f")``) or from a
     Python numeric (``BF16Float.from_value(1.0)``). Decode to a Python
-    float with ``float(self)``. Equality and hashing are bytes-based:
-    ``+0.0`` vs ``-0.0`` and distinct NaN payloads compare unequal.
+    float with ``float(self)``.
     """
 
     size_bytes: ClassVar[int] = 2
@@ -33,7 +32,7 @@ class BF16Float:
     """
     The two raw bytes of the bf16 bit pattern, stored little-endian (low
     byte first). For value 1.0 (bit pattern ``0x3F80``), ``raw`` is
-    ``b"\\x80\\x3f"``. ``hex()`` reverses to natural reading order.
+    ``b"\\x80\\x3f"``.
     """
 
     def __init__(self, raw: bytes) -> None:
@@ -74,10 +73,6 @@ class BF16Float:
             bits = ((f32_bits + rounding_bias) >> 16) & 0xFFFF
         return bits.to_bytes(BF16Float.size_bytes, "little")
 
-    def hex(self) -> str:
-        """``0x``-prefixed lowercase hex, in natural (big-endian) reading order."""
-        return f"0x{self.raw[::-1].hex()}"
-
     def __float__(self) -> float:
         # bf16 is the high 16 bits of f32 with the low 16 truncated; the
         # inverse is to zero-extend with two low bytes in little-endian.
@@ -88,9 +83,3 @@ class BF16Float:
 
     def __hash__(self) -> int:
         return hash((BF16Float, self.raw))
-
-    def __repr__(self) -> str:
-        return f"BF16Float({self.hex()})"
-
-    def __str__(self) -> str:
-        return str(float(self))


### PR DESCRIPTION
This PR simplified printing and parsing across float types, generalising it so it is easy to add new float types. Also simplifies the bf16 type as part of this.

Is stacked atop [6029](https://github.com/xdslproject/xdsl/pull/6029) 
