### PR TITLE
dialects: (fir) Add missing fields and operations

### DIFF
--- a/xdsl/dialects/experimental/fir.py
+++ b/xdsl/dialects/experimental/fir.py
@@ -44,20 +44,25 @@ from xdsl.irdl import (
     irdl_attr_definition,
     irdl_op_definition,
     operand_def,
+    opt_attr_def,
     opt_operand_def,
     opt_prop_def,
-    opt_result_def,
+    opt_region_def,
     prop_def,
     region_def,
     result_def,
     traits_def,
     var_operand_def,
-    var_region_def,
     var_result_def,
+    var_successor_def,
 )
 from xdsl.parser import AttrParser
 from xdsl.printer import Printer
-from xdsl.traits import IsTerminator, SymbolOpInterface
+from xdsl.traits import (
+    IsolatedFromAbove,
+    IsTerminator,
+    SymbolOpInterface,
+)
 
 
 class FortranVariableFlags(Enum):
@@ -479,10 +484,35 @@ class OpenMPSafeTempArrayCopyAttr(ParametrizedAttribute):
 class ReferenceType(ParametrizedAttribute, TypeAttribute):
     """
     The type of a reference to an entity in memory.
+
+    Flang 22.x added an optional ``volatile`` marker that, when present,
+    indicates the reference wraps a Fortran VOLATILE entity. The textual
+    form is ``!fir.ref<T>`` for the default and ``!fir.ref<T, volatile>``
+    when set.
     """
 
     name = "fir.ref"
+
     type: Attribute
+    is_volatile: BoolAttr
+
+    def __init__(self, type: Attribute, is_volatile: bool = False) -> None:
+        super().__init__(type, BoolAttr.from_bool(is_volatile))
+
+    def print_parameters(self, printer: Printer) -> None:
+        with printer.in_angle_brackets():
+            printer.print_attribute(self.type)
+            if self.is_volatile.value.data:
+                printer.print_string(", volatile")
+
+    @classmethod
+    def parse_parameters(cls, parser: AttrParser) -> list[Attribute]:
+        with parser.in_angle_brackets():
+            ty = parser.parse_type()
+            is_volatile = parser.parse_optional_punctuation(",") is not None
+            if is_volatile:
+                parser.parse_keyword("volatile")
+        return [ty, BoolAttr.from_bool(is_volatile)]
 
 
 @irdl_attr_definition
@@ -824,10 +854,32 @@ class ClassType(ParametrizedAttribute, TypeAttribute):
     """
     Class type is used to model the Fortran CLASS intrinsic type. A class type
     is equivalent to a fir.box type with a dynamic type.
+
+    Flang 22.x added an optional ``volatile`` marker mirroring fir.box.
     """
 
     name = "fir.class"
+
     type: Attribute
+    is_volatile: BoolAttr
+
+    def __init__(self, type: Attribute, is_volatile: bool = False) -> None:
+        super().__init__(type, BoolAttr.from_bool(is_volatile))
+
+    def print_parameters(self, printer: Printer) -> None:
+        with printer.in_angle_brackets():
+            printer.print_attribute(self.type)
+            if self.is_volatile.value.data:
+                printer.print_string(", volatile")
+
+    @classmethod
+    def parse_parameters(cls, parser: AttrParser) -> list[Attribute]:
+        with parser.in_angle_brackets():
+            ty = parser.parse_type()
+            is_volatile = parser.parse_optional_punctuation(",") is not None
+            if is_volatile:
+                parser.parse_keyword("volatile")
+        return [ty, BoolAttr.from_bool(is_volatile)]
 
 
 @irdl_attr_definition
@@ -1069,7 +1121,6 @@ class AbsentOp(IRDLOperation):
 
     name = "fir.absent"
     intype = result_def()
-    regs = var_region_def()
 
 
 @irdl_op_definition
@@ -1079,7 +1130,6 @@ class AddcOp(IRDLOperation):
     rhs = operand_def()
     fastmath = opt_prop_def(FastMathFlagsAttr)
     result = result_def()
-    regs = var_region_def()
 
 
 @irdl_op_definition
@@ -1095,7 +1145,6 @@ class AddressOfOp(IRDLOperation):
     name = "fir.address_of"
     symbol = prop_def(SymbolRefAttr)
     resTy = result_def()
-    regs = var_region_def()
 
 
 @irdl_op_definition
@@ -1118,7 +1167,6 @@ class AllocmemOp(IRDLOperation):
     shape = var_operand_def()
 
     result_0 = result_def()
-    regs = var_region_def()
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
@@ -1193,7 +1241,6 @@ class AllocaOp(IRDLOperation):
     typeparams = var_operand_def()
     shape = var_operand_def()
     result_0 = result_def()
-    regs = var_region_def()
     pinned = opt_prop_def(UnitAttr)
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
@@ -1241,10 +1288,11 @@ class ArrayAccessOp(IRDLOperation):
 
     name = "fir.array_access"
     sequence = operand_def()
-    indices = operand_def()
-    typeparams = operand_def()
+    indices = var_operand_def()
+    typeparams = var_operand_def()
     element = result_def()
-    regs = var_region_def()
+
+    irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
 
 @irdl_op_definition
@@ -1270,7 +1318,6 @@ class ArrayAmendOp(IRDLOperation):
     sequence = operand_def()
     memref = operand_def()
     result_0 = result_def()
-    regs = var_region_def()
 
 
 @irdl_op_definition
@@ -1295,12 +1342,13 @@ class ArrayCoorOp(IRDLOperation):
 
     name = "fir.array_coor"
     memref = operand_def()
-    shape = operand_def()
-    slice = operand_def()
-    indices = operand_def()
-    typeparams = operand_def()
+    shape = opt_operand_def()
+    slice = opt_operand_def()
+    indices = var_operand_def()
+    typeparams = var_operand_def()
     result_0 = result_def()
-    regs = var_region_def()
+
+    irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
 
 @irdl_op_definition
@@ -1328,10 +1376,11 @@ class ArrayFetchOp(IRDLOperation):
 
     name = "fir.array_fetch"
     sequence = operand_def()
-    indices = operand_def()
-    typeparams = operand_def()
+    indices = var_operand_def()
+    typeparams = var_operand_def()
     element = result_def()
-    regs = var_region_def()
+
+    irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
 
 @irdl_op_definition
@@ -1368,11 +1417,12 @@ class ArrayLoadOp(IRDLOperation):
 
     name = "fir.array_load"
     memref = operand_def()
-    shape = operand_def()
-    slice = operand_def()
-    typeparams = operand_def()
+    shape = opt_operand_def()
+    slice = opt_operand_def()
+    typeparams = var_operand_def()
     result_0 = result_def()
-    regs = var_region_def()
+
+    irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
 
 @irdl_op_definition
@@ -1399,9 +1449,10 @@ class ArrayMergeStoreOp(IRDLOperation):
     original = operand_def()
     sequence = operand_def()
     memref = operand_def()
