### PR TITLE
dialects: (acc) Kernel environment operation

### DIFF
--- a/tests/dialects/test_acc.py
+++ b/tests/dialects/test_acc.py
@@ -411,15 +411,8 @@ def test_host_data_init_bool_shortcut():
     assert isinstance(op.if_present, UnitAttr)
 
 
-def _empty_kernel_environment_block() -> Block:
-    """`acc.kernel_environment` has `NoTerminator` so the body is a single
-    block that need not end in a terminator. Build one with a single
-    placeholder op so the SizedRegion<1> verifier sees a non-empty region."""
-    return Block([TestOp()])
-
-
 def test_kernel_environment_empty_verifies():
-    op = acc.KernelEnvironmentOp(region=Region(_empty_kernel_environment_block()))
+    op = acc.KernelEnvironmentOp(region=Region(Block([TestOp()])))
     op.verify()
 
     assert len(op.data_clause_operands) == 0
@@ -438,7 +431,7 @@ def test_kernel_environment_unset_props_absent_from_dict():
     when not provided (rather than stored as None). The MLIR-interop
     round-trip relies on this — extra all-None entries would print as
     explicit attributes in the trailing attr-dict."""
-    op = acc.KernelEnvironmentOp(region=Region(_empty_kernel_environment_block()))
+    op = acc.KernelEnvironmentOp(region=Region(Block([TestOp()])))
 
     for prop in (
         "asyncOperandsDeviceType",
@@ -459,7 +452,7 @@ def test_kernel_environment_wait_only_no_operands_print():
     combination constructable only from the builder."""
     nvidia = acc.DeviceTypeAttr(acc.DeviceType.NVIDIA)
     op = acc.KernelEnvironmentOp(
-        region=Region(_empty_kernel_environment_block()),
+        region=Region(Block([TestOp()])),
         wait_only=ArrayAttr([nvidia]),
     )
     op.verify()

--- a/tests/dialects/test_acc.py
+++ b/tests/dialects/test_acc.py
@@ -411,6 +411,46 @@ def test_host_data_init_bool_shortcut():
     assert isinstance(op.if_present, UnitAttr)
 
 
+def _empty_kernel_environment_block() -> Block:
+    """`acc.kernel_environment` has `NoTerminator` so the body is a single
+    block that need not end in a terminator. Build one with a single
+    placeholder op so the SizedRegion<1> verifier sees a non-empty region."""
+    return Block([TestOp()])
+
+
+def test_kernel_environment_empty_verifies():
+    op = acc.KernelEnvironmentOp(region=Region(_empty_kernel_environment_block()))
+    op.verify()
+
+    assert len(op.data_clause_operands) == 0
+    assert len(op.async_operands) == 0
+    assert len(op.wait_operands) == 0
+    assert op.async_operands_device_type is None
+    assert op.async_only is None
+    assert op.wait_operands_segments is None
+    assert op.wait_operands_device_type is None
+    assert op.has_wait_devnum is None
+    assert op.wait_only is None
+
+
+def test_kernel_environment_unset_props_absent_from_dict():
+    """The optional clause properties are *absent* from `op.properties`
+    when not provided (rather than stored as None). The MLIR-interop
+    round-trip relies on this — extra all-None entries would print as
+    explicit attributes in the trailing attr-dict."""
+    op = acc.KernelEnvironmentOp(region=Region(_empty_kernel_environment_block()))
+
+    for prop in (
+        "asyncOperandsDeviceType",
+        "asyncOnly",
+        "waitOperandsSegments",
+        "waitOperandsDeviceType",
+        "hasWaitDevnum",
+        "waitOnly",
+    ):
+        assert prop not in op.properties
+
+
 def test_data_clause_modifier_attr_constructor():
     """The bit-enum constructor accepts a frozenset of enum members and stores
     it on `.data`. Pretty-form printing/parsing is covered by filecheck in

--- a/tests/dialects/test_acc.py
+++ b/tests/dialects/test_acc.py
@@ -444,25 +444,6 @@ def test_kernel_environment_unset_props_absent_from_dict():
         assert prop not in op.properties
 
 
-def test_kernel_environment_wait_only_no_operands_print():
-    """`_print_wait_body` has a printer-only branch — `wait_only` set to a
-    non-default device-type list with no `wait_operands` — that the parser
-    can never produce (`_parse_wait_body` requires a `,` after the `[dt-list]`).
-    This is the Python-only state the roadmap exception covers: a property
-    combination constructable only from the builder."""
-    nvidia = acc.DeviceTypeAttr(acc.DeviceType.NVIDIA)
-    op = acc.KernelEnvironmentOp(
-        region=Region(Block([TestOp()])),
-        wait_only=ArrayAttr([nvidia]),
-    )
-    op.verify()
-    assert len(op.wait_operands) == 0
-
-    out = io.StringIO()
-    Printer(stream=out).print_op(op)
-    assert "wait([#acc.device_type<nvidia>])" in out.getvalue()
-
-
 def test_data_clause_modifier_attr_constructor():
     """The bit-enum constructor accepts a frozenset of enum members and stores
     it on `.data`. Pretty-form printing/parsing is covered by filecheck in

