### PR TITLE
core: handle dynamic dims in `ShapedType.strides_for_shape`

### DIFF
--- a/tests/dialects/test_builtin.py
+++ b/tests/dialects/test_builtin.py
@@ -916,6 +916,20 @@ def test_strides():
     assert ShapedType.strides_for_shape((1,), factor=2) == (2,)
     assert ShapedType.strides_for_shape((2, 3)) == (3, 1)
     assert ShapedType.strides_for_shape((4, 5, 6), factor=2) == (60, 12, 2)
+    # Dynamic index
+    assert ShapedType.strides_for_shape((DYNAMIC_INDEX,)) == (1,)
+    assert ShapedType.strides_for_shape((DYNAMIC_INDEX, 3)) == (
+        3,
+        1,
+    )
+    assert ShapedType.strides_for_shape((2, DYNAMIC_INDEX)) == (
+        None,
+        1,
+    )
+    assert ShapedType.strides_for_shape((2, DYNAMIC_INDEX), factor=4) == (
+        None,
+        4,
+    )
 
 
 def test_integer_type_repr():

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -127,11 +127,24 @@ class ShapedType(Attribute, ABC):
         return all(dim != DYNAMIC_INDEX for dim in self.get_shape())
 
     @staticmethod
-    def strides_for_shape(shape: Sequence[int], factor: int = 1) -> tuple[int, ...]:
-        import operator
-        from itertools import accumulate
-
-        return tuple(accumulate(reversed(shape), operator.mul, initial=factor))[-2::-1]
+    def strides_for_shape(
+        shape: Sequence[int], factor: int = 1
+    ) -> tuple[int | None, ...]:
+        """
+        Returns a tuple of strides for a given shape, with row-major layout.
+        Strides that depend on a dynamic index are returned as `None`.
+        The optional `factor` parameter specifies the stride for the innermost
+        dimension, defaulting to 1.
+        """
+        rev_strides: list[int | None] = []
+        stride: int | None = factor
+        for dim in reversed(shape):
+            rev_strides.append(stride)
+            if stride is None or dim == DYNAMIC_INDEX:
+                stride = None
+            else:
+                stride *= dim
+        return tuple(reversed(rev_strides))
 
 
 _ContainerElementTypeT = TypeVar(

--- a/xdsl/interpreters/shaped_array.py
+++ b/xdsl/interpreters/shaped_array.py
@@ -5,7 +5,7 @@ from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from itertools import accumulate, product
 from math import prod
-from typing import Generic
+from typing import Generic, cast
 
 from typing_extensions import Self, TypeVar
 
@@ -55,6 +55,8 @@ class ShapedArray(Generic[_T]):
             raise ValueError(f"Invalid indices {index} for shape {self.shape}")
         # For each dimension, the number of elements in the nested arrays
         strides = ShapedType.strides_for_shape(self.shape)
+        assert None not in strides
+        strides = cast(tuple[int], strides)
         offset = sum(i * stride for i, stride in zip(index, strides, strict=True))
         return offset
 

--- a/xdsl/transforms/convert_memref_to_ptr.py
+++ b/xdsl/transforms/convert_memref_to_ptr.py
@@ -97,7 +97,8 @@ def get_strides(
 
     shape = memref_type.get_shape()
     if builtin.DYNAMIC_INDEX not in shape:
-        return builtin.ShapedType.strides_for_shape(shape)
+        static_strides = builtin.ShapedType.strides_for_shape(shape)
+        return cast(tuple[int], static_strides)
 
     rank = len(shape)
     strides: list[int | SSAValue] = [1] * rank


### PR DESCRIPTION
We currently silently don't handle dynamic strides in the helper, this PR fixes this.

Co-authored-by: Lishin <99582713+Lishin1215@users.noreply.github.com>