### PR TITLE
core: (Constraints) remove deprecated ConstraintVar

### DIFF
--- a/tests/irdl/test_operation_definition.py
+++ b/tests/irdl/test_operation_definition.py
@@ -27,7 +27,6 @@ from xdsl.irdl import (
     AttrSizedRegionSegments,
     AttrSizedResultSegments,
     BaseAttr,
-    ConstraintVar,
     EqAttrConstraint,
     IntVarConstraint,
     IRDLOperation,
@@ -192,90 +191,6 @@ def test_attr_verify():
     op = AttrOp.create(attributes={"attr": IntAttr(1)})
     with pytest.raises(
         VerifyException, match="#builtin.int<1> should be of base attribute string"
-    ):
-        op.verify()
-
-
-with pytest.deprecated_call():
-    # TODO: remove this test once the Annotated API is deprecated
-    @irdl_op_definition
-    class ConstraintVarOp(IRDLOperation):
-        name = "test.constraint_var_op"
-
-        T = Annotated[IntegerType | IndexType, ConstraintVar("T")]
-
-        operand = operand_def(T)
-        result = result_def(T)
-        attribute = attr_def(T)
-
-
-def test_constraint_var():
-    i32_operand = create_ssa_value(i32)
-    index_operand = create_ssa_value(IndexType())
-    op = ConstraintVarOp.create(
-        operands=[i32_operand], result_types=[i32], attributes={"attribute": i32}
-    )
-    op.verify()
-
-    op2 = ConstraintVarOp.create(
-        operands=[index_operand],
-        result_types=[IndexType()],
-        attributes={"attribute": IndexType()},
-    )
-    op2.verify()
-
-
-def test_constraint_var_fail_non_equal():
-    """Check that all uses of a constraint variable are of the same attribute."""
-    i32_operand = create_ssa_value(i32)
-    index_operand = create_ssa_value(IndexType())
-
-    # Fail because of operand
-    op = ConstraintVarOp.create(
-        operands=[index_operand], result_types=[i32], attributes={"attribute": i32}
-    )
-    with pytest.raises(
-        DiagnosticException,
-        match="Operation does not verify: result 'result' at position 0 does not verify",
-    ):
-        op.verify()
-
-    # Fail because of result
-    op2 = ConstraintVarOp.create(
-        operands=[i32_operand],
-        result_types=[IndexType()],
-        attributes={"attribute": i32},
-    )
-    with pytest.raises(
-        DiagnosticException,
-        match="Operation does not verify: result 'result' at position 0 does not verify",
-    ):
-        op2.verify()
-
-    # Fail because of attribute
-    op3 = ConstraintVarOp.create(
-        operands=[i32_operand],
-        result_types=[i32],
-        attributes={"attribute": IndexType()},
-    )
-    with pytest.raises(
-        DiagnosticException,
-        match="Operation does not verify: attribute i32 expected from variable 'T', but got index",
-    ):
-        op3.verify()
-
-
-def test_constraint_var_fail_not_satisfy_constraint():
-    """Check that all uses of a constraint variable are satisfying the constraint."""
-    test_operand = create_ssa_value(TestType("foo"))
-    op = ConstraintVarOp.create(
-        operands=[test_operand],
-        result_types=[TestType("foo")],
-        attributes={"attribute": TestType("foo")},
-    )
-    with pytest.raises(
-        DiagnosticException,
-        match="Operation does not verify: operand 'operand' at position 0 does not verify",
     ):
         op.verify()
 

--- a/xdsl/irdl/attributes.py
+++ b/xdsl/irdl/attributes.py
@@ -61,7 +61,6 @@ from .constraints import (  # noqa: TID251
     AttrConstraint,
     BaseAttr,
     ConstraintContext,
-    ConstraintVar,
     EqAttrConstraint,
     EqIntConstraint,
     IntConstraint,
@@ -72,7 +71,6 @@ from .constraints import (  # noqa: TID251
     RangeOf,
     SingleOf,
     TypeVarConstraint,
-    VarConstraint,
 )
 
 _DataElement = TypeVar("_DataElement", bound=Hashable, covariant=True)
@@ -264,17 +262,6 @@ class ParamAttrDef:
                     if value.converter is not None:
                         converter = value.converter
 
-                # Constraint variables are deprecated
-                elif get_origin(value) is Annotated or any(
-                    isinstance(arg, ConstraintVar) for arg in get_args(value)
-                ):
-                    import warnings
-
-                    warnings.warn(
-                        "The use of `ConstraintVar` is deprecated, please use `VarConstraint`",
-                        DeprecationWarning,
-                        stacklevel=2,
-                    )
                 else:
                     raise PyRDLAttrDefinitionError(
                         f"{field_name} is not a parameter definition."
@@ -283,21 +270,9 @@ class ParamAttrDef:
             parameters[field_name] = ParamDef(constraint, converter)
 
         for field_name, value in field_values.items():
-            # Anything left is a field without an annotation or a constaint var.
-            if get_origin(value) is Annotated or any(
-                isinstance(arg, ConstraintVar) for arg in get_args(value)
-            ):
-                import warnings
-
-                warnings.warn(
-                    "The use of `ConstraintVar` is deprecated, please use `VarConstraint`",
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
-            else:
-                raise PyRDLAttrDefinitionError(
-                    f"Missing field type for parameter name {field_name}"
-                )
+            raise PyRDLAttrDefinitionError(
+                f"Missing field type for parameter name {field_name}"
+            )
 
         return ParamAttrDef(name, list(parameters.items()))
 
@@ -464,15 +439,6 @@ def irdl_list_to_attr_constraint(
     If there is a `ConstraintVar` annotation, we add the entire constraint to
     the constraint variable.
     """
-    # Check for a constraint varibale first
-    for idx, arg in enumerate(pyrdl_constraints):
-        if isinstance(arg, ConstraintVar):
-            constraint = irdl_list_to_attr_constraint(
-                list(pyrdl_constraints[:idx]) + list(pyrdl_constraints[idx + 1 :]),
-                allow_type_var=allow_type_var,
-            )
-            return VarConstraint(arg.name, constraint)
-
     constraints = tuple(
         irdl_to_attr_constraint(arg, allow_type_var=allow_type_var)
         for arg in pyrdl_constraints

--- a/xdsl/irdl/constraints.py
+++ b/xdsl/irdl/constraints.py
@@ -277,21 +277,6 @@ class TypeVarConstraint(AttrConstraint):
         return res
 
 
-@dataclass(frozen=True, init=True)
-class ConstraintVar:
-    """
-    Annotation used in PyRDL to define a constraint variable.
-    For instance, the following code defines a constraint variable T,
-    that can then be used in PyRDL:
-    ```python
-    T = Annotated[PyRDLConstraint, ConstraintVar("T")]
-    ```
-    """
-
-    name: str
-    """The variable name. All uses of that name refer to the same variable."""
-
-
 @dataclass(frozen=True)
 class EqAttrConstraint(AttrConstraint[AttributeCovT], Generic[AttributeCovT]):
     """Constrain an attribute to be equal to another attribute."""

--- a/xdsl/irdl/operations.py
+++ b/xdsl/irdl/operations.py
@@ -8,15 +8,12 @@ from enum import Enum
 from types import FunctionType
 from typing import (
     TYPE_CHECKING,
-    Annotated,
     Any,
     ClassVar,
     Generic,
     Literal,
     TypeAlias,
     cast,
-    get_args,
-    get_origin,
     overload,
 )
 
@@ -54,7 +51,6 @@ from .constraints import (  # noqa: TID251
     AnyAttr,
     AttrConstraint,
     ConstraintContext,
-    ConstraintVar,
     IntConstraint,
     RangeConstraint,
     RangeOf,
@@ -1055,17 +1051,6 @@ class OpDef:
                     value, FunctionType | PropertyType | classmethod | staticmethod
                 ):
                     continue
-                # Constraint variables are deprecated
-                if get_origin(value) is Annotated:
-                    if any(isinstance(arg, ConstraintVar) for arg in get_args(value)):
-                        import warnings
-
-                        warnings.warn(
-                            "The use of `ConstraintVar` is deprecated, please use `VarConstraint`",
-                            DeprecationWarning,
-                            stacklevel=2,
-                        )
-                        continue
 
                 # Get attribute constraints from a list of pyrdl constraints
                 def get_constraint(


### PR DESCRIPTION
This has been deprecated for ages I think. Side note, maybe we should include the date which we deprecated something on the warning or as a comment?