-    slice = operand_def()
-    typeparams = operand_def()
-    regs = var_region_def()
+    slice = opt_operand_def()
+    typeparams = var_operand_def()
+
+    irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
 
 @irdl_op_definition
@@ -1437,11 +1488,12 @@ class ArrayModifyOp(IRDLOperation):
 
     name = "fir.array_modify"
     sequence = operand_def()
-    indices = operand_def()
-    typeparams = operand_def()
+    indices = var_operand_def()
+    typeparams = var_operand_def()
     result_0 = result_def()
     result_1 = result_def()
-    regs = var_region_def()
+
+    irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
 
 @irdl_op_definition
@@ -1475,10 +1527,11 @@ class ArrayUpdateOp(IRDLOperation):
     name = "fir.array_update"
     sequence = operand_def()
     merge = operand_def()
-    indices = operand_def()
-    typeparams = operand_def()
+    indices = var_operand_def()
+    typeparams = var_operand_def()
     result_0 = result_def()
-    regs = var_region_def()
+
+    irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
 
 @irdl_op_definition
@@ -1497,7 +1550,6 @@ class BoxAddrOp(IRDLOperation):
     name = "fir.box_addr"
     val = operand_def()
     result_0 = result_def()
-    regs = var_region_def()
 
 
 @irdl_op_definition
@@ -1512,7 +1564,6 @@ class BoxcharLenOp(IRDLOperation):
     name = "fir.boxchar_len"
     val = operand_def()
     result_0 = result_def()
-    regs = var_region_def()
 
 
 @irdl_op_definition
@@ -1537,7 +1588,6 @@ class BoxDimsOp(IRDLOperation):
     result_0 = result_def()
     result_1 = result_def()
     result_2 = result_def()
-    regs = var_region_def()
 
 
 @irdl_op_definition
@@ -1556,7 +1606,6 @@ class BoxElesizeOp(IRDLOperation):
     name = "fir.box_elesize"
     val = operand_def()
     result_0 = result_def()
-    regs = var_region_def()
 
 
 @irdl_op_definition
@@ -1577,7 +1626,6 @@ class BoxIsallocOp(IRDLOperation):
     name = "fir.box_isalloc"
     val = operand_def()
     result_0 = result_def()
-    regs = var_region_def()
 
 
 @irdl_op_definition
@@ -1597,7 +1645,6 @@ class BoxIsarrayOp(IRDLOperation):
     name = "fir.box_isarray"
     val = operand_def()
     result_0 = result_def()
-    regs = var_region_def()
 
 
 @irdl_op_definition
@@ -1613,7 +1660,6 @@ class BoxIsptrOp(IRDLOperation):
     name = "fir.box_isptr"
     val = operand_def()
     result_0 = result_def()
-    regs = var_region_def()
 
 
 @irdl_op_definition
@@ -1634,8 +1680,8 @@ class BoxOffsetOp(IRDLOperation):
     """
 
     name = "fir.box_offset"
+    box_ref = operand_def()
     field = prop_def()
-    val = operand_def()
     result_0 = result_def()
 
 
@@ -1656,7 +1702,6 @@ class BoxprocHostOp(IRDLOperation):
     name = "fir.boxproc_host"
     val = operand_def()
     result_0 = result_def()
-    regs = var_region_def()
 
 
 @irdl_op_definition
@@ -1676,7 +1721,6 @@ class BoxRankOp(IRDLOperation):
     name = "fir.box_rank"
     val = operand_def()
     result_0 = result_def()
-    regs = var_region_def()
 
 
 @irdl_op_definition
@@ -1692,7 +1736,6 @@ class BoxTdescOp(IRDLOperation):
     name = "fir.box_tdesc"
     val = operand_def()
     result_0 = result_def()
-    regs = var_region_def()
 
 
 @irdl_op_definition
@@ -1705,13 +1748,12 @@ class CallOp(IRDLOperation):
     """
 
     name = "fir.call"
-    callee = prop_def()
+    callee = opt_prop_def(SymbolRefAttr)
     fastmath = opt_prop_def(FastMathFlagsAttr)
     procedure_attrs = opt_prop_def(FortranProcedureFlagsAttr)
     inline_attr = opt_prop_def(FortranInlineFlagsAttr)
-    result_0 = opt_result_def()
     args = var_operand_def()
-    regs = var_region_def()
+    result_0 = var_result_def()
 
 
 @irdl_op_definition
@@ -1739,7 +1781,6 @@ class CharConvertOp(IRDLOperation):
     _from = operand_def()
     count = operand_def()
     to = operand_def()
-    regs = var_region_def()
 
 
 @irdl_op_definition
@@ -1749,10 +1790,11 @@ class CmpcOp(IRDLOperation):
     """
 
     name = "fir.cmpc"
+    predicate = prop_def(IntegerAttr)
+    fastmath = opt_prop_def(FastMathFlagsAttr)
     lhs = operand_def()
     rhs = operand_def()
     result_0 = result_def()
-    regs = var_region_def()
 
 
 @irdl_op_definition
@@ -1772,7 +1814,6 @@ class ConvertOp(IRDLOperation):
     name = "fir.convert"
     value = operand_def()
     res = result_def()
-    regs = var_region_def()
 
 
 @irdl_op_definition
@@ -1798,10 +1839,10 @@ class CoordinateOfOp(IRDLOperation):
 
     name = "fir.coordinate_of"
     baseType = prop_def()
+    field_indices = opt_prop_def()
     ref = operand_def()
     coor = var_operand_def()
     result_0 = result_def()
-    regs = var_region_def()
 
 
 @irdl_op_definition
@@ -1850,6 +1891,7 @@ class DeclareOp(IRDLOperation):
     storage_offset = opt_prop_def(IntegerAttr)
     uniq_name = prop_def(StringAttr)
     fortran_attrs = opt_prop_def(FortranVariableFlagsAttr)
+    data_attr = opt_prop_def(Attribute)
     dummy_arg_no = opt_prop_def(IntegerAttr)
     result = result_def()
 
@@ -1869,7 +1911,9 @@ class DtEntryOp(IRDLOperation):
     """
 
     name = "fir.dt_entry"
-    regs = var_region_def()
+    method = prop_def(StringAttr)
+    proc = prop_def(SymbolRefAttr)
+    deferred = opt_prop_def(UnitAttr)
 
 
 @irdl_op_definition
