### PR TITLE
core: (Constraints) add IntAttrConstraint.get

### DIFF
--- a/tests/dialects/test_builtin.py
+++ b/tests/dialects/test_builtin.py
@@ -53,7 +53,6 @@ from xdsl.dialects.builtin import (
 from xdsl.ir import Attribute, Data
 from xdsl.irdl import (
     AnyAttr,
-    AnyInt,
     AtMost,
     BaseAttr,
     ConstraintContext,
@@ -643,7 +642,7 @@ def test_tensor_constr():
     # int32 constraint with rank <= 3
     shape = ArrayOfConstraint(
         RangeLengthConstraint(
-            constraint=RangeOf(IntAttrConstraint(AnyInt())), length=AtMost(3)
+            constraint=RangeOf(IntAttrConstraint.get()), length=AtMost(3)
         )
     )
     constr = TensorType.constr(i32, shape)

--- a/tests/filecheck/dialects/memref/invalid_ops.mlir
+++ b/tests/filecheck/dialects/memref/invalid_ops.mlir
@@ -4,7 +4,7 @@ builtin.module {
   "memref.global"() {"alignment" = 64 : i32, "sym_name" = "wrong_alignment_type", "type" = memref<1xindex>, "initial_value" = dense<0> : tensor<1xindex>, "sym_visibility" = "public"} : () -> ()
 }
 
-// CHECK: Invalid value 32, expected 64
+// CHECK: Expected attribute i64 but got i32
 
 // -----
 
@@ -40,7 +40,7 @@ builtin.module {
 
 
 
-// CHECK: Invalid value 32, expected 64
+// CHECK: Expected attribute i64 but got i32
 
 // -----
 
@@ -50,7 +50,7 @@ builtin.module {
     "func.return"() : () -> ()
 }) {function_type = () -> (), sym_name = "invalid_reassociation"} : () -> ()
 
-// CHECK: Invalid value 32, expected 64
+// CHECK: Expected attribute i64 but got i32
 
 
 // -----

--- a/tests/filecheck/dialects/snitch_runtime/snitch_runtime_invalid.mlir
+++ b/tests/filecheck/dialects/snitch_runtime/snitch_runtime_invalid.mlir
@@ -4,11 +4,11 @@
 %src_i64 = arith.constant 0 : i64
 %size = arith.constant 100 : i32
 %transfer_id = "snrt.dma_start_1d"(%dst_i64, %src_i64, %size) : (i64, i64, i32) -> i32
-// CHECK: Invalid value 64, expected 32
+// CHECK: Expected attribute i64 but got i32
 
 // -----
 %dst_i32 = arith.constant 100 : i32
 %src_i32 = arith.constant 0 : i32
 %size = arith.constant 100 : i32
 %transfer_id_1 = "snrt.dma_start_1d_wideptr"(%dst_i32, %src_i32, %size) : (i32, i32, i32) -> i32
-// CHECK: Invalid value 32, expected 64
+// CHECK: Expected attribute i64 but got i32

--- a/tests/irdl/test_attr_constraint.py
+++ b/tests/irdl/test_attr_constraint.py
@@ -9,6 +9,7 @@ from typing_extensions import TypeVar
 from xdsl.dialects.bufferization import TensorFromMemRefConstraint
 from xdsl.dialects.builtin import (
     IndexType,
+    IntAttr,
     IntAttrConstraint,
     IntegerType,
     MemRefType,
@@ -29,6 +30,7 @@ from xdsl.irdl import (
     ConstraintContext,
     EqAttrConstraint,
     EqIntConstraint,
+    IntSetConstraint,
     IntTypeVarConstraint,
     ParamAttrConstraint,
     VarConstraint,
@@ -383,8 +385,12 @@ def test_mapping_type_vars():
     tv_constr = IntTypeVarConstraint(_IntT, AnyInt())
     int_attr_constr = IntAttrConstraint(tv_constr)
     my_constr = EqIntConstraint(1)
-    assert int_attr_constr.mapping_type_vars({_IntT: my_constr}) == IntAttrConstraint(
-        my_constr
+    assert int_attr_constr.mapping_type_vars({_IntT: my_constr}) == EqAttrConstraint(
+        IntAttr(1)
+    )
+    my_constr_2 = IntSetConstraint(frozenset((1, 2)))
+    assert int_attr_constr.mapping_type_vars({_IntT: my_constr_2}) == IntAttrConstraint(
+        my_constr_2
     )
 
 

--- a/tests/irdl/test_int_constraint.py
+++ b/tests/irdl/test_int_constraint.py
@@ -4,11 +4,14 @@ from typing import Literal
 import pytest
 from typing_extensions import TypeVar
 
+from xdsl.dialects.builtin import IntAttr, IntAttrConstraint
 from xdsl.irdl import (
     AnyInt,
     AtLeast,
     AtMost,
+    BaseAttr,
     ConstraintContext,
+    EqAttrConstraint,
     EqIntConstraint,
     IntSetConstraint,
     IntTypeVarConstraint,
@@ -122,3 +125,17 @@ def test_get_int_constr():
 
     with pytest.raises(PyRDLTypeError, match="Unexpected int type: <class 'str'>"):
         get_int_constraint(str)  # pyright: ignore[reportArgumentType]
+
+
+def test_int_attr_get():
+    assert IntAttrConstraint.get() == BaseAttr(IntAttr)
+    assert IntAttrConstraint.get(int) == BaseAttr(IntAttr)
+    assert IntAttrConstraint.get(1) == EqAttrConstraint(IntAttr(1))
+    assert IntAttrConstraint.get(Literal[1, 2]) == IntAttrConstraint(
+        IntSetConstraint(frozenset((1, 2)))
+    )
+    assert IntAttrConstraint.get(AnyInt()) == BaseAttr(IntAttr)
+    assert IntAttrConstraint.get(
+        IntSetConstraint(frozenset((1, 2)))
+    ) == IntAttrConstraint(IntSetConstraint(frozenset((1, 2))))
+    assert IntAttrConstraint.get(EqIntConstraint(1)) == EqAttrConstraint(IntAttr(1))

--- a/tests/test_pyrdl.py
+++ b/tests/test_pyrdl.py
@@ -16,6 +16,7 @@ from xdsl.dialects.builtin import (
     IntegerType,
     Signedness,
     SignednessAttr,
+    i32,
 )
 from xdsl.ir import Attribute, Data, ParametrizedAttribute
 from xdsl.irdl import (
@@ -445,30 +446,24 @@ def test_irdl_to_attr_constraint():
         )
     )
     assert irdl_to_attr_constraint(IntAttr) == BaseAttr(IntAttr)
-    assert irdl_to_attr_constraint(IntAttr[int]) == IntAttrConstraint(
-        int_constraint=AnyInt()
-    )
-    assert irdl_to_attr_constraint(IntAttr[Literal[1]]) == IntAttrConstraint(
-        int_constraint=EqIntConstraint(value=1)
-    )
-    assert irdl_to_attr_constraint(IntAttr[2]) == IntAttrConstraint(
-        int_constraint=EqIntConstraint(value=2)
-    )
+    assert irdl_to_attr_constraint(IntAttr[int]) == BaseAttr(IntAttr)
+    assert irdl_to_attr_constraint(IntAttr[Literal[1]]) == EqAttrConstraint(IntAttr(1))
+    assert irdl_to_attr_constraint(IntAttr[2]) == EqAttrConstraint(IntAttr(2))
 
     assert irdl_to_attr_constraint(IntegerType) == BaseAttr(IntegerType)
     # With one type arg, second default
     assert irdl_to_attr_constraint(IntegerType[int]) == ParamAttrConstraint(
         IntegerType,
-        (IntAttrConstraint(AnyInt()), BaseAttr(SignednessAttr)),
+        (BaseAttr(IntAttr), BaseAttr(SignednessAttr)),
     )
     # With both type args
     assert irdl_to_attr_constraint(IntegerType[int, Signedness]) == ParamAttrConstraint(
         IntegerType,
-        (IntAttrConstraint(AnyInt()), BaseAttr(SignednessAttr)),
+        (BaseAttr(IntAttr), BaseAttr(SignednessAttr)),
     )
     assert irdl_to_attr_constraint(IntegerType[32]) == ParamAttrConstraint(
         IntegerType,
-        (IntAttrConstraint(EqIntConstraint(32)), BaseAttr(SignednessAttr)),
+        (EqAttrConstraint(IntAttr(32)), BaseAttr(SignednessAttr)),
     )
     assert irdl_to_attr_constraint(IntegerType[Literal[32, 64]]) == ParamAttrConstraint(
         IntegerType,
@@ -477,7 +472,7 @@ def test_irdl_to_attr_constraint():
             BaseAttr(SignednessAttr),
         ),
     )
-
+    assert irdl_to_attr_constraint(I32) == EqAttrConstraint(i32)
     assert irdl_to_attr_constraint(Signedness.SIGNED) == EqAttrConstraint(
         SignednessAttr(Signedness.SIGNED)
     )
@@ -492,13 +487,7 @@ def test_irdl_to_attr_constraint():
         IntegerAttr,
         (
             BaseAttr(IntAttr),
-            ParamAttrConstraint(
-                IntegerType,
-                (
-                    IntAttrConstraint(EqIntConstraint(32)),
-                    EqAttrConstraint(SignednessAttr(Signedness.SIGNLESS)),
-                ),
-            ),
+            EqAttrConstraint(i32),
         ),
     )
     assert irdl_to_attr_constraint(IntegerAttr[IntegerType[32]]) == ParamAttrConstraint(
@@ -507,7 +496,7 @@ def test_irdl_to_attr_constraint():
             BaseAttr(IntAttr),
             ParamAttrConstraint(
                 IntegerType,
-                (IntAttrConstraint(EqIntConstraint(32)), BaseAttr(SignednessAttr)),
+                (EqAttrConstraint(IntAttr(32)), BaseAttr(SignednessAttr)),
             ),
         ),
     )

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -19,7 +19,7 @@ from typing import (
 )
 
 from immutabledict import immutabledict
-from typing_extensions import Self, TypeVar, deprecated, override
+from typing_extensions import Self, TypeForm, TypeVar, deprecated, override
 
 from xdsl.dialect_interfaces.op_asm import OpAsmDialectInterface
 from xdsl.ir import (
@@ -67,6 +67,7 @@ from xdsl.irdl import (
     RangeConstraint,
     RangeOf,
     TypeVarConstraint,
+    get_int_constraint,
     irdl_attr_definition,
     irdl_op_definition,
     irdl_to_attr_constraint,
@@ -388,7 +389,9 @@ class IntAttr(GenericData[IntCovT], Generic[IntCovT]):
 
     @staticmethod
     @override
-    def constr(constr: IntConstraint | int | None = None) -> AttrConstraint[IntAttr]:
+    def constr(
+        constr: IntConstraint | int | TypeForm[int] | None = None,
+    ) -> AttrConstraint[IntAttr]:
         return IntAttrConstraint.get(
             IntTypeVarConstraint(IntCovT, AnyInt()) if constr is None else constr
         )
@@ -402,12 +405,14 @@ class IntAttrConstraint(AttrConstraint[IntAttr]):
 
     @staticmethod
     def get(
-        int_constraint: IntConstraint | int | None = None,
+        int_constraint: IntConstraint | int | TypeForm[int] | None = None,
     ) -> AttrConstraint[IntAttr]:
-        if int_constraint is None or int_constraint == AnyInt():
+        if int_constraint is None:
             return BaseAttr(IntAttr)
-        if isinstance(int_constraint, int):
-            int_constraint = EqIntConstraint(int_constraint)
+        if not isinstance(int_constraint, IntConstraint):
+            int_constraint = get_int_constraint(int_constraint)
+        if int_constraint == AnyInt():
+            return BaseAttr(IntAttr)
         if isinstance(int_constraint, EqIntConstraint):
             return EqAttrConstraint(IntAttr(int_constraint.value))
         return IntAttrConstraint(int_constraint)

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -55,6 +55,7 @@ from xdsl.irdl import (
     ConstraintContext,
     ConstraintConvertible,
     EqAttrConstraint,
+    EqIntConstraint,
     GenericData,
     IntConstraint,
     IntTypeVarConstraint,
@@ -387,8 +388,8 @@ class IntAttr(GenericData[IntCovT], Generic[IntCovT]):
 
     @staticmethod
     @override
-    def constr(constr: IntConstraint | None = None) -> AttrConstraint[IntAttr]:
-        return IntAttrConstraint(
+    def constr(constr: IntConstraint | int | None = None) -> AttrConstraint[IntAttr]:
+        return IntAttrConstraint.get(
             IntTypeVarConstraint(IntCovT, AnyInt()) if constr is None else constr
         )
 
@@ -398,6 +399,18 @@ class IntAttrConstraint(AttrConstraint[IntAttr]):
     """
     Constrains the value of an IntAttr.
     """
+
+    @staticmethod
+    def get(
+        int_constraint: IntConstraint | int | None = None,
+    ) -> AttrConstraint[IntAttr]:
+        if int_constraint is None or int_constraint == AnyInt():
+            return BaseAttr(IntAttr)
+        if isinstance(int_constraint, int):
+            int_constraint = EqIntConstraint(int_constraint)
+        if isinstance(int_constraint, EqIntConstraint):
+            return EqAttrConstraint(IntAttr(int_constraint.value))
+        return IntAttrConstraint(int_constraint)
 
     int_constraint: IntConstraint
 
@@ -421,7 +434,7 @@ class IntAttrConstraint(AttrConstraint[IntAttr]):
     def mapping_type_vars(
         self, type_var_mapping: Mapping[TypeVar, AttrConstraint | IntConstraint]
     ):
-        return IntAttrConstraint(
+        return IntAttrConstraint.get(
             self.int_constraint.mapping_type_vars(type_var_mapping)
         )
 
@@ -1069,7 +1082,7 @@ class IntegerAttr(
         value: AttrConstraint | IntConstraint | None = None,
     ) -> AttrConstraint[IntegerAttr[_IntegerAttrType]]:
         if isinstance(value, IntConstraint):
-            value = IntAttrConstraint(value)
+            value = IntAttrConstraint.get(value)
         return cast(
             AttrConstraint[IntegerAttr[_IntegerAttrType]],
             ParamAttrConstraint.get(IntegerAttr, value, type),

--- a/xdsl/irdl/constraints.py
+++ b/xdsl/irdl/constraints.py
@@ -707,10 +707,10 @@ class ParamAttrConstraint(
 
     def mapping_type_vars(
         self, type_var_mapping: Mapping[TypeVar, AttrConstraint | IntConstraint]
-    ) -> ParamAttrConstraint[ParametrizedAttributeCovT]:
-        return ParamAttrConstraint(
+    ) -> AttrConstraint[ParametrizedAttributeCovT]:
+        return ParamAttrConstraint.get(
             self.base_attr,
-            tuple(c.mapping_type_vars(type_var_mapping) for c in self.param_constrs),
+            *(c.mapping_type_vars(type_var_mapping) for c in self.param_constrs),
         )
 
     def __or__(self, value: AttrConstraint[_AttributeCovT], /):


### PR DESCRIPTION
Adds `IntAttrConstraint.get` and a few simplifications for it:
- `IntAttrConstraint.get(AnyInt())` -> `BaseAttr(IntAttr)`
- `IntAttrConstraint.get(EqIntConstraint(x))` -> `EqAttrConstraint(IntAttr(x))`

This finally gets `irdl_to_attr_constraint(I32)` simplifying to an `EqAttrConstraint`
