### PR TITLE
dialects: (llvm) reject elementtype on function parameters

### DIFF
--- a/tests/filecheck/backend/llvm/convert_op.mlir
+++ b/tests/filecheck/backend/llvm/convert_op.mlir
@@ -59,14 +59,13 @@ builtin.module {
   llvm.func @arg_attr_types(
       %arg0: !llvm.ptr {llvm.byval = i32},
       %arg1: !llvm.ptr {llvm.sret = !llvm.struct<(i32, i32)>},
-      %arg2: !llvm.ptr {llvm.byref = i64, llvm.align = 8 : i64, llvm.noalias},
-      %arg3: !llvm.ptr {llvm.elementtype = f32}
+      %arg2: !llvm.ptr {llvm.byref = i64, llvm.align = 8 : i64, llvm.noalias}
   ) {
     llvm.return
   }
 
   // Type-valued attrs force a typed pointer so llvmlite can print name(T).
-  // CHECK: define void @"arg_attr_types"(i32* byval(i32) %".1", {i32, i32}* sret({i32, i32}) %".2", i64* byref(i64) noalias align 8 %".3", float* elementtype(float) %".4")
+  // CHECK: define void @"arg_attr_types"(i32* byval(i32) %".1", {i32, i32}* sret({i32, i32}) %".2", i64* byref(i64) noalias align 8 %".3")
   // CHECK-NEXT: {
   // CHECK-NEXT: {{.[0-9]+}}:
   // CHECK-NEXT:   ret void

--- a/tests/filecheck/dialects/llvm/invalid.mlir
+++ b/tests/filecheck/dialects/llvm/invalid.mlir
@@ -174,3 +174,11 @@ func.func @shufflevector_mask_out_of_range() {
 }
 
 // CHECK: Mask value 5 out of range [-1, 4)
+
+// -----
+
+llvm.func @elementtype_on_func(%arg0: !llvm.ptr {llvm.elementtype = f32}) {
+  llvm.return
+}
+
+// CHECK: 'llvm.elementtype' on parameter 0 is invalid: elementtype can only be applied to intrinsic callsites

--- a/xdsl/backend/llvm/convert.py
+++ b/xdsl/backend/llvm/convert.py
@@ -37,7 +37,6 @@ _ARG_ATTR_TYPES = {
     "llvm.sret": "sret",
     "llvm.inalloca": "inalloca",
     "llvm.preallocated": "preallocated",
-    "llvm.elementtype": "elementtype",
 }
 
 

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -2453,6 +2453,16 @@ class FuncOp(IRDLOperation):
             case _:
                 raise AssertionError("Invalid unnamed_addr value")
 
+    def verify_(self, verify_nested_ops: bool = True) -> None:
+        if self.arg_attrs is None:
+            return
+        for i, attrs in enumerate(self.arg_attrs):
+            if "llvm.elementtype" in attrs.data:
+                raise VerifyException(
+                    f"'llvm.elementtype' on parameter {i} is invalid: "
+                    "elementtype can only be applied to intrinsic callsites"
+                )
+
     def print(self, printer: Printer):
         if self.linkage.linkage.data != "external":
             printer.print_string(" ")


### PR DESCRIPTION
Prerequisite for #6050. Part of #6009.

Adds a verifier to `FuncOp` that rejects `llvm.elementtype` on function parameters.

LLVM only allows `elementtype` on intrinsic callsites and inline asm ([Verifier.cpp:2429](https://github.com/llvm/llvm-project/blob/9c4ff6e82edc00616d0324b4a437c0e15bf6cebf/llvm/lib/IR/Verifier.cpp#L2427-L2432), [Verifier.cpp:3156](https://github.com/llvm/llvm-project/blob/9c4ff6e82edc00616d0324b4a437c0e15bf6cebf/llvm/lib/IR/Verifier.cpp#L3156)).
