### PR TITLE
documentation: make toy a Python package installed in dev environments

### DIFF
--- a/docs/Toy/Toy_Ch0.ipynb
+++ b/docs/Toy/Toy_Ch0.ipynb
@@ -80,7 +80,7 @@
    "outputs": [],
    "source": [
     "# Uncomment the following lines to execute\n",
-    "# !python -m toy examples/interpret.toy --emit=scf --ir \\\n",
+    "# !toyc examples/interpret.toy --emit=scf --ir \\\n",
     "# | xdsl-opt -p printf-to-llvm \\\n",
     "# | mlir-opt --test-lower-to-llvm \\\n",
     "# | mlir-cpu-runner --entry-point-result=void"

--- a/docs/Toy/examples/ast.toy
+++ b/docs/Toy/examples/ast.toy
@@ -1,4 +1,4 @@
-# RUN: python -m toy %s --emit=ast | filecheck %s --strict-whitespace --match-full-lines
+# RUN: toyc %s --emit=ast | filecheck %s --strict-whitespace --match-full-lines
 
 # User defined generic function that operates on unknown shaped arguments.
 def multiply_transpose(a, b) {

--- a/docs/Toy/examples/codegen.toy
+++ b/docs/Toy/examples/codegen.toy
@@ -1,4 +1,4 @@
-# RUN: python -m toy %s --emit=toy --ir | filecheck %s
+# RUN: toyc %s --emit=toy --ir | filecheck %s
 
 # User defined generic function that operates on unknown shaped arguments
 def multiply_transpose(a, b) {

--- a/docs/Toy/examples/interpret.toy
+++ b/docs/Toy/examples/interpret.toy
@@ -1,13 +1,13 @@
-# RUN: python -m toy %s --emit=toy | filecheck %s
-# RUN: python -m toy %s --emit=toy-opt | filecheck %s
-# RUN: python -m toy %s --emit=toy-inline | filecheck %s
-# RUN: python -m toy %s --emit=shape-inference | filecheck %s
-# RUN: python -m toy %s --emit=affine | filecheck %s
-# RUN: python -m toy %s --emit=scf | filecheck %s
-# RUN: python -m toy %s --emit=riscv | filecheck %s
-# RUN: python -m toy %s --emit=riscv-regalloc | filecheck %s
-# RUN: python -m toy %s --emit=riscv-lowered | filecheck %s
-# RUN: python -m toy %s --emit=riscv-asm | filecheck %s
+# RUN: toyc %s --emit=toy | filecheck %s
+# RUN: toyc %s --emit=toy-opt | filecheck %s
+# RUN: toyc %s --emit=toy-inline | filecheck %s
+# RUN: toyc %s --emit=shape-inference | filecheck %s
+# RUN: toyc %s --emit=affine | filecheck %s
+# RUN: toyc %s --emit=scf | filecheck %s
+# RUN: toyc %s --emit=riscv | filecheck %s
+# RUN: toyc %s --emit=riscv-regalloc | filecheck %s
+# RUN: toyc %s --emit=riscv-lowered | filecheck %s
+# RUN: toyc %s --emit=riscv-asm | filecheck %s
 
 # User defined generic function that operates on unknown shaped arguments
 def multiply_transpose(a, b) {

--- a/docs/Toy/examples/scalar.toy
+++ b/docs/Toy/examples/scalar.toy
@@ -1,4 +1,4 @@
-# RUN: python -m toy %s --emit=toy --ir | filecheck %s
+# RUN: toyc %s --emit=toy --ir | filecheck %s
 
 def main() {
   var a<2, 2> = 5.5;

--- a/docs/Toy/examples/tests/infer_shapes.mlir
+++ b/docs/Toy/examples/tests/infer_shapes.mlir
@@ -1,4 +1,4 @@
-// RUN: python -m toy %s --emit=shape-inference --ir | filecheck %s
+// RUN: toyc %s --emit=shape-inference --ir | filecheck %s
 
 "builtin.module"() ({
   "toy.func"() ({

--- a/docs/Toy/examples/tests/inline.mlir
+++ b/docs/Toy/examples/tests/inline.mlir
@@ -1,4 +1,4 @@
-// RUN: python -m toy %s --emit=toy-inline --ir | filecheck %s
+// RUN: toyc %s --emit=toy-inline --ir | filecheck %s
 
 builtin.module {
 // CHECK: builtin.module {

--- a/docs/Toy/examples/tests/optimise_toy.mlir
+++ b/docs/Toy/examples/tests/optimise_toy.mlir
@@ -1,4 +1,4 @@
-// RUN: python -m toy %s --emit=toy-opt --ir | filecheck %s
+// RUN: toyc %s --emit=toy-opt --ir | filecheck %s
 
 "builtin.module"() ({
 // CHECK:       builtin.module {

--- a/docs/Toy/pyproject.toml
+++ b/docs/Toy/pyproject.toml
@@ -1,0 +1,9 @@
+[project]
+name = "toy"
+description = "Toy compiler tutorial"
+requires-python = ">=3.10"
+dependencies = ["xdsl"]
+dynamic = ["version"]
+
+[project.scripts]
+toyc = "toy.__main__:main"

--- a/docs/Toy/toy/__main__.py
+++ b/docs/Toy/toy/__main__.py
@@ -26,37 +26,39 @@ from .frontend.ir_gen import IRGen
 from .frontend.parser import ToyParser as ToyParser
 from .interpreter import Interpreter, ToyFunctions
 
-parser = argparse.ArgumentParser(description="Process Toy file")
-parser.add_argument("source", type=Path, help="toy source file")
-parser.add_argument(
-    "--emit",
-    dest="emit",
-    choices=[
-        "ast",
-        "toy",
-        "toy-opt",
-        "toy-inline",
-        "shape-inference",
-        "affine",
-        "scf",
-        "riscv",
-        "riscv-opt",
-        "riscv-regalloc",
-        "riscv-regalloc-opt",
-        "riscv-lowered",
-        "riscv-asm",
-    ],
-    default="riscv-asm",
-    help="Compilation target (default: riscv-asm)",
-)
-parser.add_argument("--ir", dest="ir", action="store_true")
-parser.add_argument("--print-op-generic", dest="print_generic", action="store_true")
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Process Toy file")
+    parser.add_argument("source", type=Path, help="toy source file")
+    parser.add_argument(
+        "--emit",
+        dest="emit",
+        choices=[
+            "ast",
+            "toy",
+            "toy-opt",
+            "toy-inline",
+            "shape-inference",
+            "affine",
+            "scf",
+            "riscv",
+            "riscv-opt",
+            "riscv-regalloc",
+            "riscv-regalloc-opt",
+            "riscv-lowered",
+            "riscv-asm",
+        ],
+        default="riscv-asm",
+        help="Compilation target (default: riscv-asm)",
+    )
+    parser.add_argument("--ir", dest="ir", action="store_true")
+    parser.add_argument("--print-op-generic", dest="print_generic", action="store_true")
+    args = parser.parse_args()
+    run(args.source, args.emit, args.ir, args.print_generic)
 
 
-def main(path: Path, emit: str, ir: bool, print_generic: bool):
+def run(path: Path, emit: str, ir: bool, print_generic: bool):
     ctx = context()
-
-    path = args.source
 
     with open(path) as f:
         match path.suffix:
@@ -101,7 +103,7 @@ def main(path: Path, emit: str, ir: bool, print_generic: bool):
     interpreter = Interpreter(module_op)
     if emit in ("toy", "toy-opt", "toy-inline", "shape-inference"):
         interpreter.register_implementations(ToyFunctions())
-    if emit in ("affine"):
+    if emit == "affine":
         interpreter.register_implementations(AffineFunctions())
     if emit in ("affine", "scf"):
         interpreter.register_implementations(ArithFunctions())
@@ -132,5 +134,4 @@ def main(path: Path, emit: str, ir: bool, print_generic: bool):
 
 
 if __name__ == "__main__":
-    args = parser.parse_args()
-    main(args.source, args.emit, args.ir, args.print_generic)
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ llvm = ["llvmlite~=0.47.0"]
 heir = ["heir_py==2026.5.18; python_version >= '3.11' and python_version < '3.13'"]
 
 [dependency-groups]
-dev = ["xdsl[dev,gui,llvm,heir]", "my_plugin"]
+dev = ["xdsl[dev,gui,llvm,heir]", "my_plugin", "toy"]
 bench = [
     "asv>=0.6.4",
     "snakeviz>=2.2.2",
@@ -92,6 +92,7 @@ zip-safe = false
 lzstring2 = { git = "https://github.com/superlopuh/lz-string.git" }
 bytesight = { git = "https://github.com/EdmundGoodman/bytesight.git", rev = "e8e8e45ec34316fdc99ee09ea8886c4f63c248be" }
 my_plugin = { path = "tests/my_plugin", editable = true }
+toy = { path = "docs/Toy", editable = true }
 
 [tool.setuptools.packages]
 find = {}

--- a/uv.lock
+++ b/uv.lock
@@ -3985,6 +3985,7 @@ bench = [
 dev = [
     { name = "my-plugin" },
     { name = "xdsl", extra = ["dev", "gui", "heir", "llvm"] },
+    { name = "toy" },
 ]
 docs = [
     { name = "lzstring2" },
@@ -4042,6 +4043,7 @@ bench = [
 dev = [
     { name = "my-plugin", editable = "tests/my_plugin" },
     { name = "xdsl", extras = ["dev", "gui", "llvm", "heir"] },
+    { name = "toy", editable = "docs/Toy" },
 ]
 docs = [
     { name = "lzstring2", git = "https://github.com/superlopuh/lz-string.git" },
@@ -4056,6 +4058,16 @@ docs = [
     { name = "pymdown-extensions", specifier = ">=10.7" },
     { name = "riscemu", specifier = "==2.2.7" },
 ]
+
+[[package]]
+name = "toy"
+source = { editable = "docs/Toy" }
+dependencies = [
+    { name = "xdsl" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "xdsl" }]
 
 [[package]]
 name = "yarl"


### PR DESCRIPTION
One step towards Toy marimo notebooks, it'll have to be built as a wheel. A minor improvement in this PR is to actually ship a command-line tool called `toyc` that will be present on dev installs. As far as I can tell, Toy is not included in xDSL wheels.