### PR TITLE
dialects: (acc) Atomic read and write operations

### DIFF
--- a/tests/dialects/test_acc.py
+++ b/tests/dialects/test_acc.py
@@ -1085,3 +1085,29 @@ def test_global_ctor_dtor_builder_shortcuts():
         region=Region(Block([acc.TerminatorOp()])),
     )
     assert dtor.sym_name == StringAttr("acc_destructor")
+
+
+def test_atomic_read_write_builders():
+    """The `AtomicReadOp` / `AtomicWriteOp` Python builders are exercised
+    here — the filecheck round-trip path constructs via the IRDL generic
+    constructor and never runs `__init__`, so the builder bodies are only
+    reachable from Python."""
+    x = create_ssa_value(MemRefType(i32, ()))
+    v = create_ssa_value(MemRefType(i32, ()))
+    expr = create_ssa_value(i32)
+    cond = create_ssa_value(i1)
+    acc.AtomicReadOp(x=x, v=v, element_type=i32).verify()
+    acc.AtomicReadOp(x=x, v=v, element_type=i32, if_cond=cond).verify()
+    acc.AtomicWriteOp(x=x, expr=expr).verify()
+    acc.AtomicWriteOp(x=x, expr=expr, if_cond=cond).verify()
+
+
+def test_atomic_write_skips_check_for_non_memref():
+    """`AtomicWriteOp.verify_` only checks the pointee-type match when `x`
+    is a `MemRefType` — for other types the check is skipped, mirroring
+    upstream's null-element-type guard. xDSL's `acc` dialect doesn't yet
+    model non-memref pointer-likes, so this branch isn't reachable from
+    filecheck."""
+    x = create_ssa_value(i32)
+    expr = create_ssa_value(i32)
+    acc.AtomicWriteOp(x=x, expr=expr).verify()

--- a/tests/filecheck/dialects/acc/ops.mlir
+++ b/tests/filecheck/dialects/acc/ops.mlir
@@ -2355,4 +2355,50 @@ builtin.module {
   // CHECK-LABEL: acc.global_dtor @acc_dtor_generic {
   // CHECK-NEXT:    acc.terminator
   // CHECK-NEXT:  }
+
+  // acc.atomic.read — two pointer-like operands plus an optional `if(%cond)`
+  // clause shared with the rest of the atomic family. The pretty form is
+  // `dest = source`; the value-type spelling `: type(v), type(x), element_type`
+  // tails the operand list and the `element_type` TypeAttr is round-tripped
+  // as a bare type.
+  func.func @acc_atomic_read(%v: memref<i32>, %x: memref<i32>) {
+    acc.atomic.read %v = %x : memref<i32>, memref<i32>, i32
+    %c = arith.constant true
+    acc.atomic.read if(%c) %v = %x : memref<i32>, memref<i32>, i32
+    func.return
+  }
+  // CHECK-LABEL: func.func @acc_atomic_read(
+  // CHECK:         acc.atomic.read %{{.*}} = %{{.*}} : memref<i32>, memref<i32>, i32
+  // CHECK-NEXT:    %{{.*}} = arith.constant true
+  // CHECK-NEXT:    acc.atomic.read if(%{{.*}}) %{{.*}} = %{{.*}} : memref<i32>, memref<i32>, i32
+
+  // acc.atomic.write — same shape as read but the right-hand-side is an
+  // arbitrary-typed value rather than a pointer; pretty form is `addr = expr`.
+  func.func @acc_atomic_write(%x: memref<i32>, %expr: i32) {
+    acc.atomic.write %x = %expr : memref<i32>, i32
+    %c = arith.constant true
+    acc.atomic.write if(%c) %x = %expr : memref<i32>, i32
+    func.return
+  }
+  // CHECK-LABEL: func.func @acc_atomic_write(
+  // CHECK:         acc.atomic.write %{{.*}} = %{{.*}} : memref<i32>, i32
+  // CHECK-NEXT:    %{{.*}} = arith.constant true
+  // CHECK-NEXT:    acc.atomic.write if(%{{.*}}) %{{.*}} = %{{.*}} : memref<i32>, i32
+
+  // Generic-form roundtrip insurance — covers the parser path that bypasses
+  // the AtomicIfClause custom directive. Note the operand order in the
+  // generic form is `(x, v[, if_cond])` for read and `(x, expr[, if_cond])`
+  // for write, matching the upstream td-definition order of the operands.
+  func.func @acc_atomic_generic(%v: memref<i32>, %x: memref<i32>, %expr: i32, %c: i1) {
+    "acc.atomic.read"(%x, %v) <{element_type = i32}> : (memref<i32>, memref<i32>) -> ()
+    "acc.atomic.read"(%x, %v, %c) <{element_type = i32}> : (memref<i32>, memref<i32>, i1) -> ()
+    "acc.atomic.write"(%x, %expr) : (memref<i32>, i32) -> ()
+    "acc.atomic.write"(%x, %expr, %c) : (memref<i32>, i32, i1) -> ()
+    func.return
+  }
+  // CHECK-LABEL: func.func @acc_atomic_generic(
+  // CHECK:         acc.atomic.read %{{.*}} = %{{.*}} : memref<i32>, memref<i32>, i32
+  // CHECK-NEXT:    acc.atomic.read if(%{{.*}}) %{{.*}} = %{{.*}} : memref<i32>, memref<i32>, i32
+  // CHECK-NEXT:    acc.atomic.write %{{.*}} = %{{.*}} : memref<i32>, i32
+  // CHECK-NEXT:    acc.atomic.write if(%{{.*}}) %{{.*}} = %{{.*}} : memref<i32>, i32
 }

