### PR TITLE
core: (Constraints) Enable better variable constraint inference.

### DIFF
--- a/tests/irdl/test_attr_constraint.py
+++ b/tests/irdl/test_attr_constraint.py
@@ -13,11 +13,14 @@ from xdsl.dialects.builtin import (
     IntAttrConstraint,
     IntegerType,
     MemRefType,
+    Signedness,
+    SignednessAttr,
     StringAttr,
     TensorType,
     UnrankedMemRefType,
     UnrankedTensorType,
     i32,
+    i64,
 )
 from xdsl.ir import Attribute, Data, ParametrizedAttribute
 from xdsl.irdl import (
@@ -32,6 +35,7 @@ from xdsl.irdl import (
     EqIntConstraint,
     IntSetConstraint,
     IntTypeVarConstraint,
+    MessageConstraint,
     ParamAttrConstraint,
     VarConstraint,
     base,
@@ -459,3 +463,59 @@ class AttrF(ParametrizedAttribute):
 )
 def test_constraint_get(constr: AttrConstraint, expected: AttrConstraint):
     assert constr == expected
+
+
+@pytest.mark.parametrize(
+    "constr, var_dict, inferred",
+    [
+        (AnyAttr(), {}, None),
+        (VarConstraint("A", AnyAttr()), {}, None),
+        (VarConstraint("A", AnyAttr()), {"A": i32}, i32),
+        (VarConstraint("A", EqAttrConstraint(i32)), {}, i32),
+        (EqAttrConstraint(i32), {}, i32),
+        (BaseAttr(type(i32)), {}, None),
+        (AnyOf((EqAttrConstraint(i32), EqAttrConstraint(i64))), {}, None),
+        (AnyOf((EqAttrConstraint(i32), EqAttrConstraint(i32))), {}, None),
+        (
+            AllOf(
+                (
+                    VarConstraint("A", AnyAttr()),
+                    EqAttrConstraint(i32),
+                )
+            ),
+            {},
+            i32,
+        ),
+        (
+            AllOf(
+                (
+                    VarConstraint("A", AnyAttr()),
+                    EqAttrConstraint(i32),
+                )
+            ),
+            {"A": i64},
+            i64,
+        ),
+        (ParamAttrConstraint(IntegerType, (AnyAttr(), AnyAttr())), {}, None),
+        (
+            ParamAttrConstraint(
+                IntegerType,
+                (
+                    EqAttrConstraint(IntAttr(32)),
+                    EqAttrConstraint(SignednessAttr(Signedness.SIGNLESS)),
+                ),
+            ),
+            {},
+            i32,
+        ),
+        (MessageConstraint(EqAttrConstraint(i32), "msg"), {}, i32),
+    ],
+)
+def test_constraint_inference(
+    constr: AttrConstraint, var_dict: dict[str, Attribute], inferred: Attribute | None
+) -> None:
+    if inferred is None:
+        assert constr.can_infer(var_dict.keys()) is False
+    else:
+        assert constr.can_infer(var_dict.keys()) is True
+        assert constr.infer(ConstraintContext(var_dict)) == inferred

--- a/tests/irdl/test_attr_constraint.py
+++ b/tests/irdl/test_attr_constraint.py
@@ -515,7 +515,7 @@ def test_constraint_inference(
     constr: AttrConstraint, var_dict: dict[str, Attribute], inferred: Attribute | None
 ) -> None:
     if inferred is None:
-        assert constr.can_infer(var_dict.keys()) is False
+        assert not constr.can_infer(var_dict.keys())
     else:
-        assert constr.can_infer(var_dict.keys()) is True
+        assert constr.can_infer(var_dict.keys())
         assert constr.infer(ConstraintContext(var_dict)) == inferred

--- a/tests/irdl/test_int_constraint.py
+++ b/tests/irdl/test_int_constraint.py
@@ -60,7 +60,7 @@ def test_at_most():
         AtMost(2).verify(3, ConstraintContext())
 
 
-def test_int_var_constraint():
+def test_int_var_constraint_verify():
     IntVarConstraint("I", EqIntConstraint(1)).verify(1, ConstraintContext())
     IntVarConstraint("I", EqIntConstraint(2)).verify(2, ConstraintContext())
     IntVarConstraint("I", AnyInt()).verify(3, ConstraintContext())
@@ -71,19 +71,26 @@ def test_int_var_constraint():
     ):
         IntVarConstraint("I", AnyInt()).verify(1, ConstraintContext({}, {}, {"I": 2}))
 