@@ -1888,11 +1932,11 @@ class DispatchOp(IRDLOperation):
     """
 
     name = "fir.dispatch"
+    method = prop_def(StringAttr)
     pass_arg_pos = opt_prop_def(IntegerAttr)
     object = operand_def()
-    args = operand_def()
-    result_0 = result_def()
-    regs = var_region_def()
+    args = var_operand_def()
+    result_0 = var_result_def()
 
 
 @irdl_op_definition
@@ -1902,7 +1946,6 @@ class DivcOp(IRDLOperation):
     rhs = operand_def()
     fastmath = opt_prop_def(FastMathFlagsAttr)
     result = result_def()
-    regs = var_region_def()
 
 
 @irdl_op_definition
@@ -1936,7 +1979,7 @@ class DoLoopOp(IRDLOperation):
     reduceAttrs = opt_prop_def(ArrayAttr)
     loopAnnotation = opt_prop_def(Attribute)
     _results = var_result_def()
-    regs = var_region_def()
+    region = region_def("single_block")
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
@@ -2041,7 +2084,6 @@ class EmboxcharOp(IRDLOperation):
     memref = operand_def()
     len = operand_def()
     result_0 = result_def()
-    regs = var_region_def()
 
 
 @irdl_op_definition
@@ -2076,7 +2118,6 @@ class EmboxOp(IRDLOperation):
     accessMap = opt_prop_def(Attribute)
     allocator_idx = opt_prop_def(IntegerAttr)
     result_0 = result_def()
-    regs = var_region_def()
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
@@ -2105,9 +2146,8 @@ class EmboxprocOp(IRDLOperation):
 
     name = "fir.emboxproc"
     func = operand_def()
-    host = operand_def()
+    host = opt_operand_def()
     result_0 = result_def()
-    regs = var_region_def()
 
 
 @irdl_op_definition
@@ -2129,9 +2169,8 @@ class ExtractValueOp(IRDLOperation):
 
     name = "fir.extract_value"
     adt = operand_def()
-    coor = opt_prop_def()
+    coor = prop_def(ArrayAttr)
     res = result_def()
-    regs = var_region_def()
 
 
 @irdl_op_definition
@@ -2152,7 +2191,6 @@ class FieldIndexOp(IRDLOperation):
     on_type = prop_def()
     typeparams = var_operand_def()
     res = result_def()
-    regs = var_region_def()
 
 
 @irdl_op_definition
@@ -2165,7 +2203,6 @@ class EndOp(IRDLOperation):
     """
 
     name = "fir.end"
-    regs = var_region_def()
 
     traits = traits_def(IsTerminator())
 
@@ -2186,7 +2223,6 @@ class FreememOp(IRDLOperation):
 
     name = "fir.freemem"
     heapref = operand_def()
-    regs = var_region_def()
 
 
 @irdl_op_definition
@@ -2204,7 +2240,8 @@ class GlobalLenOp(IRDLOperation):
     """
 
     name = "fir.global_len"
-    regs = var_region_def()
+    lenparam = prop_def(StringAttr)
+    intval = prop_def(IntegerAttr)
 
 
 @irdl_op_definition
@@ -2229,7 +2266,7 @@ class GlobalOp(IRDLOperation):
     """
 
     name = "fir.global"
-    regs = var_region_def()
+    region = opt_region_def()
     sym_name = prop_def(SymbolNameConstraint())
     symref = prop_def(SymbolRefAttr)
     type = prop_def()
@@ -2240,7 +2277,7 @@ class GlobalOp(IRDLOperation):
     data_attr = opt_prop_def()
     alignment = opt_prop_def(IntegerAttr)
 
-    traits = traits_def(SymbolOpInterface())
+    traits = traits_def(SymbolOpInterface(), IsolatedFromAbove())
 
 
 @irdl_op_definition
@@ -2262,7 +2299,6 @@ class HasValueOp(IRDLOperation):
 
     name = "fir.has_value"
     resval = operand_def()
-    regs = var_region_def()
 
     traits = traits_def(IsTerminator())
 
@@ -2284,7 +2320,9 @@ class IfOp(IRDLOperation):
 
     name = "fir.if"
     condition = operand_def()
-    regs = var_region_def()
+    output = var_result_def()
+    then_region = region_def()
+    else_region = opt_region_def()
 
 
 @irdl_op_definition
@@ -2306,10 +2344,10 @@ class InsertOnRangeOp(IRDLOperation):
     """
 
     name = "fir.insert_on_range"
+    coor = prop_def()
     seq = operand_def()
     val = operand_def()
     result_0 = result_def()
-    regs = var_region_def()
 
 
 @irdl_op_definition
@@ -2334,9 +2372,8 @@ class InsertValueOp(IRDLOperation):
     name = "fir.insert_value"
     adt = operand_def()
     val = operand_def()
-    coor = opt_prop_def()
+    coor = prop_def(ArrayAttr)
     result_0 = result_def()
-    regs = var_region_def()
 
 
 @irdl_op_definition
@@ -2353,7 +2390,6 @@ class IsPresentOp(IRDLOperation):
     name = "fir.is_present"
     val = operand_def()
     result_0 = result_def()
-    regs = var_region_def()
 
 
 @irdl_op_definition
@@ -2384,13 +2420,14 @@ class IterateWhileOp(IRDLOperation):
     """
 
     name = "fir.iterate_while"
+    finalValue = opt_prop_def(UnitAttr)
     lowerBound = operand_def()
     upperBound = operand_def()
     step = operand_def()
     iterateIn = operand_def()
-    initArgs = operand_def()
+    initArgs = var_operand_def()
     _results = var_result_def()
-    regs = var_region_def()
+    region = region_def("single_block")
 
 
 @irdl_op_definition
@@ -2407,9 +2444,10 @@ class LenParamIndexOp(IRDLOperation):
     """
 
     name = "fir.len_param_index"
-    typeparams = operand_def()
+    field_id = prop_def(StringAttr)
+    on_type = prop_def()
+    typeparams = var_operand_def()
     res = result_def()
-    regs = var_region_def()
 
 
 @irdl_op_definition
@@ -2429,7 +2467,6 @@ class LoadOp(IRDLOperation):
     name = "fir.load"
     memref = operand_def()
     res = result_def()
-    regs = var_region_def()
 
 
 @irdl_op_definition
@@ -2439,7 +2476,6 @@ class MulcOp(IRDLOperation):
     rhs = operand_def()
     fastmath = opt_prop_def(FastMathFlagsAttr)
     result = result_def()
-    regs = var_region_def()
 
 
 @irdl_op_definition
@@ -2447,7 +2483,6 @@ class NegcOp(IRDLOperation):
     name = "fir.negc"
     operand = operand_def()
     result = result_def()
-    regs = var_region_def()
 
 
 @irdl_op_definition
@@ -2469,7 +2504,6 @@ class NoReassocOp(IRDLOperation):
     name = "fir.no_reassoc"
     val = operand_def()
     res = result_def()
-    regs = var_region_def()
 
 
 @irdl_op_definition
@@ -2505,11 +2539,10 @@ class ReboxOp(IRDLOperation):
     """
 
     name = "fir.rebox"
-    box = opt_operand_def()
+    box = operand_def()
     shape = opt_operand_def()
     slice = opt_operand_def()
     result_0 = result_def()