--- a/tests/filecheck/dialects/acc/ops_invalid.mlir
+++ b/tests/filecheck/dialects/acc/ops_invalid.mlir
@@ -972,3 +972,23 @@ func.func @ke_duplicate_async() {
   func.return
 }
 // CHECK: 'async' clause specified twice
+
+// -----
+
+// acc.atomic.read forbids reading and writing to the same location — the
+// source `x` and destination `v` operands must be distinct SSA values.
+func.func @atomic_read_same(%x : memref<i32>) {
+  acc.atomic.read %x = %x : memref<i32>, memref<i32>, i32
+  func.return
+}
+// CHECK: read and write must not be to the same location for atomic reads
+
+// -----
+
+// acc.atomic.write checks that the pointer operand `x` dereferences to the
+// value operand `expr`'s type — a nested memref<memref<...>> won't.
+func.func @atomic_write_bad_type(%addr : memref<memref<i32>>, %val : i32) {
+  acc.atomic.write %addr = %val : memref<memref<i32>>, i32
+  func.return
+}
+// CHECK: address must dereference to value type

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/ops.mlir
@@ -1632,4 +1632,46 @@ builtin.module {
   // CHECK-NEXT:    acc.terminator
   // CHECK-NEXT:  }
 
+  // acc.atomic.read / acc.atomic.write — leaf atomic ops with the shared
+  // `if(%cond)` optional clause (oilist). The pretty form must round-trip
+  // bit-identically through mlir-opt, including the implicit `i1` typing
+  // of the if-cond operand.
+  func.func @acc_atomic_read(%v: memref<i32>, %x: memref<i32>) {
+    acc.atomic.read %v = %x : memref<i32>, memref<i32>, i32
+    %c = arith.constant true
+    acc.atomic.read if(%c) %v = %x : memref<i32>, memref<i32>, i32
+    func.return
+  }
+  // CHECK:       func.func @acc_atomic_read(
+  // CHECK:         acc.atomic.read %{{.*}} = %{{.*}} : memref<i32>, memref<i32>, i32
+  // CHECK-NEXT:    %{{.*}} = arith.constant true
+  // CHECK-NEXT:    acc.atomic.read if(%{{.*}}) %{{.*}} = %{{.*}} : memref<i32>, memref<i32>, i32
+
+  func.func @acc_atomic_write(%x: memref<i32>, %expr: i32) {
+    acc.atomic.write %x = %expr : memref<i32>, i32
+    %c = arith.constant true
+    acc.atomic.write if(%c) %x = %expr : memref<i32>, i32
+    func.return
+  }
+  // CHECK:       func.func @acc_atomic_write(
+  // CHECK:         acc.atomic.write %{{.*}} = %{{.*}} : memref<i32>, i32
+  // CHECK-NEXT:    %{{.*}} = arith.constant true
+  // CHECK-NEXT:    acc.atomic.write if(%{{.*}}) %{{.*}} = %{{.*}} : memref<i32>, i32
+
+  // Generic-form input — proves a hand-written generic spelling survives the
+  // xdsl ↔ mlir-opt round-trip in both directions. Operand order in generic
+  // form is `(x, v[, if_cond])` for read and `(x, expr[, if_cond])` for write.
+  func.func @acc_atomic_generic(%v: memref<i32>, %x: memref<i32>, %expr: i32, %c: i1) {
+    "acc.atomic.read"(%x, %v) <{element_type = i32}> : (memref<i32>, memref<i32>) -> ()
+    "acc.atomic.read"(%x, %v, %c) <{element_type = i32}> : (memref<i32>, memref<i32>, i1) -> ()
+    "acc.atomic.write"(%x, %expr) : (memref<i32>, i32) -> ()
+    "acc.atomic.write"(%x, %expr, %c) : (memref<i32>, i32, i1) -> ()
+    func.return
+  }
+  // CHECK:       func.func @acc_atomic_generic(
+  // CHECK:         acc.atomic.read %{{.*}} = %{{.*}} : memref<i32>, memref<i32>, i32
+  // CHECK-NEXT:    acc.atomic.read if(%{{.*}}) %{{.*}} = %{{.*}} : memref<i32>, memref<i32>, i32
+  // CHECK-NEXT:    acc.atomic.write %{{.*}} = %{{.*}} : memref<i32>, i32
+  // CHECK-NEXT:    acc.atomic.write if(%{{.*}}) %{{.*}} = %{{.*}} : memref<i32>, i32
+
 }

