### PR TITLE
testing: (llvm) fix mlir-translate interop tests

### DIFF
--- a/tests/filecheck/mlir-conversion/with-mlir/backend/llvm/convert_op.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/backend/llvm/convert_op.mlir
@@ -1,1 +1,2 @@
-// RUN: xdsl-opt %S/../../../../backend/llvm/convert_op.mlir | mlir-opt --allow-unregistered-dialect > /dev/null
+// XFAIL: *
+// RUN: xdsl-opt %S/../../../../backend/llvm/convert_op.mlir | mlir-translate --mlir-to-llvmir > /dev/null

--- a/tests/filecheck/mlir-conversion/with-mlir/backend/llvm/convert_op.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/backend/llvm/convert_op.mlir
@@ -1,2 +1,1 @@
-// XFAIL: *
 // RUN: xdsl-opt %S/../../../../backend/llvm/convert_op.mlir | mlir-translate --mlir-to-llvmir > /dev/null

--- a/tests/filecheck/mlir-conversion/with-mlir/backend/llvm/module.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/backend/llvm/module.mlir
@@ -1,0 +1,1 @@
+// RUN: xdsl-opt %S/../../../../backend/llvm/module.mlir | mlir-translate --mlir-to-llvmir > /dev/null

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/func.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/func.mlir
@@ -1,6 +1,7 @@
 // RUN: MLIR_ROUNDTRIP
 // RUN: MLIR_GENERIC_ROUNDTRIP
 // RUN: xdsl-opt %s --print-debuginfo | mlir-opt --allow-unregistered-dialect --mlir-print-local-scope | xdsl-opt --print-debuginfo | filecheck %s --check-prefix=CHECK-DEBUG-INFO
+// RUN: xdsl-opt %s | mlir-translate --mlir-to-llvmir > /dev/null
 
 // This test checks that the llvm.func operation can be parse the following
 // properties.

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/func_props.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/func_props.mlir
@@ -2,6 +2,7 @@
 // RUN: MLIR_ROUNDTRIP
 // RUN: XDSL_GENERIC_ROUNDTRIP
 // RUN: MLIR_GENERIC_ROUNDTRIP
+// RUN: xdsl-opt %s | mlir-translate --mlir-to-llvmir > /dev/null
 
 llvm.func @func_vis0_unnameaddr0()
 

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/global.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/global.mlir
@@ -1,5 +1,6 @@
 // RUN: MLIR_ROUNDTRIP
 // RUN: MLIR_GENERIC_ROUNDTRIP
+// RUN: xdsl-opt %s | mlir-translate --mlir-to-llvmir > /dev/null
 builtin.module {
   llvm.mlir.global internal constant @str0("Hello world!") {addr_space = 0 : i32} : !llvm.array<12 x i8>
   llvm.mlir.global internal constant @data(0 : i32) {addr_space = 0 : i32} : i32


### PR DESCRIPTION
Addresses [superlopuh's review comment](https://github.com/xdslproject/xdsl/pull/5876#pullrequestreview-2918453353) on #5876. Part of #6009.

Fixes the interop test RUN line (`mlir-opt` -> `mlir-translate --mlir-to-llvmir`).

Adds `mlir-translate` interop tests for `module.mlir`, `func.mlir`, `global.mlir`, `func_props.mlir`.

```bash
uv run xdsl-opt tests/filecheck/backend/llvm/module.mlir | mlir-translate --mlir-to-llvmir > /dev/null
uv run xdsl-opt tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/func.mlir | mlir-translate --mlir-to-llvmir > /dev/null
uv run xdsl-opt tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/global.mlir | mlir-translate --mlir-to-llvmir > /dev/null
uv run xdsl-opt tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/func_props.mlir | mlir-translate --mlir-to-llvmir > /dev/null
```