### PR TITLE
dialects: (builtin) Support for handling bf16 floatattr

### DIFF
--- a/tests/dialects/test_builtin.py
+++ b/tests/dialects/test_builtin.py
@@ -77,8 +77,8 @@ def test_FloatType_bitwidths():
 
 
 def test_FloatType_formats():
-    with pytest.raises(NotImplementedError):
-        bf16.format
+    # bf16 subclasses PackableType directly (no struct format string).
+    assert not hasattr(bf16, "format")
     assert f16.format == "<e"
     assert f32.format == "<f"
     assert f64.format == "<d"
@@ -137,6 +137,25 @@ def test_FloatType_packing():
 
     pi = f64.unpack(f64.pack((math.pi,)), 1)[0]
     assert pi == math.pi
+
+    # bf16 has no struct format code; pack/unpack are overridden directly.
+    bf16_nums = (-2.0, -1.0, 0.0, 1.0, 2.0)
+    bf16_buffer = bf16.pack(bf16_nums)
+    assert bf16.unpack(bf16_buffer, len(bf16_nums)) == bf16_nums
+
+
+def test_bf16_attr_construction_roundtrips():
+    # 1.5 is exactly representable in bf16.
+    a = FloatAttr(1.5, bf16)
+    assert a.value.data == 1.5
+
+
+def test_FloatAttr_skips_normalisation_for_unsupported_widths():
+    # f80 and f128 have no precision-normalisation path (their format
+    # raises NotImplementedError). FloatAttr.__init__ must take the
+    # else-branch and store the Python float as-is.
+    assert FloatAttr(0.1, f80).value.data == 0.1
+    assert FloatAttr(0.1, f128).value.data == 0.1
 
 
 def test_IntegerType_size():
@@ -339,6 +358,22 @@ def test_IntegerType_packing():
     assert attrs_i64 == tuple(IntegerAttr(n, i64) for n in nums_i64)
     assert tuple(attr for attr in IntegerAttr.iter_unpack(i64, buffer_i64)) == attrs_i64
 
+    # bf16
+    nums_bf16 = (-3.140625, -1.0, 0.0, 1.0, 3.140625)
+    buffer_bf16 = bf16.pack(nums_bf16)
+    unpacked_bf16 = bf16.unpack(buffer_bf16, len(nums_bf16))
+    assert nums_bf16 == unpacked_bf16
+    attrs_bf16 = FloatAttr.unpack(bf16, buffer_bf16, len(nums_bf16))
+    assert attrs_bf16 == tuple(FloatAttr(n, bf16) for n in nums_bf16)
+    assert (
+        tuple(attr for attr in FloatAttr.iter_unpack(bf16, buffer_bf16)) == attrs_bf16
+    )
+    # pack_into mirrors pack for the same values.
+    pack_into_buffer = bytearray(2 * len(nums_bf16))
+    for i, n in enumerate(nums_bf16):
+        bf16.pack_into(pack_into_buffer, 2 * i, n)
+    assert bytes(pack_into_buffer) == buffer_bf16
+
     # f16
     nums_f16 = (-3.140625, -1.0, 0.0, 1.0, 3.140625)
     buffer_f16 = f16.pack(nums_f16)
@@ -349,7 +384,7 @@ def test_IntegerType_packing():
     assert tuple(attr for attr in FloatAttr.iter_unpack(f16, buffer_f16)) == attrs_f16
 
     # f32
-    nums_f32 = (-3.140000104904175, -1.0, 0.0, 1.0, 3.140000104904175)
+    nums_f32 = (-3.140625, -1.0, 0.0, 1.0, 3.140625)
     buffer_f32 = f32.pack(nums_f32)
     unpacked_f32 = f32.unpack(buffer_f32, len(nums_f32))
     assert nums_f32 == unpacked_f32
@@ -358,7 +393,7 @@ def test_IntegerType_packing():
     assert tuple(attr for attr in FloatAttr.iter_unpack(f32, buffer_f32)) == attrs_f32
 
     # f64
-    nums_f64 = (-3.14159265359, -1.0, 0.0, 1.0, 3.14159265359)
+    nums_f64 = (-3.140625, -1.0, 0.0, 1.0, 3.140625)
     buffer_f64 = f64.pack(nums_f64)
     unpacked_f64 = f64.unpack(buffer_f64, len(nums_f64))
     assert nums_f64 == unpacked_f64