--- a/xdsl/dialects/acc.py
+++ b/xdsl/dialects/acc.py
@@ -28,6 +28,7 @@ from xdsl.dialects.builtin import (
     SymbolNameConstraint,
     SymbolRefAttr,
     UnitAttr,
+    i1,
     i32,
 )
 from xdsl.dialects.utils import AbstractYieldOperation, BitEnumAttribute
@@ -1186,6 +1187,49 @@ class OperandsWithKeywordOnly(CustomDirective):
         printer.print_list(
             (operand.type for operand in operands), printer.print_attribute
         )
+        printer.print_string(")")
+        state.should_emit_space = True
+        state.last_was_punctuation = False
+
+
+@irdl_custom_directive
+class AtomicIfClause(CustomDirective):
+    """Port of the `acc.atomic.*` family's `oilist( \\`if\\` \\`(\\` $ifCond \\`)\\` )`.
+
+    Single-clause oilist shared by `acc.atomic.read` / `acc.atomic.write` /
+    `acc.atomic.update` / `acc.atomic.capture`. When absent on parse, no
+    operand is set; when present, parses `if(%cond)` and types the operand
+    as `i1` implicitly (upstream `Optional<I1>:$ifCond`).
+    """
+
+    if_cond: OptionalOperandVariable
+    if_cond_type: TypeDirective
+
+    def is_optional_like(self) -> bool:
+        return True
+
+    def set_empty(self, state: ParsingState) -> None:
+        self.if_cond.set(state, None)
+        self.if_cond_type.set(state, ())
+
+    def parse(self, parser: Parser, state: ParsingState) -> bool:
+        self.set_empty(state)
+        if parser.parse_optional_keyword("if") is None:
+            return True
+        parser.parse_punctuation("(")
+        operand = parser.parse_unresolved_operand()
+        parser.parse_punctuation(")")
+        self.if_cond.set(state, operand)
+        self.if_cond_type.set(state, (i1,))
+        return True
+
+    def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
+        if_cond = self.if_cond.get(op)
+        if if_cond is None:
+            return
+        state.print_whitespace(printer)
+        printer.print_string("if(")
+        printer.print_ssa_value(if_cond)
         printer.print_string(")")
         state.should_emit_space = True
         state.last_was_punctuation = False
@@ -4228,6 +4272,108 @@ class UpdateOp(IRDLOperation):
 
 
 # ---------------------------------------------------------------------------
