### PR TITLE
dialects: (acc) Atomic capture

### DIFF
--- a/tests/dialects/test_acc.py
+++ b/tests/dialects/test_acc.py
@@ -1117,6 +1117,29 @@ def test_atomic_update_builder():
     acc.AtomicUpdateOp(x=x, region=_body(), if_cond=cond).verify()
 
 
+def test_atomic_capture_builder():
+    """The `AtomicCaptureOp` Python builder — filecheck constructs via the
+    IRDL generic constructor and never runs `__init__`."""
+    v = create_ssa_value(MemRefType(i32, ()))
+    x = create_ssa_value(MemRefType(i32, ()))
+    expr = create_ssa_value(i32)
+    cond = create_ssa_value(i1)
+
+    def _body() -> Region:
+        return Region(
+            Block(
+                [
+                    acc.AtomicReadOp(x=x, v=v, element_type=i32),
+                    acc.AtomicWriteOp(x=x, expr=expr),
+                    acc.TerminatorOp(),
+                ]
+            )
+        )
+
+    acc.AtomicCaptureOp(region=_body()).verify()
+    acc.AtomicCaptureOp(region=_body(), if_cond=cond).verify()
+
+
 def test_atomic_write_skips_check_for_non_memref():
     """`AtomicWriteOp.verify_` only checks the pointee-type match when `x`
     is a `MemRefType` — for other types the check is skipped, mirroring

--- a/tests/filecheck/dialects/acc/ops.mlir
+++ b/tests/filecheck/dialects/acc/ops.mlir
@@ -2459,4 +2459,75 @@ builtin.module {
   // CHECK-LABEL: func.func @acc_atomic_update_generic(
   // CHECK:         acc.atomic.update %{{.*}} : memref<i32> {
   // CHECK:         acc.atomic.update if(%{{.*}}) %{{.*}} : memref<i32> {
+
+  // acc.atomic.capture — region op whose body must contain exactly two
+  // atomic ops in one of three allowed sequences: (update, read),
+  // (read, update), or (read, write). The implicit acc.terminator is
+  // stripped on print to mirror upstream's
+  // `SingleBlockImplicitTerminator<TerminatorOp>` behavior.
+  func.func @acc_atomic_capture(%v: memref<i32>, %x: memref<i32>, %expr: i32) {
+    acc.atomic.capture {
+      acc.atomic.update %x : memref<i32> {
+      ^bb0(%xval: i32):
+        %newval = arith.addi %xval, %expr : i32
+        acc.yield %newval : i32
+      }
+      acc.atomic.read %v = %x : memref<i32>, memref<i32>, i32
+    }
+    acc.atomic.capture {
+      acc.atomic.read %v = %x : memref<i32>, memref<i32>, i32
+      acc.atomic.update %x : memref<i32> {
+      ^bb0(%xval: i32):
+        %newval = arith.addi %xval, %expr : i32
+        acc.yield %newval : i32
+      }
+    }
+    acc.atomic.capture {
+      acc.atomic.read %v = %x : memref<i32>, memref<i32>, i32
+      acc.atomic.write %x = %expr : memref<i32>, i32
+    }
+    %c = arith.constant true
+    acc.atomic.capture if(%c) {
+      acc.atomic.read %v = %x : memref<i32>, memref<i32>, i32
+      acc.atomic.write %x = %expr : memref<i32>, i32
+    }
+    func.return
+  }
+  // CHECK-LABEL: func.func @acc_atomic_capture(
+  // CHECK:         acc.atomic.capture {
+  // CHECK-NEXT:      acc.atomic.update %{{.*}} : memref<i32>
+  // CHECK:           acc.atomic.read %{{.*}} = %{{.*}} : memref<i32>, memref<i32>, i32
+  // CHECK-NEXT:    }
+  // CHECK:         acc.atomic.capture {
+  // CHECK-NEXT:      acc.atomic.read %{{.*}} = %{{.*}} : memref<i32>, memref<i32>, i32
+  // CHECK-NEXT:      acc.atomic.update %{{.*}} : memref<i32>
+  // CHECK:         }
+  // CHECK:         acc.atomic.capture {
+  // CHECK-NEXT:      acc.atomic.read %{{.*}} = %{{.*}} : memref<i32>, memref<i32>, i32
+  // CHECK-NEXT:      acc.atomic.write %{{.*}} = %{{.*}} : memref<i32>, i32
+  // CHECK-NEXT:    }
+  // CHECK:         acc.atomic.capture if(%{{.*}}) {
+  // CHECK-NEXT:      acc.atomic.read %{{.*}} = %{{.*}} : memref<i32>, memref<i32>, i32
+  // CHECK-NEXT:      acc.atomic.write %{{.*}} = %{{.*}} : memref<i32>, i32
+  // CHECK-NEXT:    }
+
+  // Generic-form roundtrip insurance for atomic.capture — note the implicit
+  // acc.terminator must appear in generic form (it's user-visible in the
+  // generic spelling); the pretty form strips it on print.
+  func.func @acc_atomic_capture_generic(%v: memref<i32>, %x: memref<i32>, %expr: i32, %c: i1) {
+    "acc.atomic.capture"() ({
+      "acc.atomic.read"(%x, %v) <{element_type = i32}> : (memref<i32>, memref<i32>) -> ()
+      "acc.atomic.write"(%x, %expr) : (memref<i32>, i32) -> ()
+      "acc.terminator"() : () -> ()
+    }) : () -> ()
+    "acc.atomic.capture"(%c) ({
+      "acc.atomic.read"(%x, %v) <{element_type = i32}> : (memref<i32>, memref<i32>) -> ()
+      "acc.atomic.write"(%x, %expr) : (memref<i32>, i32) -> ()
+      "acc.terminator"() : () -> ()
+    }) : (i1) -> ()
+    func.return
+  }
+  // CHECK-LABEL: func.func @acc_atomic_capture_generic(
+  // CHECK:         acc.atomic.capture {
+  // CHECK:         acc.atomic.capture if(%{{.*}}) {
 }

--- a/tests/filecheck/dialects/acc/ops_invalid.mlir
+++ b/tests/filecheck/dialects/acc/ops_invalid.mlir
@@ -1046,3 +1046,75 @@ func.func @atomic_update_too_many_args(%x : memref<i32>, %expr : i32) {
   func.return
 }
 // CHECK: the region must accept exactly one argument
+
+// -----
+
+// acc.atomic.capture's region must contain exactly two atomic ops plus the
+// implicit terminator. A single op + terminator is rejected.
+func.func @atomic_capture_too_few_ops(%v : memref<i32>, %x : memref<i32>) {
+  acc.atomic.capture {
+    acc.atomic.read %v = %x : memref<i32>, memref<i32>, i32
+  }
+  func.return
+}
+// CHECK: expected three operations in atomic.capture region (one terminator, and two atomic ops)
+
+// -----
+
+// acc.atomic.capture rejects sequences other than (update,read), (read,update),
+// or (read,write). Two reads in a row trips the sequence check.
+func.func @atomic_capture_invalid_sequence(%v : memref<i32>, %x : memref<i32>) {
+  acc.atomic.capture {
+    acc.atomic.read %v = %x : memref<i32>, memref<i32>, i32
+    acc.atomic.read %v = %x : memref<i32>, memref<i32>, i32
+  }
+  func.return
+}
+// CHECK: invalid sequence of operations in the capture region
+
+// -----
+
+// acc.atomic.capture with (update, read) requires both ops to refer to the
+// same address `x`.
+func.func @atomic_capture_update_read_var_mismatch(%x : memref<i32>, %y : memref<i32>, %v : memref<i32>, %expr : i32) {
+  acc.atomic.capture {
+    acc.atomic.update %x : memref<i32> {
+    ^bb0(%xval: i32):
+      %newval = arith.addi %xval, %expr : i32
+      acc.yield %newval : i32
+    }
+    acc.atomic.read %v = %y : memref<i32>, memref<i32>, i32
+  }
+  func.return
+}
+// CHECK: updated variable in atomic.update must be captured in second operation
+
+// -----
+
+// acc.atomic.capture with (read, update) requires both ops to refer to the
+// same address `x`.
+func.func @atomic_capture_read_update_var_mismatch(%x : memref<i32>, %y : memref<i32>, %v : memref<i32>, %expr : i32) {
+  acc.atomic.capture {
+    acc.atomic.read %v = %y : memref<i32>, memref<i32>, i32
+    acc.atomic.update %x : memref<i32> {
+    ^bb0(%xval: i32):
+      %newval = arith.addi %xval, %expr : i32
+      acc.yield %newval : i32
+    }
+  }
+  func.return
+}
+// CHECK: captured variable in atomic.read must be updated in second operation
+
+// -----
+
+// acc.atomic.capture with (read, write) requires both ops to refer to the
+// same address `x`.
+func.func @atomic_capture_read_write_var_mismatch(%x : memref<i32>, %y : memref<i32>, %v : memref<i32>, %expr : i32) {
+  acc.atomic.capture {
+    acc.atomic.read %v = %x : memref<i32>, memref<i32>, i32
+    acc.atomic.write %y = %expr : memref<i32>, i32
+  }
+  func.return
+}
+// CHECK: captured variable in atomic.read must be updated in second operation

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/ops.mlir
@@ -1729,4 +1729,72 @@ builtin.module {
   // CHECK:         acc.atomic.update %{{.*}} : memref<i32> {
   // CHECK:         acc.atomic.update if(%{{.*}}) %{{.*}} : memref<i32> {
 
+  // acc.atomic.capture — the body's implicit acc.terminator is stripped on
+  // print to mirror upstream and inserted on parse, so the round-trip with
+  // mlir-opt is bit-identical without an explicit terminator.
+  func.func @acc_atomic_capture(%v: memref<i32>, %x: memref<i32>, %expr: i32) {
+    acc.atomic.capture {
+      acc.atomic.update %x : memref<i32> {
+      ^bb0(%xval: i32):
+        %newval = arith.addi %xval, %expr : i32
+        acc.yield %newval : i32
+      }
+      acc.atomic.read %v = %x : memref<i32>, memref<i32>, i32
+    }
+    acc.atomic.capture {
+      acc.atomic.read %v = %x : memref<i32>, memref<i32>, i32
+      acc.atomic.update %x : memref<i32> {
+      ^bb0(%xval: i32):
+        %newval = arith.addi %xval, %expr : i32
+        acc.yield %newval : i32
+      }
+    }
+    acc.atomic.capture {
+      acc.atomic.read %v = %x : memref<i32>, memref<i32>, i32
+      acc.atomic.write %x = %expr : memref<i32>, i32
+    }
+    %c = arith.constant true
+    acc.atomic.capture if(%c) {
+      acc.atomic.read %v = %x : memref<i32>, memref<i32>, i32
+      acc.atomic.write %x = %expr : memref<i32>, i32
+    }
+    func.return
+  }
+  // CHECK:       func.func @acc_atomic_capture(
+  // CHECK:         acc.atomic.capture {
+  // CHECK-NEXT:      acc.atomic.update %{{.*}} : memref<i32> {
+  // CHECK:           acc.atomic.read %{{.*}} = %{{.*}} : memref<i32>, memref<i32>, i32
+  // CHECK-NEXT:    }
+  // CHECK:         acc.atomic.capture {
+  // CHECK-NEXT:      acc.atomic.read %{{.*}} = %{{.*}} : memref<i32>, memref<i32>, i32
+  // CHECK-NEXT:      acc.atomic.update %{{.*}} : memref<i32> {
+  // CHECK:         }
+  // CHECK:         acc.atomic.capture {
+  // CHECK-NEXT:      acc.atomic.read %{{.*}} = %{{.*}} : memref<i32>, memref<i32>, i32
+  // CHECK-NEXT:      acc.atomic.write %{{.*}} = %{{.*}} : memref<i32>, i32
+  // CHECK-NEXT:    }
+  // CHECK:         acc.atomic.capture if(%{{.*}}) {
+  // CHECK-NEXT:      acc.atomic.read %{{.*}} = %{{.*}} : memref<i32>, memref<i32>, i32
+  // CHECK-NEXT:      acc.atomic.write %{{.*}} = %{{.*}} : memref<i32>, i32
+  // CHECK-NEXT:    }
+
+  // Generic-form input for atomic.capture — the implicit terminator IS
+  // user-visible in the generic spelling.
+  func.func @acc_atomic_capture_generic(%v: memref<i32>, %x: memref<i32>, %expr: i32, %c: i1) {
+    "acc.atomic.capture"() ({
+      "acc.atomic.read"(%x, %v) <{element_type = i32}> : (memref<i32>, memref<i32>) -> ()
+      "acc.atomic.write"(%x, %expr) : (memref<i32>, i32) -> ()
+      "acc.terminator"() : () -> ()
+    }) : () -> ()
+    "acc.atomic.capture"(%c) ({
+      "acc.atomic.read"(%x, %v) <{element_type = i32}> : (memref<i32>, memref<i32>) -> ()
+      "acc.atomic.write"(%x, %expr) : (memref<i32>, i32) -> ()
+      "acc.terminator"() : () -> ()
+    }) : (i1) -> ()
+    func.return
+  }
+  // CHECK:       func.func @acc_atomic_capture_generic(
+  // CHECK:         acc.atomic.capture {
+  // CHECK:         acc.atomic.capture if(%{{.*}}) {
+
 }

--- a/xdsl/dialects/acc.py
+++ b/xdsl/dialects/acc.py
@@ -4522,32 +4522,23 @@ class AtomicCaptureOp(IRDLOperation):
                 "terminator, and two atomic ops)"
             )
         first_op, second_op, _terminator = ops
-        if isinstance(first_op, AtomicUpdateOp) and isinstance(second_op, AtomicReadOp):
-            if first_op.x is not second_op.x:
+        match first_op, second_op:
+            case AtomicUpdateOp(), AtomicReadOp():
+                if first_op.x is not second_op.x:
+                    raise VerifyException(
+                        "updated variable in atomic.update must be captured in "
+                        "second operation"
+                    )
+            case AtomicReadOp(), (AtomicUpdateOp() | AtomicWriteOp()):
+                if first_op.x is not second_op.x:
+                    raise VerifyException(
+                        "captured variable in atomic.read must be updated in "
+                        "second operation"
+                    )
+            case _:
                 raise VerifyException(
-                    "updated variable in atomic.update must be captured in "
-                    "second operation"
+                    "invalid sequence of operations in the capture region"
                 )
-        elif isinstance(first_op, AtomicReadOp) and isinstance(
-            second_op, AtomicUpdateOp
-        ):
-            if first_op.x is not second_op.x:
-                raise VerifyException(
-                    "captured variable in atomic.read must be updated in "
-                    "second operation"
-                )
-        elif isinstance(first_op, AtomicReadOp) and isinstance(
-            second_op, AtomicWriteOp
-        ):
-            if first_op.x is not second_op.x:
-                raise VerifyException(
-                    "captured variable in atomic.read must be updated in "
-                    "second operation"
-                )
-        else:
-            raise VerifyException(
-                "invalid sequence of operations in the capture region"
-            )
 
 
 # ---------------------------------------------------------------------------

--- a/xdsl/dialects/acc.py
+++ b/xdsl/dialects/acc.py
@@ -84,6 +84,7 @@ from xdsl.traits import (
     RecursiveMemoryEffect,
     SingleBlockImplicitTerminator,
     SymbolOpInterface,
+    ensure_terminator,
 )
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.hints import isa
@@ -4441,6 +4442,116 @@ class AtomicUpdateOp(IRDLOperation):
             raise VerifyException("input and yielded value must have the same type")
 
 
+@irdl_op_definition
+class AtomicCaptureOp(IRDLOperation):
+    """
+    Implementation of upstream acc.atomic.capture — performs an atomic capture.
+
+    The region contains exactly two atomic ops (plus an implicit acc.terminator)
+    in one of three allowed orderings: `update + read`, `read + update`, or
+    `read + write`. The two operations must operate on the same memory
+    location.
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/OpenACCDialect/#accatomiccapture-accatomiccaptureop).
+    """
+
+    name = "acc.atomic.capture"
+
+    if_cond = opt_operand_def(I1)
+
+    region = region_def("single_block")
+
+    traits = lazy_traits_def(
+        lambda: (
+            SingleBlockImplicitTerminator(TerminatorOp),
+            RecursiveMemoryEffect(),
+        )
+    )
+
+    @classmethod
+    def parse(cls, parser: Parser) -> "AtomicCaptureOp":
+        # Mirror upstream `oilist( \`if\` \`(\` $ifCond \`)\` ) $region attr-dict`
+        # plus `SingleBlockImplicitTerminator(TerminatorOp)`: accept the body
+        # without an explicit `acc.terminator` and insert one.
+        if_cond: SSAValue | None = None
+        if parser.parse_optional_keyword("if") is not None:
+            parser.parse_punctuation("(")
+            unresolved = parser.parse_unresolved_operand()
+            parser.parse_punctuation(")")
+            if_cond = parser.resolve_operand(unresolved, i1)
+        region = parser.parse_region()
+        attrs = parser.parse_optional_attr_dict()
+        op = cls(region=region, if_cond=if_cond)
+        op.attributes = {**op.attributes, **attrs}
+        for trait in op.get_traits_of_type(SingleBlockImplicitTerminator):
+            ensure_terminator(op, trait)
+        return op
+
+    def print(self, printer: Printer) -> None:
+        if self.if_cond is not None:
+            printer.print_string(" if(")
+            printer.print_ssa_value(self.if_cond)
+            printer.print_string(")")
+        printer.print_string(" ")
+        # Strip the implicit `acc.terminator` to mirror upstream's print
+        # behavior. The `SingleBlockImplicitTerminator` trait re-inserts
+        # one on parse, so this round-trips through both xdsl-opt and
+        # mlir-opt bit-identically.
+        printer.print_region(self.region, print_block_terminators=False)
+        printer.print_op_attributes(self.attributes)
+
+    def __init__(
+        self,
+        *,
+        region: Region,
+        if_cond: SSAValue | Operation | None = None,
+    ) -> None:
+        super().__init__(
+            operands=[if_cond],
+            regions=[region],
+        )
+
+    def verify_(self) -> None:
+        # Mirrors upstream AtomicCaptureOpInterface::verifyRegionsCommon.
+        # SingleBlockImplicitTerminator(TerminatorOp) guarantees the last
+        # op is an acc.terminator, so the valid op count is exactly 3:
+        # two atomic ops plus the terminator.
+        ops = list(self.region.block.ops)
+        if len(ops) != 3:
+            raise VerifyException(
+                "expected three operations in atomic.capture region (one "
+                "terminator, and two atomic ops)"
+            )
+        first_op, second_op, _terminator = ops
+        if isinstance(first_op, AtomicUpdateOp) and isinstance(
+            second_op, AtomicReadOp
+        ):
+            if first_op.x is not second_op.x:
+                raise VerifyException(
+                    "updated variable in atomic.update must be captured in "
+                    "second operation"
+                )
+        elif isinstance(first_op, AtomicReadOp) and isinstance(
+            second_op, AtomicUpdateOp
+        ):
+            if first_op.x is not second_op.x:
+                raise VerifyException(
+                    "captured variable in atomic.read must be updated in "
+                    "second operation"
+                )
+        elif isinstance(first_op, AtomicReadOp) and isinstance(
+            second_op, AtomicWriteOp
+        ):
+            if first_op.x is not second_op.x:
+                raise VerifyException(
+                    "captured variable in atomic.read must be updated in "
+                    "second operation"
+                )
+        else:
+            raise VerifyException(
+                "invalid sequence of operations in the capture region"
+            )
+
+
 # ---------------------------------------------------------------------------
 # Declare family
 # ---------------------------------------------------------------------------
@@ -5414,6 +5525,7 @@ class TerminatorOp(IRDLOperation):
                 HostDataOp,
                 GlobalConstructorOp,
                 GlobalDestructorOp,
+                AtomicCaptureOp,
             ),
         )
     )
@@ -5489,6 +5601,7 @@ ACC = Dialect(
         AtomicReadOp,
         AtomicWriteOp,
         AtomicUpdateOp,
+        AtomicCaptureOp,
         DeclareEnterOp,
         DeclareExitOp,
         DeclareOp,

--- a/xdsl/dialects/acc.py
+++ b/xdsl/dialects/acc.py
@@ -4522,9 +4522,7 @@ class AtomicCaptureOp(IRDLOperation):
                 "terminator, and two atomic ops)"
             )
         first_op, second_op, _terminator = ops
-        if isinstance(first_op, AtomicUpdateOp) and isinstance(
-            second_op, AtomicReadOp
-        ):
+        if isinstance(first_op, AtomicUpdateOp) and isinstance(second_op, AtomicReadOp):
             if first_op.x is not second_op.x:
                 raise VerifyException(
                     "updated variable in atomic.update must be captured in "


### PR DESCRIPTION
Adds the atomic capture operation from OpenACC dialect, which completes the atomic family of operations
