### PR TITLE
testing: (llvm) fix call_intrinsic_void passing args to llvm.donothing

### DIFF
--- a/tests/filecheck/backend/llvm/convert_op.mlir
+++ b/tests/filecheck/backend/llvm/convert_op.mlir
@@ -917,15 +917,15 @@ builtin.module {
   // CHECK-NEXT:   ret <4 x float> %"[[RES]]"
   // CHECK-NEXT: }
 
-  llvm.func @call_intrinsic_void(%arg0: i32) {
-    llvm.call_intrinsic "llvm.donothing"(%arg0) : (i32) -> ()
+  llvm.func @call_intrinsic_void() {
+    llvm.call_intrinsic "llvm.donothing"() : () -> ()
     llvm.return
   }
 
-  // CHECK: define void @"call_intrinsic_void"(i32 %".1")
+  // CHECK: define void @"call_intrinsic_void"()
   // CHECK-NEXT: {
   // CHECK-NEXT: [[ENTRY:.\d+]]:
-  // CHECK-NEXT:   call void @"llvm.donothing"(i32 %".1")
+  // CHECK-NEXT:   call void @"llvm.donothing"()
   // CHECK-NEXT:   ret void
   // CHECK-NEXT: }
 

--- a/tests/filecheck/dialects/llvm/invalid.mlir
+++ b/tests/filecheck/dialects/llvm/invalid.mlir
@@ -182,3 +182,12 @@ llvm.func @elementtype_on_func(%arg0: !llvm.ptr {llvm.elementtype = f32}) {
 }
 
 // CHECK: 'llvm.elementtype' on parameter 0 is invalid: elementtype can only be applied to intrinsic callsites
+
+// -----
+
+func.func @call_intrinsic_bad_name() {
+  llvm.call_intrinsic "not_an_intrinsic"() : () -> ()
+  func.return
+}
+
+// CHECK: intrinsic name must start with 'llvm.'

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -2590,6 +2590,12 @@ class CallIntrinsicOp(IRDLOperation):
         ParsePropInAttrDict(),
     )
 
+    def verify_(self) -> None:
+        if not self.intrin.data.startswith("llvm."):
+            raise VerifyException(
+                f"intrinsic name must start with 'llvm.', got '{self.intrin.data}'"
+            )
+
     def __init__(
         self,
         intrin: StringAttr | str,


### PR DESCRIPTION
Prerequisite for #6050. Part of #6009. Bug introduced in #6010.

`@call_intrinsic_void` passes an i32 to `llvm.donothing` which takes 0 args.

`mlir-translate` rejects this.