### PR TITLE
dialects: (llvm) add llvm.intr.vector.reduce.fadd and fmul ops

### DIFF
--- a/tests/dialects/test_llvm.py
+++ b/tests/dialects/test_llvm.py
@@ -762,6 +762,24 @@ def test_fpow_op():
     assert op.res.type == builtin.f32
 
 
+def test_vector_reduce_fadd_op():
+    start = create_ssa_value(builtin.f32)
+    vec = create_ssa_value(builtin.VectorType(builtin.f32, [4]))
+    op = llvm.VectorReduceFAddOp(start, vec)
+    assert op.start_value == start
+    assert op.vector == vec
+    assert op.res.type == builtin.f32
+
+
+def test_vector_reduce_fmul_op():
+    start = create_ssa_value(builtin.f32)
+    vec = create_ssa_value(builtin.VectorType(builtin.f32, [4]))
+    op = llvm.VectorReduceFMulOp(start, vec)
+    assert op.start_value == start
+    assert op.vector == vec
+    assert op.res.type == builtin.f32
+
+
 def test_stacksave_op():
     op = llvm.StackSaveOp()
     assert not op.operands

--- a/tests/filecheck/dialects/llvm/llvm_intrinsics.mlir
+++ b/tests/filecheck/dialects/llvm/llvm_intrinsics.mlir
@@ -176,6 +176,24 @@
 %pow_vec = llvm.intr.pow(%vec_f32, %vec_f32) : (vector<4xf32>, vector<4xf32>) -> vector<4xf32>
 // CHECK-NEXT: %pow_vec = llvm.intr.pow(%vec_f32, %vec_f32) : (vector<4xf32>, vector<4xf32>) -> vector<4xf32>
 
