### PR TITLE
core: Simplified the parsing and printing of floats

### DIFF
--- a/xdsl/parser/attribute_parser.py
+++ b/xdsl/parser/attribute_parser.py
@@ -70,11 +70,6 @@ from xdsl.dialects.builtin import (
 from xdsl.ir import Attribute, Data, ParametrizedAttribute, TypeAttribute
 from xdsl.ir.affine import AffineMap, AffineSet
 from xdsl.irdl import base
-from xdsl.utils.bitwise_casts import (
-    convert_u16_to_f16,
-    convert_u32_to_f32,
-    convert_u64_to_f64,
-)
 from xdsl.utils.exceptions import ParseError, VerifyException
 from xdsl.utils.hints import isa
 from xdsl.utils.lexer import Position, Span
@@ -1449,17 +1444,8 @@ class AttrParser(BaseParser):
         if isinstance(type, AnyFloat):
             if is_hexadecimal_token:
                 assert isinstance(value, int)
-                match type:
-                    case Float16Type():
-                        return FloatAttr(convert_u16_to_f16(value), type)
-                    case Float32Type():
-                        return FloatAttr(convert_u32_to_f32(value), type)
-                    case Float64Type():
-                        return FloatAttr(convert_u64_to_f64(value), type)
-                    case _:
-                        raise NotImplementedError(
-                            f"Cannot parse hexadecimal literal for float type of bit width {type}"
-                        )
+                raw = value.to_bytes(type.compile_time_size, "little")
+                return FloatAttr(next(type.iter_unpack(raw)), type)
             return FloatAttr(float(value), type)
 
         if isa(type, IntegerType | IndexType):

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -16,7 +16,6 @@ from xdsl.dialects.builtin import (
     AnyFloat,
     BuiltinAttribute,
     ComplexType,
-    Float16Type,
     Float32Type,
     Float64Type,
     FunctionType,
@@ -43,7 +42,6 @@ from xdsl.ir import (
 from xdsl.traits import IsolatedFromAbove, IsTerminator
 from xdsl.utils.base_printer import BasePrinter
 from xdsl.utils.bitwise_casts import (
-    convert_f16_to_u16,
     convert_f32_to_u32,
     convert_f64_to_u64,
 )
@@ -359,16 +357,8 @@ class Printer(BasePrinter):
 
     def print_float(self, value: float, type: AnyFloat):
         if math.isnan(value) or math.isinf(value):
-            if isinstance(type, Float16Type):
-                self.print_string(hex(convert_f16_to_u16(value)))
-            elif isinstance(type, Float32Type):
-                self.print_string(hex(convert_f32_to_u32(value)))
-            elif isinstance(type, Float64Type):
-                self.print_string(hex(convert_f64_to_u64(value)))
-            else:
-                raise NotImplementedError(
-                    f"Cannot print '{value}' value for float type {type!s}"
-                )
+            raw = type.pack((value,))
+            self.print_string(f"0x{raw[::-1].hex()}")
         else:
             # to mirror mlir-opt, attempt to print scientific notation iff the value parses losslessly
             float_str = f"{value:.5e}"


### PR DESCRIPTION
This PR simplifies the parsing and printing of floats, delegating this to the type. Makes the handling of these more generic for additional float types which might not fit directly into Python floats. Existing tests cover all this functionality.
