### PR TITLE
transformations: elide RemoveUnusedOperations when folding greedily

### DIFF
--- a/xdsl/transforms/canonicalize.py
+++ b/xdsl/transforms/canonicalize.py
@@ -9,7 +9,7 @@ from xdsl.pattern_rewriter import (
     RewritePattern,
 )
 from xdsl.traits import HasCanonicalizationPatternsTrait
-from xdsl.transforms.dead_code_elimination import RemoveUnusedOperations, region_dce
+from xdsl.transforms.dead_code_elimination import region_dce
 
 
 class CanonicalizationRewritePattern(RewritePattern):
@@ -36,7 +36,5 @@ class CanonicalizePass(ModulePass):
     name = "canonicalize"
 
     def apply(self, ctx: Context, op: builtin.ModuleOp) -> None:
-        pattern = GreedyRewritePatternApplier(
-            [RemoveUnusedOperations(), CanonicalizationRewritePattern()]
-        )
+        pattern = GreedyRewritePatternApplier([CanonicalizationRewritePattern()])
         PatternRewriteWalker(pattern, post_walk_func=region_dce).rewrite_module(op)

--- a/xdsl/transforms/stencil_bufferize.py
+++ b/xdsl/transforms/stencil_bufferize.py
@@ -41,7 +41,6 @@ from xdsl.pattern_rewriter import (
 from xdsl.rewriter import InsertPoint
 from xdsl.traits import MemoryEffectKind, get_effects
 from xdsl.transforms.canonicalization_patterns.stencil import ApplyUnusedResults
-from xdsl.transforms.dead_code_elimination import RemoveUnusedOperations
 from xdsl.utils.hints import isa
 
 _TypeElement = TypeVar("_TypeElement", bound=Attribute)
@@ -592,7 +591,6 @@ class StencilBufferize(ModulePass):
                     CombineStoreFold(),
                     LoadBufferFoldPattern(),
                     ApplyStoreFoldPattern(),
-                    RemoveUnusedOperations(),
                     ApplyUnusedResults(),
                     SwapBufferize(),
                 ]


### PR DESCRIPTION
The GreedyRewritePatternApplier already dces by default, so no need for the extra dce pattern.