### PR TITLE
dialects: use negated isinstance check for FastMathAttr

### DIFF
--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -2866,7 +2866,7 @@ class AbstractFloatArithOp(IRDLOperation, ABC):
         fast_math: FastMathAttr | FastMathFlag | None = None,
         attrs: dict[str, Attribute] | None = None,
     ):
-        if isinstance(fast_math, FastMathFlag | str | None):
+        if not isinstance(fast_math, FastMathAttr):
             fast_math = FastMathAttr(fast_math)
 
         super().__init__(
@@ -3029,7 +3029,7 @@ class FAbsOp(IRDLOperation):
         result_type: Attribute,
         fast_math: FastMathAttr | FastMathFlag | None = None,
     ):
-        if isinstance(fast_math, FastMathFlag | str | None):
+        if not isinstance(fast_math, FastMathAttr):
             fast_math = FastMathAttr(fast_math)
         super().__init__(
             operands=[input],
@@ -3062,7 +3062,7 @@ class FCeilOp(IRDLOperation):
         arg: Operation | SSAValue,
         fast_math: FastMathAttr | FastMathFlag | None = None,
     ):
-        if isinstance(fast_math, FastMathFlag | str | None):
+        if not isinstance(fast_math, FastMathAttr):
             fast_math = FastMathAttr(fast_math)
         super().__init__(
             operands=[arg],
@@ -3095,7 +3095,7 @@ class FSqrtOp(IRDLOperation):
         arg: Operation | SSAValue,
         fast_math: FastMathAttr | FastMathFlag | None = None,
     ):
-        if isinstance(fast_math, FastMathFlag | str | None):
+        if not isinstance(fast_math, FastMathAttr):
             fast_math = FastMathAttr(fast_math)
         super().__init__(
             operands=[arg],
@@ -3128,7 +3128,7 @@ class FLogOp(IRDLOperation):
         arg: Operation | SSAValue,
         fast_math: FastMathAttr | FastMathFlag | None = None,
     ):
-        if isinstance(fast_math, FastMathFlag | str | None):
+        if not isinstance(fast_math, FastMathAttr):
             fast_math = FastMathAttr(fast_math)
         super().__init__(
             operands=[arg],
@@ -3342,7 +3342,7 @@ class VectorFMaxOp(IRDLOperation):
         rhs: Operation | SSAValue,
         fast_math: FastMathAttr | FastMathFlag | None = None,
     ):
-        if isinstance(fast_math, FastMathFlag | str | None):
+        if not isinstance(fast_math, FastMathAttr):
             fast_math = FastMathAttr(fast_math)
         super().__init__(
             operands=[lhs, rhs],
@@ -3379,7 +3379,7 @@ class FMAOp(IRDLOperation):
         c: Operation | SSAValue,
         fast_math: FastMathAttr | FastMathFlag | None = None,
     ):
-        if isinstance(fast_math, FastMathFlag | str | None):
+        if not isinstance(fast_math, FastMathAttr):
             fast_math = FastMathAttr(fast_math)
         super().__init__(
             operands=[a, b, c],


### PR DESCRIPTION
Replace `isinstance(fast_math, FastMathFlag | str | None)` with `not isinstance(fast_math, FastMathAttr)` across all 7 existing usages in `llvm.py`. The negated check is simpler and correctly covers all non-FastMathAttr inputs without enumerating them.

Affected ops: AbstractFloatArithOp, FAbsOp, FCeilOp, FSqrtOp, FLogOp, VectorFMaxOp, FMAOp.