### PR TITLE
core: (Operation) add NotImplementedError on setting operands

### DIFF
--- a/tests/irdl/test_accessors.py
+++ b/tests/irdl/test_accessors.py
@@ -1,0 +1,16 @@
+import pytest
+
+from xdsl.dialects.arith import AddiOp
+from xdsl.dialects.builtin import i32
+from xdsl.dialects.test import TestOp
+
+
+def test_accessor_set():
+    t = TestOp(result_types=(i32,))
+    t2 = TestOp(result_types=(i32,))
+
+    add = AddiOp(t, t)
+    with pytest.raises(
+        NotImplementedError, match="Setting operands via accessors is not implemented"
+    ):
+        add.lhs = t2  # pyright: ignore

--- a/xdsl/irdl/operations.py
+++ b/xdsl/irdl/operations.py
@@ -1791,6 +1791,9 @@ class BaseAccessor(ABC):
         args = get_op_constructs(obj, self.construct)
         return self.index(args)
 
+    def __set__(self, obj, value):
+        raise NotImplementedError("Setting operands via accessors is not implemented")
+
 
 @dataclass(frozen=True)
 class BeforeVariadicSingleAccessor(BaseAccessor):


### PR DESCRIPTION
Adds a `__set__` to operation accessors which throws an error. Pyright already complained about this but at least now it doesn't silently fail

I couldn't find a good place to put the test but I'm sure there is one somewhere. Can't remember where the rest of the tests for these accessors went.