### PR TITLE
dialects: (llvm) reject incompatible types in LLVMFunctionType

### DIFF
--- a/tests/dialects/test_llvm.py
+++ b/tests/dialects/test_llvm.py
@@ -283,6 +283,17 @@ def test_addressof_op():
     assert address_of.result.type == ptr_type
 
 
+def test_function_type_rejects_incompatible_types():
+    with pytest.raises(VerifyException, match="incompatible type"):
+        llvm.LLVMFunctionType([builtin.IndexType()])
+
+    with pytest.raises(VerifyException, match="incompatible type"):
+        llvm.LLVMFunctionType([], builtin.IndexType())
+
+    with pytest.raises(VerifyException, match="incompatible type"):
+        llvm.LLVMFunctionType([llvm.LLVMVoidType()])
+
+
 def test_implicit_void_func_return():
     func_type = llvm.LLVMFunctionType([])
 

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -15,15 +15,22 @@ from xdsl.dialects.builtin import (
     I64,
     AnyFloatConstr,
     ArrayAttr,
+    BFloat16Type,
     DenseArrayBase,
     DenseIntOrFPElementsAttr,
     DictionaryAttr,
+    Float16Type,
+    Float32Type,
+    Float64Type,
+    Float80Type,
+    Float128Type,
     FloatAttr,
     FunctionType,
     IntAttr,
     IntegerAttr,
     IntegerType,
     NoneAttr,
+    Signedness,
     SignlessIntegerConstraint,
     StringAttr,
     SymbolNameConstraint,
@@ -230,6 +237,40 @@ class LLVMVoidType(ParametrizedAttribute, TypeAttribute):
     name = "llvm.void"
 
 
+def is_compatible_type(type_attr: Attribute) -> bool:
+    """
+    Check if a type is compatible with the LLVM dialect.
+
+    Matches MLIR's LLVMDialect::isCompatibleType: signless integers, floats,
+    LLVM dialect types, and 1-D fixed vectors of compatible element types.
+    """
+    if isa(type_attr, IntegerType):
+        return type_attr.signedness.data == Signedness.SIGNLESS
+    if isinstance(
+        type_attr,
+        (
+            BFloat16Type,
+            Float16Type,
+            Float32Type,
+            Float64Type,
+            Float80Type,
+            Float128Type,
+            LLVMStructType,
+            LLVMPointerType,
+            LLVMArrayType,
+            LLVMFunctionType,
+        ),
+    ):
+        return True
+    if isa(type_attr, VectorType):
+        return (
+            type_attr.get_num_dims() == 1
+            and type_attr.get_num_scalable_dims() == 0
+            and is_compatible_type(type_attr.element_type)
+        )
+    return False
+
+
 @irdl_attr_definition
 class LLVMFunctionType(ParametrizedAttribute, TypeAttribute):
     """
@@ -260,6 +301,19 @@ class LLVMFunctionType(ParametrizedAttribute, TypeAttribute):
     @property
     def is_variadic(self) -> bool:
         return isinstance(self.variadic, UnitAttr)
+
+    def verify(self) -> None:
+        for i, inp in enumerate(self.inputs):
+            if not is_compatible_type(inp):
+                raise VerifyException(
+                    f"LLVM function argument #{i} has incompatible type '{inp}'"
+                )
+        if not isinstance(self.output, LLVMVoidType) and not is_compatible_type(
+            self.output
+        ):
+            raise VerifyException(
+                f"LLVM function result has incompatible type '{self.output}'"
+            )
 
     def print_parameters(self, printer: Printer) -> None:
         with printer.in_angle_brackets():


### PR DESCRIPTION
Adds `is_compatible_type()` matching MLIR's `LLVMDialect::isCompatibleType` (signless integers, floats, LLVM dialect types, 1-D fixed vectors) and wires it into `LLVMFunctionType.verify()`. IndexType and other non-LLVM types in function signatures are now caught at construction time, matching MLIR's invariant that index should already be lowered to a concrete integer type before reaching the LLVM dialect.

Supersedes #5705 with a verifier-based approach instead of backend conversion.

MLIR reference: `mlir/lib/Dialect/LLVMIR/IR/LLVMTypes.cpp` `isCompatibleType`, `mlir/lib/Conversion/LLVMCommon/TypeConverter.cpp` `convertIndexType`.