### PR TITLE
core: (Constraints) add ParamAttrConstraint.get

### DIFF
--- a/docs/marimo/irdl.py
+++ b/docs/marimo/irdl.py
@@ -236,7 +236,7 @@ def _(ConstraintContext, IntAttr, VerifyException, i32, i64):
     from xdsl.irdl import ParamAttrConstraint
 
     # Construct the constraint. Note that we are using the coercion defined previously.
-    param_constraint = ParamAttrConstraint(IntegerAttr, [IntAttr, i32])
+    param_constraint = ParamAttrConstraint.get(IntegerAttr, IntAttr, i32)
 
     # This will pass without triggering an exception.
     param_constraint.verify(IntegerAttr(IntAttr(42), i32), ConstraintContext())

--- a/tests/irdl/test_attr_constraint.py
+++ b/tests/irdl/test_attr_constraint.py
@@ -35,6 +35,7 @@ from xdsl.irdl import (
     base,
     eq,
     irdl_attr_definition,
+    irdl_to_attr_constraint,
 )
 from xdsl.utils.exceptions import PyRDLError
 
@@ -388,3 +389,40 @@ class AttrE(ParametrizedAttribute, Generic[_T]):
 def test_param_instantiated_generic():
     with pytest.raises(PyRDLError):
         ParamAttrConstraint.get(AttrE[AttrB])
+
+
+class AttrF(ParametrizedAttribute):
+    param1: Attribute
+    param2: Attribute
+
+
+@pytest.mark.parametrize(
+    "constr, expected",
+    [
+        (ParamAttrConstraint.get(AttrA), ParamAttrConstraint(AttrA, ())),
+        (
+            ParamAttrConstraint.get(AttrB, None),
+            ParamAttrConstraint(AttrB, (AnyAttr(),)),
+        ),
+        (
+            ParamAttrConstraint.get(AttrF, None, None),
+            ParamAttrConstraint(AttrF, (AnyAttr(), AnyAttr())),
+        ),
+        (
+            ParamAttrConstraint.get(AttrF, AttrA, AttrB),
+            ParamAttrConstraint(
+                AttrF, (irdl_to_attr_constraint(AttrA), irdl_to_attr_constraint(AttrB))
+            ),
+        ),
+        (
+            ParamAttrConstraint.get(
+                AttrF, None, ParamAttrConstraint.get(AttrF, None, None)
+            ),
+            ParamAttrConstraint(
+                AttrF, (AnyAttr(), ParamAttrConstraint(AttrF, (AnyAttr(), AnyAttr())))
+            ),
+        ),
+    ],
+)
+def test_param_attr_get(constr: AttrConstraint, expected: AttrConstraint):
+    assert constr == expected

--- a/tests/irdl/test_attr_constraint.py
+++ b/tests/irdl/test_attr_constraint.py
@@ -1,6 +1,7 @@
 import re
 from abc import ABC
 from dataclasses import dataclass
+from typing import Generic
 
 import pytest
 from typing_extensions import TypeVar
@@ -375,3 +376,15 @@ def test_mapping_type_vars():
     assert int_attr_constr.mapping_type_vars({_IntT: my_constr}) == IntAttrConstraint(
         my_constr
     )
+
+
+_T = TypeVar("_T")
+
+
+class AttrE(ParametrizedAttribute, Generic[_T]):
+    param: _T
+
+
+def test_param_instantiated_generic():
+    with pytest.raises(PyRDLError):
+        ParamAttrConstraint.get(AttrE[AttrB])

--- a/tests/irdl/test_attr_constraint.py
+++ b/tests/irdl/test_attr_constraint.py
@@ -100,8 +100,8 @@ class AttrD(Base):
         ),
         (AllOf((AnyAttr(), BaseAttr(Base))), None),
         (AllOf((AnyAttr(), BaseAttr(AttrA))), {AttrA}),