--- a/tests/dialects/test_acc.py
+++ b/tests/dialects/test_acc.py
@@ -451,6 +451,25 @@ def test_kernel_environment_unset_props_absent_from_dict():
         assert prop not in op.properties
 
 
+def test_kernel_environment_wait_only_no_operands_print():
+    """`_print_wait_body` has a printer-only branch — `wait_only` set to a
+    non-default device-type list with no `wait_operands` — that the parser
+    can never produce (`_parse_wait_body` requires a `,` after the `[dt-list]`).
+    This is the Python-only state the roadmap exception covers: a property
+    combination constructable only from the builder."""
+    nvidia = acc.DeviceTypeAttr(acc.DeviceType.NVIDIA)
+    op = acc.KernelEnvironmentOp(
+        region=Region(_empty_kernel_environment_block()),
+        wait_only=ArrayAttr([nvidia]),
+    )
+    op.verify()
+    assert len(op.wait_operands) == 0
+
+    out = io.StringIO()
+    Printer(stream=out).print_op(op)
+    assert "wait([#acc.device_type<nvidia>])" in out.getvalue()
+
+
 def test_data_clause_modifier_attr_constructor():
     """The bit-enum constructor accepts a frozenset of enum members and stores
     it on `.data`. Pretty-form printing/parsing is covered by filecheck in

--- a/tests/filecheck/dialects/acc/ops.mlir
+++ b/tests/filecheck/dialects/acc/ops.mlir
@@ -619,6 +619,109 @@ builtin.module {
   // CHECK-NEXT:    acc.kernels {
   // CHECK-NEXT:    }
 
+  // acc.kernel_environment — decomposition of a compute construct that
+  // captures only the data / async / wait clauses. Body is a `SizedRegion<1>`
+  // with no terminator (the trait is `NoTerminator`) and typically wraps a
+  // `gpu.launch`; here a `test.op` placeholder stands in. Clause shape
+  // mirrors acc.data: same custom directives for async / wait, plus the
+  // variadic dataOperands.
+  func.func @ke_data_operand(%m : memref<10xf32>) {
+    %c = acc.copyin varPtr(%m : memref<10xf32>) -> memref<10xf32>
+    acc.kernel_environment dataOperands(%c : memref<10xf32>) {
+      "test.op"() : () -> ()
+    }
+    func.return
+  }
+  // CHECK-LABEL: func.func @ke_data_operand(
+  // CHECK:         acc.kernel_environment dataOperands(%{{.*}} : memref<10xf32>) {
+  // CHECK-NEXT:      "test.op"() : () -> ()
+  // CHECK-NEXT:    }
+
+  func.func @ke_async_bare() {
+    acc.kernel_environment async {
+      "test.op"() : () -> ()
+    }
+    func.return
+  }
+  // CHECK-LABEL: func.func @ke_async_bare() {
+  // CHECK-NEXT:    acc.kernel_environment async {
+  // CHECK-NEXT:      "test.op"() : () -> ()
+  // CHECK-NEXT:    }
+
+  func.func @ke_async_dt_only() {
+    acc.kernel_environment async([#acc.device_type<nvidia>]) {
+      "test.op"() : () -> ()
+    }
+    func.return
+  }
+  // CHECK-LABEL: func.func @ke_async_dt_only() {
+  // CHECK-NEXT:    acc.kernel_environment async([#acc.device_type<nvidia>]) {
+
+  func.func @ke_async_operand(%a : i32) {
+    acc.kernel_environment async(%a : i32 [#acc.device_type<nvidia>]) {
+      "test.op"() : () -> ()
+    }
+    func.return
+  }
+  // CHECK-LABEL: func.func @ke_async_operand(
+  // CHECK:         acc.kernel_environment async(%{{.*}} : i32 [#acc.device_type<nvidia>]) {
+
+  func.func @ke_wait_bare() {
+    acc.kernel_environment wait {
+      "test.op"() : () -> ()
+    }
+    func.return
+  }
+  // CHECK-LABEL: func.func @ke_wait_bare() {
+  // CHECK-NEXT:    acc.kernel_environment wait {
+
+  func.func @ke_wait_devnum(%a : i64, %b : i32) {
+    acc.kernel_environment wait({devnum: %a : i64, %b : i32}) {
+      "test.op"() : () -> ()
+    }
+    func.return
+  }
+  // CHECK-LABEL: func.func @ke_wait_devnum(
+  // CHECK:         acc.kernel_environment wait({devnum: %{{.*}} : i64, %{{.*}} : i32}) {
+
+  func.func @ke_full(%a : i32, %w : i64, %m : memref<10xf32>) {
+    %c = acc.copyin varPtr(%m : memref<10xf32>) -> memref<10xf32>
+    acc.kernel_environment dataOperands(%c : memref<10xf32>) async(%a : i32) wait({%w : i64}) {
+      "test.op"() : () -> ()
+    }
+    func.return
+  }
+  // CHECK-LABEL: func.func @ke_full(
+  // CHECK:         acc.kernel_environment dataOperands(%{{.*}} : memref<10xf32>) async(%{{.*}} : i32) wait({%{{.*}} : i64}) {
+
+  // Source spells the clauses in non-canonical order (wait, dataOperands,
+  // async); the oilist directive accepts any order on parse and re-emits
+  // them in upstream's td-definition order (dataOperands, async, wait).
+  func.func @ke_clauses_reordered(%a : i32, %w : i64, %m : memref<10xf32>) {
+    %c = acc.copyin varPtr(%m : memref<10xf32>) -> memref<10xf32>
+    acc.kernel_environment wait({%w : i64}) dataOperands(%c : memref<10xf32>) async(%a : i32) {
+      "test.op"() : () -> ()
+    }
+    func.return
+  }
+  // CHECK-LABEL: func.func @ke_clauses_reordered(
+  // CHECK:         acc.kernel_environment dataOperands(%{{.*}} : memref<10xf32>) async(%{{.*}} : i32) wait({%{{.*}} : i64}) {
+
+  // Generic-form roundtrip insurance — proves the parser path that
+  // bypasses the declarative custom assembly format still parses. The body
+  // carries an op because `SizedRegion<1>` rejects an empty (0-block)
+  // region in both upstream and xDSL.
+  func.func @ke_generic_roundtrip_retained() {
+    "acc.kernel_environment"() <{operandSegmentSizes = array<i32: 0, 0, 0>}> ({
+      "test.op"() : () -> ()
+    }) : () -> ()
+    func.return
+  }
+  // CHECK-LABEL: func.func @ke_generic_roundtrip_retained() {
+  // CHECK-NEXT:    acc.kernel_environment {
+  // CHECK-NEXT:      "test.op"() : () -> ()
+  // CHECK-NEXT:    }
+
   // acc.data — structured data construct. Body uses acc.terminator (same
   // SingleBlockImplicitTerminator(TerminatorOp) shape as kernels). The
   // verifier additionally requires either at least one operand or

--- a/tests/filecheck/dialects/acc/ops_invalid.mlir
+++ b/tests/filecheck/dialects/acc/ops_invalid.mlir
@@ -932,3 +932,43 @@ func.func @routine_bind_bad() {
 }
 acc.routine @rt_bind_bad func(@routine_bind_bad) bind(1 : i64)
 // CHECK: expected SymbolRef or string attribute in bind clause
+
+// -----
+
+// acc.kernel_environment uses `SizedRegion<1>`: the body must be exactly
+// one block. A multi-block body is rejected by the region's single-block
+// constraint (independent of `NoTerminator`, which only relaxes the
+// terminator requirement).
+func.func @ke_multi_block() {
+  "acc.kernel_environment"() <{operandSegmentSizes = array<i32: 0, 0, 0>}> ({
+  ^bb0:
+    "cf.br"()[^bb1] : () -> ()
+  ^bb1:
+  }) : () -> ()
+  func.return
+}
+// CHECK: Region 'region' at position 0 expected a single block, but got 2 blocks
+
+// -----
+
+// `SizedRegion<1>` also rejects a 0-block body. Both upstream MLIR and
+// xDSL refuse the empty `({})` form.
+func.func @ke_no_block() {
+  "acc.kernel_environment"() <{operandSegmentSizes = array<i32: 0, 0, 0>}> ({
+  }) : () -> ()
+  func.return
+}
+// CHECK: Region 'region' at position 0 expected a single block, but got 0 blocks
+
+// -----
+
+// The oilist directive lets the three clauses appear in any order, but
+// each clause may appear at most once. Repeating a keyword fires the
+// directive's own diagnostic.
+func.func @ke_duplicate_async() {
+  acc.kernel_environment async async {
+    "test.op"() : () -> ()
+  }
+  func.return
+}
+// CHECK: 'async' clause specified twice

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/ops.mlir
@@ -418,6 +418,86 @@ builtin.module {
   // CHECK:         acc.kernels combined(loop) async(%{{.*}} : i64) num_workers(%{{.*}} : i64) vector_length(%{{.*}} : i32) wait({%{{.*}} : i64}) self(%{{.*}}) if(%{{.*}}) {
   // CHECK-NEXT:    } attributes {defaultAttr = #acc<defaultvalue present>, selfAttr}
 
+  // acc.kernel_environment — body is a `SizedRegion<1>` with the
+  // `NoTerminator` trait, so the empty `{}` body is *not* valid (both
+  // upstream and xDSL reject 0-block regions); each test carries a
+  // `test.op` placeholder where a real `gpu.launch` would sit.
+  func.func @ke_data_operand(%m : memref<10xf32>) {
+    %c = acc.copyin varPtr(%m : memref<10xf32>) -> memref<10xf32>
+    acc.kernel_environment dataOperands(%c : memref<10xf32>) {
+      "test.op"() : () -> ()
+    }
+    func.return
+  }
+  // CHECK:       func.func @ke_data_operand(
+  // CHECK:         acc.kernel_environment dataOperands(%{{.*}} : memref<10xf32>) {
+  // CHECK-NEXT:      "test.op"() : () -> ()
+  // CHECK-NEXT:    }
+
+  func.func @ke_async_bare() {
+    acc.kernel_environment async {
+      "test.op"() : () -> ()
+    }
+    func.return
+  }
+  // CHECK:       func.func @ke_async_bare() {
+  // CHECK-NEXT:    acc.kernel_environment async {
+
+  // The bare `async([#acc.device_type<...>])` (keyword-only, no operand)
+  // form is omitted: upstream mlir-opt rejects that spelling on every
+  // compute construct (it requires a `,` after the dt-list). xDSL's
+  // ops.mlir still covers it.
+
+  func.func @ke_async_operand(%a : i32) {
+    acc.kernel_environment async(%a : i32 [#acc.device_type<nvidia>]) {
+      "test.op"() : () -> ()
+    }
+    func.return
+  }
+  // CHECK:       func.func @ke_async_operand(
+  // CHECK:         acc.kernel_environment async(%{{.*}} : i32 [#acc.device_type<nvidia>]) {
+
+  func.func @ke_wait_bare() {
+    acc.kernel_environment wait {
+      "test.op"() : () -> ()
+    }
+    func.return
+  }
+  // CHECK:       func.func @ke_wait_bare() {
+  // CHECK-NEXT:    acc.kernel_environment wait {
+
+  func.func @ke_wait_devnum(%a : i64, %b : i32) {
+    acc.kernel_environment wait({devnum: %a : i64, %b : i32}) {
+      "test.op"() : () -> ()
+    }
+    func.return
+  }
+  // CHECK:       func.func @ke_wait_devnum(
+  // CHECK:         acc.kernel_environment wait({devnum: %{{.*}} : i64, %{{.*}} : i32}) {
+
+  func.func @ke_full(%a : i32, %w : i64, %m : memref<10xf32>) {
+    %c = acc.copyin varPtr(%m : memref<10xf32>) -> memref<10xf32>
+    acc.kernel_environment dataOperands(%c : memref<10xf32>) async(%a : i32) wait({%w : i64}) {
+      "test.op"() : () -> ()
+    }
+    func.return
+  }
+  // CHECK:       func.func @ke_full(
+  // CHECK:         acc.kernel_environment dataOperands(%{{.*}} : memref<10xf32>) async(%{{.*}} : i32) wait({%{{.*}} : i64}) {
+
+  // Generic-form input — proves a hand-written generic spelling survives
+  // the xdsl ↔ mlir-opt round-trip in both directions.
+  func.func @ke_generic_form() {
+    "acc.kernel_environment"() <{operandSegmentSizes = array<i32: 0, 0, 0>}> ({
+      "test.op"() : () -> ()
+    }) : () -> ()
+    func.return
+  }
+  // CHECK:       func.func @ke_generic_form() {
+  // CHECK-NEXT:    acc.kernel_environment {
+  // CHECK-NEXT:      "test.op"() : () -> ()
+  // CHECK-NEXT:    }
+
   // acc.data — round-trips through mlir-opt's OpenACC dialect in both
   // pretty and generic form. defaultAttr is required on bodies with no
   // operand to satisfy upstream's verifier (matches xDSL's port).

--- a/xdsl/dialects/acc.py
+++ b/xdsl/dialects/acc.py
@@ -448,9 +448,7 @@ def _print_typed_operand(printer: Printer, operand: SSAValue) -> None:
     printer.print_attribute(operand.type)
 
 
-def _emit_clause_keyword(
-    printer: Printer, state: PrintingState, keyword: str
-) -> None:
+def _emit_clause_keyword(printer: Printer, state: PrintingState, keyword: str) -> None:
     """Print whitespace + a clause keyword and update print state so the
     body's first character (typically ``(``) lands adjacent (e.g.
     ``async(``). Used by the three clauses of `KernelEnvironmentClauses`."""

--- a/xdsl/dialects/acc.py
+++ b/xdsl/dialects/acc.py
@@ -448,6 +448,18 @@ def _print_typed_operand(printer: Printer, operand: SSAValue) -> None:
     printer.print_attribute(operand.type)
 
 
+def _emit_clause_keyword(
+    printer: Printer, state: PrintingState, keyword: str
+) -> None:
+    """Print whitespace + a clause keyword and update print state so the
+    body's first character (typically ``(``) lands adjacent (e.g.
+    ``async(``). Shared between every oilist-style clause printer."""
+    state.print_whitespace(printer)
+    printer.print_string(keyword)
+    state.should_emit_space = True
+    state.last_was_punctuation = False
+
+
 def _print_operand_with_dt(printer: Printer, operand: SSAValue, dt: Attribute) -> None:
     """Print `%v : <type> ( [#acc.device_type<...>] )?`."""
     _print_typed_operand(printer, operand)
@@ -800,7 +812,8 @@ def _parse_wait_body(
     Returns ``(operands, types, device_types, segments, has_devnum,
     keyword_only)``. The bare-keyword form (no parens) yields
     ``keyword_only = [#acc.device_type<none>]`` and all other slots
-    ``None`` / empty.
+    ``None`` / empty. Shared between :class:`WaitClause` and the
+    :class:`KernelEnvironmentClauses` oilist.
     """
     if not parser.parse_optional_punctuation("("):
         return (
@@ -959,6 +972,118 @@ class WaitClause(CustomDirective):
             self.segments.get(op),
             self.has_devnum.get(op),
         )
