### PR TITLE
core: (Constraints) simplify unary AnyOf

### DIFF
--- a/tests/irdl/test_attr_constraint.py
+++ b/tests/irdl/test_attr_constraint.py
@@ -447,7 +447,7 @@ class AttrF(ParametrizedAttribute):
         (VarConstraint.get("T", AttrA), VarConstraint("T", BaseAttr(AttrA))),
         (VarConstraint.get("T", BaseAttr(AttrA)), VarConstraint("T", BaseAttr(AttrA))),
         (AnyOf.get(), AnyOf(())),
-        (AnyOf.get(AttrA), AnyOf((BaseAttr(AttrA),))),
+        (AnyOf.get(AttrA), BaseAttr(AttrA)),
         (AnyOf.get(AttrA, AttrB), AnyOf((BaseAttr(AttrA), BaseAttr(AttrB)))),
     ],
 )

--- a/xdsl/irdl/attributes.py
+++ b/xdsl/irdl/attributes.py
@@ -564,19 +564,14 @@ def irdl_to_attr_constraint(
                     allow_type_var=allow_type_var,
                 )
             )
-        if len(constraints) > 1:
-            return cast(AttrConstraint[AttributeInvT], AnyOf.get(*constraints))
-        return cast(AttrConstraint[AttributeInvT], constraints[0])
+        return cast(AttrConstraint[AttributeInvT], AnyOf.get(*constraints))
 
     if isclass(irdl) and issubclass(irdl, ConstraintConvertible):
         attr_data = cast(type[ConstraintConvertible[AttributeInvT]], irdl)
         return attr_data.base_constr()
 
     if origin is Literal:
-        literal_args = get_args(irdl)
-        if len(literal_args) == 1:
-            return irdl_to_attr_constraint(literal_args[0])
-        return AnyOf.get(*literal_args)
+        return AnyOf.get(*get_args(irdl))
 
     # Better error messages for missing GenericData in Data definitions
     if isclass(origin) and issubclass(origin, Data):

--- a/xdsl/irdl/constraints.py
+++ b/xdsl/irdl/constraints.py
@@ -421,6 +421,9 @@ class AnyOf(AttrConstraint[AttributeCovT], Generic[AttributeCovT]):
 
         constrs = tuple(irdl_to_attr_constraint(c) for c in attr_constrs)
 
+        if len(constrs) == 1:
+            return constrs[0]
+
         return AnyOf(constrs)
 
     def __init__(


### PR DESCRIPTION
An AnyOf of one thing may as well be the one thing.
There were a couple of places where this was manually checked which are now simplified.