### PR TITLE
dialects: (arith) truncate bits when folding SignlessIntegerBinaryOperation

### DIFF
--- a/tests/dialects/test_arith.py
+++ b/tests/dialects/test_arith.py
@@ -54,6 +54,7 @@ from xdsl.dialects.arith import (
     XOrIOp,
 )
 from xdsl.dialects.builtin import (
+    BoolAttr,
     DenseIntOrFPElementsAttr,
     DenseResourceAttr,
     FloatAttr,
@@ -572,6 +573,16 @@ def test_fold():
     # x + x cannot be folded
     addi_val_val = AddiOp(some_value, some_value)
     assert addi_val_val.fold() is None
+
+    false_attr = BoolAttr.from_bool(False)
+    false_op = ConstantOp(false_attr)
+    true_attr = BoolAttr.from_bool(True)
+    true_op = ConstantOp(true_attr)
+
+    assert AddiOp(false_op, false_op).fold() == (false_attr,)
+    assert AddiOp(false_op, true_op).fold() == (true_attr,)
+    assert AddiOp(true_op, false_op).fold() == (true_attr,)
+    assert AddiOp(true_op, true_op).fold() == (false_attr,)
 
 
 @pytest.mark.parametrize(

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -231,7 +231,7 @@ class SignlessIntegerBinaryOperation(IRDLOperation, HasFolderInterface, abc.ABC)
                 assert lhs.type == rhs.type
                 result = self.py_operation(lhs.value.data, rhs.value.data)
                 if result is not None:
-                    return (IntegerAttr(result, lhs.type),)
+                    return (IntegerAttr(result, lhs.type, truncate_bits=True),)
         if isa(rhs, IntegerAttr) and self.is_right_unit(rhs):
             return (self.lhs,)
         if not self.has_trait(Commutative):


### PR DESCRIPTION
Fixes one of the two issues blocking #5497.

CC @radosavkrunic33 