### PR TITLE
core: Implement base functions for the symbol table helper

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,20 @@ scripts.xdsl-tblgen = "xdsl.tools.xdsl_tblgen:main"
 entry-points."xdsl.universe".xdsl = "xdsl.universe:XDSL_UNIVERSE"
 
 [dependency-groups]
+<<<<<<< HEAD
 dev = [ "my-plugin", "toy", "xdsl[dev,gui,heir,llvm]" ]
+=======
+dev = ["xdsl[dev,gui,llvm,heir]", "my_plugin", "toy"]
+bench = [
+    "asv>=0.6.4",
+    "snakeviz>=2.2.2",
+    "viztracer>=1.0.1",
+    "flameprof>=0.4",
+    "orjson>=3.10.15",
+    "pyinstrument>=5.0.1",
+    "bytesight",
+]
+>>>>>>> bb1d5f25 (documentation: make toy a Python package installed in dev environments (#6104))
 docs = [
   "lzstring2",
   "micropip>=0.7",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,20 +56,7 @@ scripts.xdsl-tblgen = "xdsl.tools.xdsl_tblgen:main"
 entry-points."xdsl.universe".xdsl = "xdsl.universe:XDSL_UNIVERSE"
 
 [dependency-groups]
-<<<<<<< HEAD
 dev = [ "my-plugin", "toy", "xdsl[dev,gui,heir,llvm]" ]
-=======
-dev = ["xdsl[dev,gui,llvm,heir]", "my_plugin", "toy"]
-bench = [
-    "asv>=0.6.4",
-    "snakeviz>=2.2.2",
-    "viztracer>=1.0.1",
-    "flameprof>=0.4",
-    "orjson>=3.10.15",
-    "pyinstrument>=5.0.1",
-    "bytesight",
-]
->>>>>>> bb1d5f25 (documentation: make toy a Python package installed in dev environments (#6104))
 docs = [
   "lzstring2",
   "micropip>=0.7",

--- a/tests/utils/test_symbol_table.py
+++ b/tests/utils/test_symbol_table.py
@@ -115,7 +115,17 @@ def test_symbol_table_remove():
         match="Expected this operation to be inside of the operation with this SymbolTable",
     ):
         empty_table.remove(op_a)
+
+    with pytest.raises(
+        ValueError,
+        match="Expected this operation to be inside of the operation with this SymbolTable",
+    ):
         table.remove(op_b)
+
+    with pytest.raises(
+        ValueError,
+        match="Expected this operation to be inside of the operation with this SymbolTable",
+    ):
         table.remove(op_c)
 
 

--- a/tests/utils/test_symbol_table.py
+++ b/tests/utils/test_symbol_table.py
@@ -66,34 +66,84 @@ def test_symbol_table_init():
 
 def test_symbol_table_lookup():
     """Test SymbolTable.lookup method."""
-    module = ModuleOp([], sym_name=StringAttr("test_module"))
-    symbol_table = SymbolTable(module)
+    op_a = TestSymbolOp(properties={"sym_name": StringAttr("a")})
+    op_b = TestSymbolOp(properties={"sym_name": StringAttr("b")})
 
-    # This will raise NotImplementedError until implemented
-    with pytest.raises(NotImplementedError):
-        symbol_table.lookup("test_symbol")
+    op_not_symbol = TestOp(properties={"sym_name": StringAttr("c")})
+
+    module = ModuleOp([op_a, op_b, op_not_symbol])
+    empty_module = ModuleOp([])
+
+    table = SymbolTable(module)
+    empty_table = SymbolTable(empty_module)
+
+    assert table.lookup("a") is op_a
+    assert table.lookup(StringAttr("a")) is op_a
+    assert table.lookup("b") is table.lookup(StringAttr("b"))
+
+    assert table.lookup("c") is None
+
+    assert empty_table.lookup("anything") is None
+
+    assert table.lookup("@a") is None
+    assert table.lookup("A") is None
 
 
 def test_symbol_table_remove():
     """Test SymbolTable.remove method."""
-    module = ModuleOp([], sym_name=StringAttr("test_module"))
-    symbol_table = SymbolTable(module)
-    test_op = TestOp()
+    op_a = TestSymbolOp(properties={"sym_name": StringAttr("a")})
+    op_b = TestSymbolOp(properties={"sym_name": StringAttr("b")})
+    op_c = TestSymbolOp(properties={"sym_name": StringAttr("c")})
 
-    # This will raise NotImplementedError until implemented
-    with pytest.raises(NotImplementedError):
-        symbol_table.remove(test_op)
+    module = ModuleOp([op_a, op_b])
+    empty_module = ModuleOp([])
+
+    table = SymbolTable(module)
+    empty_table = SymbolTable(empty_module)
+
+    assert table.lookup("a") is op_a
+    assert table.lookup("b") is op_b
+    assert op_b.parent is not None
+
+    table.remove(op_b)
+    assert table.lookup("a") is op_a
+    assert table.lookup("b") is None
+    assert op_b.parent is not None
+
+    with pytest.raises(
+        ValueError,
+        match="Expected this operation to be inside of the operation with this SymbolTable",
+    ):
+        empty_table.remove(op_a)
+        table.remove(op_b)
+        table.remove(op_c)
 
 
 def test_symbol_table_erase():
     """Test SymbolTable.erase method."""
-    module = ModuleOp([], sym_name=StringAttr("test_module"))
-    symbol_table = SymbolTable(module)
-    test_op = TestOp()
+    op_a = TestSymbolOp(properties={"sym_name": StringAttr("a")})
+    op_b = TestSymbolOp(properties={"sym_name": StringAttr("b")})
+    op_c = TestSymbolOp(properties={"sym_name": StringAttr("c")})
 
-    # This will raise NotImplementedError until implemented
-    with pytest.raises(NotImplementedError):
-        symbol_table.erase(test_op)
+    module = ModuleOp([op_a, op_b])
+
+    table = SymbolTable(module)
+
+    assert table.lookup("a") is op_a
+    assert op_b.parent is not None
+    assert table.lookup("b") is op_b
+
+    table.erase(op_b)
+
+    assert table.lookup("b") is None
+    assert op_b.parent is None
+    assert op_a.parent is not None
+
+    with pytest.raises(
+        ValueError,
+        match="Expected this operation to be inside of the operation with this SymbolTable",
+    ):
+        table.erase(op_c)
 
 
 def test_symbol_table_insert():

--- a/xdsl/utils/symbol_table.py
+++ b/xdsl/utils/symbol_table.py
@@ -81,12 +81,10 @@ class SymbolTable:
         self._symbol_table = {}
         self._uniquing_counter = 0
 
-
         block = self._symbol_table_op.regions[0].blocks[0]
         for op in block.ops:
             if (name := get_name_if_symbol(op)) is not None:
                 self._symbol_table[name] = op
-
 
     def lookup(self, name: str | StringAttr) -> Operation | None:
         """

--- a/xdsl/utils/symbol_table.py
+++ b/xdsl/utils/symbol_table.py
@@ -92,15 +92,27 @@ class SymbolTable:
         exists.
         Names never include the `@` on them.
         """
-        raise NotImplementedError
+        n: str = name.name if isinstance(name, StringAttr) else name
+        return self._symbol_table[n] if n in self._symbol_table.keys() else None
 
     def remove(self, op: Operation) -> None:
         """Remove the given symbol from the table, without deleting it."""
-        raise NotImplementedError
+        name = get_name_if_symbole(op)
+
+        if name is None:
+            raise Exception("Expected valid 'name' attribute")
+
+        if name not in self._symbol_table:
+            raise Exception(
+                "Expected this operation to be inside of the operation with this SymbolTable"
+            )
+
+        self._symbol_table.pop(name)
 
     def erase(self, op: Operation) -> None:
         """Erase the given symbol from the table and delete the operation."""
-        raise NotImplementedError
+        self.remove(op)
+        op.erase()
 
     def insert(self, symbol: Operation, insertion_point: InsertPoint) -> StringAttr:
         """

--- a/xdsl/utils/symbol_table.py
+++ b/xdsl/utils/symbol_table.py
@@ -97,17 +97,13 @@ class SymbolTable:
 
     def remove(self, op: Operation) -> None:
         """Remove the given symbol from the table, without deleting it."""
-        name = get_name_if_symbol(op)
-
-        if name is None:
+        if (name := get_name_if_symbol(op)) is None:
             raise ValueError("Expected valid 'name' attribute")
 
-        if name not in self._symbol_table:
+        if self._symbol_table.pop(name, None) is None:
             raise ValueError(
                 "Expected this operation to be inside of the operation with this SymbolTable"
             )
-
-        self._symbol_table.pop(name)
 
     def erase(self, op: Operation) -> None:
         """Erase the given symbol from the table and delete the operation."""

--- a/xdsl/utils/symbol_table.py
+++ b/xdsl/utils/symbol_table.py
@@ -92,18 +92,18 @@ class SymbolTable:
         exists.
         Names never include the `@` on them.
         """
-        n: str = name.name if isinstance(name, StringAttr) else name
-        return self._symbol_table[n] if n in self._symbol_table.keys() else None
+        name = name.data if isinstance(name, StringAttr) else name
+        return self._symbol_table.get(name)
 
     def remove(self, op: Operation) -> None:
         """Remove the given symbol from the table, without deleting it."""
-        name = get_name_if_symbole(op)
+        name = get_name_if_symbol(op)
 
         if name is None:
-            raise Exception("Expected valid 'name' attribute")
+            raise ValueError("Expected valid 'name' attribute")
 
         if name not in self._symbol_table:
-            raise Exception(
+            raise ValueError(
                 "Expected this operation to be inside of the operation with this SymbolTable"
             )
 
@@ -112,6 +112,7 @@ class SymbolTable:
     def erase(self, op: Operation) -> None:
         """Erase the given symbol from the table and delete the operation."""
         self.remove(op)
+        op.detach()
         op.erase()
 
     def insert(self, symbol: Operation, insertion_point: InsertPoint) -> StringAttr:

--- a/xdsl/utils/symbol_table.py
+++ b/xdsl/utils/symbol_table.py
@@ -81,10 +81,12 @@ class SymbolTable:
         self._symbol_table = {}
         self._uniquing_counter = 0
 
+
         block = self._symbol_table_op.regions[0].blocks[0]
         for op in block.ops:
             if (name := get_name_if_symbol(op)) is not None:
                 self._symbol_table[name] = op
+
 
     def lookup(self, name: str | StringAttr) -> Operation | None:
         """


### PR DESCRIPTION
Port lookup, erase and remove functions of the SymbolTable helper from MLIR with corresponding test suit.