+# Atomic family
+# ---------------------------------------------------------------------------
+#
+# `acc.atomic.read` and `acc.atomic.write` are the leaf atomic ops. Each has
+# two pointer-like operands plus an optional `if(%cond)` clause shared with
+# the rest of the family via the `AtomicIfClause` custom directive.
+# `acc.atomic.update` and `acc.atomic.capture` follow in subsequent PRs.
+
+
+@irdl_op_definition
+class AtomicReadOp(IRDLOperation):
+    """
+    Implementation of upstream acc.atomic.read — performs an atomic read.
+
+    The operand `x` is the address from where the value is atomically read.
+    The operand `v` is the address where the value is stored after reading.
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/OpenACCDialect/#accatomicread-accatomicreadop).
+    """
+
+    name = "acc.atomic.read"
+
+    x = operand_def()
+    v = operand_def()
+    if_cond = opt_operand_def(I1)
+
+    element_type = prop_def(TypeAttribute)
+
+    irdl_options = (ParsePropInAttrDict(),)
+
+    custom_directives = (AtomicIfClause,)
+
+    assembly_format = (
+        "custom<AtomicIfClause>($if_cond, type($if_cond))"
+        " $v `=` $x `:` type($v) `,` type($x) `,` $element_type attr-dict"
+    )
+
+    def __init__(
+        self,
+        *,
+        x: SSAValue | Operation,
+        v: SSAValue | Operation,
+        element_type: TypeAttribute,
+        if_cond: SSAValue | Operation | None = None,
+    ) -> None:
+        super().__init__(
+            operands=[x, v, if_cond],
+            properties={"element_type": element_type},
+        )
+
+    def verify_(self) -> None:
+        # Mirrors upstream `AtomicReadOpInterface::verifyCommon`.
+        if self.x is self.v:
+            raise VerifyException(
+                "read and write must not be to the same location for atomic reads"
+            )
+
+
+@irdl_op_definition
+class AtomicWriteOp(IRDLOperation):
+    """
+    Implementation of upstream acc.atomic.write — performs an atomic write.
+
+    The operand `x` is the address to where `expr` is atomically written.
+    In general the type of `x` must dereference to the type of `expr`.
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/OpenACCDialect/#accatomicwrite-accatomicwriteop).
+    """
+
+    name = "acc.atomic.write"
+
+    x = operand_def()
+    expr = operand_def()
+    if_cond = opt_operand_def(I1)
+
+    custom_directives = (AtomicIfClause,)
+
+    assembly_format = (
+        "custom<AtomicIfClause>($if_cond, type($if_cond))"
+        " $x `=` $expr `:` type($x) `,` type($expr) attr-dict"
+    )
+
+    def __init__(
+        self,
+        *,
+        x: SSAValue | Operation,
+        expr: SSAValue | Operation,
+        if_cond: SSAValue | Operation | None = None,
+    ) -> None:
+        super().__init__(operands=[x, expr, if_cond])
+
+    def verify_(self) -> None:
+        # Mirrors upstream `AtomicWriteOpInterface::verifyCommon`: the
+        # pointee type of `x` (currently restricted to `MemRefType`) must
+        # match `expr`'s type. Non-memref pointer-likes are not yet
+        # modelled in xDSL's `acc` dialect; when they land, extend the
+        # element-type lookup accordingly.
+        x_type = self.x.type
+        if isa(x_type, MemRefType):
+            if x_type.element_type != self.expr.type:
+                raise VerifyException("address must dereference to value type")
+
+
+# ---------------------------------------------------------------------------
 # Declare family
 # ---------------------------------------------------------------------------
 #
@@ -5271,6 +5417,8 @@ ACC = Dialect(
         EnterDataOp,
         ExitDataOp,
         UpdateOp,
+        AtomicReadOp,
+        AtomicWriteOp,
         DeclareEnterOp,
         DeclareExitOp,
         DeclareOp,


### PR DESCRIPTION
This PR adds OpenACC atomic read and write operations, both of which are similar and leverage the AtomicIfClause as custom assembly format. There will be a couple more PRs for atomic operations that follow here, all building on this and leverage this same custom assembly format added in this PR.