-    regs = var_region_def()
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
@@ -2524,7 +2557,6 @@ class ResultOp(IRDLOperation):
     """
 
     name = "fir.result"
-    regs = var_region_def()
     _results = var_operand_def()
 
     traits = traits_def(IsTerminator())
@@ -2577,9 +2609,10 @@ class SaveResultOp(IRDLOperation):
     name = "fir.save_result"
     value = operand_def()
     memref = operand_def()
-    shape = operand_def()
-    typeparams = operand_def()
-    regs = var_region_def()
+    shape = opt_operand_def()
+    typeparams = var_operand_def()
+
+    irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
 
 @irdl_op_definition
@@ -2601,9 +2634,13 @@ class SelectCaseOp(IRDLOperation):
 
     name = "fir.select_case"
     selector = operand_def()
-    compareArgs = operand_def()
-    targetArgs = operand_def()
-    regs = var_region_def()
+    compareArgs = var_operand_def()
+    targetArgs = var_operand_def()
+    case_tags = prop_def(ArrayAttr)
+    targets = var_successor_def()
+
+    traits = traits_def(IsTerminator())
+    irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
 
 @irdl_op_definition
@@ -2625,9 +2662,13 @@ class SelectOp(IRDLOperation):
 
     name = "fir.select"
     selector = operand_def()
-    compareArgs = operand_def()
-    targetArgs = operand_def()
-    regs = var_region_def()
+    compareArgs = var_operand_def()
+    targetArgs = var_operand_def()
+    case_tags = prop_def(ArrayAttr)
+    targets = var_successor_def()
+
+    traits = traits_def(IsTerminator())
+    irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
 
 @irdl_op_definition
@@ -2648,9 +2689,13 @@ class SelectRankOp(IRDLOperation):
 
     name = "fir.select_rank"
     selector = operand_def()
-    compareArgs = operand_def()
-    targetArgs = operand_def()
-    regs = var_region_def()
+    compareArgs = var_operand_def()
+    targetArgs = var_operand_def()
+    case_tags = prop_def(ArrayAttr)
+    targets = var_successor_def()
+
+    traits = traits_def(IsTerminator())
+    irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
 
 @irdl_op_definition
@@ -2672,9 +2717,13 @@ class SelectTypeOp(IRDLOperation):
 
     name = "fir.select_type"
     selector = operand_def()
-    compareArgs = operand_def()
-    targetArgs = operand_def()
-    regs = var_region_def()
+    compareArgs = var_operand_def()
+    targetArgs = var_operand_def()
+    case_tags = prop_def(ArrayAttr)
+    targets = var_successor_def()
+
+    traits = traits_def(IsTerminator())
+    irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
 
 @irdl_op_definition
@@ -2710,7 +2759,6 @@ class ShapeShiftOp(IRDLOperation):
     name = "fir.shape_shift"
     pairs = var_operand_def()
     result_0 = result_def()
-    regs = var_region_def()
 
 
 @irdl_op_definition
@@ -2728,7 +2776,6 @@ class ShiftOp(IRDLOperation):
     name = "fir.shift"
     origins = var_operand_def()
     result_0 = result_def()
-    regs = var_region_def()
 
 
 @irdl_op_definition
@@ -2760,11 +2807,12 @@ class SliceOp(IRDLOperation):
     """
 
     name = "fir.slice"
-    triples = operand_def()
-    fields = operand_def()
-    substr = operand_def()
+    triples = var_operand_def()
+    fields = var_operand_def()
+    substr = var_operand_def()
     result_0 = result_def()
-    regs = var_region_def()
+
+    irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
 
 @irdl_op_definition
@@ -2786,7 +2834,6 @@ class StoreOp(IRDLOperation):
     name = "fir.store"
     value = operand_def()
     memref = operand_def()
-    regs = var_region_def()
 
 
 @irdl_op_definition
@@ -2804,7 +2851,8 @@ class StringLitOp(IRDLOperation):
 
     name = "fir.string_lit"
     size = attr_def(IntegerAttr[IntegerType])
-    value = attr_def(StringAttr)
+    value = opt_attr_def(StringAttr)
+    xlist = opt_attr_def(ArrayAttr)
     result_0 = result_def()
 
 
@@ -2815,7 +2863,6 @@ class SubcOp(IRDLOperation):
     rhs = operand_def()
     fastmath = opt_prop_def(FastMathFlagsAttr)
     result = result_def()
-    regs = var_region_def()
 
 
 @irdl_op_definition
@@ -2832,7 +2879,6 @@ class UnboxcharOp(IRDLOperation):
     boxchar = operand_def()
     result_0 = result_def()
     result_1 = result_def()
-    regs = var_region_def()
 
 
 @irdl_op_definition
@@ -2849,7 +2895,6 @@ class UnboxprocOp(IRDLOperation):
     boxproc = operand_def()
     result_0 = result_def()
     refTuple = result_def()
-    regs = var_region_def()
 
 
 @irdl_op_definition
@@ -2867,7 +2912,6 @@ class UndefinedOp(IRDLOperation):
 
     name = "fir.undefined"
     intype = result_def()
-    regs = var_region_def()
 
 
 @irdl_op_definition
