### PR TITLE
dialects: (acc) RoutineInfoAttr and SpecializedRoutineInfoAttr

### DIFF
--- a/tests/dialects/test_acc.py
+++ b/tests/dialects/test_acc.py
@@ -475,6 +475,44 @@ def test_var_name_attr_constructor():
     assert from_attr.var_name.data == "bar"
 
 
+def test_routine_info_attr_constructor():
+    """`RoutineInfoAttr` accepts either an `ArrayAttr[SymbolRefAttr]` or
+    a plain `Sequence[SymbolRefAttr]` (Python-builder convenience) and
+    stores the result on `.acc_routines`. Pretty-form `<[...]>` is
+    covered by filecheck in `tests/filecheck/dialects/acc/attrs.mlir`."""
+    rt1 = SymbolRefAttr("rt1")
+    rt2 = SymbolRefAttr("rt2")
+
+    from_seq = acc.RoutineInfoAttr([rt1, rt2])
+    assert isinstance(from_seq.acc_routines, ArrayAttr)
+    assert tuple(from_seq.acc_routines.data) == (rt1, rt2)
+
+    from_array = acc.RoutineInfoAttr(ArrayAttr([rt1]))
+    assert tuple(from_array.acc_routines.data) == (rt1,)
+
+
+def test_specialized_routine_attr_constructor():
+    """`SpecializedRoutineAttr` accepts plain `str` for `routine` /
+    `func_name` and a bare `ParLevel` enum value for `level`, normalising
+    each to its attribute counterpart. Filecheck owns pretty-form
+    round-tripping; the conversions here are Python-only and would not
+    otherwise be exercised."""
+    from_strings = acc.SpecializedRoutineAttr("rt1", acc.ParLevel.GANG_DIM1, "foo")
+    assert from_strings.routine == SymbolRefAttr("rt1")
+    assert isinstance(from_strings.level, acc.ParLevelAttr)
+    assert from_strings.level.data == acc.ParLevel.GANG_DIM1
+    assert from_strings.func_name == StringAttr("foo")
+
+    from_attrs = acc.SpecializedRoutineAttr(
+        SymbolRefAttr("rt2"),
+        acc.ParLevelAttr(acc.ParLevel.VECTOR),
+        StringAttr("bar"),
+    )
+    assert from_attrs.routine == SymbolRefAttr("rt2")
+    assert from_attrs.level.data == acc.ParLevel.VECTOR
+    assert from_attrs.func_name == StringAttr("bar")
+
+
 def test_copyin_minimal_defaulted_props_absent_from_dict():
     """Defaulted props (`dataClause` / `structured` / `implicit` / `modifiers`)
     must be *absent* from `op.properties` when not explicitly set, even though

--- a/tests/filecheck/dialects/acc/attrs.mlir
+++ b/tests/filecheck/dialects/acc/attrs.mlir
@@ -94,6 +94,47 @@
                 #acc.var_name<"a_longer_variable_name">,
                 // CHECK-SAME: #acc.var_name<"a_longer_variable_name">
 
+                // Parallelism-level attribute. Consumed inline as the
+                // `$level` parameter of `#acc.specialized_routine` and
+                // also reachable standalone (dot form
+                // `#acc.par_level<value>`).
+                #acc.par_level<seq>,
+                // CHECK-SAME: #acc.par_level<seq>
+                #acc.par_level<gang_dim1>,
+                // CHECK-SAME: #acc.par_level<gang_dim1>
+                #acc.par_level<gang_dim2>,
+                // CHECK-SAME: #acc.par_level<gang_dim2>
+                #acc.par_level<gang_dim3>,
+                // CHECK-SAME: #acc.par_level<gang_dim3>
+                #acc.par_level<worker>,
+                // CHECK-SAME: #acc.par_level<worker>
+                #acc.par_level<vector>,
+                // CHECK-SAME: #acc.par_level<vector>
+
+                // Routine-info metadata attribute. Upstream attaches it
+                // as a discardable attribute on `func.func` declarations
+                // referenced by an `acc routine` directive — the array
+                // points back at the matching `acc.routine` symbols.
+                #acc.routine_info<[]>,
+                // CHECK-SAME: #acc.routine_info<[]>
+                #acc.routine_info<[@rt1]>,
+                // CHECK-SAME: #acc.routine_info<[@rt1]>
+                #acc.routine_info<[@rt_gang, @rt_vector]>,
+                // CHECK-SAME: #acc.routine_info<[@rt_gang, @rt_vector]>
+
+                // Specialized-routine metadata attribute. Attached to
+                // the device-specialized `func.func` produced by the
+                // routine-specialization pass. The `$level` slot prints
+                // inline as `<value>` (no `#acc.par_level` prefix), so
+                // the on-the-wire form is
+                // `<@routine, <level>, "origname">`.
+                #acc.specialized_routine<@rt_gang, <gang_dim1>, "foo">,
+                // CHECK-SAME: #acc.specialized_routine<@rt_gang, <gang_dim1>, "foo">
+                #acc.specialized_routine<@rt_vector, <vector>, "foo">,
+                // CHECK-SAME: #acc.specialized_routine<@rt_vector, <vector>, "foo">
+                #acc.specialized_routine<@scope::@rt_worker, <worker>, "bar">,
+                // CHECK-SAME: #acc.specialized_routine<@scope::@rt_worker, <worker>, "bar">
+
                 // Combined constructs attribute. Used by `acc.loop` to
                 // identify the user-level `kernels loop` / `parallel loop`
                 // / `serial loop` it was decomposed from.

--- a/tests/filecheck/dialects/acc/attrs_invalid.mlir
+++ b/tests/filecheck/dialects/acc/attrs_invalid.mlir
@@ -1,0 +1,16 @@
+// RUN: xdsl-opt %s --parsing-diagnostics --verify-diagnostics --split-input-file | filecheck %s
+
+// #acc.routine_info: every entry in the `[...]` payload must be a symbol
+// reference (`@name`). A non-symref entry trips the parser's isinstance
+// check; the diagnostic names the offending value so users can spot the
+// bad entry in long lists.
+"test.op"() {x = #acc.routine_info<["foo"]>} : () -> ()
+// CHECK: expected symbol reference in #acc.routine_info, got "foo"
+
+// -----
+
+// #acc.specialized_routine: the first parameter (`$routine`) must be a
+// symbol reference back to the originating `acc.routine`. Any other
+// attribute kind is rejected at parse time.
+"test.op"() {x = #acc.specialized_routine<"foo", <gang_dim1>, "bar">} : () -> ()
+// CHECK: expected symbol reference in #acc.specialized_routine, got "foo"

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/attrs.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/attrs.mlir
@@ -103,6 +103,49 @@
                 #acc.var_name<"a_longer_variable_name">,
                 // CHECK-SAME: #acc.var_name<"a_longer_variable_name">
 
+                // Parallelism-level attribute. Standalone dot form
+                // (matching upstream's `EnumAttr` default
+                // `assemblyFormat = "`<` $value `>`"`); the inline
+                // spelling without the `#acc.par_level` prefix is
+                // exercised through `#acc.specialized_routine` below.
+                #acc.par_level<seq>,
+                // CHECK-SAME: #acc.par_level<seq>
+                #acc.par_level<gang_dim1>,
+                // CHECK-SAME: #acc.par_level<gang_dim1>
+                #acc.par_level<gang_dim2>,
+                // CHECK-SAME: #acc.par_level<gang_dim2>
+                #acc.par_level<gang_dim3>,
+                // CHECK-SAME: #acc.par_level<gang_dim3>
+                #acc.par_level<worker>,
+                // CHECK-SAME: #acc.par_level<worker>
+                #acc.par_level<vector>,
+                // CHECK-SAME: #acc.par_level<vector>
+
+                // Routine-info metadata attribute. Upstream attaches it
+                // as a discardable attribute on `func.func` declarations
+                // referenced by an `acc routine` directive. Carrying it
+                // here proves the xdsl `<[...]>` spelling is bit-
+                // compatible with upstream `mlir-opt`. Note: upstream's
+                // tablegen-generated parser rejects `<[]>` — the array
+                // must be non-empty — so the empty case lives in
+                // `tests/dialects/test_acc.py` (Python API) instead.
+                #acc.routine_info<[@rt1]>,
+                // CHECK-SAME: #acc.routine_info<[@rt1]>
+                #acc.routine_info<[@rt_gang, @rt_vector]>,
+                // CHECK-SAME: #acc.routine_info<[@rt_gang, @rt_vector]>
+
+                // Specialized-routine metadata attribute. Upstream
+                // attaches this to device-specialized `func.func`s
+                // produced by the routine-specialization pass. The
+                // `$level` slot is the `par_level` enum and prints
+                // inline as `<value>` (no `#acc.par_level` prefix).
+                #acc.specialized_routine<@rt_gang, <gang_dim1>, "foo">,
+                // CHECK-SAME: #acc.specialized_routine<@rt_gang, <gang_dim1>, "foo">
+                #acc.specialized_routine<@rt_vector, <vector>, "foo">,
+                // CHECK-SAME: #acc.specialized_routine<@rt_vector, <vector>, "foo">
+                #acc.specialized_routine<@scope::@rt_worker, <worker>, "bar">,
+                // CHECK-SAME: #acc.specialized_routine<@scope::@rt_worker, <worker>, "bar">
+
                 // Combined constructs attribute. Upstream's `EnumAttr`
                 // default produces the dot form `#acc.combined_constructs<...>`
                 // — *not* the spaced opaque form

--- a/xdsl/dialects/acc.py
+++ b/xdsl/dialects/acc.py
@@ -235,6 +235,24 @@ class CombinedConstructsType(StrEnum):
     SERIAL_LOOP = "serial_loop"
 
 
+class ParLevel(StrEnum):
+    """Parallelism level used by `acc.specialized_routine` to mark a
+    function variant for a specific OpenACC level.
+
+    See upstream `mlir::acc::ParLevel`. `gang_dim1` is the default gang
+    level (equivalent to a bare `gang`); `gang_dim2` / `gang_dim3` cover
+    `gang(dim:2)` / `gang(dim:3)`. The enum is consumed by
+    `SpecializedRoutineAttr` — it is not stored on any op directly.
+    """
+
+    SEQ = "seq"
+    GANG_DIM1 = "gang_dim1"
+    GANG_DIM2 = "gang_dim2"
+    GANG_DIM3 = "gang_dim3"
+    WORKER = "worker"
+    VECTOR = "vector"
+
+
 @irdl_attr_definition
 class DeviceTypeAttr(EnumAttribute[DeviceType]):
     """
