### PR TITLE
core: print deprecation warnings from xdsl-opt

### DIFF
--- a/tests/filecheck/xdsl_opt/deprecation_warning.mlir
+++ b/tests/filecheck/xdsl_opt/deprecation_warning.mlir
@@ -1,0 +1,5 @@
+// RUN: xdsl-opt -p test-deprecation %s 2>&1 | filecheck %s
+
+module {}
+
+// CHECK: DeprecationWarning: hello

--- a/xdsl/tools/xdsl_opt.py
+++ b/xdsl/tools/xdsl_opt.py
@@ -1,7 +1,12 @@
+import warnings
+
 from xdsl.xdsl_opt_main import xDSLOptMain
 
 
 def main():
+    # Python ignores DeprecationWarnings and some others by default:
+    # https://docs.python.org/3/library/warnings.html#default-warning-filter
+    warnings.filterwarnings("default", category=DeprecationWarning)
     xDSLOptMain().run()
 
 

--- a/xdsl/transforms/__init__.py
+++ b/xdsl/transforms/__init__.py
@@ -610,6 +610,11 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
 
         return test_lower_linalg_to_snitch.TestLowerLinalgToSnitchPass
 
+    def get_test_deprecation():
+        from xdsl.transforms import test_deprecation
+
+        return test_deprecation.TestDeprecationPass
+
     def get_test_specialised_constant_folding():
         from xdsl.transforms import test_constant_folding
 
@@ -789,6 +794,7 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
         "stencil-unroll": get_stencil_unroll,
         "test-add-timers-to-top-level-funcs": get_test_add_timers_to_top_level_funcs,
         "test-constant-folding": get_test_constant_folding,
+        "test-deprecation": get_test_deprecation,
         "test-lower-linalg-to-snitch": get_test_lower_linalg_to_snitch,
         "test-specialised-constant-folding": get_test_specialised_constant_folding,
         "test-transform-dialect-erase-schedule": get_test_transform_dialect_erase_schedule,

--- a/xdsl/transforms/__init__.py
+++ b/xdsl/transforms/__init__.py
@@ -613,7 +613,7 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
     def get_test_deprecation():
         from xdsl.transforms import test_deprecation
 
-        return test_deprecation.TestDeprecationPass
+        return test_deprecation.TestDeprecationPass  # pyright: ignore[reportDeprecated]
 
     def get_test_specialised_constant_folding():
         from xdsl.transforms import test_constant_folding

--- a/xdsl/transforms/test_deprecation.py
+++ b/xdsl/transforms/test_deprecation.py
@@ -1,0 +1,16 @@
+import warnings
+
+from xdsl.context import Context
+from xdsl.dialects import builtin
+from xdsl.passes import ModulePass
+
+
+class TestDeprecationPass(ModulePass):
+    """
+    Test pass that does nothing and raises a DeprecationWarning.
+    """
+
+    name = "test-deprecation"
+
+    def apply(self, ctx: Context, op: builtin.ModuleOp) -> None:
+        warnings.warn("hello", DeprecationWarning)

--- a/xdsl/transforms/test_deprecation.py
+++ b/xdsl/transforms/test_deprecation.py
@@ -1,10 +1,11 @@
-import warnings
+from typing_extensions import deprecated
 
 from xdsl.context import Context
 from xdsl.dialects import builtin
 from xdsl.passes import ModulePass
 
 
+@deprecated("hello")
 class TestDeprecationPass(ModulePass):
     """
     Test pass that does nothing and raises a DeprecationWarning.
@@ -12,5 +13,4 @@ class TestDeprecationPass(ModulePass):
 
     name = "test-deprecation"
 
-    def apply(self, ctx: Context, op: builtin.ModuleOp) -> None:
-        warnings.warn("hello", DeprecationWarning)
+    def apply(self, ctx: Context, op: builtin.ModuleOp) -> None: ...

--- a/xdsl/xdsl_opt_main.py
+++ b/xdsl/xdsl_opt_main.py
@@ -2,7 +2,6 @@ import argparse
 import dataclasses
 import inspect
 import sys
-import warnings
 from collections.abc import Callable, Sequence
 from importlib.metadata import version
 from io import StringIO
@@ -90,9 +89,6 @@ class xDSLOptMain(CommandLineTool):
         """
         Executes the different steps.
         """
-        # Python ignores DeprecationWarnings and some others by default:
-        # https://docs.python.org/3/library/warnings.html#default-warning-filter
-        warnings.filterwarnings("default", category=DeprecationWarning)
         chunks, file_extension = self.prepare_input()
         output_stream = self.prepare_output()
         try:

--- a/xdsl/xdsl_opt_main.py
+++ b/xdsl/xdsl_opt_main.py
@@ -2,6 +2,7 @@ import argparse
 import dataclasses
 import inspect
 import sys
+import warnings
 from collections.abc import Callable, Sequence
 from importlib.metadata import version
 from io import StringIO
@@ -89,6 +90,7 @@ class xDSLOptMain(CommandLineTool):
         """
         Executes the different steps.
         """
+        warnings.filterwarnings("default", category=DeprecationWarning)
         chunks, file_extension = self.prepare_input()
         output_stream = self.prepare_output()
         try:

--- a/xdsl/xdsl_opt_main.py
+++ b/xdsl/xdsl_opt_main.py
@@ -90,6 +90,8 @@ class xDSLOptMain(CommandLineTool):
         """
         Executes the different steps.
         """
+        # Python ignores DeprecationWarnings and some others by default:
+        # https://docs.python.org/3/library/warnings.html#default-warning-filter
         warnings.filterwarnings("default", category=DeprecationWarning)
         chunks, file_extension = self.prepare_input()
         output_stream = self.prepare_output()


### PR DESCRIPTION
Turns out they're not actually printed by default if they're raised from a file other than `__main__`, I think we want to always have them on in xdsl-opt.