+%scalar_f64 = "test.op"() : () -> f64
+%vec_f64 = "test.op"() : () -> vector<2xf64>
+
+%reduce_fadd_f32 = "llvm.intr.vector.reduce.fadd"(%f32, %vec_f32) <{fastmathFlags = #llvm.fastmath<none>}> : (f32, vector<4xf32>) -> f32
+// CHECK: %reduce_fadd_f32 = "llvm.intr.vector.reduce.fadd"(%f32, %vec_f32) <{fastmathFlags = #llvm.fastmath<none>}> : (f32, vector<4xf32>) -> f32
+
+%reduce_fadd_f64 = "llvm.intr.vector.reduce.fadd"(%scalar_f64, %vec_f64) <{fastmathFlags = #llvm.fastmath<none>}> : (f64, vector<2xf64>) -> f64
+// CHECK: %reduce_fadd_f64 = "llvm.intr.vector.reduce.fadd"(%scalar_f64, %vec_f64) <{fastmathFlags = #llvm.fastmath<none>}> : (f64, vector<2xf64>) -> f64
+
+%reduce_fadd_fast = "llvm.intr.vector.reduce.fadd"(%f32, %vec_f32) <{fastmathFlags = #llvm.fastmath<fast>}> : (f32, vector<4xf32>) -> f32
+// CHECK: %reduce_fadd_fast = "llvm.intr.vector.reduce.fadd"(%f32, %vec_f32) <{fastmathFlags = #llvm.fastmath<fast>}> : (f32, vector<4xf32>) -> f32
+
+%reduce_fmul_f32 = "llvm.intr.vector.reduce.fmul"(%f32, %vec_f32) <{fastmathFlags = #llvm.fastmath<none>}> : (f32, vector<4xf32>) -> f32
+// CHECK: %reduce_fmul_f32 = "llvm.intr.vector.reduce.fmul"(%f32, %vec_f32) <{fastmathFlags = #llvm.fastmath<none>}> : (f32, vector<4xf32>) -> f32
+
+%reduce_fmul_f64 = "llvm.intr.vector.reduce.fmul"(%scalar_f64, %vec_f64) <{fastmathFlags = #llvm.fastmath<none>}> : (f64, vector<2xf64>) -> f64
+// CHECK: %reduce_fmul_f64 = "llvm.intr.vector.reduce.fmul"(%scalar_f64, %vec_f64) <{fastmathFlags = #llvm.fastmath<none>}> : (f64, vector<2xf64>) -> f64
+
 "test.op"() ({
 ^bb0(%br_arg: i32):
   llvm.br ^bb1(%br_arg : i32)

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/llvm_intrinsics.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/llvm_intrinsics.mlir
@@ -152,5 +152,22 @@
 llvm.intr.masked.store %vec_val, %ptr, %vec_mask {alignment = 32 : i32} : vector<4xf32>, vector<4xi1> into !llvm.ptr
 // CHECK: llvm.intr.masked.store [[vec_val]], [[ptr]], [[vec_mask]] {alignment = 32 : i32} : vector<4xf32>, vector<4xi1> into !llvm.ptr
 
+%scalar_f64 = "test.op"() : () -> f64
+// CHECK: [[scalar_f64:%\d+]] = "test.op"
+%vec_f64 = "test.op"() : () -> vector<2xf64>
+// CHECK: [[vec_f64:%\d+]] = "test.op"
+
+%reduce_fadd_f32 = "llvm.intr.vector.reduce.fadd"(%arg0, %arg2) <{fastmathFlags = #llvm.fastmath<none>}> : (f32, vector<4xf32>) -> f32
+// CHECK: "llvm.intr.vector.reduce.fadd"([[arg0]], [[arg2]]) <{fastmathFlags = #llvm.fastmath<none>}> : (f32, vector<4xf32>) -> f32
+
+%reduce_fadd_f64 = "llvm.intr.vector.reduce.fadd"(%scalar_f64, %vec_f64) <{fastmathFlags = #llvm.fastmath<none>}> : (f64, vector<2xf64>) -> f64
+// CHECK: "llvm.intr.vector.reduce.fadd"([[scalar_f64]], [[vec_f64]]) <{fastmathFlags = #llvm.fastmath<none>}> : (f64, vector<2xf64>) -> f64
+
+%reduce_fmul_f32 = "llvm.intr.vector.reduce.fmul"(%arg0, %arg2) <{fastmathFlags = #llvm.fastmath<none>}> : (f32, vector<4xf32>) -> f32
+// CHECK: "llvm.intr.vector.reduce.fmul"([[arg0]], [[arg2]]) <{fastmathFlags = #llvm.fastmath<none>}> : (f32, vector<4xf32>) -> f32
+
+%reduce_fmul_f64 = "llvm.intr.vector.reduce.fmul"(%scalar_f64, %vec_f64) <{fastmathFlags = #llvm.fastmath<none>}> : (f64, vector<2xf64>) -> f64
+// CHECK: "llvm.intr.vector.reduce.fmul"([[scalar_f64]], [[vec_f64]]) <{fastmathFlags = #llvm.fastmath<none>}> : (f64, vector<2xf64>) -> f64
+
 %stack = llvm.intr.stacksave : !llvm.ptr
 // CHECK: llvm.intr.stacksave : !llvm.ptr

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -3724,6 +3724,44 @@ class StackSaveOp(IRDLOperation):
         super().__init__(result_types=[LLVMPointerType()])
 
 
+class VectorReduceOperation(IRDLOperation, ABC):
+    T: ClassVar = VarConstraint("T", AnyFloatConstr)
+
+    start_value = operand_def(T)
+    vector = operand_def(VectorType.constr(T))
+    res = result_def(T)
+
+    fastmathFlags = prop_def(FastMathAttr, default_value=FastMathAttr(None))
+
+    irdl_options = (ParsePropInAttrDict(),)
+
+    traits = traits_def(Pure())
+
+    def __init__(
+        self,
+        start_value: Operation | SSAValue,
+        vector: Operation | SSAValue,
+        fast_math: FastMathAttr | FastMathFlag | None = None,
+    ):
+        if not isinstance(fast_math, FastMathAttr):
+            fast_math = FastMathAttr(fast_math)
+        super().__init__(
+            operands=[start_value, vector],
+            result_types=[SSAValue.get(start_value).type],
+            properties={"fastmathFlags": fast_math},
+        )
+
+
+@irdl_op_definition
+class VectorReduceFAddOp(VectorReduceOperation):
+    name = "llvm.intr.vector.reduce.fadd"
+
+
+@irdl_op_definition
+class VectorReduceFMulOp(VectorReduceOperation):
+    name = "llvm.intr.vector.reduce.fmul"
+
+
 @irdl_op_definition
 class UnreachableOp(IRDLOperation):
     name = "llvm.unreachable"
@@ -3800,6 +3838,8 @@ LLVM = Dialect(
         UnreachableOp,
         VectorFMaxOp,
         VectorFMinOp,
+        VectorReduceFAddOp,
+        VectorReduceFMulOp,
         XOrOp,
         ZExtOp,
         ZeroOp,


### PR DESCRIPTION
Add typed LLVM dialect ops for float vector reductions (llvm.intr.vector.reduce.fadd, llvm.intr.vector.reduce.fmul), matching upstream MLIR. Both ops take a scalar start value and a float vector, returning a scalar result. Uses generic format (no custom assembly format) to match MLIR.

Refs:
- MLIR: https://mlir.llvm.org/docs/Dialects/LLVM/#llvmintrinsic-operations
- LLVM LangRef fadd: https://llvm.org/docs/LangRef.html#llvm-vector-reduce-fadd-intrinsic
- LLVM LangRef fmul: https://llvm.org/docs/LangRef.html#llvm-vector-reduce-fmul-intrinsic