-        (ParamAttrConstraint(AttrB, [BaseAttr(AttrA)]), {AttrB}),
-        (ParamAttrConstraint(Base, [BaseAttr(AttrA)]), None),
+        (ParamAttrConstraint(AttrB, (BaseAttr(AttrA),)), {AttrB}),
+        (ParamAttrConstraint(Base, (BaseAttr(AttrA),)), None),
         (VarConstraint("T", BaseAttr(Base)), None),
         (VarConstraint("T", BaseAttr(AttrA)), {AttrA}),
         (

--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import textwrap
 from collections.abc import Callable
 from io import StringIO
-from typing import ClassVar, Generic
+from typing import ClassVar, Generic, cast
 
 import pytest
 from typing_extensions import TypeVar
@@ -2804,10 +2804,12 @@ def test_nested_inference():
             n: AttrConstraint | None = None,
             p: AttrConstraint[_T] | None = None,
             q: AttrConstraint | None = None,
-        ) -> BaseAttr[ParamOne[_T]] | ParamAttrConstraint[ParamOne[_T]]:
+        ) -> AttrConstraint[ParamOne[_T]]:
             if n is None and p is None and q is None:
                 return BaseAttr[ParamOne[_T]](ParamOne)
-            return ParamAttrConstraint[ParamOne[_T]](ParamOne, (n, p, q))
+            return cast(
+                AttrConstraint[ParamOne[_T]], ParamAttrConstraint.get(ParamOne, n, p, q)
+            )
 
     @irdl_op_definition
     class TwoOperandsNestedVarOp(IRDLOperation):

--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -2844,10 +2844,10 @@ def test_nested_inference_variable():
         p: _T
 
         @staticmethod
-        def constr(
-            *, p: AttrConstraint[_T] | None = None
-        ) -> ParamAttrConstraint[ParamOne[_T]]:
-            return ParamAttrConstraint[ParamOne[_T]](ParamOne, (p,))
+        def constr(*, p: AttrConstraint[_T]) -> AttrConstraint[ParamOne[_T]]:
+            return cast(
+                AttrConstraint[ParamOne[_T]], ParamAttrConstraint(ParamOne, (p,))
+            )
 
     @irdl_op_definition
     class ResultTypeIsOperandParamOp(IRDLOperation):

--- a/tests/test_pyrdl.py
+++ b/tests/test_pyrdl.py
@@ -278,7 +278,7 @@ def test_allof_verify_multiple_failures():
 def test_param_attr_verify():
     bool_true = BoolData(True)
     constraint = ParamAttrConstraint(
-        DoubleParamAttr, [EqAttrConstraint(bool_true), BaseAttr(IntData)]
+        DoubleParamAttr, (EqAttrConstraint(bool_true), BaseAttr(IntData))
     )
     constraint.verify(DoubleParamAttr(bool_true, IntData(0)), ConstraintContext())
     constraint.verify(DoubleParamAttr(bool_true, IntData(42)), ConstraintContext())
