### PR TITLE
dialects: (tensor) fix `tensor.pad` verifier for dynamic source dims

### DIFF
--- a/tests/filecheck/dialects/tensor/ops.mlir
+++ b/tests/filecheck/dialects/tensor/ops.mlir
@@ -23,11 +23,17 @@
 %v = tensor.splat %s : tensor<8xf32>
 %v2 = tensor.splat %s[%index, %index1] : tensor<?x8x?xf32>
 
-%pval, %ptensor = "test.op"() : () -> (f32, tensor<12x20x20xf32>) 
+%pval, %ptensor = "test.op"() : () -> (f32, tensor<12x20x20xf32>)
 %padded = tensor.pad %ptensor low[1, %dim1, 2] high[%dim2, 3, 3] {
   ^bb0(%arg0: index, %arg1: index, %arg2: index):
     tensor.yield %pval : f32
   } : tensor<12x20x20xf32> to tensor<?x?x25xf32>
+
+%pval2, %dtensor = "test.op"() : () -> (f32, tensor<?x49x10x1xf32>)
+%padded_dyn_src = tensor.pad %dtensor low[0, 4, 1, 0] high[0, 5, 1, 0] {
+  ^bb0(%arg0: index, %arg1: index, %arg2: index, %arg3: index):
+    tensor.yield %pval2 : f32
+  } : tensor<?x49x10x1xf32> to tensor<?x58x12x1xf32>
 
 // CHECK: builtin.module {
 // CHECK-NEXT:   %index, %index1, %tensor = "test.op"() : () -> (index, index, tensor<?x?xf32>)
@@ -53,6 +59,11 @@
 // CHECK-NEXT:    ^bb0(%arg0: index, %arg1: index, %arg2: index):
 // CHECK-NEXT:      tensor.yield %pval : f32
 // CHECK-NEXT:    } : tensor<12x20x20xf32> to tensor<?x?x25xf32>
+// CHECK-NEXT:  %pval2, %dtensor = "test.op"() : () -> (f32, tensor<?x49x10x1xf32>)
+// CHECK-NEXT:  %padded_dyn_src = tensor.pad %dtensor low[0, 4, 1, 0] high[0, 5, 1, 0] {
+// CHECK-NEXT:    ^bb1(%arg0_1: index, %arg1_1: index, %arg2_1: index, %arg3: index):
+// CHECK-NEXT:      tensor.yield %pval2 : f32
+// CHECK-NEXT:    } : tensor<?x49x10x1xf32> to tensor<?x58x12x1xf32>
 // CHECK-NEXT: }
 
 // CHECK-GENERIC: "builtin.module"() ({
@@ -79,4 +90,9 @@
 // CHECK-GENERIC-NEXT:    ^bb0(%arg0: index, %arg1: index, %arg2: index):
 // CHECK-GENERIC-NEXT:     "tensor.yield"(%pval) : (f32) -> ()
 // CHECK-GENERIC-NEXT:    }) : (tensor<12x20x20xf32>, index, index) -> tensor<?x?x25xf32>
+// CHECK-GENERIC-NEXT:   %pval2, %dtensor = "test.op"() : () -> (f32, tensor<?x49x10x1xf32>)
+// CHECK-GENERIC-NEXT:   %padded_dyn_src = "tensor.pad"(%dtensor) <{static_low = array<i64: 0, 4, 1, 0>, static_high = array<i64: 0, 5, 1, 0>, operandSegmentSizes = array<i32: 1, 0, 0>}> ({
+// CHECK-GENERIC-NEXT:    ^bb1(%arg0_1: index, %arg1_1: index, %arg2_1: index, %arg3: index):
+// CHECK-GENERIC-NEXT:     "tensor.yield"(%pval2) : (f32) -> ()
+// CHECK-GENERIC-NEXT:    }) : (tensor<?x49x10x1xf32>) -> tensor<?x58x12x1xf32>
 // CHECK-GENERIC-NEXT: }) : () -> ()

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/tensor/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/tensor/ops.mlir
@@ -27,11 +27,17 @@
 %v = tensor.splat %s : tensor<8xf32>
 %v2 = tensor.splat %s[%index, %index1] : tensor<?x8x?xf32>
 
-%pval, %ptensor = "test.op"() : () -> (f32, tensor<12x20x20xf32>) 
+%pval, %ptensor = "test.op"() : () -> (f32, tensor<12x20x20xf32>)
 %padded = tensor.pad %ptensor nofold low[1, %dim1, 2] high[%dim2, 3, 3] {
  ^bb0(%arg0: index, %arg1: index, %arg2: index):
    tensor.yield %pval : f32
  } : tensor<12x20x20xf32> to tensor<?x?x25xf32>
+
+%pval2, %dtensor = "test.op"() : () -> (f32, tensor<?x49x10x1xf32>)
+%padded_dyn_src = tensor.pad %dtensor low[0, 4, 1, 0] high[0, 5, 1, 0] {
+ ^bb0(%arg0_1: index, %arg1_1: index, %arg2_1: index, %arg3: index):
+   tensor.yield %pval2 : f32
+ } : tensor<?x49x10x1xf32> to tensor<?x58x12x1xf32>
 
 // CHECK:       module {
 // CHECK-NEXT:  %0 = tensor.empty() :  tensor<2x3xf32>
