### PR TITLE
documentation: (toy) return riscemu interpretation output instead of printing

### DIFF
--- a/docs/Toy/Toy_Ch0.ipynb
+++ b/docs/Toy/Toy_Ch0.ipynb
@@ -24,7 +24,8 @@
      "output_type": "stream",
      "text": [
       "[[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]\n",
-      "[[2.0, 4.0, 6.0], [8.0, 10.0, 12.0]]\n"
+      "[[2.0, 4.0, 6.0], [8.0, 10.0, 12.0]]\n",
+      "\n"
      ]
     }
    ],
@@ -58,9 +59,11 @@
     "\n",
     "try:\n",
     "    code = compile(program)\n",
-    "    emulate_riscv(code)\n",
+    "    res = emulate_riscv(code)\n",
     "except VerifyException as e:\n",
-    "    print(e)"
+    "    res = str(e)\n",
+    "\n",
+    "print(res)"
    ]
   },
   {

--- a/docs/Toy/toy/__main__.py
+++ b/docs/Toy/toy/__main__.py
@@ -90,7 +90,7 @@ def main(path: Path, emit: str, ir: bool, print_generic: bool):
             print(code)
             return
 
-        emulate_riscv(code)
+        print(emulate_riscv(code))
         return
 
     if ir:

--- a/docs/Toy/toy/compiler.py
+++ b/docs/Toy/toy/compiler.py
@@ -161,7 +161,9 @@ def compile(program: str) -> str:
     return io.getvalue()
 
 
-def emulate_riscv(program: str):
+def emulate_riscv(program: str) -> str:
     from xdsl.interpreters.riscv_emulator import run_riscv
 
-    run_riscv(program, unlimited_regs=True, verbosity=0)
+    io = StringIO()
+    run_riscv(program, unlimited_regs=True, verbosity=0, output=io)
+    return io.getvalue()

--- a/tests/interpreters/test_riscv_emulator.py
+++ b/tests/interpreters/test_riscv_emulator.py
@@ -1,4 +1,3 @@
-from contextlib import redirect_stdout
 from io import StringIO
 
 import pytest
@@ -36,14 +35,11 @@ def test_simple():
 
     code = riscv.riscv_code(module)
 
-    with StringIO() as stream, redirect_stdout(stream):
-        run_riscv(
-            code,
-            extensions=[RV_Debug],
-            unlimited_regs=True,
-            verbosity=0,
-        )
-        assert stream.getvalue() == "42\n"
+    stream = StringIO()
+    run_riscv(
+        code, extensions=[RV_Debug], unlimited_regs=True, verbosity=0, output=stream
+    )
+    assert stream.getvalue() == "42\n"
 
 
 def test_multiply_add():
@@ -152,11 +148,8 @@ def test_multiply_add():
     RISCVAllocateRegistersPass().apply(ctx, module)
 
     code = riscv.riscv_code(module)
-    with StringIO() as stream, redirect_stdout(stream):
-        run_riscv(
-            code,
-            extensions=[RV_Debug],
-            unlimited_regs=True,
-            verbosity=0,
-        )
-        assert stream.getvalue() == "7\n"
+    stream = StringIO()
+    run_riscv(
+        code, extensions=[RV_Debug], unlimited_regs=True, verbosity=0, output=stream
+    )
+    assert stream.getvalue() == "7\n"

--- a/xdsl/interpreters/riscv_emulator.py
+++ b/xdsl/interpreters/riscv_emulator.py
@@ -24,7 +24,7 @@ def run_riscv(
     extensions: Sequence[type[InstructionSet]] = (),
     unlimited_regs: bool = False,
     verbosity: int = 5,
-    output: IO[str] | None = None,
+    output: IO[str],
 ):
     cfg = RunConfig(
         debug_instruction=False,

--- a/xdsl/interpreters/riscv_emulator.py
+++ b/xdsl/interpreters/riscv_emulator.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from contextlib import redirect_stdout
 from io import StringIO
+from typing import IO
 
 from riscemu.config import RunConfig
 from riscemu.instructions import (
@@ -18,9 +20,11 @@ from riscemu.riscemu_main import RiscemuMain, RiscemuSource
 
 def run_riscv(
     code: str,
+    *,
     extensions: Sequence[type[InstructionSet]] = (),
     unlimited_regs: bool = False,
     verbosity: int = 5,
+    output: IO[str] | None = None,
 ):
     cfg = RunConfig(
         debug_instruction=False,
@@ -46,7 +50,8 @@ def run_riscv(
     source = RiscemuSource("example.asm", StringIO(code))
     main.input_files.append(source)
 
-    try:
-        main.run()
-    except Exception as ex:
-        print(ex)
+    with redirect_stdout(output):
+        try:
+            main.run()
+        except Exception as ex:
+            print(ex)

--- a/xdsl/targets/riscemu.py
+++ b/xdsl/targets/riscemu.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from contextlib import redirect_stdout
 from dataclasses import dataclass
 from typing import IO
 
@@ -26,9 +25,9 @@ class RISCVEmulatorTarget(Target):
         from xdsl.dialects.riscv import riscv_code
 
         code = riscv_code(module)
-        with redirect_stdout(output):
-            run_riscv(
-                code,
-                unlimited_regs=self.unlimited_regs,
-                verbosity=self.verbosity,
-            )
+        run_riscv(
+            code,
+            unlimited_regs=self.unlimited_regs,
+            verbosity=self.verbosity,
+            output=output,
+        )


### PR DESCRIPTION
I'm slowly cleaning up the Toy tutorial notebooks, with the aim of moving them to Marimo. Marimo in `edit` mode can display printed things, but in `run` mode doesn't show stdout. This change pipes the stdout of `run_riscv` to a local variable, so that it can be printed manually for now, and in the future displayed in a nice way in the notebook. This also simplifies the tests.