--- a/tests/filecheck/mlir-conversion/with-mlir/parser-printer/bfloat16.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/parser-printer/bfloat16.mlir
@@ -1,0 +1,15 @@
+// RUN: MLIR_GENERIC_ROUNDTRIP
+
+"builtin.module"() ({
+  "test.op"() {"value" = 1.5 : bf16} : () -> ()
+  // CHECK:      "test.op"() {value = 1.500000e+00 : bf16} : () -> ()
+
+  "test.op"() {"value" = -2.0 : bf16} : () -> ()
+  // CHECK-NEXT: "test.op"() {value = -2.000000e+00 : bf16} : () -> ()
+
+  "test.op"() {"weights" = dense<[1.0, 2.0, -1.5]> : tensor<3xbf16>} : () -> ()
+  // CHECK-NEXT: "test.op"() {weights = dense<[1.000000e+00, 2.000000e+00, -1.500000e+00]> : tensor<3xbf16>} : () -> ()
+
+  "test.op"() {"splat" = dense<3.0> : tensor<4xbf16>} : () -> ()
+  // CHECK-NEXT: "test.op"() {splat = dense<3.000000e+00> : tensor<4xbf16>} : () -> ()
+}) : () -> ()

--- a/tests/filecheck/parser-printer/bfloat16_parsing.mlir
+++ b/tests/filecheck/parser-printer/bfloat16_parsing.mlir
@@ -1,0 +1,33 @@
+// RUN: XDSL_ROUNDTRIP
+
+
+"builtin.module"() ({
+  "test.op"() {"value" = 1.5 : bf16} : () -> ()
+  // CHECK:      "test.op"() {value = 1.500000e+00 : bf16} : () -> ()
+
+  "test.op"() {"value" = -2.0 : bf16} : () -> ()
+  // CHECK-NEXT: "test.op"() {value = -2.000000e+00 : bf16} : () -> ()
+
+  // 0.1 is not exactly representable in bf16; it must be quantised to
+  // its nearest bf16 value on parse and print as the rounded form.
+  "test.op"() {"value" = 0.1 : bf16} : () -> ()
+  // CHECK-NEXT: "test.op"() {value = 1.000980e-01 : bf16} : () -> ()
+
+  "test.op"() {"value" = 0x7fc0 : bf16} : () -> ()
+  // CHECK-NEXT: "test.op"() {value = 0x7fc0 : bf16} : () -> ()
+
+  "test.op"() {"value" = 0x7f80 : bf16} : () -> ()
+  // CHECK-NEXT: "test.op"() {value = 0x7f80 : bf16} : () -> ()
+
+  "test.op"() {"value" = 0xff80 : bf16} : () -> ()
+  // CHECK-NEXT: "test.op"() {value = 0xff80 : bf16} : () -> ()
+
+  "test.op"() {"weights" = array<bf16: 1.0, 2.0, -1.5>} : () -> ()
+  // CHECK-NEXT: "test.op"() {weights = array<bf16: 1.000000e+00, 2.000000e+00, -1.500000e+00>} : () -> ()
+
+  "test.op"() {"t" = dense<[1.0, 2.0]> : tensor<2xbf16>} : () -> ()
+  // CHECK-NEXT: "test.op"() {t = dense<[1.000000e+00, 2.000000e+00]> : tensor<2xbf16>} : () -> ()
+
+  "test.op"() {"s" = dense<3.0> : tensor<4xbf16>} : () -> ()
+  // CHECK-NEXT: "test.op"() {s = dense<3.000000e+00> : tensor<4xbf16>} : () -> ()
+}) : () -> ()

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -25,6 +25,7 @@ from xdsl.dialects.builtin import (
     StringAttr,
     SymbolRefAttr,
     UnknownLoc,
+    bf16,
     i32,
 )
 from xdsl.dialects.func import Func, FuncOp
