### PR TITLE
core: (Constraints) ParamAttrConstraint to BaseAttr

### DIFF
--- a/tests/irdl/test_attr_constraint.py
+++ b/tests/irdl/test_attr_constraint.py
@@ -409,13 +409,14 @@ class AttrF(ParametrizedAttribute):
     "constr, expected",
     [
         (ParamAttrConstraint.get(AttrA), EqAttrConstraint(AttrA())),
+        (ParamAttrConstraint.get(AttrB, AttrA()), EqAttrConstraint(AttrB(AttrA()))),
         (
-            ParamAttrConstraint.get(AttrB, None),
-            ParamAttrConstraint(AttrB, (AnyAttr(),)),
+            ParamAttrConstraint.get(AttrB, AnyAttr()),
+            BaseAttr(AttrB),
         ),
         (
             ParamAttrConstraint.get(AttrF, None, None),
-            ParamAttrConstraint(AttrF, (AnyAttr(), AnyAttr())),
+            BaseAttr(AttrF),
         ),
         (
             ParamAttrConstraint.get(AttrF, AttrA, AttrB),
@@ -425,11 +426,18 @@ class AttrF(ParametrizedAttribute):
         ),
         (
             ParamAttrConstraint.get(
-                AttrF, None, ParamAttrConstraint.get(AttrF, None, None)
+                AttrF, None, ParamAttrConstraint.get(AttrF, AttrA, None)
             ),
             ParamAttrConstraint(
-                AttrF, (AnyAttr(), ParamAttrConstraint(AttrF, (AnyAttr(), AnyAttr())))
+                AttrF,
+                (AnyAttr(), ParamAttrConstraint(AttrF, (BaseAttr(AttrA), AnyAttr()))),
             ),
+        ),
+        (
+            ParamAttrConstraint.get(
+                AttrF, None, ParamAttrConstraint.get(AttrF, None, None)
+            ),
+            ParamAttrConstraint(AttrF, (AnyAttr(), BaseAttr(AttrF))),
         ),
         (
             ParamAttrConstraint.get(Base, AttrA()),

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -1068,8 +1068,6 @@ class IntegerAttr(
         *,
         value: AttrConstraint | IntConstraint | None = None,
     ) -> AttrConstraint[IntegerAttr[_IntegerAttrType]]:
-        if value is None and type == AnyAttr():
-            return BaseAttr[IntegerAttr[_IntegerAttrType]](IntegerAttr)
         if isinstance(value, IntConstraint):
             value = IntAttrConstraint(value)
         return cast(
@@ -1450,8 +1448,6 @@ class ComplexType(
     def constr(
         element_type: IRDLAttrConstraint[ComplexElementCovT] | None = None,
     ) -> AttrConstraint[ComplexType[ComplexElementCovT]]:
-        if element_type is None:
-            return BaseAttr[ComplexType[ComplexElementCovT]](ComplexType)
         return cast(
             AttrConstraint[ComplexType[ComplexElementCovT]],
             ParamAttrConstraint.get(
@@ -1574,8 +1570,6 @@ class VectorType(
         shape: IRDLAttrConstraint[ArrayAttr[IntAttr]] | None = None,
         scalable_dims: IRDLAttrConstraint[ArrayAttr[BoolAttr]] | None = None,
     ) -> AttrConstraint[VectorType[AttributeCovT]]:
-        if element_type is None and shape is None and scalable_dims is None:
-            return BaseAttr[VectorType[AttributeCovT]](VectorType)
         shape_constr = AnyAttr() if shape is None else shape
         scalable_dims_constr = AnyAttr() if scalable_dims is None else scalable_dims
         return cast(
@@ -1643,12 +1637,9 @@ class TensorType(
         element_type: IRDLAttrConstraint[AttributeInvT] | None = None,
         shape: IRDLAttrConstraint[AttributeInvT] | None = None,
     ) -> AttrConstraint[TensorType[AttributeInvT]]:
-        if element_type is None and shape is None:
-            return BaseAttr[TensorType[AttributeInvT]](TensorType)
-        shape_constr = AnyAttr() if shape is None else shape
         return cast(
             AttrConstraint[TensorType[AttributeInvT]],
-            ParamAttrConstraint.get(TensorType, shape_constr, element_type, AnyAttr()),
+            ParamAttrConstraint.get(TensorType, shape, element_type, AnyAttr()),
         )
 
 
@@ -1959,8 +1950,6 @@ class DenseArrayBase(
     def constr(
         element_type: IRDLAttrConstraint[DenseArrayInvT] | None = None,
     ) -> AttrConstraint[DenseArrayBase[DenseArrayInvT]]:
-        if element_type is None:
-            return BaseAttr[DenseArrayBase[DenseArrayInvT]](DenseArrayBase)
         return cast(
             AttrConstraint[DenseArrayBase[DenseArrayInvT]],
             ParamAttrConstraint.get(DenseArrayBase, element_type, AnyAttr()),
@@ -2634,13 +2623,6 @@ class MemRefType(
         layout: IRDLAttrConstraint | None = None,
         memory_space: IRDLAttrConstraint | None = None,
     ) -> AttrConstraint[MemRefType[_MemRefTypeElement]]:
-        if (
-            shape is None
-            and element_type == AnyAttr()
-            and layout is None
-            and memory_space is None
-        ):
-            return BaseAttr[MemRefType[_MemRefTypeElement]](MemRefType)
         return cast(
             AttrConstraint[MemRefType[_MemRefTypeElement]],
             ParamAttrConstraint.get(

--- a/xdsl/dialects/stencil.py
+++ b/xdsl/dialects/stencil.py
@@ -35,7 +35,6 @@ from xdsl.irdl import (
     AnyAttr,
     AttrConstraint,
     AttrSizedOperandSegments,
-    BaseAttr,
     ConstraintContext,
     IRDLOperation,
     MessageConstraint,
@@ -399,8 +398,6 @@ class StencilType(
         bounds: AttrConstraint | None = None,
         element_type: AttrConstraint[_FieldTypeElement] | None = None,
     ) -> AttrConstraint[StencilType[_FieldTypeElement]]:
-        if bounds is None and element_type is None:
-            return BaseAttr[StencilType[_FieldTypeElement]](StencilType)
         return cast(
             AttrConstraint[StencilType[_FieldTypeElement]],
             ParamAttrConstraint.get(StencilType, bounds, element_type),

--- a/xdsl/irdl/constraints.py
+++ b/xdsl/irdl/constraints.py
@@ -658,6 +658,9 @@ class ParamAttrConstraint(
                 base_attr.new(tuple(cast(EqAttrConstraint, c).attr for c in constrs))
             )
 
+        if all(c == AnyAttr() for c in constrs):
+            return BaseAttr(base_attr)
+
         return ParamAttrConstraint[ParametrizedAttributeT](base_attr, constrs)
 
     def __repr__(self):


### PR DESCRIPTION
Convert a `ParamAttrConstraint` with only `AnyAttr` constraints for the parameters to a `BaseAttr` Constraint. This allows a bunch of `constr` methods to be simplified, as we were doing the same check in each one.