### PR TITLE
dialects: (acc) DeclareAttr and DeclareActionAttr

### DIFF
--- a/tests/dialects/test_acc.py
+++ b/tests/dialects/test_acc.py
@@ -12,6 +12,7 @@ from xdsl.dialects.builtin import (
     IndexType,
     IntegerAttr,
     MemRefType,
+    NoneAttr,
     StringAttr,
     SymbolRefAttr,
     UnitAttr,
@@ -511,6 +512,42 @@ def test_specialized_routine_attr_constructor():
     assert from_attrs.routine == SymbolRefAttr("rt2")
     assert from_attrs.level.data == acc.ParLevel.VECTOR
     assert from_attrs.func_name == StringAttr("bar")
+
+
+def test_declare_attr_constructor():
+    """The filecheck round-trip never reaches `DeclareAttr.__init__`
+    (the parser builds the parameter tuple directly via
+    `super().__init__`), so the two `isinstance` coercion branches —
+    bare `DataClause` enum -> `DataClauseAttr`, bare `bool` ->
+    `BoolAttr` — are only exercised here. One case per branch keeps
+    the test tight."""
+    coerced = acc.DeclareAttr(acc.DataClause.ACC_CREATE, True)
+    assert coerced.data_clause.data == acc.DataClause.ACC_CREATE
+    assert coerced.implicit == IntegerAttr.from_bool(True)
+
+    pass_through = acc.DeclareAttr(
+        acc.DataClauseAttr(acc.DataClause.ACC_COPYOUT),
+        IntegerAttr.from_bool(False),
+    )
+    assert pass_through.data_clause.data == acc.DataClause.ACC_COPYOUT
+    assert pass_through.implicit == IntegerAttr.from_bool(False)
+
+
+def test_declare_action_attr_constructor():
+    """The filecheck round-trip never reaches
+    `DeclareActionAttr.__init__` / `_coerce_optional_symref` (the
+    parser builds the parameter tuple directly), so the three coercion
+    branches — `None` -> `NoneAttr`, `str` -> `SymbolRefAttr`,
+    `SymbolRefAttr` pass-through — are only exercised here. A single
+    call hits all three across the four slots."""
+    attr = acc.DeclareActionAttr(
+        pre_alloc="a",
+        pre_dealloc=SymbolRefAttr("scope", ["inner"]),
+    )
+    assert attr.pre_alloc == SymbolRefAttr("a")
+    assert isinstance(attr.post_alloc, NoneAttr)
+    assert attr.pre_dealloc == SymbolRefAttr("scope", ["inner"])
+    assert isinstance(attr.post_dealloc, NoneAttr)
 
 
 def test_copyin_minimal_defaulted_props_absent_from_dict():

--- a/tests/dialects/test_acc.py
+++ b/tests/dialects/test_acc.py
@@ -534,15 +534,18 @@ def test_declare_attr_constructor():
 
 
 def test_declare_action_attr_constructor():
-    """The filecheck round-trip never reaches
-    `DeclareActionAttr.__init__` / `_coerce_optional_symref` (the
-    parser builds the parameter tuple directly), so the three coercion
-    branches — `None` -> `NoneAttr`, `str` -> `SymbolRefAttr`,
-    `SymbolRefAttr` pass-through — are only exercised here. A single
-    call hits all three across the four slots."""
+    """The filecheck round-trip never reaches the
+    `_coerce_optional_symref` converter (the parser builds the
+    parameter tuple directly via `attr_def.new`, which bypasses
+    converters), so the three coercion branches — `None` ->
+    `NoneAttr`, `str` -> `SymbolRefAttr`, `SymbolRefAttr` pass-through
+    — are only exercised here. A single call hits all three across
+    the four (positional) slots."""
     attr = acc.DeclareActionAttr(
-        pre_alloc="a",
-        pre_dealloc=SymbolRefAttr("scope", ["inner"]),
+        "a",
+        None,
+        SymbolRefAttr("scope", ["inner"]),
+        None,
     )
     assert attr.pre_alloc == SymbolRefAttr("a")
     assert isinstance(attr.post_alloc, NoneAttr)

--- a/tests/filecheck/dialects/acc/attrs.mlir
+++ b/tests/filecheck/dialects/acc/attrs.mlir
@@ -135,6 +135,45 @@
                 #acc.specialized_routine<@scope::@rt_worker, <worker>, "bar">,
                 // CHECK-SAME: #acc.specialized_routine<@scope::@rt_worker, <worker>, "bar">
 
+                // Declare-clause metadata attribute. Upstream attaches it
+                // to a variable's creation site (e.g. `memref.global`,
+                // `llvm.mlir.global`, allocations) to advertise which
+                // user-level `acc declare` clause produced the capture.
+                // `implicit` defaults to `false` and is elided in that
+                // case; struct-style fields parse in any order but print
+                // in the upstream declaration order (`dataClause`,
+                // `implicit`).
+                #acc.declare<dataClause = acc_create>,
+                // CHECK-SAME: #acc.declare<dataClause = acc_create>
+                #acc.declare<dataClause = acc_copyin, implicit = true>,
+                // CHECK-SAME: #acc.declare<dataClause = acc_copyin, implicit = true>
+                // `implicit = false` round-trips to the elided form.
+                #acc.declare<dataClause = acc_copyout, implicit = false>,
+                // CHECK-SAME: #acc.declare<dataClause = acc_copyout>
+                // Field order is not load-bearing on parse.
+                #acc.declare<implicit = true, dataClause = acc_declare_device_resident>,
+                // CHECK-SAME: #acc.declare<dataClause = acc_declare_device_resident, implicit = true>
+
+                // Declare-action metadata attribute. Upstream attaches
+                // it to the variable's allocation site so the declare-
+                // directive lowering can find the pre/post (de)alloc
+                // hooks for the variable. Each of the four slots is
+                // independently optional; absent slots are stored as
+                // `NoneAttr` and elided on print. The all-empty form
+                // is `<>` (matches upstream).
+                #acc.declare_action<>,
+                // CHECK-SAME: #acc.declare_action<>
+                #acc.declare_action<preAlloc = @pre_alloc_hook>,
+                // CHECK-SAME: #acc.declare_action<preAlloc = @pre_alloc_hook>
+                #acc.declare_action<postAlloc = @scope::@post_alloc_hook>,
+                // CHECK-SAME: #acc.declare_action<postAlloc = @scope::@post_alloc_hook>
+                #acc.declare_action<preAlloc = @a, postAlloc = @b, preDealloc = @c, postDealloc = @d>,
+                // CHECK-SAME: #acc.declare_action<preAlloc = @a, postAlloc = @b, preDealloc = @c, postDealloc = @d>
+                // Subset + reordered input prints back in declaration
+                // order (preAlloc, postAlloc, preDealloc, postDealloc).
+                #acc.declare_action<postDealloc = @d, preAlloc = @a>,
+                // CHECK-SAME: #acc.declare_action<preAlloc = @a, postDealloc = @d>
+
                 // Combined constructs attribute. Used by `acc.loop` to
                 // identify the user-level `kernels loop` / `parallel loop`
                 // / `serial loop` it was decomposed from.

--- a/tests/filecheck/dialects/acc/attrs_invalid.mlir
+++ b/tests/filecheck/dialects/acc/attrs_invalid.mlir
@@ -14,3 +14,34 @@
 // attribute kind is rejected at parse time.
 "test.op"() {x = #acc.specialized_routine<"foo", <gang_dim1>, "bar">} : () -> ()
 // CHECK: expected symbol reference in #acc.specialized_routine, got "foo"
+
+// -----
+
+// #acc.declare: `dataClause` is required (upstream
+// `DefaultValuedParameter<>` only defaults `implicit`, not the
+// clause). Omitting it trips the parser's missing-required check.
+"test.op"() {x = #acc.declare<implicit = true>} : () -> ()
+// CHECK: struct is missing required parameter: dataClause
+
+// -----
+
+// #acc.declare: each struct field may appear at most once. The
+// parser rejects duplicates with the same diagnostic upstream uses.
+"test.op"() {x = #acc.declare<dataClause = acc_create, dataClause = acc_copyin>} : () -> ()
+// CHECK: duplicate struct parameter name: dataClause
+
+// -----
+
+// #acc.declare_action: each of the four slots may appear at most
+// once. Repeating any one of them trips the parser's
+// dedupe check (here exercised on `postAlloc`).
+"test.op"() {x = #acc.declare_action<postAlloc = @a, postAlloc = @b>} : () -> ()
+// CHECK: duplicate struct parameter name: postAlloc
+
+// -----
+
+// #acc.declare_action: every slot, if present, must hold a symbol
+// reference. A string literal trips the parser's isinstance check
+// with a per-slot diagnostic naming the offending field.
+"test.op"() {x = #acc.declare_action<preAlloc = "foo">} : () -> ()
+// CHECK: expected symbol reference for #acc.declare_action parameter 'preAlloc', got "foo"

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/attrs.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/acc/attrs.mlir
@@ -146,6 +146,53 @@
                 #acc.specialized_routine<@scope::@rt_worker, <worker>, "bar">,
                 // CHECK-SAME: #acc.specialized_routine<@scope::@rt_worker, <worker>, "bar">
 
+                // Declare-clause metadata attribute. Upstream attaches
+                // it to a variable's creation site (e.g. `memref.global`,
+                // `llvm.mlir.global`) to advertise which user-level
+                // `acc declare` clause produced the capture. Upstream's
+                // `struct(params)` printer adds extra whitespace around
+                // the `DataClauseAttr` value (`dataClause =  acc_create`)
+                // — xDSL emits the cleaner single-space form
+                // (`dataClause = acc_create`), and the final `xdsl-opt`
+                // re-emission in the round-trip chain produces the
+                // single-space form regardless of which spelling
+                // `mlir-opt` reflected back.
+                #acc.declare<dataClause = acc_create>,
+                // CHECK-SAME: #acc.declare<dataClause = acc_create>
+                #acc.declare<dataClause = acc_copyin, implicit = true>,
+                // CHECK-SAME: #acc.declare<dataClause = acc_copyin, implicit = true>
+                // `implicit = false` round-trips to the elided form on
+                // both sides — `DefaultValuedParameter<"bool", "false">`
+                // upstream and the matching Python-side default.
+                #acc.declare<dataClause = acc_copyout, implicit = false>,
+                // CHECK-SAME: #acc.declare<dataClause = acc_copyout>
+                // Field-reorder on parse: both dialects accept any
+                // order and re-emit in the upstream declaration order
+                // (`dataClause`, `implicit`).
+                #acc.declare<implicit = true, dataClause = acc_declare_device_resident>,
+                // CHECK-SAME: #acc.declare<dataClause = acc_declare_device_resident, implicit = true>
+
+                // Declare-action metadata attribute. Upstream attaches
+                // it to the variable's allocation site so the declare-
+                // directive lowering can find the pre/post (de)alloc
+                // hooks. All four slots are independently optional
+                // (`OptionalParameter<SymbolRefAttr>`), so the empty
+                // `<>` form is bit-compatible across both dialects.
+                #acc.declare_action<>,
+                // CHECK-SAME: #acc.declare_action<>
+                #acc.declare_action<postAlloc = @post_alloc_hook>,
+                // CHECK-SAME: #acc.declare_action<postAlloc = @post_alloc_hook>
+                // Nested symref slots round-trip identically.
+                #acc.declare_action<preAlloc = @scope::@pre_alloc_hook>,
+                // CHECK-SAME: #acc.declare_action<preAlloc = @scope::@pre_alloc_hook>
+                #acc.declare_action<preAlloc = @a, postAlloc = @b, preDealloc = @c, postDealloc = @d>,
+                // CHECK-SAME: #acc.declare_action<preAlloc = @a, postAlloc = @b, preDealloc = @c, postDealloc = @d>
+                // Subset + reordered input: both dialects re-emit in
+                // declaration order (preAlloc, postAlloc, preDealloc,
+                // postDealloc), dropping absent slots.
+                #acc.declare_action<postDealloc = @d, preAlloc = @a>,
+                // CHECK-SAME: #acc.declare_action<preAlloc = @a, postDealloc = @d>
+
                 // Combined constructs attribute. Upstream's `EnumAttr`
                 // default produces the dot form `#acc.combined_constructs<...>`
                 // — *not* the spaced opaque form

--- a/xdsl/dialects/acc.py
+++ b/xdsl/dialects/acc.py
@@ -55,6 +55,7 @@ from xdsl.irdl import (
     operand_def,
     opt_operand_def,
     opt_prop_def,
+    param_def,
     prop_def,
     region_def,
     result_def,
@@ -623,6 +624,23 @@ class DeclareAttr(ParametrizedAttribute):
         return [seen["dataClause"], seen.get("implicit", IntegerAttr.from_bool(False))]
 
 
+def _coerce_optional_symref(
+    value: SymbolRefAttr | str | None,
+) -> SymbolRefAttr | NoneAttr:
+    """`param_def` converter for `DeclareActionAttr`'s four slots.
+    Absent (None) → `NoneAttr`; bare name → `SymbolRefAttr`; an
+    already-built `SymbolRefAttr` passes through unchanged. Only fires
+    on the Python-construction path; the parser bypasses converters
+    via `attr_def.new(...)`, so parser-produced values must already be
+    `SymbolRefAttr` / `NoneAttr`.
+    """
+    if value is None:
+        return NoneAttr()
+    if isinstance(value, str):
+        return SymbolRefAttr(value)
+    return value
+
+
 @irdl_attr_definition
 class DeclareActionAttr(ParametrizedAttribute):
     """
@@ -643,10 +661,12 @@ class DeclareActionAttr(ParametrizedAttribute):
 
     name = "acc.declare_action"
 
-    pre_alloc: SymbolRefAttr | NoneAttr
-    post_alloc: SymbolRefAttr | NoneAttr
-    pre_dealloc: SymbolRefAttr | NoneAttr
-    post_dealloc: SymbolRefAttr | NoneAttr
+    pre_alloc: SymbolRefAttr | NoneAttr = param_def(converter=_coerce_optional_symref)
+    post_alloc: SymbolRefAttr | NoneAttr = param_def(converter=_coerce_optional_symref)
+    pre_dealloc: SymbolRefAttr | NoneAttr = param_def(converter=_coerce_optional_symref)
+    post_dealloc: SymbolRefAttr | NoneAttr = param_def(
+        converter=_coerce_optional_symref
+    )
 
     def __init__(
         self,
@@ -655,12 +675,7 @@ class DeclareActionAttr(ParametrizedAttribute):
         pre_dealloc: SymbolRefAttr | str | None = None,
         post_dealloc: SymbolRefAttr | str | None = None,
     ) -> None:
-        super().__init__(
-            _coerce_optional_symref(pre_alloc),
-            _coerce_optional_symref(post_alloc),
-            _coerce_optional_symref(pre_dealloc),
-            _coerce_optional_symref(post_dealloc),
-        )
+        super().__init__(pre_alloc, post_alloc, pre_dealloc, post_dealloc)
 
     def print_parameters(self, printer: Printer) -> None:
         slots = (
@@ -702,14 +717,6 @@ class DeclareActionAttr(ParametrizedAttribute):
                 parser.raise_error(f"duplicate struct parameter name: {key}")
             seen[key] = ref
         return [seen.get(name, NoneAttr()) for name in fields]
-
-
-def _coerce_optional_symref(value: SymbolRefAttr | str | None) -> Attribute:
-    if value is None:
-        return NoneAttr()
-    if isinstance(value, str):
-        return SymbolRefAttr(value)
-    return value
 
 
 @irdl_attr_definition

--- a/xdsl/dialects/acc.py
+++ b/xdsl/dialects/acc.py
@@ -24,6 +24,7 @@ from xdsl.dialects.builtin import (
     IntegerAttr,
     IntegerType,
     MemRefType,
+    NoneAttr,
     StringAttr,
     SymbolNameConstraint,
     SymbolRefAttr,
@@ -555,6 +556,160 @@ class SpecializedRoutineAttr(ParametrizedAttribute):
             parser.parse_punctuation(",")
             func_name = parser.parse_str_literal()
         return [routine, level, StringAttr(func_name)]
+
+
+@irdl_attr_definition
+class DeclareAttr(ParametrizedAttribute):
+    """
+    Records that a variable is captured by an `acc declare` directive
+    (upstream `#acc.declare<dataClause = <clause>[, implicit = true]>`).
+
+    Upstream attaches this as a *discardable* attribute to the variable's
+    creation site — typically a global op (`memref.global`,
+    `llvm.mlir.global`, …) or its allocation site — to advertise which
+    user-level declare clause produced the capture. It pairs with
+    `acc.declare_enter` / `acc.declare_exit` ops, which describe *how*
+    the data action runs at runtime; the attribute itself just preserves
+    the source-level clause kind so analyses can find the variable.
+
+    Parameters mirror upstream: a required `DataClauseAttr` and a
+    defaulted `implicit` flag (`false` unless an OpenACC routine /
+    standalone-declare lowering produced the capture implicitly). When
+    `implicit` is `false` the print form omits it, matching upstream's
+    `DefaultValuedParameter<"bool", "false">` behaviour.
+    """
+
+    name = "acc.declare"
+
+    data_clause: DataClauseAttr
+    implicit: BoolAttr
+
+    def __init__(
+        self,
+        data_clause: DataClauseAttr | DataClause,
+        implicit: BoolAttr | bool = False,
+    ) -> None:
+        if isinstance(data_clause, DataClause):
+            data_clause = DataClauseAttr(data_clause)
+        if isinstance(implicit, bool):
+            implicit = IntegerAttr.from_bool(implicit)
+        super().__init__(data_clause, implicit)
+
+    def print_parameters(self, printer: Printer) -> None:
+        with printer.in_angle_brackets():
+            printer.print_string("dataClause = ")
+            printer.print_string(self.data_clause.data.value)
+            if self.implicit.value.data:
+                printer.print_string(", implicit = true")
+
+    @classmethod
+    def parse_parameters(cls, parser: AttrParser) -> list[Attribute]:
+        def parse_field() -> tuple[str, Attribute]:
+            key = parser.parse_keyword_in(("dataClause", "implicit"))
+            parser.parse_punctuation("=")
+            if key == "dataClause":
+                return key, DataClauseAttr(parser.parse_str_enum(DataClause))
+            return key, IntegerAttr.from_bool(parser.parse_boolean())
+
+        seen: dict[str, Attribute] = {}
+        for key, value in parser.parse_comma_separated_list(
+            AttrParser.Delimiter.ANGLE, parse_field
+        ):
+            if key in seen:
+                parser.raise_error(f"duplicate struct parameter name: {key}")
+            seen[key] = value
+        if "dataClause" not in seen:
+            parser.raise_error("struct is missing required parameter: dataClause")
+        return [seen["dataClause"], seen.get("implicit", IntegerAttr.from_bool(False))]
+
+
+@irdl_attr_definition
+class DeclareActionAttr(ParametrizedAttribute):
+    """
+    Per-variable pre/post (de)allocation hook bundle for the OpenACC
+    declare lowering (upstream
+    `#acc.declare_action<preAlloc = @sym, postAlloc = @sym, ...>`).
+
+    Upstream attaches this as a *discardable* attribute to the variable's
+    allocation site so the declare-directive lowering pass can find the
+    runtime helpers it must invoke around the allocation. Each of the
+    four slots is independently optional: a slot is *absent* if the
+    corresponding hook does not exist for this variable. Absence is
+    modelled with `NoneAttr` (xDSL has no `OptionalParameter` analogue
+    for `ParametrizedAttribute`), and the printer omits absent slots so
+    the on-the-wire form matches upstream's `struct(params)` spelling
+    (`<>` when every slot is absent).
+    """
+
+    name = "acc.declare_action"
+
+    pre_alloc: SymbolRefAttr | NoneAttr
+    post_alloc: SymbolRefAttr | NoneAttr
+    pre_dealloc: SymbolRefAttr | NoneAttr
+    post_dealloc: SymbolRefAttr | NoneAttr
+
+    def __init__(
+        self,
+        pre_alloc: SymbolRefAttr | str | None = None,
+        post_alloc: SymbolRefAttr | str | None = None,
+        pre_dealloc: SymbolRefAttr | str | None = None,
+        post_dealloc: SymbolRefAttr | str | None = None,
+    ) -> None:
+        super().__init__(
+            _coerce_optional_symref(pre_alloc),
+            _coerce_optional_symref(post_alloc),
+            _coerce_optional_symref(pre_dealloc),
+            _coerce_optional_symref(post_dealloc),
+        )
+
+    def print_parameters(self, printer: Printer) -> None:
+        slots = (
+            ("preAlloc", self.pre_alloc),
+            ("postAlloc", self.post_alloc),
+            ("preDealloc", self.pre_dealloc),
+            ("postDealloc", self.post_dealloc),
+        )
+        present = [
+            (name, value) for name, value in slots if not isinstance(value, NoneAttr)
+        ]
+        with printer.in_angle_brackets():
+            for i, (name, value) in enumerate(present):
+                if i:
+                    printer.print_string(", ")
+                printer.print_string(f"{name} = ")
+                printer.print_attribute(value)
+
+    @classmethod
+    def parse_parameters(cls, parser: AttrParser) -> list[Attribute]:
+        fields = ("preAlloc", "postAlloc", "preDealloc", "postDealloc")
+
+        def parse_field() -> tuple[str, SymbolRefAttr]:
+            key = parser.parse_keyword_in(fields)
+            parser.parse_punctuation("=")
+            ref = parser.parse_attribute()
+            if not isinstance(ref, SymbolRefAttr):
+                parser.raise_error(
+                    f"expected symbol reference for #acc.declare_action "
+                    f"parameter '{key}', got {ref}"
+                )
+            return key, ref
+
+        seen: dict[str, SymbolRefAttr] = {}
+        for key, ref in parser.parse_comma_separated_list(
+            AttrParser.Delimiter.ANGLE, parse_field
+        ):
+            if key in seen:
+                parser.raise_error(f"duplicate struct parameter name: {key}")
+            seen[key] = ref
+        return [seen.get(name, NoneAttr()) for name in fields]
+
+
+def _coerce_optional_symref(value: SymbolRefAttr | str | None) -> Attribute:
+    if value is None:
+        return NoneAttr()
+    if isinstance(value, str):
+        return SymbolRefAttr(value)
+    return value
 
 
 @irdl_attr_definition
@@ -5799,6 +5954,8 @@ ACC = Dialect(
         ParLevelAttr,
         RoutineInfoAttr,
         SpecializedRoutineAttr,
+        DeclareAttr,
+        DeclareActionAttr,
         DataBoundsType,
         DeclareTokenType,
     ],

--- a/xdsl/dialects/acc.py
+++ b/xdsl/dialects/acc.py
@@ -668,15 +668,6 @@ class DeclareActionAttr(ParametrizedAttribute):
         converter=_coerce_optional_symref
     )
 
-    def __init__(
-        self,
-        pre_alloc: SymbolRefAttr | str | None = None,
-        post_alloc: SymbolRefAttr | str | None = None,
-        pre_dealloc: SymbolRefAttr | str | None = None,
-        post_dealloc: SymbolRefAttr | str | None = None,
-    ) -> None:
-        super().__init__(pre_alloc, post_alloc, pre_dealloc, post_dealloc)
-
     def print_parameters(self, printer: Printer) -> None:
         slots = (
             ("preAlloc", self.pre_alloc),


### PR DESCRIPTION
This adds the OpenACC DeclareAttr family (both DeclareAttr and DeclareActionAttr which sit together) and completes the outstanding attribute set of the dialect
