### PR TITLE
dialects: (acc) Atomic update OpenACC operation

### DIFF
--- a/tests/dialects/test_acc.py
+++ b/tests/dialects/test_acc.py
@@ -1102,6 +1102,21 @@ def test_atomic_read_write_builders():
     acc.AtomicWriteOp(x=x, expr=expr, if_cond=cond).verify()
 
 
+def test_atomic_update_builder():
+    """The `AtomicUpdateOp` Python builder — filecheck constructs via the
+    IRDL generic constructor and never runs `__init__`."""
+    x = create_ssa_value(MemRefType(i32, ()))
+    cond = create_ssa_value(i1)
+
+    def _body() -> Region:
+        block = Block(arg_types=[i32])
+        block.add_op(acc.YieldOp.create(operands=[block.args[0]]))
+        return Region(block)
+
+    acc.AtomicUpdateOp(x=x, region=_body()).verify()
+    acc.AtomicUpdateOp(x=x, region=_body(), if_cond=cond).verify()
+
+
 def test_atomic_write_skips_check_for_non_memref():
     """`AtomicWriteOp.verify_` only checks the pointee-type match when `x`
     is a `MemRefType` — for other types the check is skipped, mirroring

--- a/tests/filecheck/dialects/acc/ops.mlir
+++ b/tests/filecheck/dialects/acc/ops.mlir
@@ -2401,4 +2401,62 @@ builtin.module {
   // CHECK-NEXT:    acc.atomic.read if(%{{.*}}) %{{.*}} = %{{.*}} : memref<i32>, memref<i32>, i32
   // CHECK-NEXT:    acc.atomic.write %{{.*}} = %{{.*}} : memref<i32>, i32
   // CHECK-NEXT:    acc.atomic.write if(%{{.*}}) %{{.*}} = %{{.*}} : memref<i32>, i32
+
+  // acc.atomic.update — single-operand region op whose body takes the
+  // current value of `x` as its single block argument and yields the
+  // updated value via acc.yield. Implicit-terminator: omitting acc.yield
+  // is fine at print time but the verifier still pins the yielded type to
+  // the block argument's type.
+  func.func @acc_atomic_update(%x: memref<i32>, %expr: i32) {
+    acc.atomic.update %x : memref<i32> {
+    ^bb0(%xval: i32):
+      %newval = arith.addi %xval, %expr : i32
+      acc.yield %newval : i32
+    }
+    %c = arith.constant true
+    acc.atomic.update if(%c) %x : memref<i32> {
+    ^bb0(%xval: i32):
+      %newval = arith.addi %xval, %expr : i32
+      acc.yield %newval : i32
+    }
+    // No-op update: yielding the argument unchanged is a valid form.
+    acc.atomic.update %x : memref<i32> {
+    ^bb0(%xval: i32):
+      acc.yield %xval : i32
+    }
+    func.return
+  }
+  // CHECK-LABEL: func.func @acc_atomic_update(
+  // CHECK:         acc.atomic.update %{{.*}} : memref<i32> {
+  // CHECK-NEXT:    ^{{.*}}(%{{.*}}: i32):
+  // CHECK-NEXT:      %{{.*}} = arith.addi %{{.*}}, %{{.*}} : i32
+  // CHECK-NEXT:      acc.yield %{{.*}} : i32
+  // CHECK-NEXT:    }
+  // CHECK:         acc.atomic.update if(%{{.*}}) %{{.*}} : memref<i32> {
+  // CHECK-NEXT:    ^{{.*}}(%{{.*}}: i32):
+  // CHECK-NEXT:      %{{.*}} = arith.addi %{{.*}}, %{{.*}} : i32
+  // CHECK-NEXT:      acc.yield %{{.*}} : i32
+  // CHECK-NEXT:    }
+  // CHECK:         acc.atomic.update %{{.*}} : memref<i32> {
+  // CHECK-NEXT:    ^{{.*}}(%[[XVAL:.*]]: i32):
+  // CHECK-NEXT:      acc.yield %[[XVAL]] : i32
+  // CHECK-NEXT:    }
+
+  // Generic-form roundtrip insurance for atomic.update — covers the parser
+  // path that bypasses the AtomicIfClause custom directive.
+  func.func @acc_atomic_update_generic(%x: memref<i32>, %expr: i32, %c: i1) {
+    "acc.atomic.update"(%x) ({
+    ^bb0(%xval: i32):
+      %newval = arith.addi %xval, %expr : i32
+      "acc.yield"(%newval) : (i32) -> ()
+    }) : (memref<i32>) -> ()
+    "acc.atomic.update"(%x, %c) ({
+    ^bb0(%xval: i32):
+      "acc.yield"(%xval) : (i32) -> ()
+    }) : (memref<i32>, i1) -> ()
+    func.return
+  }
+  // CHECK-LABEL: func.func @acc_atomic_update_generic(
+  // CHECK:         acc.atomic.update %{{.*}} : memref<i32> {
+  // CHECK:         acc.atomic.update if(%{{.*}}) %{{.*}} : memref<i32> {
 }

--- a/tests/filecheck/dialects/acc/ops_invalid.mlir
+++ b/tests/filecheck/dialects/acc/ops_invalid.mlir
@@ -992,3 +992,57 @@ func.func @atomic_write_bad_type(%addr : memref<memref<i32>>, %val : i32) {
   func.return
 }
 // CHECK: address must dereference to value type
+
+// -----
+
+// acc.atomic.update's region argument type must match the pointee of `x`.
+// A memref<i32> with an f32 block argument fails the verifier.
+func.func @atomic_update_arg_type_mismatch(%x : memref<i32>, %expr : f32) {
+  acc.atomic.update %x : memref<i32> {
+  ^bb0(%xval: f32):
+    %newval = arith.addf %xval, %expr : f32
+    acc.yield %newval : f32
+  }
+  func.return
+}
+// CHECK: the type of the operand must be a pointer type whose element type is the same as that of the region argument
+
+// -----
+
+// acc.atomic.update's yield must produce exactly one value — the updated
+// scalar.
+func.func @atomic_update_multi_yield(%x : memref<i32>, %expr : i32) {
+  acc.atomic.update %x : memref<i32> {
+  ^bb0(%xval: i32):
+    %newval = arith.addi %xval, %expr : i32
+    acc.yield %newval, %expr : i32, i32
+  }
+  func.return
+}
+// CHECK: only updated value must be returned
+
+// -----
+
+// acc.atomic.update's yielded value must have the same type as the region
+// argument.
+func.func @atomic_update_yield_type_mismatch(%x : memref<i32>, %y : f32) {
+  acc.atomic.update %x : memref<i32> {
+  ^bb0(%xval: i32):
+    acc.yield %y : f32
+  }
+  func.return
+}
+// CHECK: input and yielded value must have the same type
+
+// -----
+
+// acc.atomic.update's region must accept exactly one block argument.
+func.func @atomic_update_too_many_args(%x : memref<i32>, %expr : i32) {
+  acc.atomic.update %x : memref<i32> {
+  ^bb0(%xval: i32, %tmp: i32):
+    %newval = arith.addi %xval, %expr : i32
+    acc.yield %newval : i32
+  }
+  func.return
+}
+// CHECK: the region must accept exactly one argument

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/ops.mlir
@@ -1674,4 +1674,59 @@ builtin.module {
   // CHECK-NEXT:    acc.atomic.write %{{.*}} = %{{.*}} : memref<i32>, i32
   // CHECK-NEXT:    acc.atomic.write if(%{{.*}}) %{{.*}} = %{{.*}} : memref<i32>, i32
 
+  // acc.atomic.update — region op with `SingleBlockImplicitTerminator<YieldOp>`.
+  // Round-trips with mlir-opt in both pretty and generic form.
+  func.func @acc_atomic_update(%x: memref<i32>, %expr: i32) {
+    acc.atomic.update %x : memref<i32> {
+    ^bb0(%xval: i32):
+      %newval = arith.addi %xval, %expr : i32
+      acc.yield %newval : i32
+    }
+    %c = arith.constant true
+    acc.atomic.update if(%c) %x : memref<i32> {
+    ^bb0(%xval: i32):
+      %newval = arith.addi %xval, %expr : i32
+      acc.yield %newval : i32
+    }
+    // No-op update: yielding the argument unchanged is a valid form.
+    acc.atomic.update %x : memref<i32> {
+    ^bb0(%xval: i32):
+      acc.yield %xval : i32
+    }
+    func.return
+  }
+  // CHECK:       func.func @acc_atomic_update(
+  // CHECK:         acc.atomic.update %{{.*}} : memref<i32> {
+  // CHECK-NEXT:    ^{{.*}}(%{{.*}}: i32):
+  // CHECK-NEXT:      %{{.*}} = arith.addi %{{.*}}, %{{.*}} : i32
+  // CHECK-NEXT:      acc.yield %{{.*}} : i32
+  // CHECK-NEXT:    }
+  // CHECK:         acc.atomic.update if(%{{.*}}) %{{.*}} : memref<i32> {
+  // CHECK-NEXT:    ^{{.*}}(%{{.*}}: i32):
+  // CHECK-NEXT:      %{{.*}} = arith.addi %{{.*}}, %{{.*}} : i32
+  // CHECK-NEXT:      acc.yield %{{.*}} : i32
+  // CHECK-NEXT:    }
+  // CHECK:         acc.atomic.update %{{.*}} : memref<i32> {
+  // CHECK-NEXT:    ^{{.*}}(%[[XVAL:.*]]: i32):
+  // CHECK-NEXT:      acc.yield %[[XVAL]] : i32
+  // CHECK-NEXT:    }
+
+  // Generic-form input for atomic.update — proves the hand-written generic
+  // spelling survives the xdsl ↔ mlir-opt round-trip.
+  func.func @acc_atomic_update_generic(%x: memref<i32>, %expr: i32, %c: i1) {
+    "acc.atomic.update"(%x) ({
+    ^bb0(%xval: i32):
+      %newval = arith.addi %xval, %expr : i32
+      "acc.yield"(%newval) : (i32) -> ()
+    }) : (memref<i32>) -> ()
+    "acc.atomic.update"(%x, %c) ({
+    ^bb0(%xval: i32):
+      "acc.yield"(%xval) : (i32) -> ()
+    }) : (memref<i32>, i1) -> ()
+    func.return
+  }
+  // CHECK:       func.func @acc_atomic_update_generic(
+  // CHECK:         acc.atomic.update %{{.*}} : memref<i32> {
+  // CHECK:         acc.atomic.update if(%{{.*}}) %{{.*}} : memref<i32> {
+
 }

--- a/xdsl/dialects/acc.py
+++ b/xdsl/dialects/acc.py
@@ -4373,6 +4373,74 @@ class AtomicWriteOp(IRDLOperation):
                 raise VerifyException("address must dereference to value type")
 
 
+@irdl_op_definition
+class AtomicUpdateOp(IRDLOperation):
+    """
+    Implementation of upstream acc.atomic.update — performs an atomic update.
+
+    The operand `x` is the address of the variable being updated. The region
+    describes how to update the value: it takes the current value at `x` as
+    its single block argument and must yield the updated value via acc.yield.
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/OpenACCDialect/#accatomicupdate-accatomicupdateop).
+    """
+
+    name = "acc.atomic.update"
+
+    x = operand_def()
+    if_cond = opt_operand_def(I1)
+
+    region = region_def("single_block")
+
+    custom_directives = (AtomicIfClause,)
+
+    assembly_format = (
+        "custom<AtomicIfClause>($if_cond, type($if_cond))"
+        " $x `:` type($x) $region attr-dict"
+    )
+
+    traits = lazy_traits_def(
+        lambda: (
+            SingleBlockImplicitTerminator(YieldOp),
+            RecursiveMemoryEffect(),
+        )
+    )
+
+    def __init__(
+        self,
+        *,
+        x: SSAValue | Operation,
+        region: Region,
+        if_cond: SSAValue | Operation | None = None,
+    ) -> None:
+        super().__init__(
+            operands=[x, if_cond],
+            regions=[region],
+        )
+
+    def verify_(self) -> None:
+        # Mirrors upstream `AtomicUpdateOpInterface::verifyCommon` +
+        # `verifyRegionsCommon`. The terminator-kind / single-block /
+        # non-empty-block checks are handled by the
+        # `SingleBlockImplicitTerminator(YieldOp)` trait.
+        block = self.region.block
+        if len(block.args) != 1:
+            raise VerifyException("the region must accept exactly one argument")
+
+        arg_type = block.args[0].type
+        x_type = self.x.type
+        if isa(x_type, MemRefType) and x_type.element_type != arg_type:
+            raise VerifyException(
+                "the type of the operand must be a pointer type whose "
+                "element type is the same as that of the region argument"
+            )
+
+        terminator = cast(YieldOp, block.last_op)
+        if len(terminator.operands) != 1:
+            raise VerifyException("only updated value must be returned")
+        if terminator.operands[0].type != arg_type:
+            raise VerifyException("input and yielded value must have the same type")
+
+
 # ---------------------------------------------------------------------------
 # Declare family
 # ---------------------------------------------------------------------------
@@ -5374,6 +5442,7 @@ class YieldOp(AbstractYieldOperation[Attribute]):
                 PrivateRecipeOp,
                 FirstprivateRecipeOp,
                 ReductionRecipeOp,
+                AtomicUpdateOp,
             ),
         )
     )
@@ -5419,6 +5488,7 @@ ACC = Dialect(
         UpdateOp,
         AtomicReadOp,
         AtomicWriteOp,
+        AtomicUpdateOp,
         DeclareEnterOp,
         DeclareExitOp,
         DeclareOp,


### PR DESCRIPTION
This PR adds the atomic update OpenACC operation, it leverages the same custom assembly syntax we added in the previous PR so is just the operation itself that is added here
