### PR TITLE
core: (Constraints) optimise ParamAttrConstraint of EqAttrConstraint

### DIFF
--- a/tests/dialects/test_builtin.py
+++ b/tests/dialects/test_builtin.py
@@ -52,11 +52,13 @@ from xdsl.dialects.builtin import (
 )
 from xdsl.ir import Attribute, Data
 from xdsl.irdl import (
+    AnyAttr,
     AnyInt,
     AtMost,
     BaseAttr,
     ConstraintContext,
     NotEqualIntConstraint,
+    ParamAttrConstraint,
     RangeLengthConstraint,
     RangeOf,
     RangeVarConstraint,
@@ -926,6 +928,7 @@ def test_integer_type_repr():
 
 def test_vector_constr():
     constr = VectorType.constr(i32)
+    assert constr == ParamAttrConstraint.get(VectorType, i32, AnyAttr(), AnyAttr())
     constr.verify(VectorType(i32, [1]), ConstraintContext())
     constr.verify(VectorType(i32, [1, 2]), ConstraintContext())
     with pytest.raises(VerifyException):
@@ -938,6 +941,7 @@ def test_vector_constr():
         shape=shape,
         scalable_dims=scalable_dims,
     )
+    assert constr == ParamAttrConstraint.get(VectorType, i32, shape, scalable_dims)
     constr.verify(VectorType(i32, shape, scalable_dims), ConstraintContext())
     with pytest.raises(VerifyException):
         constr.verify(VectorType(i32, [1, 2], scalable_dims), ConstraintContext())

--- a/tests/irdl/test_attr_constraint.py
+++ b/tests/irdl/test_attr_constraint.py
@@ -431,6 +431,10 @@ class AttrF(ParametrizedAttribute):
                 AttrF, (AnyAttr(), ParamAttrConstraint(AttrF, (AnyAttr(), AnyAttr())))
             ),
         ),
+        (
+            ParamAttrConstraint.get(Base, AttrA()),
+            ParamAttrConstraint(Base, (EqAttrConstraint(AttrA()),)),
+        ),
         (VarConstraint.get("T"), VarConstraint("T", AnyAttr())),
         (VarConstraint.get("T", AttrA), VarConstraint("T", BaseAttr(AttrA))),
         (VarConstraint.get("T", BaseAttr(AttrA)), VarConstraint("T", BaseAttr(AttrA))),

--- a/tests/irdl/test_attr_constraint.py
+++ b/tests/irdl/test_attr_constraint.py
@@ -408,7 +408,7 @@ class AttrF(ParametrizedAttribute):
 @pytest.mark.parametrize(
     "constr, expected",
     [
-        (ParamAttrConstraint.get(AttrA), ParamAttrConstraint(AttrA, ())),
+        (ParamAttrConstraint.get(AttrA), EqAttrConstraint(AttrA())),
         (
             ParamAttrConstraint.get(AttrB, None),
             ParamAttrConstraint(AttrB, (AnyAttr(),)),

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -1500,8 +1500,8 @@ class VectorType(
 ):
     name = "vector"
 
-    shape: ArrayAttr[IntAttr]
     element_type: AttributeCovT
+    shape: ArrayAttr[IntAttr]
     scalable_dims: ArrayAttr[BoolAttr]
 
     def __init__(
@@ -1516,7 +1516,7 @@ class VectorType(
         if scalable_dims is None:
             false = BoolAttr(False, i1)
             scalable_dims = ArrayAttr(false for _ in shape)
-        super().__init__(shape, element_type, scalable_dims)
+        super().__init__(element_type, shape, scalable_dims)
 
     @staticmethod
     def _print_vector_dim(printer: Printer, pair: tuple[IntAttr, BoolAttr]):
@@ -1582,8 +1582,8 @@ class VectorType(
             AttrConstraint[VectorType[AttributeCovT]],
             ParamAttrConstraint.get(
                 VectorType,
-                shape_constr,
                 element_type,
+                shape_constr,
                 scalable_dims_constr,
             ),
         )

--- a/xdsl/irdl/constraints.py
+++ b/xdsl/irdl/constraints.py
@@ -648,9 +648,11 @@ class ParamAttrConstraint(
                 f"Argument to ParamAttConstraint {base_attr} should not be an instantiated generic"
             )
 
-        if all(isinstance(c, EqAttrConstraint) for c in constrs):
+        if is_runtime_final(base_attr) and all(
+            isinstance(c, EqAttrConstraint) for c in constrs
+        ):
             return EqAttrConstraint(
-                base_attr(*(cast(EqAttrConstraint, c).attr for c in constrs))
+                base_attr.new(tuple(cast(EqAttrConstraint, c).attr for c in constrs))
             )
 
         return ParamAttrConstraint[ParametrizedAttributeT](base_attr, constrs)

--- a/xdsl/irdl/constraints.py
+++ b/xdsl/irdl/constraints.py
@@ -648,6 +648,11 @@ class ParamAttrConstraint(
                 f"Argument to ParamAttConstraint {base_attr} should not be an instantiated generic"
             )
 
+        if all(isinstance(c, EqAttrConstraint) for c in constrs):
+            return EqAttrConstraint(
+                base_attr(*(cast(EqAttrConstraint, c).attr for c in constrs))
+            )
+
         return ParamAttrConstraint[ParametrizedAttributeT](base_attr, constrs)
 
     def __repr__(self):


### PR DESCRIPTION
Converts a ParamAttrConstraint where all the parameters are equality constraints to a single equality constraint.

I will add a test that `irdl_to_attr_constraint(I32) == EqAttrConstraint(i32)`.

I also noticed that the parameters for `VectorType` mismatched the `__init__` order. Is there a better method to use to construct the attribute (maybe `create` or something)?