@@ -64,4 +70,9 @@
 // CHECK-NEXT:   ^bb0(%arg0: index, %arg1: index, %arg2: index):
 // CHECK-NEXT:     tensor.yield %9#0 : f32
 // CHECK-NEXT:   } : tensor<12x20x20xf32> to tensor<?x?x25xf32>
+// CHECK-NEXT:  %{{.*}}:2 = "test.op"() : () -> (f32, tensor<?x49x10x1xf32>)
+// CHECK-NEXT:  %padded{{.*}} = tensor.pad %{{.*}}#1 low[0, 4, 1, 0] high[0, 5, 1, 0] {
+// CHECK-NEXT:   ^bb0(%arg0: index, %arg1: index, %arg2: index, %arg3: index):
+// CHECK-NEXT:     tensor.yield %{{.*}}#0 : f32
+// CHECK-NEXT:   } : tensor<?x49x10x1xf32> to tensor<?x58x12x1xf32>
 // CHECK-NEXT: }

--- a/xdsl/dialects/tensor.py
+++ b/xdsl/dialects/tensor.py
@@ -963,7 +963,7 @@ class PadOp(IRDLOperation):
         # OR either pad amount on that dim is dynamic.
         dynamic_dims = tuple(
             i
-            for i, (s, l, h) in enumerate(
+            for i, i_dims in enumerate(
                 zip(
                     source_shape,
                     self.static_low.get_values(),
@@ -971,7 +971,7 @@ class PadOp(IRDLOperation):
                     strict=True,
                 )
             )
-            if s == DYNAMIC_INDEX or l == DYNAMIC_INDEX or h == DYNAMIC_INDEX
+            if DYNAMIC_INDEX in i_dims
         )
         result_dynamic_dims = tuple(
             i for i, s in enumerate(self.result.type.get_shape()) if s == DYNAMIC_INDEX

--- a/xdsl/dialects/tensor.py
+++ b/xdsl/dialects/tensor.py
@@ -952,14 +952,14 @@ class PadOp(IRDLOperation):
                 f"pad sizes low ({len(self.static_low)}) and high ({len(self.static_high)})"
                 " must have an equal number of dimensions"
             )
-        source_type = cast(TensorType[Attribute], self.source.type) # verified by IRDL
+        source_type = cast(TensorType[Attribute], self.source.type)  # verified by IRDL
         source_shape = source_type.get_shape()
         if len(self.static_low) != len(source_shape):
             raise VerifyException(
                 f"number of pad sizes ({len(self.static_low)}) must equal number of dimensions"
                 f" in source tensor ({len(source_type.get_shape())})"
             )
-        # A result dim is dynamic when the source dim is dynamic 
+        # A result dim is dynamic when the source dim is dynamic
         # OR either pad amount on that dim is dynamic.
         dynamic_dims = tuple(
             i

--- a/xdsl/dialects/tensor.py
+++ b/xdsl/dialects/tensor.py
@@ -952,24 +952,26 @@ class PadOp(IRDLOperation):
                 f"pad sizes low ({len(self.static_low)}) and high ({len(self.static_high)})"
                 " must have an equal number of dimensions"
             )
-        source_type = self.source.type
-        if isinstance(source_type, TensorType) and len(self.static_low) != len(
-            source_type.get_shape()
-        ):
+        source_type = cast(TensorType[Attribute], self.source.type) # verified by IRDL
+        source_shape = source_type.get_shape()
+        if len(self.static_low) != len(source_shape):
             raise VerifyException(
                 f"number of pad sizes ({len(self.static_low)}) must equal number of dimensions"
                 f" in source tensor ({len(source_type.get_shape())})"
             )
+        # A result dim is dynamic when the source dim is dynamic 
+        # OR either pad amount on that dim is dynamic.
         dynamic_dims = tuple(
             i
-            for i, (l, h) in enumerate(
+            for i, (s, l, h) in enumerate(
                 zip(
+                    source_shape,
                     self.static_low.get_values(),
                     self.static_high.get_values(),
                     strict=True,
                 )
             )
-            if l == DYNAMIC_INDEX or h == DYNAMIC_INDEX
+            if s == DYNAMIC_INDEX or l == DYNAMIC_INDEX or h == DYNAMIC_INDEX
         )
         result_dynamic_dims = tuple(
             i for i, s in enumerate(self.result.type.get_shape()) if s == DYNAMIC_INDEX


### PR DESCRIPTION
The previous verifier considered a result dim dynamic only when the corresponding `low` or `high` pad amount was dynamic. This rejected valid IR in which a dynamic source dim is padded by static amounts — e.g. `tensor.pad %x low[0,4,1,0] high[0,5,1,0] :
tensor<?x49x10x1xf32> to tensor<?x58x12x1xf32>` — because the source already contributes a dynamic dim to the result.