@@ -2883,7 +2927,6 @@ class UnreachableOp(IRDLOperation):
     """
 
     name = "fir.unreachable"
-    regs = var_region_def()
 
     traits = traits_def(IsTerminator())
 
@@ -2901,7 +2944,6 @@ class ZeroBitsOp(IRDLOperation):
 
     name = "fir.zero_bits"
     intype = result_def()
-    regs = var_region_def()
 
 
 @irdl_op_definition
@@ -2948,14 +2990,14 @@ class DeclareReductionOp(IRDLOperation):
     sym_name = prop_def(SymbolNameConstraint())
     type = prop_def()
     byref_element_type = opt_prop_def()
-    allocRegion = region_def()
+    allocRegion = opt_region_def()
     initializerRegion = region_def()
     reductionRegion = region_def()
     atomicReductionRegion = region_def()
     cleanupRegion = region_def()
     dataPtrPtrRegion = region_def()
 
-    traits = traits_def(SymbolOpInterface())
+    traits = traits_def(SymbolOpInterface(), IsolatedFromAbove())
 
 
 @irdl_op_definition
@@ -3036,7 +3078,7 @@ class LocalitySpecifierOp(IRDLOperation):
     copy_region = region_def()
     dealloc_region = region_def()
 
-    traits = traits_def(SymbolOpInterface())
+    traits = traits_def(SymbolOpInterface(), IsolatedFromAbove())
 
 
 @irdl_op_definition
@@ -3114,7 +3156,7 @@ class TypeInfoOp(IRDLOperation):
     dispatch_table = region_def()
     component_info = region_def()
 
-    traits = traits_def(SymbolOpInterface())
+    traits = traits_def(SymbolOpInterface(), IsolatedFromAbove())
 
 
 @irdl_op_definition

--- a/xdsl/dialects/experimental/fir.py
+++ b/xdsl/dialects/experimental/fir.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass
 from enum import Enum
+from typing import cast
 
 from xdsl.dialects.arith import FastMathFlagsAttr
 from xdsl.dialects.builtin import (
@@ -134,6 +135,344 @@ class FortranVariableFlagsAttrBase(Data[tuple[FortranVariableFlags, ...]]):
 @irdl_attr_definition
 class FortranVariableFlagsAttr(FortranVariableFlagsAttrBase):
     name = "fir.var_attrs"
+
+
+class FortranProcedureFlags(Enum):
+    """Fortran procedure attributes (F2023 15.6.2.1). BIND attribute (18.3.7)
+    is also tracked in the same enum."""
+
+    NOATTRIBUTES = "none"
+    ELEMENTAL = "elemental"
+    PURE = "pure"
+    NON_RECURSIVE = "non_recursive"
+    SIMPLE = "simple"
+    BIND_C = "bind_c"
+
+    @staticmethod
+    def try_parse(parser: AttrParser) -> set[FortranProcedureFlags] | None:
+        for option in FortranProcedureFlags:
+            if parser.parse_optional_characters(option.value) is not None:
+                return {option}
+        return None
+
+
+@dataclass(frozen=True)
+class FortranProcedureFlagsAttrBase(Data[tuple[FortranProcedureFlags, ...]]):
+    @property
+    def flags(self) -> set[FortranProcedureFlags]:
+        return set(self.data)
+
+    def __init__(self, flags: Sequence[FortranProcedureFlags]):
+        super().__init__(tuple(set(flags)))
+
+    @classmethod
+    def parse_parameter(cls, parser: AttrParser) -> tuple[FortranProcedureFlags, ...]:
+        with parser.in_angle_brackets():
+            flags = FortranProcedureFlags.try_parse(parser)
+            if flags is None:
+                return tuple()
+            while parser.parse_optional_punctuation(",") is not None:
+                flag = parser.expect(
+                    lambda: FortranProcedureFlags.try_parse(parser),
+                    "fortran procedure flag expected",
+                )
+                flags.update(flag)
+            return tuple(flags)
+
+    def print_parameter(self, printer: Printer):
+        with printer.in_angle_brackets():
+            flags = self.data
+            printer.print_list(
+                tuple(flag.value for flag in FortranProcedureFlags if flag in flags),
+                printer.print_string,
+                ",",
+            )
+
+
+@irdl_attr_definition
+class FortranProcedureFlagsAttr(FortranProcedureFlagsAttrBase):
+    name = "fir.proc_attrs"
+
+
+class FortranInlineFlags(Enum):
+    """Fortran inline hint attributes for fir.call."""
+
+    NONE = "none"
+    NO_INLINE = "no_inline"
+    ALWAYS_INLINE = "always_inline"
+    INLINE_HINT = "inline_hint"
+
+    @staticmethod
+    def try_parse(parser: AttrParser) -> set[FortranInlineFlags] | None:
+        for option in FortranInlineFlags:
+            if parser.parse_optional_characters(option.value) is not None:
+                return {option}
+        return None
+
+
+@dataclass(frozen=True)
+class FortranInlineFlagsAttrBase(Data[tuple[FortranInlineFlags, ...]]):
+    @property
+    def flags(self) -> set[FortranInlineFlags]:
+        return set(self.data)
+
+    def __init__(self, flags: Sequence[FortranInlineFlags]):
+        super().__init__(tuple(set(flags)))
+
+    @classmethod
+    def parse_parameter(cls, parser: AttrParser) -> tuple[FortranInlineFlags, ...]:
+        with parser.in_angle_brackets():
+            flags = FortranInlineFlags.try_parse(parser)
+            if flags is None:
+                return tuple()
+            while parser.parse_optional_punctuation(",") is not None:
+                flag = parser.expect(
+                    lambda: FortranInlineFlags.try_parse(parser),
+                    "fortran inline flag expected",
+                )
+                flags.update(flag)
+            return tuple(flags)
+
+    def print_parameter(self, printer: Printer):
+        with printer.in_angle_brackets():
+            flags = self.data
+            printer.print_list(
+                tuple(flag.value for flag in FortranInlineFlags if flag in flags),
+                printer.print_string,
+                ",",
+            )
+
+
+@irdl_attr_definition
+class FortranInlineFlagsAttr(FortranInlineFlagsAttrBase):
+    name = "fir.inline_attrs"
+
+
+class PackArrayHeuristics(Enum):
+    """Optimization heuristics for fir.pack_array."""
+
+    NONE = "none"
+    LOOP_ONLY = "loop_only"
+
+    @staticmethod
+    def try_parse(parser: AttrParser) -> set[PackArrayHeuristics] | None:
+        for option in PackArrayHeuristics:
+            if parser.parse_optional_characters(option.value) is not None:
+                return {option}
+        return None
+
+
+@dataclass(frozen=True)
+class PackArrayHeuristicsAttrBase(Data[tuple[PackArrayHeuristics, ...]]):
+    @property
+    def flags(self) -> set[PackArrayHeuristics]:
+        return set(self.data)
+
+    def __init__(self, flags: Sequence[PackArrayHeuristics]):
+        super().__init__(tuple(set(flags)))
+
+    @classmethod
+    def parse_parameter(cls, parser: AttrParser) -> tuple[PackArrayHeuristics, ...]:
+        with parser.in_angle_brackets():
+            flags = PackArrayHeuristics.try_parse(parser)
+            if flags is None:
+                return tuple()
+            while parser.parse_optional_punctuation(",") is not None:
+                flag = parser.expect(
+                    lambda: PackArrayHeuristics.try_parse(parser),
+                    "pack_array heuristic expected",
+                )
+                flags.update(flag)
+            return tuple(flags)
+
+    def print_parameter(self, printer: Printer):
+        with printer.in_angle_brackets():
+            flags = self.data
+            printer.print_list(
+                tuple(flag.value for flag in PackArrayHeuristics if flag in flags),
+                printer.print_string,
+                ",",
+            )
+
+
+@irdl_attr_definition
+class PackArrayHeuristicsAttr(PackArrayHeuristicsAttrBase):
+    name = "fir.pack_array_heuristics"
+
+
+class ReduceOperator(Enum):
+    """Intrinsic reduction operations for DO CONCURRENT REDUCE.
+    Upstream this is an I32BitEnumAttr; in practice each reduction
+    declaration selects a single operation, so a single value is stored."""
+
+    ADD = "add"
+    MULTIPLY = "multiply"
+    AND = "and"
+    OR = "or"
+    EQV = "eqv"
+    NEQV = "neqv"
+    MAX = "max"
+    MIN = "min"
+    IAND = "iand"
+    IOR = "ior"
+    IEOR = "ieor"
+
+    @staticmethod
+    def try_parse(parser: AttrParser) -> ReduceOperator | None:
+        for option in ReduceOperator:
+            if parser.parse_optional_characters(option.value) is not None:
+                return option
+        return None
+
+
+@dataclass(frozen=True)
+class ReduceAttrBase(Data[ReduceOperator]):
+    @classmethod
+    def parse_parameter(cls, parser: AttrParser) -> ReduceOperator:
+        with parser.in_angle_brackets():
+            return parser.expect(
+                lambda: ReduceOperator.try_parse(parser),
+                "reduce operation expected",
+            )
+
+    def print_parameter(self, printer: Printer):
+        with printer.in_angle_brackets():
+            printer.print_string(self.data.value)
+
+
+@irdl_attr_definition
+class ReduceAttr(ReduceAttrBase):
+    name = "fir.reduce_attr"
+
+
+class LocationKind(Enum):
+    """Flang location kind for debug info."""
+
+    BASE = "base"
+    INCLUSION = "inclusion"
+
+    @staticmethod
+    def try_parse(parser: AttrParser) -> LocationKind | None:
+        for option in LocationKind:
+            if parser.parse_optional_characters(option.value) is not None:
+                return option
+        return None
+
+
+@dataclass(frozen=True)
+class LocationKindAttrBase(Data[LocationKind]):
+    @classmethod
+    def parse_parameter(cls, parser: AttrParser) -> LocationKind:
+        with parser.in_angle_brackets():
+            return parser.expect(
+                lambda: LocationKind.try_parse(parser),
+                "location kind expected",
+            )
+
+    def print_parameter(self, printer: Printer):
+        with printer.in_angle_brackets():
+            printer.print_string(self.data.value)
+
+
+@irdl_attr_definition
+class LocationKindAttr(LocationKindAttrBase):
+    name = "fir.loc_kind"
+
+
+@dataclass(frozen=True)
+class LocationKindArrayAttrBase(Data[tuple[LocationKind, ...]]):
+    @classmethod
+    def parse_parameter(cls, parser: AttrParser) -> tuple[LocationKind, ...]:
+        with parser.in_square_brackets():
+            kinds: list[LocationKind] = []
+            first = LocationKind.try_parse(parser)
+            if first is None:
+                return tuple()
+            kinds.append(first)
+            while parser.parse_optional_punctuation(",") is not None:
+                kinds.append(
+                    parser.expect(
+                        lambda: LocationKind.try_parse(parser),
+                        "location kind expected",
+                    )
+                )
+            return tuple(kinds)
+
+    def print_parameter(self, printer: Printer):
+        with printer.in_square_brackets():
+            printer.print_list(
+                tuple(k.value for k in self.data),
+                printer.print_string,
+                ",",
+            )
+
+
+@irdl_attr_definition
+class LocationKindArrayAttr(LocationKindArrayAttrBase):
+    name = "fir.loc_kind_array"
+
+
+class LocalitySpecifierType(Enum):
+    """Locality kind for fir.local: LOCAL vs LOCAL_INIT."""
+
+    LOCAL = "local"
+    LOCAL_INIT = "local_init"
+
+    @staticmethod
+    def try_parse(parser: AttrParser) -> LocalitySpecifierType | None:
+        for option in LocalitySpecifierType:
+            if parser.parse_optional_characters(option.value) is not None:
+                return option
+        return None
+
+
+@dataclass(frozen=True)
+class LocalitySpecifierTypeAttrBase(Data[LocalitySpecifierType]):
+    @classmethod
+    def parse_parameter(cls, parser: AttrParser) -> LocalitySpecifierType:
+        parser.parse_punctuation("{")
+        parser.parse_keyword("type")
+        parser.parse_punctuation("=")
+        value = parser.expect(
+            lambda: LocalitySpecifierType.try_parse(parser),
+            "locality specifier type expected",
+        )
+        parser.parse_punctuation("}")
+        return value
+
+    def print_parameter(self, printer: Printer):
+        printer.print_string("{type = ")
+        printer.print_string(self.data.value)
+        printer.print_string("}")
+
+
+@irdl_attr_definition
+class LocalitySpecifierTypeAttr(LocalitySpecifierTypeAttrBase):
+    name = "fir.locality_specifier_type"
+
+
+@irdl_attr_definition
+class UseRenameAttr(ParametrizedAttribute):
+    """A single rename mapping for a Fortran USE statement: local_name => module_var."""
+
+    name = "fir.use_rename"
+
+    local_name: StringAttr
+    symbol: SymbolRefAttr
+
+
+@irdl_attr_definition
+class OpenACCSafeTempArrayCopyAttr(ParametrizedAttribute):
+    """Marker attribute implementing SafeTempArrayCopyAttrInterface for OpenACC."""
+
+    name = "fir.acc_safe_temp_array_copy"
+
+
+@irdl_attr_definition
+class OpenMPSafeTempArrayCopyAttr(ParametrizedAttribute):
+    """Marker attribute implementing SafeTempArrayCopyAttrInterface for OpenMP."""
+
+    name = "fir.omp_safe_temp_array_copy"
 
 
 @irdl_attr_definition
@@ -349,6 +688,77 @@ class CharacterType(ParametrizedAttribute, TypeAttribute):
             else:
                 upper = IntAttr(1)
         return [lower, upper]
+
+
+@irdl_attr_definition
+class RecordType(ParametrizedAttribute, TypeAttribute):
+    """
+    Fortran derived type (TYPE).
+
+    The name includes any KIND type parameters. The record may carry runtime
+    slots for LEN type parameters and for data components. Both lists are
+    optional in the assembly form.
+
+    Examples:
+        !fir.type<t>
+        !fir.type<t{i:i32,c:!fir.char<1,10>}>
+        !fir.type<tp(len1:i32){i:i32}>
+
+    Self-referential derived types (e.g. !fir.type<t{p:!fir.ptr<!fir.type<t>>}>)
+    are not yet supported and will fail to parse if encountered.
+    """
+
+    name = "fir.type"
+
+    type_name: StringAttr
+    lenparams: ArrayAttr
+    components: ArrayAttr
+
+    def print_parameters(self, printer: Printer) -> None:
+        def print_pair(pair: Attribute) -> None:
+            arr = cast(ArrayAttr[Attribute], pair)
+            field_name = arr.data[0]
+            field_type = arr.data[1]
+            assert isinstance(field_name, StringAttr)
+            printer.print_string(field_name.data)
+            printer.print_string(":")
+            printer.print_attribute(field_type)
+
+        with printer.in_angle_brackets():
+            printer.print_string(self.type_name.data)
+            if len(self.lenparams.data) > 0:
+                printer.print_string("(")
+                printer.print_list(self.lenparams.data, print_pair, ",")
+                printer.print_string(")")
+            if len(self.components.data) > 0:
+                printer.print_string("{")
+                printer.print_list(self.components.data, print_pair, ",")
+                printer.print_string("}")
+
+    @classmethod
+    def parse_parameters(cls, parser: AttrParser) -> list[Attribute]:
+        def parse_pair() -> ArrayAttr:
+            field_name = parser.parse_identifier()
+            parser.parse_punctuation(":")
+            field_type = parser.parse_type()
+            return ArrayAttr([StringAttr(field_name), field_type])
+
+        with parser.in_angle_brackets():
+            type_name = parser.parse_identifier()
+            lenparams: list[Attribute] = []
+            if parser.parse_optional_punctuation("(") is not None:
+                lenparams.append(parse_pair())
+                while parser.parse_optional_punctuation(",") is not None:
+                    lenparams.append(parse_pair())
+                parser.parse_punctuation(")")
+            components: list[Attribute] = []
+            if parser.parse_optional_punctuation("{") is not None:
+                if parser.parse_optional_punctuation("}") is None:
+                    components.append(parse_pair())
+                    while parser.parse_optional_punctuation(",") is not None:
+                        components.append(parse_pair())
+                    parser.parse_punctuation("}")
+        return [StringAttr(type_name), ArrayAttr(lenparams), ArrayAttr(components)]
 
 
 @irdl_attr_definition
@@ -1297,6 +1707,8 @@ class CallOp(IRDLOperation):
     name = "fir.call"
     callee = prop_def()
     fastmath = opt_prop_def(FastMathFlagsAttr)
+    procedure_attrs = opt_prop_def(FortranProcedureFlagsAttr)
+    inline_attr = opt_prop_def(FortranInlineFlagsAttr)
     result_0 = opt_result_def()
     args = var_operand_def()
     regs = var_region_def()
@@ -2117,6 +2529,20 @@ class ResultOp(IRDLOperation):
 
 
 @irdl_op_definition
+class YieldOp(IRDLOperation):
+    """
+    fir.yield yields SSA values from a fir dialect op region and terminates the
+    region. Used as the terminator for fir.local and fir.declare_reduction
+    bodies.
+    """
+
+    name = "fir.yield"
+    _results = var_operand_def()
+
+    traits = traits_def(IsTerminator())
+
+
+@irdl_op_definition
 class SaveResultOp(IRDLOperation):
     """
     Save the result of a function returning an array, box, or record type value