@@ -379,6 +397,32 @@ class CombinedConstructsTypeAttr(EnumAttribute[CombinedConstructsType]):
 
 
 @irdl_attr_definition
+class ParLevelAttr(EnumAttribute[ParLevel]):
+    """
+    Parallelism level attribute consumed by `SpecializedRoutineAttr` to
+    record which OpenACC level (`seq` / `gang_dim*` / `worker` /
+    `vector`) a function variant was specialized for. Prints using the
+    pretty form `#acc.par_level<value>` to match upstream MLIR (whose
+    `EnumAttr` default `assemblyFormat = "`<` $value `>`"` produces the
+    dot form). When embedded as the `$level` parameter of
+    `#acc.specialized_routine`, the surrounding attribute prints just
+    the `<value>` slice — matching upstream's inline spelling
+    `<@routine, <gang_dim1>, "foo">`.
+    """
+
+    name = "acc.par_level"
+
+    def print_parameter(self, printer: Printer) -> None:
+        with printer.in_angle_brackets():
+            printer.print_string(self.data.value)
+
+    @classmethod
+    def parse_parameter(cls, parser: AttrParser) -> ParLevel:
+        with parser.in_angle_brackets():
+            return parser.parse_str_enum(ParLevel)
+
+
+@irdl_attr_definition
 class VarNameAttr(ParametrizedAttribute):
     """
     Variable-name metadata attribute (upstream `#acc.var_name<"x">`).
@@ -409,6 +453,108 @@ class VarNameAttr(ParametrizedAttribute):
         with parser.in_angle_brackets():
             var_name = parser.parse_str_literal()
         return [StringAttr(var_name)]
+
+
+@irdl_attr_definition
+class RoutineInfoAttr(ParametrizedAttribute):
+    """
+    Records the `acc.routine` declarations associated with a function
+    (upstream `#acc.routine_info<[@rt1, @rt2]>`).
+
+    Upstream attaches this as a *discardable* attribute on `func.func`
+    declarations whose names were referenced by `acc routine`
+    directives. It is **not** an op argument on any acc op — the
+    `acc.routine` op itself holds the per-directive clauses, and this
+    attribute is the back-edge from the routine target back to its
+    declarations.
+    """
+
+    name = "acc.routine_info"
+
+    acc_routines: ArrayAttr[SymbolRefAttr]
+
+    def __init__(
+        self, acc_routines: ArrayAttr[SymbolRefAttr] | Sequence[SymbolRefAttr]
+    ) -> None:
+        if not isinstance(acc_routines, ArrayAttr):
+            acc_routines = ArrayAttr(acc_routines)
+        super().__init__(acc_routines)
+
+    def print_parameters(self, printer: Printer) -> None:
+        with printer.in_angle_brackets():
+            with printer.in_square_brackets():
+                printer.print_list(self.acc_routines.data, printer.print_attribute)
+
+    @classmethod
+    def parse_parameters(cls, parser: AttrParser) -> list[Attribute]:
+        with parser.in_angle_brackets():
+            refs = parser.parse_comma_separated_list(
+                AttrParser.Delimiter.SQUARE, parser.parse_attribute
+            )
+        for ref in refs:
+            if not isinstance(ref, SymbolRefAttr):
+                parser.raise_error(
+                    f"expected symbol reference in #acc.routine_info, got {ref}"
+                )
+        return [ArrayAttr(cast(list[SymbolRefAttr], refs))]
+
+
+@irdl_attr_definition
+class SpecializedRoutineAttr(ParametrizedAttribute):
+    """
+    Marks a function as a device-specialized variant of an `acc.routine`
+    (upstream `#acc.specialized_routine<@routine, <par_level>, "name">`).
+
+    Upstream attaches this as a *discardable* attribute on the
+    specialized `func.func` produced by the routine-specialization pass.
+    It captures the parallelism level, a `SymbolRefAttr` reference back
+    to the originating `acc.routine`, and the *original* (pre-rename)
+    function name. The `par_level` parameter prints inline as
+    `<gang_dim1>` (no `#acc.par_level` prefix) to match upstream's
+    spelling.
+    """
+
+    name = "acc.specialized_routine"
+
+    routine: SymbolRefAttr
+    level: ParLevelAttr
+    func_name: StringAttr
+
+    def __init__(
+        self,
+        routine: SymbolRefAttr | str,
+        level: ParLevelAttr | ParLevel,
+        func_name: StringAttr | str,
+    ) -> None:
+        if isinstance(routine, str):
+            routine = SymbolRefAttr(routine)
+        if isinstance(level, ParLevel):
+            level = ParLevelAttr(level)
+        if isinstance(func_name, str):
+            func_name = StringAttr(func_name)
+        super().__init__(routine, level, func_name)
+
+    def print_parameters(self, printer: Printer) -> None:
+        with printer.in_angle_brackets():
+            printer.print_attribute(self.routine)
+            printer.print_string(", ")
+            self.level.print_parameter(printer)
+            printer.print_string(", ")
+            printer.print_attribute(self.func_name)
+
+    @classmethod
+    def parse_parameters(cls, parser: AttrParser) -> list[Attribute]:
+        with parser.in_angle_brackets():
+            routine = parser.parse_attribute()
+            if not isinstance(routine, SymbolRefAttr):
+                parser.raise_error(
+                    f"expected symbol reference in #acc.specialized_routine, got {routine}"
+                )
+            parser.parse_punctuation(",")
+            level = ParLevelAttr(ParLevelAttr.parse_parameter(parser))
+            parser.parse_punctuation(",")
+            func_name = parser.parse_str_literal()
+        return [routine, level, StringAttr(func_name)]
 
 
 @irdl_attr_definition
@@ -5650,6 +5796,9 @@ ACC = Dialect(
         GangArgTypeAttr,
         CombinedConstructsTypeAttr,
         VarNameAttr,
+        ParLevelAttr,
+        RoutineInfoAttr,
+        SpecializedRoutineAttr,
         DataBoundsType,
         DeclareTokenType,
     ],


### PR DESCRIPTION
This PR adds the OpenACC RoutineInfoAttr  and SpecializedRoutineInfoAttr which attach optionally to acc.routine (added in a previous PR) and were postponed at the time as self contained. As part of the later it also requires ParLevelAttr (which is an enum) and this is also provided in the PR. 