-    assert IntVarConstraint("I", AnyInt()).can_infer(set()) is False
-    assert IntVarConstraint("I", AnyInt()).can_infer({"I"}) is True
-    assert IntVarConstraint("I", EqIntConstraint(1)).can_infer(set()) is True
-    assert IntVarConstraint("I", EqIntConstraint(1)).infer(ConstraintContext()) == 1
-    assert (
-        IntVarConstraint("I", EqIntConstraint(1)).infer(
-            ConstraintContext({}, {}, {"I": 2})
-        )
-        == 2
-    )
-    assert (
-        IntVarConstraint("I", AnyInt()).infer(ConstraintContext({}, {}, {"I": 2})) == 2
-    )
+
+@pytest.mark.parametrize(
+    "constraint, context_dict, inferred",
+    [
+        (IntVarConstraint("I", AnyInt()), {}, None),
+        (IntVarConstraint("I", AnyInt()), {"I": 2}, 2),
+        (IntVarConstraint("I", EqIntConstraint(1)), {}, 1),
+        (IntVarConstraint("I", EqIntConstraint(1)), {"I": 2}, 2),
+    ],
+)
+def test_int_var_constraint_infer(
+    constraint: IntVarConstraint,
+    context_dict: dict[str, int],
+    inferred: int | None,
+) -> None:
+    if inferred is None:
+        assert not constraint.can_infer(context_dict.keys())
+    else:
+        assert constraint.can_infer(context_dict.keys())
+        assert constraint.infer(ConstraintContext({}, {}, context_dict)) == inferred
 
 
 def test_eq():

--- a/tests/irdl/test_int_constraint.py
+++ b/tests/irdl/test_int_constraint.py
@@ -15,6 +15,7 @@ from xdsl.irdl import (
     EqIntConstraint,
     IntSetConstraint,
     IntTypeVarConstraint,
+    IntVarConstraint,
     get_int_constraint,
     get_optional_int_constraint,
 )
@@ -57,6 +58,32 @@ def test_at_most():
     AtMost(2).verify(1, ConstraintContext())
     with pytest.raises(VerifyException, match="Expected integer <= 2, got 3"):
         AtMost(2).verify(3, ConstraintContext())
+
+
+def test_int_var_constraint():
+    IntVarConstraint("I", EqIntConstraint(1)).verify(1, ConstraintContext())
+    IntVarConstraint("I", EqIntConstraint(2)).verify(2, ConstraintContext())
+    IntVarConstraint("I", AnyInt()).verify(3, ConstraintContext())
+    IntVarConstraint("I", AnyInt()).verify(4, ConstraintContext({}, {}, {"I": 4}))
+
+    with pytest.raises(
+        VerifyException, match="integer 2 expected from int variable 'I', but got 1"
+    ):
+        IntVarConstraint("I", AnyInt()).verify(1, ConstraintContext({}, {}, {"I": 2}))
+
+    assert IntVarConstraint("I", AnyInt()).can_infer(set()) is False
+    assert IntVarConstraint("I", AnyInt()).can_infer({"I"}) is True
+    assert IntVarConstraint("I", EqIntConstraint(1)).can_infer(set()) is True
+    assert IntVarConstraint("I", EqIntConstraint(1)).infer(ConstraintContext()) == 1
+    assert (
+        IntVarConstraint("I", EqIntConstraint(1)).infer(
+            ConstraintContext({}, {}, {"I": 2})
+        )
+        == 2
+    )
+    assert (
+        IntVarConstraint("I", AnyInt()).infer(ConstraintContext({}, {}, {"I": 2})) == 2
+    )
 
 
 def test_eq():

--- a/tests/irdl/test_range_constraint.py
+++ b/tests/irdl/test_range_constraint.py
@@ -1,9 +1,10 @@
+import re
 from collections.abc import Mapping, Sequence
 
 import pytest
 from typing_extensions import TypeVar
 
