### PR TITLE
core: Add function to easily get symbol names

### DIFF
--- a/tests/utils/test_symbol_table.py
+++ b/tests/utils/test_symbol_table.py
@@ -1,14 +1,23 @@
 import pytest
 
 from xdsl.dialects.builtin import ModuleOp, StringAttr
-from xdsl.dialects.test import TestOp
+from xdsl.dialects.test import TestOp, TestSymbolOp
 from xdsl.ir import Block, Region
 from xdsl.utils.symbol_table import (
     SymbolTable,
     SymbolTableCollection,
     Visibility,
+    get_name_if_symbol,
     walk_symbol_table,
 )
+
+
+def test_get_name_if_symbol():
+    symbol = TestSymbolOp(properties={"sym_name": StringAttr("a")})
+    not_symbol = TestOp()
+
+    assert get_name_if_symbol(symbol) == "a"
+    assert get_name_if_symbol(not_symbol) is None
 
 
 def test_walk_symbol_table():

--- a/xdsl/dialects/test.py
+++ b/xdsl/dialects/test.py
@@ -36,6 +36,7 @@ from xdsl.traits import (
     MemoryReadEffect,
     MemoryWriteEffect,
     Pure,
+    SymbolOpInterface,
 )
 
 
@@ -289,6 +290,46 @@ class TestType(Data[str], TypeAttribute):
             printer.print_string_literal(self.data)
 
 
+@irdl_op_definition
+class TestSymbolOp(IRDLOperation):
+    """
+    This operation can produce an arbitrary number of SSAValues with arbitrary
+    types. It is used in filecheck testing to reduce to artificial dependencies
+    on other dialects (i.e. dependencies that only come from the structure of
+    the test rather than the actual dialect).
+    Its main difference with TestOp is that it satisfies the SymbolOpInterface trait,
+    meaning that we can attach a symbol name to it.
+    """
+
+    name = "test.op_with_symbol"
+
+    res = var_result_def()
+    ops = var_operand_def()
+    regs = var_region_def()
+
+    prop1 = opt_prop_def()
+    prop2 = opt_prop_def()
+    prop3 = opt_prop_def()
+
+    traits = traits_def(SymbolOpInterface())
+
+    def __init__(
+        self,
+        operands: Sequence[SSAValue | Operation] = (),
+        result_types: Sequence[Attribute] = (),
+        attributes: Mapping[str, Attribute | None] | None = None,
+        properties: Mapping[str, Attribute | None] | None = None,
+        regions: Sequence[Region | Sequence[Operation] | Sequence[Block]] = (),
+    ):
+        super().__init__(
+            operands=(operands,),
+            result_types=(result_types,),
+            attributes=attributes,
+            properties=properties,
+            regions=(regions,),
+        )
+
+
 Test = Dialect(
     "test",
     [
@@ -297,6 +338,7 @@ Test = Dialect(
         TestReadOp,
         TestTermOp,
         TestWriteOp,
+        TestSymbolOp,
     ],
     [
         TestType,

--- a/xdsl/dialects/test.py
+++ b/xdsl/dialects/test.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 
 from xdsl.dialect_interfaces.op_asm import OpAsmDialectInterface
-from xdsl.dialects.builtin import IntegerAttr, IntegerType
+from xdsl.dialects.builtin import IntegerAttr, IntegerType, SymbolNameConstraint
 from xdsl.interfaces import HasFolderInterface
 from xdsl.ir import (
     Attribute,
@@ -307,10 +307,7 @@ class TestSymbolOp(IRDLOperation):
     ops = var_operand_def()
     regs = var_region_def()
 
-    prop1 = opt_prop_def()
-    prop2 = opt_prop_def()
-    prop3 = opt_prop_def()
-
+    sym_name = prop_def(SymbolNameConstraint())
     traits = traits_def(SymbolOpInterface())
 
     def __init__(

--- a/xdsl/utils/symbol_table.py
+++ b/xdsl/utils/symbol_table.py
@@ -48,6 +48,7 @@ class SymbolUse(NamedTuple):
 
 
 def get_name_if_symbol(op: Operation) -> None | str:
+    """Returns the symbol name if this operation has one"""
     sym_interface = op.get_trait(traits.SymbolOpInterface)
     if sym_interface is None:
         return None

--- a/xdsl/utils/symbol_table.py
+++ b/xdsl/utils/symbol_table.py
@@ -49,13 +49,10 @@ class SymbolUse(NamedTuple):
 
 def get_name_if_symbol(op: Operation) -> None | str:
     """Returns the symbol name if this operation has one"""
-    sym_interface = op.get_trait(traits.SymbolOpInterface)
-    if sym_interface is None:
-        return None
-
-    name_attr = sym_interface.get_sym_attr_name(op)
-
-    return name_attr.data if name_attr is not None else None
+    if (sym_interface := op.get_trait(traits.SymbolOpInterface)) is not None and (
+        name_attr := sym_interface.get_sym_attr_name(op)
+    ) is not None:
+        return name_attr.data
 
 
 class SymbolTable:

--- a/xdsl/utils/symbol_table.py
+++ b/xdsl/utils/symbol_table.py
@@ -47,6 +47,16 @@ class SymbolUse(NamedTuple):
     """The symbol reference that this use represents."""
 
 
+def get_name_if_symbol(op: Operation) -> None | str:
+    sym_interface = op.get_trait(traits.SymbolOpInterface)
+    if sym_interface is None:
+        return None
+
+    name_attr = sym_interface.get_sym_attr_name(op)
+
+    return name_attr.data if name_attr is not None else None
+
+
 class SymbolTable:
     """
     This class allows for representing and managing the symbol table used by operations


### PR DESCRIPTION
Add TestSymbolOp will be used to test the SymbolTable helper.
Add get_name_if_symbol returns the symbol name associated with on operation if it has one.