@@ -287,7 +287,7 @@ def test_param_attr_verify():
 def test_param_attr_verify_base_fail():
     bool_true = BoolData(True)
     constraint = ParamAttrConstraint(
-        DoubleParamAttr, [EqAttrConstraint(bool_true), BaseAttr(IntData)]
+        DoubleParamAttr, (EqAttrConstraint(bool_true), BaseAttr(IntData))
     )
     with pytest.raises(
         VerifyException,
@@ -298,7 +298,7 @@ def test_param_attr_verify_base_fail():
 
 def test_param_attr_verify_params_num_params_fail():
     bool_true = BoolData(True)
-    constraint = ParamAttrConstraint(DoubleParamAttr, [EqAttrConstraint(bool_true)])
+    constraint = ParamAttrConstraint(DoubleParamAttr, (EqAttrConstraint(bool_true),))
     attr = DoubleParamAttr(bool_true, IntData(0))
     with pytest.raises(VerifyException, match="1 parameters expected, but got 2"):
         constraint.verify(attr, ConstraintContext())
@@ -308,7 +308,11 @@ def test_param_attr_verify_params_fail():
     bool_true = BoolData(True)
     bool_false = BoolData(False)
     constraint = ParamAttrConstraint(
-        DoubleParamAttr, [EqAttrConstraint(bool_true), BaseAttr(IntData)]
+        DoubleParamAttr,
+        (
+            EqAttrConstraint(bool_true),
+            BaseAttr(IntData),
+        ),
     )
 
     with pytest.raises(

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -356,7 +356,7 @@ class EmptyArrayAttrConstraint(AttrConstraint):
 
 
 FlatSymbolRefAttrConstr = MessageConstraint(
-    ParamAttrConstraint(SymbolRefAttr, [AnyAttr(), EmptyArrayAttrConstraint()]),
+    ParamAttrConstraint.get(SymbolRefAttr, AnyAttr(), EmptyArrayAttrConstraint()),
     "Expected SymbolRefAttr with no nested symbols.",
 )
 """Constrain SymbolRef to be FlatSymbolRef"""
@@ -1072,12 +1072,9 @@ class IntegerAttr(
             return BaseAttr[IntegerAttr[_IntegerAttrType]](IntegerAttr)
         if isinstance(value, IntConstraint):
             value = IntAttrConstraint(value)
-        return ParamAttrConstraint[IntegerAttr[_IntegerAttrType]](
-            IntegerAttr,
-            (
-                value,
-                type,
-            ),
+        return cast(
+            AttrConstraint[IntegerAttr[_IntegerAttrType]],
+            ParamAttrConstraint.get(IntegerAttr, value, type),
         )
 
     def __bool__(self) -> bool:
@@ -1356,9 +1353,10 @@ class FloatAttr(BuiltinAttribute, TypedAttribute, Generic[_FloatAttrType]):
     def constr(
         type: IRDLAttrConstraint[_FloatAttrType] = AnyFloatConstr,
     ) -> AttrConstraint[FloatAttr[_FloatAttrType]]:
-        return ParamAttrConstraint[FloatAttr[_FloatAttrType]](
-            FloatAttr,
-            (
+        return cast(
+            AttrConstraint[FloatAttr[_FloatAttrType]],
+            ParamAttrConstraint.get(
+                FloatAttr,
                 None,
                 type,
             ),
@@ -1454,8 +1452,12 @@ class ComplexType(
     ) -> AttrConstraint[ComplexType[ComplexElementCovT]]:
         if element_type is None:
             return BaseAttr[ComplexType[ComplexElementCovT]](ComplexType)
-        return ParamAttrConstraint[ComplexType[ComplexElementCovT]](
-            ComplexType, (element_type,)
+        return cast(
+            AttrConstraint[ComplexType[ComplexElementCovT]],
+            ParamAttrConstraint.get(
+                ComplexType,
+                element_type,
+            ),
         )
 
 
@@ -1576,9 +1578,10 @@ class VectorType(
             return BaseAttr[VectorType[AttributeCovT]](VectorType)
         shape_constr = AnyAttr() if shape is None else shape
         scalable_dims_constr = AnyAttr() if scalable_dims is None else scalable_dims
-        return ParamAttrConstraint[VectorType[AttributeCovT]](
-            VectorType,
-            (
+        return cast(
+            AttrConstraint[VectorType[AttributeCovT]],
+            ParamAttrConstraint.get(
+                VectorType,
                 shape_constr,
                 element_type,
                 scalable_dims_constr,
@@ -1643,8 +1646,9 @@ class TensorType(
         if element_type is None and shape is None:
             return BaseAttr[TensorType[AttributeInvT]](TensorType)
         shape_constr = AnyAttr() if shape is None else shape
-        return ParamAttrConstraint[TensorType[AttributeInvT]](
-            TensorType, (shape_constr, element_type, AnyAttr())
+        return cast(
+            AttrConstraint[TensorType[AttributeInvT]],
+            ParamAttrConstraint.get(TensorType, shape_constr, element_type, AnyAttr()),
         )
 
 
@@ -1957,8 +1961,9 @@ class DenseArrayBase(
     ) -> AttrConstraint[DenseArrayBase[DenseArrayInvT]]:
         if element_type is None:
             return BaseAttr[DenseArrayBase[DenseArrayInvT]](DenseArrayBase)
-        return ParamAttrConstraint[DenseArrayBase[DenseArrayInvT]](
-            DenseArrayBase, (element_type, AnyAttr())
+        return cast(
+            AttrConstraint[DenseArrayBase[DenseArrayInvT]],
+            ParamAttrConstraint.get(DenseArrayBase, element_type, AnyAttr()),
         )
 
 
@@ -2636,8 +2641,11 @@ class MemRefType(
             and memory_space is None
         ):
             return BaseAttr[MemRefType[_MemRefTypeElement]](MemRefType)
-        return ParamAttrConstraint[MemRefType[_MemRefTypeElement]](
-            MemRefType, (shape, element_type, layout, memory_space)
+        return cast(
+            AttrConstraint[MemRefType[_MemRefTypeElement]],
+            ParamAttrConstraint.get(
+                MemRefType, shape, element_type, layout, memory_space
+            ),
         )
 
 

--- a/xdsl/dialects/stencil.py
+++ b/xdsl/dialects/stencil.py
@@ -393,19 +393,18 @@ class StencilType(
                     printer.print_string("?x")
             printer.print_attribute(self.element_type)
 
-    @classmethod
+    @staticmethod
     def constr(
-        cls,
         *,
         bounds: AttrConstraint | None = None,
         element_type: AttrConstraint[_FieldTypeElement] | None = None,
-    ) -> (
-        BaseAttr[StencilType[_FieldTypeElement]]
-        | ParamAttrConstraint[StencilType[_FieldTypeElement]]
-    ):
+    ) -> AttrConstraint[StencilType[_FieldTypeElement]]:
         if bounds is None and element_type is None:
-            return BaseAttr(cls)
-        return ParamAttrConstraint(cls, (bounds, element_type))
+            return BaseAttr[StencilType[_FieldTypeElement]](StencilType)
+        return cast(
+            AttrConstraint[StencilType[_FieldTypeElement]],
+            ParamAttrConstraint.get(StencilType, bounds, element_type),
+        )
 
 
 @irdl_attr_definition(init=False)
@@ -1537,14 +1536,12 @@ class StoreResultOp(IRDLOperation):
         )
     )
     res = result_def(
-        ParamAttrConstraint(
+        ParamAttrConstraint.get(
             ResultType,
-            [
-                MessageConstraint(
-                    VarConstraint("T", AnyAttr()),
-                    "Expected return type to carry the operand type.",
-                )
-            ],
+            MessageConstraint(
+                VarConstraint("T", AnyAttr()),
+                "Expected return type to carry the operand type.",
+            ),
         )
     )
 

--- a/xdsl/irdl/attributes.py
+++ b/xdsl/irdl/attributes.py
@@ -554,7 +554,9 @@ def irdl_to_attr_constraint(
         else:
             base_constr = ParamAttrConstraint(
                 origin,
-                [param.constr for _, param in origin.get_irdl_definition().parameters],
+                tuple(
+                    param.constr for _, param in origin.get_irdl_definition().parameters
+                ),
             )
 
         type_vars = get_type_var_from_generic_class(cast(type, origin))

--- a/xdsl/irdl/constraints.py
+++ b/xdsl/irdl/constraints.py
@@ -11,6 +11,7 @@ from typing import (
     TypeAlias,
     TypeGuard,
     cast,
+    get_origin,
 )
 
 from typing_extensions import TypeVar, deprecated
@@ -623,7 +624,7 @@ ParametrizedAttributeCovT = TypeVar(
 )
 
 
-@dataclass(frozen=True, init=False)
+@dataclass(frozen=True)
 class ParamAttrConstraint(
     AttrConstraint[ParametrizedAttributeCovT], Generic[ParametrizedAttributeCovT]
 ):
@@ -638,19 +639,25 @@ class ParamAttrConstraint(
     param_constrs: tuple[AttrConstraint, ...]
     """The attribute parameter constraints"""
 
-    def __init__(
-        self,
-        base_attr: type[ParametrizedAttributeCovT],
-        param_constrs: Sequence[IRDLAttrConstraint | None],
-    ):
+    @staticmethod
+    def get(
+        base_attr: type[ParametrizedAttributeT],
+        *param_constrs: IRDLAttrConstraint | None,
+    ) -> AttrConstraint[ParametrizedAttributeT]:
         from xdsl.irdl import irdl_to_attr_constraint
 
         constrs = tuple(
             irdl_to_attr_constraint(constr) if constr is not None else AnyAttr()
             for constr in param_constrs
         )
-        object.__setattr__(self, "base_attr", base_attr)
-        object.__setattr__(self, "param_constrs", constrs)
+
+        # We don't want to allow instantiated generics here, as they don't get checked
+        if get_origin(base_attr) is not None:
+            raise PyRDLError(
+                f"Argument to ParamAttConstraint {base_attr} should not be an instantiated generic"
+            )
+
+        return ParamAttrConstraint[ParametrizedAttributeT](base_attr, constrs)
 
     def __repr__(self):
         return f"ParamAttrConstraint({self.base_attr.__name__}, {self.param_constrs!r})"


### PR DESCRIPTION
As discussed on zulip, adds a `get` method to `ParamAttrConstr`, removing its custom init method

This forces the user to do an explicit cast if they want something of type
`AttrConstraint[SomeType[SomeParam]]`. This is probably desirable as the constraint does not understand the instantiated generic.

I added a test to make sure that the type you passed in is not of this form. I'm not sure if "instantiated generic" is the correct python terminology for this so I'm happy to change it. I can also split out that change separately.

I plan to do similar things to each constraint, and then add constraint simplification into these get methods, but I thought it would be nice to try one first so people can see what it looks like.