### PR TITLE
core: (irdl) Fix region entry args verification

### DIFF
--- a/tests/filecheck/dialects/stencil/invalid.mlir
+++ b/tests/filecheck/dialects/stencil/invalid.mlir
@@ -206,7 +206,7 @@ builtin.module {
   }
 }
 
-// CHECK: region #0 entry arguments do not verify:
+// CHECK: Region 'body' at position 0 entry arguments do not verify:
 // CHECK: attribute f64 expected from variable 'T', but got i32
 
 // -----
@@ -265,5 +265,5 @@ builtin.module {
   }
 }
 
-// CHECK: region #0 entry arguments do not verify:
+// CHECK: Region 'body' at position 0 entry arguments do not verify:
 // CHECK: incorrect length for range variable

--- a/tests/irdl/test_operation_builder.py
+++ b/tests/irdl/test_operation_builder.py
@@ -549,6 +549,7 @@ def test_var_sbregion_one_block():
     op1 = VarSBRegionOp.build(regions=[[[Block([TestTermOp.create()])]]])
     op2 = VarSBRegionOp.build(regions=[[Region(), [Block(), Block()]]])
     op1.verify()
+    # op2 would not verify - here we are testing that building works regardless of verification
     assert len(op1.regs) == 1
     assert len(op2.regs) == 2
     assert len(op2.regs[0].blocks) == 0

--- a/tests/irdl/test_operation_builder.py
+++ b/tests/irdl/test_operation_builder.py
@@ -549,7 +549,6 @@ def test_var_sbregion_one_block():
     op1 = VarSBRegionOp.build(regions=[[[Block([TestTermOp.create()])]]])
     op2 = VarSBRegionOp.build(regions=[[Region(), [Block(), Block()]]])
     op1.verify()
-    op2.verify()
     assert len(op1.regs) == 1
     assert len(op2.regs) == 2
     assert len(op2.regs[0].blocks) == 0

--- a/tests/irdl/test_operation_definition.py
+++ b/tests/irdl/test_operation_definition.py
@@ -873,7 +873,7 @@ def test_entry_args_op():
     with pytest.raises(
         VerifyException,
         match="""\
-Operation does not verify: region #0 entry arguments do not verify:
+Operation does not verify: Region 'body' at position 0 entry arguments do not verify:
 .*Expected attribute i32 but got i64""",
     ):
         op.verify()
@@ -882,10 +882,47 @@ Operation does not verify: region #0 entry arguments do not verify:
     with pytest.raises(
         VerifyException,
         match="""\
-Operation does not verify: region #0 entry arguments do not verify:
+Operation does not verify: Region 'body' at position 0 entry arguments do not verify:
 .*Expected attribute i32 but got i64""",
     ):
         op.verify()
+
+
+@irdl_op_definition
+class MultipleEntryArgsOp(IRDLOperation):
+    name = "test.entry_args"
+    body1 = opt_region_def(entry_args=RangeOf(AnyAttr()).of_length(1))
+    bodies1 = var_region_def(entry_args=RangeOf(AnyAttr()).of_length(2))
+    bodies2 = var_region_def(entry_args=RangeOf(AnyAttr()).of_length(3))
+
+    traits = traits_def(NoTerminator())
+
+    irdl_options = (AttrSizedRegionSegments(),)
+
+
+def test_multiple_entry_args_op():
+
+    op = MultipleEntryArgsOp.build(regions=[None, [], []])
+    op.verify()
+
+    op = MultipleEntryArgsOp.build(regions=[Region(Block(arg_types=[i32])), [], []])
+    op.verify()
+
+    op = MultipleEntryArgsOp.build(regions=[None, [Region(Block(arg_types=[i32]))], []])
+    with pytest.raises(
+        VerifyException,
+        match=r"Region 'bodies1\[0\]' at position 0 entry arguments do not verify:",
+    ):
+        op.verify()
+
+    op = MultipleEntryArgsOp.build(
+        regions=[
+            Region(Block(arg_types=[i32])),
+            [Region(Block(arg_types=[i32, i32])), Region(Block(arg_types=[i32, i32]))],
+            [],
+        ]
+    )
+    op.verify()
 
 
 class OptionlessMultipleVarOp(IRDLOperation):

