### PR TITLE
dialects: (acc) Var name attribute

### DIFF
--- a/tests/dialects/test_acc.py
+++ b/tests/dialects/test_acc.py
@@ -462,6 +462,19 @@ def test_data_clause_modifier_attr_constructor():
     )
 
 
+def test_var_name_attr_constructor():
+    """`VarNameAttr` accepts both `str` and `StringAttr` and stores the
+    StringAttr on `.var_name`. Pretty-form `<"..."` printing/parsing is
+    covered by filecheck in `tests/filecheck/dialects/acc/attrs.mlir`."""
+    from_str = acc.VarNameAttr("foo")
+    assert isinstance(from_str.var_name, StringAttr)
+    assert from_str.var_name.data == "foo"
+
+    from_attr = acc.VarNameAttr(StringAttr("bar"))
+    assert isinstance(from_attr.var_name, StringAttr)
+    assert from_attr.var_name.data == "bar"
+
+
 def test_copyin_minimal_defaulted_props_absent_from_dict():
     """Defaulted props (`dataClause` / `structured` / `implicit` / `modifiers`)
     must be *absent* from `op.properties` when not explicitly set, even though

--- a/tests/filecheck/dialects/acc/attrs.mlir
+++ b/tests/filecheck/dialects/acc/attrs.mlir
@@ -83,6 +83,17 @@
                 #acc.gang_arg_type<Static>,
                 // CHECK-SAME: #acc.gang_arg_type<Static>
 
+                // Variable-name metadata attribute. Upstream uses it
+                // purely as a discardable attribute on non-acc ops
+                // (e.g. `memref.alloca`) to preserve source-level
+                // variable names through transforms. Included here so
+                // the xdsl-only round-trip is exercised alongside
+                // every other `acc.*` attribute.
+                #acc.var_name<"foo">,
+                // CHECK-SAME: #acc.var_name<"foo">
+                #acc.var_name<"a_longer_variable_name">,
+                // CHECK-SAME: #acc.var_name<"a_longer_variable_name">
+
                 // Combined constructs attribute. Used by `acc.loop` to
                 // identify the user-level `kernels loop` / `parallel loop`
                 // / `serial loop` it was decomposed from.

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/attrs.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/attrs.mlir
@@ -92,6 +92,17 @@
                 #acc.gang_arg_type<Static>,
                 // CHECK-SAME: #acc.gang_arg_type<Static>
 
+                // Variable-name metadata attribute. Upstream uses it
+                // purely as a discardable attribute on non-acc ops
+                // (e.g. `memref.alloca`) to preserve source-level
+                // variable names through transforms. Including it on
+                // the carrier `"test.op"` is enough to prove the
+                // xdsl `<"..."` spelling round-trips through `mlir-opt`.
+                #acc.var_name<"foo">,
+                // CHECK-SAME: #acc.var_name<"foo">
+                #acc.var_name<"a_longer_variable_name">,
+                // CHECK-SAME: #acc.var_name<"a_longer_variable_name">
+
                 // Combined constructs attribute. Upstream's `EnumAttr`
                 // default produces the dot form `#acc.combined_constructs<...>`
                 // — *not* the spaced opaque form

--- a/xdsl/dialects/acc.py
+++ b/xdsl/dialects/acc.py
@@ -379,6 +379,39 @@ class CombinedConstructsTypeAttr(EnumAttribute[CombinedConstructsType]):
 
 
 @irdl_attr_definition
+class VarNameAttr(ParametrizedAttribute):
+    """
+    Variable-name metadata attribute (upstream `#acc.var_name<"x">`).
+
+    Upstream attaches this purely as a *discardable* attribute on
+    non-acc-dialect ops (e.g. `memref.alloca`, casts) to preserve
+    source-level variable names through transformations. It is **not**
+    an op argument on any acc op — the `name` slot on the data-clause
+    family is `OptionalAttr<StrAttr>:$name` upstream, so xDSL keeps the
+    plain `StringAttr` there too.
+    """
+
+    name = "acc.var_name"
+
+    var_name: StringAttr
+
+    def __init__(self, name: str | StringAttr) -> None:
+        if isinstance(name, str):
+            name = StringAttr(name)
+        super().__init__(name)
+
+    def print_parameters(self, printer: Printer) -> None:
+        with printer.in_angle_brackets():
+            printer.print_attribute(self.var_name)
+
+    @classmethod
+    def parse_parameters(cls, parser: AttrParser) -> list[Attribute]:
+        with parser.in_angle_brackets():
+            var_name = parser.parse_str_literal()
+        return [StringAttr(var_name)]
+
+
+@irdl_attr_definition
 class DataBoundsType(ParametrizedAttribute, TypeAttribute):
     """
     Type used for `acc.bounds` results. Holds normalized bounds information
@@ -5616,6 +5649,7 @@ ACC = Dialect(
         ReductionOpKindAttr,
         GangArgTypeAttr,
         CombinedConstructsTypeAttr,
+        VarNameAttr,
         DataBoundsType,
         DeclareTokenType,
     ],


### PR DESCRIPTION
Adds the varname OpenACC attribute, whilst the python test is mainly coverable from filecheck I kept it in as it enables us to exercise the str to StringAttr support (which filecheck doesn't, as that is always StringAttr) - so I think this does have testing value.