@@ -2603,7 +3029,7 @@ class LocalitySpecifierOp(IRDLOperation):
     name = "fir.local"
     sym_name = prop_def(SymbolNameConstraint())
     type = prop_def()
-    locality_specifier_type = prop_def()
+    locality_specifier_type = prop_def(LocalitySpecifierTypeAttr)
     init_region = region_def()
     copy_region = region_def()
     dealloc_region = region_def()
@@ -2624,7 +3050,7 @@ class PackArrayOp(IRDLOperation):
     max_size = opt_prop_def(IntegerAttr)
     max_element_size = opt_prop_def(IntegerAttr)
     min_stride = opt_prop_def(IntegerAttr)
-    heuristics = opt_prop_def(Attribute)
+    heuristics = opt_prop_def(PackArrayHeuristicsAttr)
     is_safe = opt_prop_def(ArrayAttr)
     result = result_def()
 
@@ -2805,9 +3231,20 @@ FIR = Dialect(
         TypeInfoOp,
         UseStmtOp,
         VolatileCastOp,
+        YieldOp,
     ],
     [
         FortranVariableFlagsAttr,
+        FortranProcedureFlagsAttr,
+        FortranInlineFlagsAttr,
+        PackArrayHeuristicsAttr,
+        ReduceAttr,
+        LocationKindAttr,
+        LocationKindArrayAttr,
+        LocalitySpecifierTypeAttr,
+        UseRenameAttr,
+        OpenACCSafeTempArrayCopyAttr,
+        OpenMPSafeTempArrayCopyAttr,
         ReferenceType,
         DeferredAttr,
         DummyScopeType,
@@ -2833,5 +3270,6 @@ FIR = Dialect(
         VoidType,
         SliceType,
         VectorType,
+        RecordType,
     ],
 )