--- a/tests/irdl/test_operation_definition.py
+++ b/tests/irdl/test_operation_definition.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from typing import Annotated, ClassVar, Generic
 
 import pytest
@@ -911,7 +912,9 @@ def test_multiple_entry_args_op():
     op = MultipleEntryArgsOp.build(regions=[None, [Region(Block(arg_types=[i32]))], []])
     with pytest.raises(
         VerifyException,
-        match=r"Region 'bodies1\[0\]' at position 0 entry arguments do not verify:",
+        match=re.escape(
+            "Region 'bodies1[0]' at position 0 entry arguments do not verify:"
+        ),
     ):
         op.verify()
 

--- a/xdsl/irdl/operations.py
+++ b/xdsl/irdl/operations.py
@@ -1433,20 +1433,43 @@ def irdl_op_verify_regions(
     op: Operation, op_def: OpDef, constraint_context: ConstraintContext
 ):
     verify_variadic_size(op, op_def, VarIRConstruct.REGION)
-    for i, (region, (name, region_def)) in enumerate(zip(op.regions, op_def.regions)):
-        if isinstance(region_def, SingleBlockRegionDef) and len(region.blocks) != 1:
-            raise VerifyException(
-                f"Region '{name}' at position {i} expected a single block, but got "
-                f"{len(region.blocks)} blocks"
-            )
-        if (first_block := region.blocks.first) is not None:
-            entry_args_types = first_block.arg_types
-            try:
-                region_def.entry_args.verify(entry_args_types, constraint_context)
-            except VerifyException as e:
-                raise VerifyException(
-                    f"region #{i} entry arguments do not verify:\n{e}"
-                ) from e
+
+    idx = 0
+    for region_def_name, region_def in op_def.regions:
+        regions: None | Region | tuple[Region, ...] = getattr(op, region_def_name)
+        block_counts: list[int] = []
+        entry_arg_types_list: list[None | Sequence[Attribute]] = []
+        if isinstance(regions, tuple):
+            for region in regions:
+                block_counts.append(len(region.blocks))
+                entry_block = region.first_block
+                entry_arg_types_list.append(entry_block and entry_block.arg_types)
+        elif isinstance(regions, Region):
+            block_counts.append(len(regions.blocks))
+            entry_block = regions.first_block
+            entry_arg_types_list.append(entry_block and entry_block.arg_types)
+
+        if isinstance(
+            region_def,
+            SingleBlockRegionDef | VarSingleBlockRegionDef | OptSingleBlockRegionDef,
+        ):
+            for i, block_count in enumerate(block_counts):
+                if block_count != 1:
+                    idx_msg = f"[{i}]" if isinstance(regions, tuple) else ""
+                    raise VerifyException(
+                        f"Region '{region_def_name}{idx_msg}' at position {idx + i} expected a single block, but got "
+                        f"{block_count} blocks"
+                    )
+        for i, entry_arg_types in enumerate(entry_arg_types_list):
+            if entry_arg_types is not None:
+                try:
+                    region_def.entry_args.verify(entry_arg_types, constraint_context)
+                except VerifyException as e:
+                    idx_msg = f"[{i}]" if isinstance(regions, tuple) else ""
+                    raise VerifyException(
+                        f"Region '{region_def_name}{idx_msg}' at position {idx + i} entry arguments do not verify:\n{e}"
+                    ) from e
+        idx += len(block_counts)
 
 
 def irdl_op_verify_arg_list(


### PR DESCRIPTION
There was a bug where the verification for regions did not account for optional or variadic regions. I.e. each RegionDef was used to verify exactly one (the next) region regardless of if the rregionDef was variadic or optional.  The fix generally follows how the code works for operand/results. 

One existing test now failed because it should not have verified - I removed the verify check because i don't think it was relevant to the test (`IRDLOperation.build` testing) anyway. 