### PR TITLE
dialects: (llvm) fix isinstance check for fast_math

### DIFF
--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -3326,7 +3326,7 @@ class FLog2Op(IRDLOperation):
         arg: Operation | SSAValue,
         fast_math: FastMathAttr | FastMathFlag | None = None,
     ):
-        if isinstance(fast_math, FastMathFlag | str | None):
+        if not isinstance(fast_math, FastMathAttr):
             fast_math = FastMathAttr(fast_math)
         super().__init__(
             operands=[arg],
@@ -3542,7 +3542,7 @@ class FCopySignOp(IRDLOperation):
         rhs: Operation | SSAValue,
         fast_math: FastMathAttr | FastMathFlag | None = None,
     ):
-        if isinstance(fast_math, FastMathFlag | str | None):
+        if not isinstance(fast_math, FastMathAttr):
             fast_math = FastMathAttr(fast_math)
         super().__init__(
             operands=[lhs, rhs],
@@ -3649,7 +3649,7 @@ class FPowOp(IRDLOperation):
         rhs: Operation | SSAValue,
         fast_math: FastMathAttr | FastMathFlag | None = None,
     ):
-        if isinstance(fast_math, FastMathFlag | str | None):
+        if not isinstance(fast_math, FastMathAttr):
             fast_math = FastMathAttr(fast_math)
         super().__init__(
             operands=[lhs, rhs],


### PR DESCRIPTION
Use `not isinstance(fast_math, FastMathAttr)` instead of `isinstance(fast_math, FastMathFlag | str | None)` in FLog2Op, FCopySignOp, and FPowOp to match the pattern already used by every other op in the file.

`FastMathFlag` is a `StrEnum` (subclass of `str`), so the old check was equivalent to `isinstance(fast_math, str | None)`, making the `FastMathFlag` branch redundant. The inverted form is clearer: if it is not already a `FastMathAttr`, wrap it.