--- a/xdsl/dialects/experimental/fir.py
+++ b/xdsl/dialects/experimental/fir.py
@@ -2148,7 +2148,9 @@ class FieldIndexOp(IRDLOperation):
     """
 
     name = "fir.field_index"
-    typeparams = operand_def()
+    field_id = prop_def(StringAttr)
+    on_type = prop_def()
+    typeparams = var_operand_def()
     res = result_def()
     regs = var_region_def()
 

--- a/xdsl/dialects/experimental/hlfir.py
+++ b/xdsl/dialects/experimental/hlfir.py
@@ -12,6 +12,9 @@ See external [documentation](https://flang.llvm.org/docs/HighLevelFIR.html).
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from enum import Enum
+
 from xdsl.dialects.arith import FastMathFlagsAttr
 from xdsl.dialects.builtin import (
     ArrayAttr,
@@ -29,7 +32,7 @@ from xdsl.dialects.experimental.fir import (
     FortranVariableFlagsAttr,
     NoneType,
 )
-from xdsl.ir import Dialect, TypeAttribute
+from xdsl.ir import Data, Dialect, TypeAttribute
 from xdsl.irdl import (
     AttrSizedOperandSegments,
     IRDLOperation,
@@ -49,6 +52,40 @@ from xdsl.irdl import (
 from xdsl.parser import AttrParser
 from xdsl.printer import Printer
 from xdsl.traits import IsTerminator
+
+
+class CharExtremumPredicate(Enum):
+    """min / max selector for hlfir.char_extremum."""
+
+    MIN = "min"
+    MAX = "max"
+
+    @staticmethod
+    def try_parse(parser: AttrParser) -> CharExtremumPredicate | None:
+        for option in CharExtremumPredicate:
+            if parser.parse_optional_characters(option.value) is not None:
+                return option
+        return None
+
+
+@dataclass(frozen=True)
+class CharExtremumPredicateAttrBase(Data[CharExtremumPredicate]):
+    @classmethod
+    def parse_parameter(cls, parser: AttrParser) -> CharExtremumPredicate:
+        with parser.in_angle_brackets():
+            return parser.expect(
+                lambda: CharExtremumPredicate.try_parse(parser),
+                "char_extremum predicate (min or max) expected",
+            )
+
+    def print_parameter(self, printer: Printer):
+        with printer.in_angle_brackets():
+            printer.print_string(self.data.value)
+
+
+@irdl_attr_definition
+class CharExtremumPredicateAttr(CharExtremumPredicateAttrBase):
+    name = "hlfir.char_extremum_predicate"
 
 
 @irdl_attr_definition
@@ -1110,11 +1147,9 @@ class CharExtremumOp(IRDLOperation):
     """  # noqa E501
 
     name = "hlfir.char_extremum"
-    predicate = operand_def()
+    predicate = prop_def(CharExtremumPredicateAttr)
     strings = var_operand_def()
     result = result_def()
-
-    irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
 
 @irdl_op_definition
@@ -1295,5 +1330,6 @@ HLFIR = Dialect(
     ],
     [
         ExprType,
+        CharExtremumPredicateAttr,
     ],
 )