+
+
+@irdl_custom_directive
+class KernelEnvironmentClauses(CustomDirective):
+    """Port of upstream `acc.kernel_environment`'s `oilist(...)`.
+
+    Accepts the three optional clauses `dataOperands` / `async` / `wait` in
+    any order on parse; emits them in upstream's td-definition order on
+    print (data, async, wait). Each clause may appear at most once. The
+    body parsers/printers for `async` and `wait` are shared with
+    :class:`DeviceTypeOperandsWithKeywordOnly` and :class:`WaitClause` via
+    the `_parse/_print_dt_kw_only_body` and `_parse/_print_wait_body`
+    helpers, so the spelling is bit-identical.
+    """
+
+    data_clause_operands: VariadicOperandVariable
+    data_clause_operand_types: TypeDirective
+    async_operands: VariadicOperandVariable
+    async_operand_types: TypeDirective
+    async_device_types: AttributeVariable
+    async_only: AttributeVariable
+    wait_operands: VariadicOperandVariable
+    wait_operand_types: TypeDirective
+    wait_device_types: AttributeVariable
+    wait_segments: AttributeVariable
+    wait_has_devnum: AttributeVariable
+    wait_only: AttributeVariable
+
+    def is_optional_like(self) -> bool:
+        return True
+
+    def set_empty(self, state: ParsingState) -> None:
+        self.data_clause_operands.set(state, ())
+        self.data_clause_operand_types.set(state, ())
+        self.async_operands.set(state, ())
+        self.async_operand_types.set(state, ())
+        self.wait_operands.set(state, ())
+        self.wait_operand_types.set(state, ())
+
+    _CLAUSE_KEYWORDS = ("dataOperands", "async", "wait")
+
+    def parse(self, parser: Parser, state: ParsingState) -> bool:
+        self.set_empty(state)
+        seen: set[str] = set()
+        while (
+            kw := parser.parse_optional_keyword_in(self._CLAUSE_KEYWORDS)
+        ) is not None:
+            if kw in seen:
+                parser.raise_error(f"'{kw}' clause specified twice")
+            seen.add(kw)
+            if kw == "dataOperands":
+                with parser.in_parens():
+                    pairs = parser.parse_comma_separated_list(
+                        parser.Delimiter.NONE, lambda: _parse_typed_operand(parser)
+                    )
+                operands, types = zip(*pairs)
+                self.data_clause_operands.set(state, operands)
+                self.data_clause_operand_types.set(state, types)
+            elif kw == "async":
+                ops, types, dts, kw_only = _parse_dt_kw_only_body(parser)
+                self.async_operands.set(state, ops)
+                self.async_operand_types.set(state, types)
+                if dts is not None:
+                    self.async_device_types.set(state, dts)
+                if kw_only is not None:
+                    self.async_only.set(state, kw_only)
+            else:  # wait
+                ops, types, dts, segs, devnum, kw_only = _parse_wait_body(parser)
+                self.wait_operands.set(state, ops)
+                self.wait_operand_types.set(state, types)
+                if dts is not None:
+                    self.wait_device_types.set(state, dts)
+                if segs is not None:
+                    self.wait_segments.set(state, segs)
+                if devnum is not None:
+                    self.wait_has_devnum.set(state, devnum)
+                if kw_only is not None:
+                    self.wait_only.set(state, kw_only)
+        return True
+
+    def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
+        if data_operands := self.data_clause_operands.get(op):
+            _emit_clause_keyword(printer, state, "dataOperands")
+            printer.print_string("(")
+            printer.print_list(
+                data_operands, lambda v: _print_typed_operand(printer, v)
+            )
+            printer.print_string(")")
+
+        async_operands = self.async_operands.get(op)
+        async_only = self.async_only.get(op)
+        async_device_types = self.async_device_types.get(op)
+        if async_operands or async_only is not None or async_device_types is not None:
+            _emit_clause_keyword(printer, state, "async")
+            _print_dt_kw_only_body(
+                printer, state, async_operands, async_only, async_device_types
+            )
+
+        wait_operands = self.wait_operands.get(op)
+        wait_only = self.wait_only.get(op)
+        wait_device_types = self.wait_device_types.get(op)
+        if wait_operands or wait_only is not None or wait_device_types is not None:
+            _emit_clause_keyword(printer, state, "wait")
+            _print_wait_body(
+                printer,
+                state,
+                wait_operands,
+                wait_only,
+                wait_device_types,
+                self.wait_segments.get(op),
+                self.wait_has_devnum.get(op),
+            )
 
 
 @irdl_custom_directive
