### PR TITLE
core: (Constraints) restrict ParamAttrConstraint merging

### DIFF
--- a/tests/irdl/test_attr_constraint.py
+++ b/tests/irdl/test_attr_constraint.py
@@ -285,6 +285,15 @@ def test_constraint_simplification(lhs: AttrConstraint, rhs: AttrConstraint):
     assert lhs == rhs
 
 
+def test_param_attr_merge_failure():
+    # ParamAttrConstraints as below cannot be merged into a single constraint
+    # Therefore the 'any_of' fails
+    with pytest.raises(PyRDLError):
+        _ = ParamAttrConstraint(
+            AttrB, (BaseAttr(AttrA), BaseAttr(AttrA))
+        ) | ParamAttrConstraint(AttrB, (BaseAttr(AttrC), BaseAttr(AttrC)))
+
+
 @pytest.mark.parametrize(
     "c1, c2, msg",
     [

--- a/xdsl/irdl/constraints.py
+++ b/xdsl/irdl/constraints.py
@@ -706,6 +706,7 @@ class ParamAttrConstraint(
         if (
             not isinstance(value, ParamAttrConstraint)
             or self.base_attr is not cast(ParamAttrConstraint[Any], value).base_attr
+            or len(self.param_constrs) > 1
         ):
             return super().__or__(value)  # pyright: ignore[reportUnknownArgumentType]
         return ParamAttrConstraint(


### PR DESCRIPTION
Found a bug while looking at constraint simplification. Seems we were allowing merges that were too permissive.