@@ -928,6 +929,10 @@ def test_parse_number(
         ("0x7ff8000000000000 : f64", FloatAttr(float("nan"), 64)),
         ("0x7ff0000000000000 : f64", FloatAttr(float("inf"), 64)),
         ("0xfff0000000000000 : f64", FloatAttr(float("-inf"), 64)),
+        ("-1.5: bf16", FloatAttr(-1.5, bf16)),
+        ("0x7fc0 : bf16", FloatAttr(float("nan"), bf16)),
+        ("0x7f80 : bf16", FloatAttr(float("inf"), bf16)),
+        ("0xff80 : bf16", FloatAttr(float("-inf"), bf16)),
         # ("3 : f64", None),  # todo this fails in mlir-opt but not in xdsl
     ],
 )

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -29,6 +29,7 @@ from xdsl.dialects.builtin import (
     SymbolRefAttr,
     UnitAttr,
     UnknownLoc,
+    bf16,
     f32,
     i1,
     i32,
@@ -1007,6 +1008,10 @@ def test_float_attr_specials():
     _test_attr_print("0x7e00 : f16", FloatAttr(float("nan"), 16))
     _test_attr_print("0x7c00 : f16", FloatAttr(float("inf"), 16))
     _test_attr_print("0xfc00 : f16", FloatAttr(float("-inf"), 16))
+
+    _test_attr_print("0x7fc0 : bf16", FloatAttr(float("nan"), bf16))
+    _test_attr_print("0x7f80 : bf16", FloatAttr(float("inf"), bf16))
+    _test_attr_print("0xff80 : bf16", FloatAttr(float("-inf"), bf16))
 
     _test_attr_print("0x7fc00000 : f32", FloatAttr(float("nan"), 32))
     _test_attr_print("0x7f800000 : f32", FloatAttr(float("inf"), 32))

--- a/tests/utils/test_bf16_float.py
+++ b/tests/utils/test_bf16_float.py
@@ -1,0 +1,89 @@
+import struct
+
+import pytest
+
+from xdsl.utils.bf16_float import BF16Float
+
+
+@pytest.mark.parametrize(
+    "i, f",
+    [
+        (0x0000, 0.0),
+        (0x8000, -0.0),
+        (0x3F80, 1.0),
+        (0xBF80, -1.0),
+        (0x4000, 2.0),
+        (0x7F80, float("inf")),
+        (0xFF80, float("-inf")),
+    ],
+)
+def test_bf16_round_trip(i: int, f: float):
+    encoded = BF16Float.from_value(f)
+    assert encoded.raw == BF16Float.from_value(i).raw
+    # Round-trip via struct so -0.0 and 0.0 compare distinctly.
+    assert struct.pack(">f", float(encoded)) == struct.pack(">f", f)
+
+
+def test_bf16_nan_stays_nan():
+    encoded = BF16Float.from_value(float("nan"))
+    bits = int.from_bytes(encoded.raw, "little")
+    assert (bits & 0x7F80) == 0x7F80  # exponent all-ones
+    assert (bits & 0x007F) != 0  # mantissa non-zero
+    assert bits & 0x0040  # quiet bit set
+
+
+def test_bf16_round_to_nearest_even():
+    # Halfway between two bf16 values; ties go to even (mantissa LSB 0).
+    halfway = 1.0 + 2.0**-8
+    assert BF16Float.from_value(halfway).raw == BF16Float.from_value(0x3F80).raw
+    just_above = 1.0 + 2.0**-8 + 2.0**-20
+    assert BF16Float.from_value(just_above).raw == BF16Float.from_value(0x3F81).raw
+
+
+def test_bf16_lossy_roundtrip():
+    rt = float(BF16Float.from_value(0.1))
+    assert rt != 0.1
+    assert abs(rt - 0.1) < 2**-6
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (0.0, b"\x00\x00"),
+        (-0.0, b"\x00\x80"),
+        (1.0, b"\x80\x3f"),
+        (-1.0, b"\x80\xbf"),
+        (2.0, b"\x00\x40"),
+        (float("inf"), b"\x80\x7f"),
+        (float("-inf"), b"\x80\xff"),
+    ],
+)
+def test_bf16_encode(value: float, expected: bytes):
+    assert BF16Float.encode(value) == expected
+
+
+def test_bf16_encode_nan_is_quiet():
+    raw = BF16Float.encode(float("nan"))
+    bits = int.from_bytes(raw, "little")
+    assert (bits & 0x7F80) == 0x7F80  # exponent all-ones
+    assert (bits & 0x007F) != 0  # mantissa non-zero
+    assert bits & 0x0040  # quiet bit set
+
+
+def test_bf16_encode_round_to_nearest_even():
+    halfway = 1.0 + 2.0**-8
+    assert BF16Float.encode(halfway) == (0x3F80).to_bytes(2, "little")
+    just_above = 1.0 + 2.0**-8 + 2.0**-20
+    assert BF16Float.encode(just_above) == (0x3F81).to_bytes(2, "little")
+
+
+def test_bf16_size_bytes():
+    assert BF16Float.size_bytes == 2
+    assert len(BF16Float.from_value(1.0).raw) == 2
+
+
+def test_bf16_rejects_wrong_byte_count():
+    with pytest.raises(ValueError, match="expects 2 bytes"):
+        BF16Float(b"\x00")
+    with pytest.raises(ValueError, match="expects 2 bytes"):
+        BF16Float(b"\x00\x00\x00")

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -84,6 +84,7 @@ from xdsl.traits import (
     OpTrait,
     SymbolTable,
 )