@@ -2420,6 +2545,93 @@ class KernelsOp(IRDLOperation):
                 "selfAttr": self_attr_prop,
                 "defaultAttr": default_prop,
                 "combined": combined_prop,
+            },
+            regions=[region],
+        )
+
+
+@irdl_op_definition
+class KernelEnvironmentOp(IRDLOperation):
+    """
+    Implementation of upstream acc.kernel_environment — a decomposition of an
+    OpenACC compute construct that captures only the data-mapping and
+    asynchronous-behavior clauses (data / async / wait), leaving kernel
+    execution parallelism and privatization to be handled separately. The
+    body is a single block with no terminator and typically wraps a
+    `gpu.launch`.
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/OpenACCDialect/#acckernel_environment-acckernelenvironmentop).
+    """
+
+    name = "acc.kernel_environment"
+
+    data_clause_operands = var_operand_def()
+    async_operands = var_operand_def(IntegerType | IndexType)
+    wait_operands = var_operand_def(IntegerType | IndexType)
+
+    async_operands_device_type = opt_prop_def(
+        ArrayAttr[DeviceTypeAttr], prop_name="asyncOperandsDeviceType"
+    )
+    async_only = opt_prop_def(ArrayAttr[DeviceTypeAttr], prop_name="asyncOnly")
+    wait_operands_segments = opt_prop_def(
+        DenseArrayBase.constr(IntegerType(32)), prop_name="waitOperandsSegments"
+    )
+    wait_operands_device_type = opt_prop_def(
+        ArrayAttr[DeviceTypeAttr], prop_name="waitOperandsDeviceType"
+    )
+    has_wait_devnum = opt_prop_def(ArrayAttr[BoolAttr], prop_name="hasWaitDevnum")
+    wait_only = opt_prop_def(ArrayAttr[DeviceTypeAttr], prop_name="waitOnly")
+
+    region = region_def("single_block")
+
+    irdl_options = (
+        AttrSizedOperandSegments(as_property=True),
+        ParsePropInAttrDict(),
+    )
+
+    custom_directives = (KernelEnvironmentClauses,)
+
+    # Port of upstream's `oilist(dataOperands | async | wait)`: the three
+    # clause keywords are order-independent on parse, and the directive
+    # always emits in upstream td-definition order (data, async, wait) on
+    # print so the round-trip is bit-identical with mlir-opt.
+    assembly_format = (
+        "custom<KernelEnvironmentClauses>($data_clause_operands,"
+        " type($data_clause_operands), $async_operands, type($async_operands),"
+        " $asyncOperandsDeviceType, $asyncOnly, $wait_operands,"
+        " type($wait_operands), $waitOperandsDeviceType, $waitOperandsSegments,"
+        " $hasWaitDevnum, $waitOnly)"
+        " $region attr-dict-with-keyword"
+    )
+
+    traits = traits_def(NoTerminator(), RecursiveMemoryEffect())
+
+    def __init__(
+        self,
+        *,
+        region: Region,
+        data_clause_operands: Sequence[SSAValue | Operation] = (),
+        async_operands: Sequence[SSAValue | Operation] = (),
+        wait_operands: Sequence[SSAValue | Operation] = (),
+        async_operands_device_type: ArrayAttr[DeviceTypeAttr] | None = None,
+        async_only: ArrayAttr[DeviceTypeAttr] | None = None,
+        wait_operands_segments: DenseArrayBase | None = None,
+        wait_operands_device_type: ArrayAttr[DeviceTypeAttr] | None = None,
+        has_wait_devnum: ArrayAttr[BoolAttr] | None = None,
+        wait_only: ArrayAttr[DeviceTypeAttr] | None = None,
+    ) -> None:
+        super().__init__(
+            operands=[
+                data_clause_operands,
+                async_operands,
+                wait_operands,
+            ],
+            properties={
+                "asyncOperandsDeviceType": async_operands_device_type,
+                "asyncOnly": async_only,
+                "waitOperandsSegments": wait_operands_segments,
+                "waitOperandsDeviceType": wait_operands_device_type,
+                "hasWaitDevnum": has_wait_devnum,
+                "waitOnly": wait_only,
             },
             regions=[region],
         )
@@ -5029,6 +5241,7 @@ ACC = Dialect(
         ParallelOp,
         SerialOp,
         KernelsOp,
+        KernelEnvironmentOp,
         LoopOp,
         DataOp,
         HostDataOp,

--- a/xdsl/dialects/acc.py
+++ b/xdsl/dialects/acc.py
@@ -453,7 +453,7 @@ def _emit_clause_keyword(
 ) -> None:
     """Print whitespace + a clause keyword and update print state so the
     body's first character (typically ``(``) lands adjacent (e.g.
-    ``async(``). Shared between every oilist-style clause printer."""
+    ``async(``). Used by the three clauses of `KernelEnvironmentClauses`."""
     state.print_whitespace(printer)
     printer.print_string(keyword)
     state.should_emit_space = True


### PR DESCRIPTION
This PR adds the OpenACC kernel environment operation, its a single operation but follows custom assembly format which adds extra code handling that (but I think all fairly straightforward and all driven by this operation, so we need it in place for testing to make sense).