### PR TITLE
dialects: (riscv) canonicalization pattern added (xor 0 = mv)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -63,7 +63,7 @@ Here are some examples of first PRs from existing contributors:
 The first step is finding a missing optimisation pattern.
 You're welcome to come up with your own, or do one of the following:
 
-- `xori %x, 0`  to `mv %x` (always x)
+- `%y = xori %x, a; %z = xori %y, b`  to `%z = xori %x, a ^ b` ((x ^ a) ^ b = x ^ (a ^ b))
 - `div 0, %x` to `li 0` (%x != 0)
 
 The patterns are defined in

--- a/tests/filecheck/backend/riscv/canonicalize.mlir
+++ b/tests/filecheck/backend/riscv/canonicalize.mlir
@@ -171,6 +171,8 @@ builtin.module {
   %xori_immediate = riscv.xori %i3, 7 : (!riscv.reg) -> !riscv.reg<a0>
   "test.op"(%xori_immediate) : (!riscv.reg<a0>) -> ()
 
+  %xori_zero = riscv.xori %i2, 0 : (!riscv.reg) -> !riscv.reg<a0>
+
   // (x ^ a) ^ a -> x, intermediate has one use
   %xori_tmp = riscv.xori %i2, 42 : (!riscv.reg) -> !riscv.reg
   %xori_self_inverse = riscv.xori %xori_tmp, 42 : (!riscv.reg) -> !riscv.reg<a0>
@@ -362,6 +364,8 @@ builtin.module {
 
 // CHECK-NEXT:   %xori_immediate = rv32.li 99 : !riscv.reg<a0>
 // CHECK-NEXT:   "test.op"(%xori_immediate) : (!riscv.reg<a0>) -> ()
+
+// CHECK-NEXT:   %xori_zero = riscv.mv %i2 : (!riscv.reg) -> !riscv.reg<a0>
 
 // CHECK-NEXT:   %xori_self_inverse = riscv.mv %i2 : (!riscv.reg) -> !riscv.reg<a0>
 // CHECK-NEXT:   "test.op"(%xori_self_inverse) : (!riscv.reg<a0>) -> ()

--- a/xdsl/dialects/riscv/ops.py
+++ b/xdsl/dialects/riscv/ops.py
@@ -221,9 +221,10 @@ class XoriOpHasCanonicalizationPatternsTrait(HasCanonicalizationPatternsTrait):
         from xdsl.transforms.canonicalization_patterns.riscv import (
             XoriImmediate,
             XoriSelfInverse,
+            XoriZero,
         )
 
-        return (XoriSelfInverse(), XoriImmediate())
+        return (XoriZero(), XoriSelfInverse(), XoriImmediate())
 
 
 @irdl_op_definition

--- a/xdsl/transforms/canonicalization_patterns/riscv.py
+++ b/xdsl/transforms/canonicalization_patterns/riscv.py
@@ -271,6 +271,17 @@ class OriImmediateZero(RewritePattern):
             rewriter.replace_op(op, riscv.MVOp(op.rs1, rd=op.rd.type))
 
 
+class XoriZero(RewritePattern):
+    """
+    xor(x, 0) -> mv x
+    """
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: riscv.XoriOp, rewriter: PatternRewriter) -> None:
+        if isinstance(op.immediate, IntegerAttr) and op.immediate.value.data == 0:
+            rewriter.replace_op(op, riscv.MVOp(op.rs1, rd=op.rd.type))
+
+
 class XoriSelfInverse(RewritePattern):
     """
     (x ^ a) ^ a -> x


### PR DESCRIPTION
Add small canonicalization patter: `%y = xori %x, 0` -> `%y = mv %x`.

Also update the docs with a new pattern proposal.