+from xdsl.utils.bf16_float import BF16Float
 from xdsl.utils.comparisons import (
     signed_upper_bound,
     signed_value_range,
@@ -1107,7 +1108,7 @@ class IntegerAttr(
 BoolAttr: TypeAlias = IntegerAttr[Annotated[IntegerType, IntegerType(1)]]
 
 
-class _FloatType(StructPackableType[float], FixedBitwidthType, BuiltinAttribute, ABC):
+class _FloatType(PackableType[float], FixedBitwidthType, BuiltinAttribute, ABC):
     @property
     @abstractmethod
     def bitwidth(self) -> int:
@@ -1126,13 +1127,28 @@ class BFloat16Type(ParametrizedAttribute, _FloatType):
     def bitwidth(self) -> int:
         return 16
 
+    def iter_unpack(self, buffer: ReadableBuffer, /) -> Iterator[float]:
+        mv = memoryview(buffer)
+        for i in range(0, len(mv), 2):
+            yield float(BF16Float(bytes(mv[i : i + 2])))
+
+    def unpack(self, buffer: ReadableBuffer, num: int, /) -> tuple[float, ...]:
+        mv = memoryview(buffer)
+        return tuple(float(BF16Float(bytes(mv[i * 2 : i * 2 + 2]))) for i in range(num))
+
+    def pack_into(self, buffer: WriteableBuffer, offset: int, value: float) -> None:
+        memoryview(buffer)[offset : offset + 2] = BF16Float.from_value(value).raw
+
+    def pack(self, values: Sequence[float]) -> bytes:
+        return b"".join(BF16Float.from_value(v).raw for v in values)
+
     @property
-    def format(self) -> str:
-        raise NotImplementedError()
+    def compile_time_size(self) -> int:
+        return 2
 
 
 @irdl_attr_definition
-class Float16Type(ParametrizedAttribute, _FloatType):
+class Float16Type(ParametrizedAttribute, _FloatType, StructPackableType[float]):
     name = "f16"
 
     @property
@@ -1145,7 +1161,7 @@ class Float16Type(ParametrizedAttribute, _FloatType):
 
 
 @irdl_attr_definition
-class Float32Type(ParametrizedAttribute, _FloatType):
+class Float32Type(ParametrizedAttribute, _FloatType, StructPackableType[float]):
     name = "f32"
 
     @property
@@ -1158,7 +1174,7 @@ class Float32Type(ParametrizedAttribute, _FloatType):
 
 
 @irdl_attr_definition
-class Float64Type(ParametrizedAttribute, _FloatType):
+class Float64Type(ParametrizedAttribute, _FloatType, StructPackableType[float]):
     name = "f64"
 
     @property
@@ -1171,7 +1187,7 @@ class Float64Type(ParametrizedAttribute, _FloatType):
 
 
 @irdl_attr_definition
-class Float80Type(ParametrizedAttribute, _FloatType):
+class Float80Type(ParametrizedAttribute, _FloatType, StructPackableType[float]):
     name = "f80"
 
     @property
@@ -1184,7 +1200,7 @@ class Float80Type(ParametrizedAttribute, _FloatType):
 
 
 @irdl_attr_definition
-class Float128Type(ParametrizedAttribute, _FloatType):
+class Float128Type(ParametrizedAttribute, _FloatType, StructPackableType[float]):
     name = "f128"
 
     @property
@@ -1272,7 +1288,7 @@ class FloatAttr(BuiltinAttribute, TypedAttribute, Generic[_FloatAttrType]):
         value: float = data.data if isinstance(data, FloatData) else data
         # for supported types, constrain value to precision of floating point type
         # else, allow full python float precision
-        if isinstance(type, Float64Type | Float32Type | Float16Type):
+        if isinstance(type, Float64Type | Float32Type | Float16Type | BFloat16Type):
             value = type.unpack(type.pack((value,)), 1)[0]
 
         data_attr = FloatData(value)

--- a/xdsl/utils/bf16_float.py
+++ b/xdsl/utils/bf16_float.py
@@ -1,0 +1,79 @@
+"""
+Typed wrapper around the raw 2 bytes of a bfloat16 value.
+
+bf16 has no native Python representation. ``BF16Float`` owns the format
+codec (round-to-nearest-even, NaN-quiet preservation; matches LLVM
+APFloat) and lets the rest of xDSL pass bf16 values around as a typed
+object instead of a bare ``int`` bit pattern.
+"""
+
+from __future__ import annotations
+
+import struct
+from typing import ClassVar
+
+from typing_extensions import Self
+
+
+class BF16Float:
+    """
+    Typed wrapper around the raw little-endian bytes of a bfloat16 value.
+
+    Construct from raw bytes (``BF16Float(b"\\x80\\x3f")``) or from a
+    Python numeric (``BF16Float.from_value(1.0)``). Decode to a Python
+    float with ``float(self)``.
+    """
+
+    size_bytes: ClassVar[int] = 2
+
+    __slots__ = ("raw",)
+
+    raw: bytes
+    """
+    The two raw bytes of the bf16 bit pattern, stored little-endian (low
+    byte first). For value 1.0 (bit pattern ``0x3F80``), ``raw`` is
+    ``b"\\x80\\x3f"``.
+    """
+
+    def __init__(self, raw: bytes) -> None:
+        if len(raw) != self.size_bytes:
+            raise ValueError(
+                f"BF16Float expects {self.size_bytes} bytes, got {len(raw)}"
+            )
+        self.raw = raw
+
+    @classmethod
+    def from_value(cls, value: float | int) -> Self:
+        """
+        Build from a Python numeric value.
+
+        ``int`` is interpreted as the raw bit pattern (little-endian),
+        ``float`` is encoded through the bf16 codec.
+        """
+        if isinstance(value, int):
+            return cls(value.to_bytes(cls.size_bytes, "little"))
+        return cls(cls.encode(value))
+
+    @staticmethod
+    def encode(value: float) -> bytes:
+        """
+        Encode a Python float (interpreted as IEEE 754 binary32 after
+        Python's f64 -> f32 narrowing) as bf16 bytes, little-endian.
+        Round-to-nearest-even, quiet-NaN preservation; matches LLVM
+        APFloat semantics.
+        """
+        f32_bits = struct.unpack("<I", struct.pack("<f", value))[0]
+        # NaN must remain a NaN after truncation; force the quiet bit on so
+        # a signaling NaN with mantissa entirely in the truncated bits
+        # doesn't become inf.
+        if (f32_bits & 0x7FFFFFFF) > 0x7F800000:
+            bits = ((f32_bits >> 16) | 0x0040) & 0xFFFF
+        else:
+            rounding_bias = 0x7FFF + ((f32_bits >> 16) & 1)
+            bits = ((f32_bits + rounding_bias) >> 16) & 0xFFFF
+        return bits.to_bytes(BF16Float.size_bytes, "little")
+
+    def __float__(self) -> float:
+        # bf16 is the high 16 bits of f32 with the low 16 truncated; the
+        # inverse is to zero-extend with two low bytes in little-endian.
+        return struct.unpack("<f", b"\x00\x00" + self.raw)[0]


### PR DESCRIPTION
This PR adds support into the builtin dialect for the bf16 float, previously it was present but was not implemented so raised an error. There are two modifications here, firstly to the builtin dialect and secondly the BF16Float class added into utils that abstracts representation of bf16. All other modified files are tests.

Due to the behaviour of bf16, internally xDSL represents it as a float.
