### PR TITLE
core: (Operation) add Error on setting operands

### DIFF
--- a/tests/irdl/test_operation_definition.py
+++ b/tests/irdl/test_operation_definition.py
@@ -16,8 +16,8 @@ from xdsl.dialects.builtin import (
     i32,
     i64,
 )
-from xdsl.dialects.test import TestType
-from xdsl.ir import Block, Region
+from xdsl.dialects.test import TestTermOp, TestType
+from xdsl.ir import Attribute, Block, OpResult, Region, SSAValue, SSAValues
 from xdsl.irdl import (
     AnyAttr,
     AnyInt,
@@ -26,6 +26,7 @@ from xdsl.irdl import (
     AttrSizedOperandSegments,
     AttrSizedRegionSegments,
     AttrSizedResultSegments,
+    AttrSizedSuccessorSegments,
     BaseAttr,
     EqAttrConstraint,
     IntVarConstraint,
@@ -54,6 +55,7 @@ from xdsl.irdl import (
     var_operand_def,
     var_region_def,
     var_result_def,
+    var_successor_def,
 )
 from xdsl.parser import Parser
 from xdsl.traits import NoTerminator
@@ -618,6 +620,100 @@ def test_undefined_property():
         + " Use the dictionary attribute to add arbitrary information to the operation.",
     ):
         op.verify()
+
+
+def test_op_accessor_assignment():
+    """Test that operation constructs cannot be assigned via an op's named constructs."""
+    val1, val2 = create_ssa_value(i32), create_ssa_value(i32)
+    op1 = TestTermOp.create(operands=[val1, val2])
+    op1.verify()
+
+    new_operands: SSAValues[SSAValue[Attribute]] = SSAValues((val1, val2))
+    with pytest.raises(
+        NotImplementedError,
+        match="Cannot write to named operands, regions, results, or successors.",
+    ):
+        op1.ops = new_operands
+
+    new_results: SSAValues[OpResult[Attribute]] = SSAValues((val1, val2))
+    with pytest.raises(
+        NotImplementedError,
+        match="Cannot write to named operands, regions, results, or successors.",
+    ):
+        op1.res = new_results
+
+    with pytest.raises(
+        NotImplementedError,
+        match="Cannot write to named operands, regions, results, or successors.",
+    ):
+        op1.regs = (Region(),)
+
+    with pytest.raises(
+        NotImplementedError,
+        match="Cannot write to named operands, regions, results, or successors.",
+    ):
+        op1.successor = [Block(), Block()]
+
+
+def test_op_segmented_accessor_assignment():
+    """Test that operation constructs cannot be assigned via an op's named constructs when using segment size based accessors."""
+
+    @irdl_op_definition
+    class TestSegmentedOp(IRDLOperation):
+        name = "test.segmentedop"
+        operands1 = var_operand_def()
+        operands2 = var_operand_def()
+
+        results1 = var_result_def()
+        results2 = var_result_def()
+
+        regions1 = var_region_def()
+        regions2 = var_region_def()
+
+        successors1 = var_successor_def()
+        successors2 = var_successor_def()
+
+        irdl_options = (
+            AttrSizedOperandSegments(as_property=True),
+            AttrSizedResultSegments(as_property=True),
+            AttrSizedRegionSegments(as_property=True),
+            AttrSizedSuccessorSegments(as_property=True),
+        )
+
+    val1, val2 = create_ssa_value(i32), create_ssa_value(i32)
+    op1 = TestSegmentedOp.build(
+        operands=[[val1], [val2]],
+        result_types=[[], []],
+        regions=[[], []],
+        successors=[[], []],
+    )
+    op1.verify()
+
+    new_operands: SSAValues[SSAValue[Attribute]] = SSAValues((val1, val2))
+    with pytest.raises(
+        NotImplementedError,
+        match="Cannot write to named operands, regions, results, or successors.",
+    ):
+        op1.operands1 = new_operands
+
+    new_results: SSAValues[OpResult[Attribute]] = SSAValues((val1, val2))
+    with pytest.raises(
+        NotImplementedError,
+        match="Cannot write to named operands, regions, results, or successors.",
+    ):
+        op1.results1 = new_results
+
+    with pytest.raises(
+        NotImplementedError,
+        match="Cannot write to named operands, regions, results, or successors.",
+    ):
+        op1.regions1 = (Region(),)
+
+    with pytest.raises(
+        NotImplementedError,
+        match="Cannot write to named operands, regions, results, or successors.",
+    ):
+        op1.successors1 = [Block(), Block()]
 
 
 ################################################################################

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -18,18 +18,28 @@ from xdsl.dialects.builtin import (
 from xdsl.dialects.cf import Cf
 from xdsl.dialects.func import Func
 from xdsl.ir import (
+    Attribute,
     Block,
     ErasedSSAValue,
     Operation,
+    OpResult,
     Region,
     SSAValue,
+    SSAValues,
 )
 from xdsl.irdl import (
+    AttrSizedOperandSegments,
+    AttrSizedRegionSegments,
+    AttrSizedResultSegments,
+    AttrSizedSuccessorSegments,
     IRDLOperation,
     irdl_op_definition,
     operand_def,
     prop_def,
+    var_operand_def,
     var_region_def,
+    var_result_def,
+    var_successor_def,
 )
 from xdsl.parser import Parser
 from xdsl.utils.exceptions import VerifyException
@@ -245,6 +255,76 @@ def test_op_operands_comparison():
     op1.verify()
 
     assert op1.operands != op2.operands
+
+
+def test_op_accessor_assignment():
+    """Test that operation constructs cannot be assigned via an op's named constructs."""
+    val1, val2 = create_ssa_value(i32), create_ssa_value(i32)
+    op1 = test.TestTermOp.create(operands=[val1, val2])
+    op1.verify()
+
+    new_operands: SSAValues[SSAValue[Attribute]] = SSAValues((val1, val2))
+    with pytest.raises(AssertionError):
+        op1.ops = new_operands
+
+    new_results: SSAValues[OpResult[Attribute]] = SSAValues((val1, val2))
+    with pytest.raises(AssertionError):
+        op1.res = new_results
+
+    with pytest.raises(AssertionError):
+        op1.regs = (Region(),)
+
+    with pytest.raises(AssertionError):
+        op1.successor = [Block(), Block()]
+
+
+def test_op_segmented_accessor_assignment():
+    """Test that operation constructs cannot be assigned via an op's named constructs when using segment size based accessors."""
+
+    @irdl_op_definition
+    class TestSegmentedOp(IRDLOperation):
+        name = "test.segmentedop"
+        operands1 = var_operand_def()
+        operands2 = var_operand_def()
+
+        results1 = var_result_def()
+        results2 = var_result_def()
+
+        regions1 = var_region_def()
+        regions2 = var_region_def()
+
+        successors1 = var_successor_def()
+        successors2 = var_successor_def()
+
+        irdl_options = (
+            AttrSizedOperandSegments(as_property=True),
+            AttrSizedResultSegments(as_property=True),
+            AttrSizedRegionSegments(as_property=True),
+            AttrSizedSuccessorSegments(as_property=True),
+        )
+
+    val1, val2 = create_ssa_value(i32), create_ssa_value(i32)
+    op1 = TestSegmentedOp.build(
+        operands=[[val1], [val2]],
+        result_types=[[], []],
+        regions=[[], []],
+        successors=[[], []],
+    )
+    op1.verify()
+
+    new_operands: SSAValues[SSAValue[Attribute]] = SSAValues((val1, val2))
+    with pytest.raises(AssertionError):
+        op1.operands1 = new_operands
+
+    new_results: SSAValues[OpResult[Attribute]] = SSAValues((val1, val2))
+    with pytest.raises(AssertionError):
+        op1.results1 = new_results
+
+    with pytest.raises(AssertionError):
+        op1.regions1 = (Region(),)
+
+    with pytest.raises(AssertionError):
+        op1.successors1 = [Block(), Block()]
 
 
 def test_op_clone():

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -18,28 +18,18 @@ from xdsl.dialects.builtin import (
 from xdsl.dialects.cf import Cf
 from xdsl.dialects.func import Func
 from xdsl.ir import (
-    Attribute,
     Block,
     ErasedSSAValue,
     Operation,
-    OpResult,
     Region,
     SSAValue,
-    SSAValues,
 )
 from xdsl.irdl import (
-    AttrSizedOperandSegments,
-    AttrSizedRegionSegments,
-    AttrSizedResultSegments,
-    AttrSizedSuccessorSegments,
     IRDLOperation,
     irdl_op_definition,
     operand_def,
     prop_def,
-    var_operand_def,
     var_region_def,
-    var_result_def,
-    var_successor_def,
 )
 from xdsl.parser import Parser
 from xdsl.utils.exceptions import VerifyException
@@ -255,100 +245,6 @@ def test_op_operands_comparison():
     op1.verify()
 
     assert op1.operands != op2.operands
-
-
-def test_op_accessor_assignment():
-    """Test that operation constructs cannot be assigned via an op's named constructs."""
-    val1, val2 = create_ssa_value(i32), create_ssa_value(i32)
-    op1 = test.TestTermOp.create(operands=[val1, val2])
-    op1.verify()
-
-    new_operands: SSAValues[SSAValue[Attribute]] = SSAValues((val1, val2))
-    with pytest.raises(
-        NotImplementedError,
-        match="Cannot write to named operands, regions, results, or successors.",
-    ):
-        op1.ops = new_operands
-
-    new_results: SSAValues[OpResult[Attribute]] = SSAValues((val1, val2))
-    with pytest.raises(
-        NotImplementedError,
-        match="Cannot write to named operands, regions, results, or successors.",
-    ):
-        op1.res = new_results
-
-    with pytest.raises(
-        NotImplementedError,
-        match="Cannot write to named operands, regions, results, or successors.",
-    ):
-        op1.regs = (Region(),)
-
-    with pytest.raises(
-        NotImplementedError,
-        match="Cannot write to named operands, regions, results, or successors.",
-    ):
-        op1.successor = [Block(), Block()]
-
-
-def test_op_segmented_accessor_assignment():
-    """Test that operation constructs cannot be assigned via an op's named constructs when using segment size based accessors."""
-
-    @irdl_op_definition
-    class TestSegmentedOp(IRDLOperation):
-        name = "test.segmentedop"
-        operands1 = var_operand_def()
-        operands2 = var_operand_def()
-
-        results1 = var_result_def()
-        results2 = var_result_def()
-
-        regions1 = var_region_def()
-        regions2 = var_region_def()
-
-        successors1 = var_successor_def()
-        successors2 = var_successor_def()
-
-        irdl_options = (
-            AttrSizedOperandSegments(as_property=True),
-            AttrSizedResultSegments(as_property=True),
-            AttrSizedRegionSegments(as_property=True),
-            AttrSizedSuccessorSegments(as_property=True),
-        )
-
-    val1, val2 = create_ssa_value(i32), create_ssa_value(i32)
-    op1 = TestSegmentedOp.build(
-        operands=[[val1], [val2]],
-        result_types=[[], []],
-        regions=[[], []],
-        successors=[[], []],
-    )
-    op1.verify()
-
-    new_operands: SSAValues[SSAValue[Attribute]] = SSAValues((val1, val2))
-    with pytest.raises(
-        NotImplementedError,
-        match="Cannot write to named operands, regions, results, or successors.",
-    ):
-        op1.operands1 = new_operands
-
-    new_results: SSAValues[OpResult[Attribute]] = SSAValues((val1, val2))
-    with pytest.raises(
-        NotImplementedError,
-        match="Cannot write to named operands, regions, results, or successors.",
-    ):
-        op1.results1 = new_results
-
-    with pytest.raises(
-        NotImplementedError,
-        match="Cannot write to named operands, regions, results, or successors.",
-    ):
-        op1.regions1 = (Region(),)
-
-    with pytest.raises(
-        NotImplementedError,
-        match="Cannot write to named operands, regions, results, or successors.",
-    ):
-        op1.successors1 = [Block(), Block()]
 
 
 def test_op_clone():

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -264,17 +264,29 @@ def test_op_accessor_assignment():
     op1.verify()
 
     new_operands: SSAValues[SSAValue[Attribute]] = SSAValues((val1, val2))
-    with pytest.raises(AssertionError):
+    with pytest.raises(
+        NotImplementedError,
+        match="Cannot write to named operands, regions, results, or successors.",
+    ):
         op1.ops = new_operands
 
     new_results: SSAValues[OpResult[Attribute]] = SSAValues((val1, val2))
-    with pytest.raises(AssertionError):
+    with pytest.raises(
+        NotImplementedError,
+        match="Cannot write to named operands, regions, results, or successors.",
+    ):
         op1.res = new_results
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(
+        NotImplementedError,
+        match="Cannot write to named operands, regions, results, or successors.",
+    ):
         op1.regs = (Region(),)
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(
+        NotImplementedError,
+        match="Cannot write to named operands, regions, results, or successors.",
+    ):
         op1.successor = [Block(), Block()]
 
 
@@ -313,17 +325,29 @@ def test_op_segmented_accessor_assignment():
     op1.verify()
 
     new_operands: SSAValues[SSAValue[Attribute]] = SSAValues((val1, val2))
-    with pytest.raises(AssertionError):
+    with pytest.raises(
+        NotImplementedError,
+        match="Cannot write to named operands, regions, results, or successors.",
+    ):
         op1.operands1 = new_operands
 
     new_results: SSAValues[OpResult[Attribute]] = SSAValues((val1, val2))
-    with pytest.raises(AssertionError):
+    with pytest.raises(
+        NotImplementedError,
+        match="Cannot write to named operands, regions, results, or successors.",
+    ):
         op1.results1 = new_results
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(
+        NotImplementedError,
+        match="Cannot write to named operands, regions, results, or successors.",
+    ):
         op1.regions1 = (Region(),)
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(
+        NotImplementedError,
+        match="Cannot write to named operands, regions, results, or successors.",
+    ):
         op1.successors1 = [Block(), Block()]
 
 

--- a/xdsl/irdl/operations.py
+++ b/xdsl/irdl/operations.py
@@ -12,6 +12,7 @@ from typing import (
     ClassVar,
     Generic,
     Literal,
+    NoReturn,
     TypeAlias,
     cast,
     overload,
@@ -1791,6 +1792,13 @@ class BaseAccessor(ABC):
         args = get_op_constructs(obj, self.construct)
         return self.index(args)
 
+    def __set__(self, instance, value) -> NoReturn:
+        """Writing to a named Operation construct is unsupported.
+        It is recommended to create a new operation instead."""
+        raise AssertionError(
+            "Cannot write to named operands, regions, results, or successors."
+        )
+
 
 @dataclass(frozen=True)
 class BeforeVariadicSingleAccessor(BaseAccessor):
@@ -1916,6 +1924,13 @@ class BaseAttrAccessor(ABC):
         attr = self.option.container(obj)[self.option.attribute_name]
         args = get_op_constructs(obj, self.construct)
         return self.index(attr.get_values(), args)  # pyright: ignore[reportUnknownMemberType,reportAttributeAccessIssue,reportUnknownArgumentType]
+
+    def __set__(self, instance, value) -> NoReturn:
+        """Writing to a named Operation construct is unsupported.
+        It is recommended to create a new operation instead."""
+        raise AssertionError(
+            "Cannot write to named operands, regions, results, or successors."
+        )
 
 
 @dataclass(frozen=True)

--- a/xdsl/irdl/operations.py
+++ b/xdsl/irdl/operations.py
@@ -1795,7 +1795,7 @@ class BaseAccessor(ABC):
     def __set__(self, instance, value) -> NoReturn:
         """Writing to a named Operation construct is unsupported.
         It is recommended to create a new operation instead."""
-        raise AssertionError(
+        raise NotImplementedError(
             "Cannot write to named operands, regions, results, or successors."
         )
 
@@ -1928,7 +1928,7 @@ class BaseAttrAccessor(ABC):
     def __set__(self, instance, value) -> NoReturn:
         """Writing to a named Operation construct is unsupported.
         It is recommended to create a new operation instead."""
-        raise AssertionError(
+        raise NotImplementedError(
             "Cannot write to named operands, regions, results, or successors."
         )
 


### PR DESCRIPTION
Just did this and realised it does the same job as https://github.com/xdslproject/xdsl/pull/6066 but i think covers an extra case. 
Very happy to change to a different exception - just put `AssertionError` in as a bit of a placeholder in case it was suggested to make a new exception etc