-from xdsl.dialects.builtin import StringAttr
+from xdsl.dialects.builtin import StringAttr, i32
 from xdsl.ir import Attribute
 from xdsl.irdl import (
     AnyAttr,
@@ -11,6 +12,7 @@ from xdsl.irdl import (
     AttrConstraint,
     BaseAttr,
     ConstraintContext,
+    EqAttrConstraint,
     EqIntConstraint,
     IntConstraint,
     IntTypeVarConstraint,
@@ -18,6 +20,8 @@ from xdsl.irdl import (
     RangeConstraint,
     RangeLengthConstraint,
     RangeOf,
+    RangeVarConstraint,
+    SingleOf,
     VarConstraint,
 )
 from xdsl.utils.exceptions import VerifyException
@@ -145,3 +149,84 @@ def test_empty_range():
     assert constr.can_infer(set(), length_known=False)
 
     assert constr.infer(ConstraintContext(), length=None) == ()
+
+
+def test_range_var_constraint():
+    RangeVarConstraint("R", SingleOf(EqAttrConstraint(i32))).verify(
+        (i32,), ConstraintContext()
+    )
+    RangeVarConstraint("R", SingleOf(AnyAttr())).verify(
+        (i32,), ConstraintContext({}, {"R": (i32,)})
+    )
+
+    with pytest.raises(
+        VerifyException,
+        match=re.escape(
+            "attributes ('i32',) expected from range variable 'R', but got ('i32', 'i32')"
+        ),
+    ):
+        RangeVarConstraint("R", SingleOf(AnyAttr())).verify(
+            (i32, i32), ConstraintContext({}, {"R": (i32,)})
+        )
+
+    assert (
+        RangeVarConstraint("R", SingleOf(AnyAttr())).can_infer(
+            set(), length_known=False
+        )
+        is False
+    )
+    assert (
+        RangeVarConstraint("R", SingleOf(EqAttrConstraint(i32))).can_infer(
+            set(), length_known=False
+        )
+        is True
+    )
+    assert (
+        RangeVarConstraint("R", RangeOf(EqAttrConstraint(i32))).can_infer(
+            set(), length_known=True
+        )
+        is True
+    )
+    assert (
+        RangeVarConstraint("R", RangeOf(EqAttrConstraint(i32))).can_infer(
+            set(), length_known=False
+        )
+        is False
+    )
+    assert (
+        RangeVarConstraint("R", AnyRangeConstraint()).can_infer(
+            {"R"}, length_known=True
+        )
+        is True
+    )
+    assert (
+        RangeVarConstraint("R", AnyRangeConstraint()).can_infer(
+            set(), length_known=True
+        )
+        is False
+    )
+    assert (
+        RangeVarConstraint("R", AnyRangeConstraint()).can_infer(
+            {"R"}, length_known=False
+        )
+        is True
+    )
+    assert (
+        RangeVarConstraint("R", AnyRangeConstraint()).can_infer(
+            set(), length_known=False
+        )
+        is False
+    )
+
+    assert RangeVarConstraint("R", SingleOf(EqAttrConstraint(i32))).infer(
+        ConstraintContext(), length=None
+    ) == (i32,)
+    assert RangeVarConstraint("R", RangeOf(EqAttrConstraint(i32))).infer(
+        ConstraintContext(), length=3
+    ) == (i32, i32, i32)
+    assert RangeVarConstraint("R", AnyRangeConstraint()).infer(
+        ConstraintContext({}, {"R": (i32, i32)}), length=2
+    ) == (i32, i32)
+    assert RangeVarConstraint("R", AnyRangeConstraint()).infer(
+        ConstraintContext({}, {"R": (i32, StringAttr("str"))}), length=None
+    ) == (i32, StringAttr("str"))

--- a/tests/irdl/test_range_constraint.py
+++ b/tests/irdl/test_range_constraint.py
@@ -151,7 +151,7 @@ def test_empty_range():
     assert constr.infer(ConstraintContext(), length=None) == ()
 
 
-def test_range_var_constraint():
+def test_range_var_constraint_verify():
     RangeVarConstraint("R", SingleOf(EqAttrConstraint(i32))).verify(
         (i32,), ConstraintContext()
     )
@@ -169,64 +169,51 @@ def test_range_var_constraint():
             (i32, i32), ConstraintContext({}, {"R": (i32,)})
         )
 
-    assert (
-        RangeVarConstraint("R", SingleOf(AnyAttr())).can_infer(
-            set(), length_known=False
-        )
-        is False
-    )
-    assert (
-        RangeVarConstraint("R", SingleOf(EqAttrConstraint(i32))).can_infer(
-            set(), length_known=False
-        )
-        is True
-    )
-    assert (
-        RangeVarConstraint("R", RangeOf(EqAttrConstraint(i32))).can_infer(
-            set(), length_known=True
-        )
-        is True
-    )
-    assert (
-        RangeVarConstraint("R", RangeOf(EqAttrConstraint(i32))).can_infer(
-            set(), length_known=False
-        )
-        is False
-    )
-    assert (
-        RangeVarConstraint("R", AnyRangeConstraint()).can_infer(
-            {"R"}, length_known=True
-        )
-        is True
-    )
-    assert (
-        RangeVarConstraint("R", AnyRangeConstraint()).can_infer(
-            set(), length_known=True
-        )
-        is False
-    )
-    assert (
-        RangeVarConstraint("R", AnyRangeConstraint()).can_infer(
-            {"R"}, length_known=False
-        )
-        is True
-    )
-    assert (
-        RangeVarConstraint("R", AnyRangeConstraint()).can_infer(
-            set(), length_known=False
-        )
-        is False
-    )
 
-    assert RangeVarConstraint("R", SingleOf(EqAttrConstraint(i32))).infer(
-        ConstraintContext(), length=None
-    ) == (i32,)
-    assert RangeVarConstraint("R", RangeOf(EqAttrConstraint(i32))).infer(
-        ConstraintContext(), length=3
-    ) == (i32, i32, i32)
-    assert RangeVarConstraint("R", AnyRangeConstraint()).infer(
-        ConstraintContext({}, {"R": (i32, i32)}), length=2
-    ) == (i32, i32)
-    assert RangeVarConstraint("R", AnyRangeConstraint()).infer(
-        ConstraintContext({}, {"R": (i32, StringAttr("str"))}), length=None
-    ) == (i32, StringAttr("str"))
+@pytest.mark.parametrize(
+    "constraint, context_dict, length, inferred",
+    [
+        (RangeVarConstraint("R", SingleOf(AnyAttr())), {}, None, None),
+        (RangeVarConstraint("R", SingleOf(EqAttrConstraint(i32))), {}, True, (i32,)),
+        (RangeVarConstraint("R", RangeOf(EqAttrConstraint(i32))), {}, None, None),
+        (RangeVarConstraint("R", RangeOf(EqAttrConstraint(i32))), {}, 2, (i32, i32)),
+        (RangeVarConstraint("R", AnyRangeConstraint()), {}, None, None),
+        (
+            RangeVarConstraint("R", AnyRangeConstraint()),
+            {"R": (i32, i32, i32)},
+            None,
+            (i32, i32, i32),
+        ),
+        (
+            RangeVarConstraint("R", AnyRangeConstraint()),
+            {"R": (i32, i32, i32)},
+            2,
+            (i32, i32, i32),
+        ),
+        (
+            RangeVarConstraint("R", AnyRangeConstraint()),
+            {"R": (i32, i32, i32)},
+            3,
+            (i32, i32, i32),
+        ),
+        (RangeVarConstraint("R", AnyRangeConstraint()), {}, 3, None),
+    ],
+)
+def test_range_var_constraint_infer(
+    constraint: RangeVarConstraint,
+    context_dict: dict[str, tuple[Attribute, ...]],
+    length: int | None,
+    inferred: tuple[Attribute, ...] | None,
+) -> None:
+    if inferred is None:
+        assert not constraint.can_infer(
+            context_dict.keys(), length_known=length is not None
+        )
+    else:
+        assert constraint.can_infer(
+            context_dict.keys(), length_known=length is not None
+        )
+        assert (
+            constraint.infer(ConstraintContext({}, context_dict), length=length)
+            == inferred
+        )

--- a/xdsl/irdl/constraints.py
+++ b/xdsl/irdl/constraints.py
@@ -259,10 +259,14 @@ class VarConstraint(AttrConstraint[AttributeCovT]):
 
     def infer(self, context: ConstraintContext) -> AttributeCovT:
         v = context.get_variable(self.name)
+        if v is None:
+            return self.constraint.infer(context)
         return cast(AttributeCovT, v)
 
     def can_infer(self, var_constraint_names: AbstractSet[str]) -> bool:
-        return self.name in var_constraint_names
+        return self.name in var_constraint_names or self.constraint.can_infer(
+            var_constraint_names
+        )
 
     def get_bases(self) -> set[type[Attribute]] | None:
         return self.constraint.get_bases()
@@ -988,14 +992,17 @@ class IntVarConstraint(IntConstraint):
         return self.constraint.variables() | {self.name}
 
     def can_infer(self, var_constraint_names: AbstractSet[str]) -> bool:
-        return self.name in var_constraint_names
+        return self.name in var_constraint_names or self.constraint.can_infer(
+            var_constraint_names
+        )
 
     def infer(
         self,
         context: ConstraintContext,
     ) -> int:
         v = context.get_int_variable(self.name)
-        assert isinstance(v, int)
+        if v is None:
+            return self.constraint.infer(context)
         return v
 
     def mapping_type_vars(
@@ -1234,12 +1241,16 @@ class RangeVarConstraint(RangeConstraint[AttributeCovT]):
     def can_infer(
         self, var_constraint_names: AbstractSet[str], *, length_known: bool
     ) -> bool:
-        return self.name in var_constraint_names
+        return self.name in var_constraint_names or self.constraint.can_infer(
+            var_constraint_names, length_known=length_known
+        )
 
     def infer(
         self, context: ConstraintContext, *, length: int | None
     ) -> Sequence[AttributeCovT]:
         v = context.get_range_variable(self.name)
+        if v is None:
+            return self.constraint.infer(context, length=length)
         return cast(Sequence[AttributeCovT], v)
 
     def mapping_type_vars(


### PR DESCRIPTION
Lets the 3 kinds of variable constraint use their inner constraints when checking if they can infer and then when inferring.