--- a/xdsl/dialects/experimental/hlfir.py
+++ b/xdsl/dialects/experimental/hlfir.py
@@ -21,7 +21,6 @@ from xdsl.dialects.builtin import (
     Attribute,
     BoolAttr,
     DenseArrayBase,
-    IntAttr,
     IntegerAttr,
     ParametrizedAttribute,
     StringAttr,
@@ -41,17 +40,16 @@ from xdsl.irdl import (
     operand_def,
     opt_operand_def,
     opt_prop_def,
+    opt_region_def,
     prop_def,
     region_def,
     result_def,
     traits_def,
     var_operand_def,
-    var_region_def,
-    var_result_def,
 )
 from xdsl.parser import AttrParser
 from xdsl.printer import Printer
-from xdsl.traits import IsTerminator
+from xdsl.traits import HasParent, IsTerminator, Pure
 
 
 class CharExtremumPredicate(Enum):
@@ -189,8 +187,9 @@ class DeclareOp(IRDLOperation):
     dummy_scope = opt_operand_def()
     storage = opt_operand_def()
     storage_offset = opt_prop_def(IntegerAttr)
-    uniq_name = opt_prop_def(StringAttr)
+    uniq_name = prop_def(StringAttr)
     fortran_attrs = opt_prop_def(FortranVariableFlagsAttr)
+    data_attr = opt_prop_def(Attribute)
     skip_rebox = opt_prop_def(UnitAttr)
     dummy_arg_no = opt_prop_def(IntegerAttr)
     result = result_def()
@@ -292,8 +291,8 @@ class AssignOp(IRDLOperation):
     """
 
     name = "hlfir.assign"
-    lhs = operand_def()
     rhs = operand_def()
+    lhs = operand_def()
     realloc = opt_prop_def(UnitAttr)
     keep_lhs_length_if_realloc = opt_prop_def(UnitAttr)
     temporary_lhs = opt_prop_def(UnitAttr)
@@ -475,6 +474,8 @@ class GetLengthOp(IRDLOperation):
     name = "hlfir.get_length"
     expr = operand_def()
     result = result_def()
+
+    traits = traits_def(Pure())
 
 
 @irdl_op_definition
@@ -672,8 +673,8 @@ class ElementalOp(IRDLOperation):
     mold = opt_operand_def()
     typeparams = var_operand_def()
     unordered = opt_prop_def(UnitAttr)
-    regs = var_region_def()
     result = result_def()
+    region = region_def("single_block")
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
@@ -691,7 +692,7 @@ class YieldElementOp(IRDLOperation):
     name = "hlfir.yield_element"
     element_value = operand_def()
 
-    traits = traits_def(IsTerminator())
+    traits = traits_def(IsTerminator(), HasParent(ElementalOp), Pure())
 
 
 @irdl_op_definition
@@ -793,7 +794,8 @@ class CopyInOp(IRDLOperation):
     var = operand_def()
     tempBox = operand_def()
     var_is_present = opt_operand_def()
-    result = var_result_def()
+    copied_in = result_def()
+    was_copied = result_def()
 
 
 @irdl_op_definition
@@ -829,6 +831,8 @@ class ShapeOfOp(IRDLOperation):
     expr = operand_def()
     result = result_def()
 
+    traits = traits_def(Pure())
+
 
 @irdl_op_definition
 class GetExtentOp(IRDLOperation):
@@ -841,8 +845,10 @@ class GetExtentOp(IRDLOperation):
 
     name = "hlfir.get_extent"
     shape = operand_def()
-    dim = prop_def(IntAttr)
+    dim = prop_def(IntegerAttr)
     result = result_def()
+
+    traits = traits_def(Pure())
 
 
 @irdl_op_definition
@@ -884,9 +890,9 @@ class RegionAssignOp(IRDLOperation):
     """
 
     name = "hlfir.region_assign"
-    rhs_region = region_def()
-    lhs_region = region_def()
-    user_defined_assignment = region_def()
+    rhs_region = region_def("single_block")
+    lhs_region = region_def("single_block")
+    user_defined_assignment = opt_region_def()
 
 
 @irdl_op_definition
@@ -912,7 +918,7 @@ class YieldOp(IRDLOperation):
 
     name = "hlfir.yield"
     entity = operand_def()
-    cleanup = region_def()
+    cleanup = opt_region_def()
 
     traits = traits_def(IsTerminator())
 
@@ -960,8 +966,10 @@ class ElementalAddrOp(IRDLOperation):
     mold = opt_operand_def()
     typeparams = var_operand_def()
     unordered = opt_prop_def(UnitAttr)
-    body = region_def()
-    cleanup = region_def()
+    body = region_def("single_block")
+    cleanup = opt_region_def()
+
+    traits = traits_def(IsTerminator(), HasParent(RegionAssignOp))
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
@@ -1019,10 +1027,10 @@ class ForallOp(IRDLOperation):
     """
 
     name = "hlfir.forall"
-    lb_region = region_def()
-    ub_region = region_def()
-    step_region = region_def()
-    body = region_def()
+    lb_region = region_def("single_block")
+    ub_region = region_def("single_block")
+    step_region = opt_region_def()
+    body = region_def("single_block")
 
 
 @irdl_op_definition
@@ -1059,8 +1067,8 @@ class ForallMaskOp(IRDLOperation):
     """
 
     name = "hlfir.forall_mask"
-    mask_region = region_def()
-    body = region_def()
+    mask_region = region_def("single_block")
+    body = region_def("single_block")
 
 
 @irdl_op_definition
@@ -1084,8 +1092,8 @@ class AssignmentMaskOp(IRDLOperation):
     """
 
     name = "hlfir.where"
-    mask_region = region_def()
-    body = region_def()
+    mask_region = region_def("single_block")
+    body = region_def("single_block")
 
 
 @irdl_op_definition
@@ -1106,8 +1114,10 @@ class ElseWhereOp(IRDLOperation):
     """
 
     name = "hlfir.elsewhere"
-    mask_region = region_def()
-    body = region_def()
+    mask_region = opt_region_def()
+    body = region_def("single_block")
+
+    traits = traits_def(IsTerminator())
 
 
 @irdl_op_definition
@@ -1131,8 +1141,10 @@ class ForallIndexOp(IRDLOperation):
 
     name = "hlfir.forall_index"
     index = operand_def()
-    indexname = prop_def(StringAttr)
+    index_name = prop_def(StringAttr, prop_name="name")
     result = result_def()
+
+    traits = traits_def(Pure())
 
 
 @irdl_op_definition
@@ -1167,7 +1179,7 @@ class CmpCharOp(IRDLOperation):
     """Lexicographic compare of two character strings."""
 
     name = "hlfir.cmpchar"
-    predicate = prop_def(Attribute)
+    predicate = prop_def(IntegerAttr)
     lchr = operand_def()
     rchr = operand_def()
     result = result_def()
@@ -1226,7 +1238,7 @@ class IndexOp(IRDLOperation):
 
     name = "hlfir.index"
     substr = operand_def()
-    string = operand_def()
+    str = operand_def()
     back = opt_operand_def()
     result = result_def()
 

--- a/xdsl/dialects/experimental/hlfir.py
+++ b/xdsl/dialects/experimental/hlfir.py
@@ -341,6 +341,7 @@ class ConcatOp(IRDLOperation):
     name = "hlfir.concat"
     strings = var_operand_def()
     length = operand_def()
+    result = result_def()
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 


### PR DESCRIPTION
This PR adds missing fields and operations to the FIR and HLFIR dialects to bring into conformance with LLVM 22.1.2. Previously we changed the top level operations that were causing the most conflicts, this more deeply brings the other individual operations into alignment.

As in experimental branch no tests, but passes other requirements
