### PR TITLE
testing: add TestRegisterType to test dialect

### DIFF
--- a/tests/backend/test_assembly_printer.py
+++ b/tests/backend/test_assembly_printer.py
@@ -1,25 +1,11 @@
 from xdsl.backend.assembly_printer import RegisterNameSpec, reg
-from xdsl.backend.register_type import RegisterType
-from xdsl.irdl import irdl_attr_definition
+from xdsl.dialects.test import TestRegisterType
 from xdsl.utils.test_value import create_ssa_value
 
 
-@irdl_attr_definition
-class TestRegister(RegisterType):
-    name = "test.reg"
-
-    @classmethod
-    def index_by_name(cls) -> dict[str, int]:
-        return {"x0": 0, "x1": 1, "a0": 0, "a1": 1}
-
-    @classmethod
-    def infinite_register_prefix(cls):
-        return "y"
-
-
 def test_reg():
-    x0_val = create_ssa_value(TestRegister.from_name("x0"))
-    x1_val = create_ssa_value(TestRegister.from_name("x1"))
+    x0_val = create_ssa_value(TestRegisterType.from_name("x0"))
+    x1_val = create_ssa_value(TestRegisterType.from_name("x1"))
     assert reg(x0_val) == "x0"
     assert reg(x1_val) == "x1"
 
@@ -29,7 +15,7 @@ def test_register_name_spec():
         def get_register_name(self, index: int) -> str:
             return f"hello{index}"
 
-    x0_val = create_ssa_value(TestRegister.from_name("x0"))
-    x1_val = create_ssa_value(TestRegister.from_name("x1"))
+    x0_val = create_ssa_value(TestRegisterType.from_name("x0"))
+    x1_val = create_ssa_value(TestRegisterType.from_name("x1"))
     assert reg(x0_val, TestSpec()) == "hello0"
     assert reg(x1_val, TestSpec()) == "hello1"

--- a/tests/backend/test_register.py
+++ b/tests/backend/test_register.py
@@ -4,6 +4,7 @@ import pytest
 
 from xdsl.backend.register_type import RegisterType
 from xdsl.dialects.builtin import IntAttr, NoneAttr, StringAttr
+from xdsl.dialects.test import TestRegisterType
 from xdsl.irdl import irdl_attr_definition
 from xdsl.utils.exceptions import VerifyException
 
@@ -29,86 +30,73 @@ def test_register_clashes():
                 return "x"
 
 
-@irdl_attr_definition
-class TestRegister(RegisterType):
-    name = "test.reg"
-
-    @classmethod
-    def index_by_name(cls) -> dict[str, int]:
-        return {"x0": 0, "x1": 1, "a0": 0, "a1": 1}
-
-    @classmethod
-    def infinite_register_prefix(cls):
-        return "y"
-
-
 def test_unallocated_register():
-    assert not TestRegister.unallocated().is_allocated
-    assert TestRegister.from_name("x0").is_allocated
+    assert not TestRegisterType.unallocated().is_allocated
+    assert TestRegisterType.from_name("x0").is_allocated
 
 
 def test_register_from_string():
     # Register with valid ABI name is fine
-    assert TestRegister.from_name("x0").register_name == StringAttr("x0")
-    assert TestRegister.from_name("x0").index == IntAttr(0)
-    assert TestRegister.from_name("x1").register_name == StringAttr("x1")
-    assert TestRegister.from_name("x1").index == IntAttr(1)
+    assert TestRegisterType.from_name("x0").register_name == StringAttr("x0")
+    assert TestRegisterType.from_name("x0").index == IntAttr(0)
+    assert TestRegisterType.from_name("x1").register_name == StringAttr("x1")
+    assert TestRegisterType.from_name("x1").index == IntAttr(1)
 
     # Register with infinite ABI name is fine
-    assert TestRegister.from_name("y0").register_name == StringAttr("y0")
-    assert TestRegister.from_name("y0").index == IntAttr(-1)
-    assert TestRegister.from_name("y1").register_name == StringAttr("y1")
-    assert TestRegister.from_name("y1").index == IntAttr(-2)
+    assert TestRegisterType.from_name("y0").register_name == StringAttr("y0")
+    assert TestRegisterType.from_name("y0").index == IntAttr(-1)
+    assert TestRegisterType.from_name("y1").register_name == StringAttr("y1")
+    assert TestRegisterType.from_name("y1").index == IntAttr(-2)
 
     # Infinite prefix but not a number
     with pytest.raises(
         VerifyException,
         match="Invalid register name yy for register type test.reg",
     ):
-        TestRegister.from_name("yy")
+        TestRegisterType.from_name("yy")
 
     # Incorrect name
     with pytest.raises(
         VerifyException, match="Invalid register name z0 for register type test.reg"
     ):
-        TestRegister.from_name("z0")
+        TestRegisterType.from_name("z0")
 
 
 def test_invalid_register_name():
     with pytest.raises(
         VerifyException, match="Invalid register name foo for register type test.reg."
     ):
-        TestRegister.from_name("foo")
+        TestRegisterType.from_name("foo")
 
 
 def test_invalid_index():
     with pytest.raises(
         AssertionError, match="Infinite index must be positive, got -1."
     ):
-        TestRegister.infinite_register(-1)
+        TestRegisterType.infinite_register(-1)
 
     with pytest.raises(
         VerifyException, match="Invalid index 1 for unallocated register."
     ):
-        TestRegister(IntAttr(1), StringAttr(""))
+        TestRegisterType(IntAttr(1), StringAttr(""))
 
     with pytest.raises(
         VerifyException, match="Missing index for register x1, expected 1."
     ):
-        TestRegister(NoneAttr(), StringAttr("x1"))
+        TestRegisterType(NoneAttr(), StringAttr("x1"))
 
     with pytest.raises(
         VerifyException, match="Invalid index 2 for register x1, expected 1."
     ):
-        TestRegister(IntAttr(2), StringAttr("x1"))
+        TestRegisterType(IntAttr(2), StringAttr("x1"))
 
 
 def test_name_by_index():
-    assert TestRegister.abi_name_by_index() == {0: "a0", 1: "a1"}
+    assert TestRegisterType.abi_name_by_index() == {0: "a0", 1: "a1"}
 
 
 def test_from_index():
-    assert TestRegister.from_index(0) == TestRegister.from_name("a0")
-    assert TestRegister.from_index(1) == TestRegister.from_name("a1")
-    assert TestRegister.from_index(-1) == TestRegister.infinite_register(0)
-    assert TestRegister.from_index(-2) == TestRegister.infinite_register(1)
+    assert TestRegisterType.from_index(0) == TestRegisterType.from_name("a0")
+    assert TestRegisterType.from_index(1) == TestRegisterType.from_name("a1")
+    assert TestRegisterType.from_index(-1) == TestRegisterType.infinite_register(0)
+    assert TestRegisterType.from_index(-2) == TestRegisterType.infinite_register(1)

--- a/tests/backend/test_register_allocation.py
+++ b/tests/backend/test_register_allocation.py
@@ -15,7 +15,7 @@ from xdsl.backend.register_allocator import ValueAllocator
 from xdsl.backend.register_stack import OutOfRegisters, RegisterStack
 from xdsl.backend.register_type import RegisterAllocatedMemoryEffect, RegisterType
 from xdsl.builder import Builder
-from xdsl.dialects.test import TestOp
+from xdsl.dialects.test import TestOp, TestRegisterType
 from xdsl.ir import Attribute, Block, SSAValue
 from xdsl.irdl import (
     AttrSizedOperandSegments,
@@ -33,19 +33,6 @@ from xdsl.irdl import (
 )
 from xdsl.utils.exceptions import DiagnosticException
 from xdsl.utils.test_value import create_ssa_value
-
-
-@irdl_attr_definition
-class TestRegister(RegisterType):
-    name = "test.reg"
-
-    @classmethod
-    def index_by_name(cls) -> dict[str, int]:
-        return {"x0": 0, "x1": 1, "a0": 0, "a1": 1}
-
-    @classmethod
-    def infinite_register_prefix(cls):
-        return "y"
 
 
 @irdl_attr_definition
@@ -126,9 +113,9 @@ def op(
 
 
 def test_gather_allocated():
-    u = TestRegister.unallocated()
-    x0 = TestRegister.from_name("x0")
-    x1 = TestRegister.from_name("x0")
+    u = TestRegisterType.unallocated()
+    x0 = TestRegisterType.from_name("x0")
+    x1 = TestRegisterType.from_name("x0")
 
     @Builder.implicit_region
     def no_preallocated_body() -> None:
@@ -186,7 +173,7 @@ def test_deprecated_iter_used_registers():
     raise a deprecation warning.
     """
 
-    x1 = TestRegister.from_name("x1")
+    x1 = TestRegisterType.from_name("x1")
 
     @irdl_op_definition
     class TestDepracatedAllocatableOp(IRDLOperation, HasRegisterConstraints):
@@ -220,12 +207,12 @@ def test_new_type_for_value():
         def infinite_register_prefix(cls):
             return "y"
 
-    u = TestRegister.unallocated()
-    a0 = TestRegister.from_name("a0")
-    a1 = TestRegister.from_name("a1")
+    u = TestRegisterType.unallocated()
+    a0 = TestRegisterType.from_name("a0")
+    a1 = TestRegisterType.from_name("a1")
 
     available_registers = RegisterStack.get((a0, a1))
-    allocator = ValueAllocator(available_registers, TestRegister)
+    allocator = ValueAllocator(available_registers, TestRegisterType)
 
     r0, r1, r2, r3 = op(
         (), u, a0, OtherRegister.unallocated(), OtherRegister.from_index(1)
@@ -238,13 +225,13 @@ def test_new_type_for_value():
 
 
 def test_allocate_value():
-    u = TestRegister.unallocated()
-    a0 = TestRegister.from_name("a0")
-    a1 = TestRegister.from_name("a1")
-    y0 = TestRegister.from_name("y0")
+    u = TestRegisterType.unallocated()
+    a0 = TestRegisterType.from_name("a0")
+    a1 = TestRegisterType.from_name("a1")
+    y0 = TestRegisterType.from_name("y0")
 
     register_stack = RegisterStack.get((a0, a1), allow_infinite=True)
-    allocator = ValueAllocator(register_stack, TestRegister)
+    allocator = ValueAllocator(register_stack, TestRegisterType)
 
     op0 = op((), u, u, u, u)
     r00, r01, r02, _r03 = op0.results
@@ -347,13 +334,13 @@ def test_allocate_value():
 
 
 def test_allocate_values_same_reg():
-    u = TestRegister.unallocated()
-    a0 = TestRegister.from_name("a0")
-    a1 = TestRegister.from_name("a1")
-    y0 = TestRegister.from_name("y0")
+    u = TestRegisterType.unallocated()
+    a0 = TestRegisterType.from_name("a0")
+    a1 = TestRegisterType.from_name("a1")
+    y0 = TestRegisterType.from_name("y0")
 
     register_stack = RegisterStack.get((a0, a1))
-    allocator = ValueAllocator(register_stack, TestRegister)
+    allocator = ValueAllocator(register_stack, TestRegisterType)
 
     # Empty
     assert not allocator.allocate_values_same_reg(())
@@ -409,12 +396,12 @@ def test_multiple_outputs():
             return RegisterConstraints(self.operands, self.results, ())
 
     available_registers = RegisterStack(allow_infinite=True)
-    register_allocator = BlockNaiveAllocator(available_registers, TestRegister)
+    register_allocator = BlockNaiveAllocator(available_registers, TestRegisterType)
 
     op = AllocatableTestOp(
         result_types=(
-            TestRegister.unallocated(),
-            TestRegister.unallocated(),
+            TestRegisterType.unallocated(),
+            TestRegisterType.unallocated(),
         )
     )
 
@@ -429,7 +416,7 @@ def test_fail_error_message():
     class InoutOp(HasRegisterConstraints, IRDLOperation):
         name = "test.inout"
 
-        T: ClassVar = VarConstraint("T", base(TestRegister))
+        T: ClassVar = VarConstraint("T", base(TestRegisterType))
 
         a = operand_def(T)
         b = result_def(T)
@@ -437,10 +424,12 @@ def test_fail_error_message():
         def get_register_constraints(self) -> RegisterConstraints:
             return RegisterConstraints((), (), ((self.a, self.b),))
 
-    a = create_ssa_value(TestRegister.from_index(0))
-    block = Block((InoutOp(operands=[a], result_types=[TestRegister.from_index(1)]),))
+    a = create_ssa_value(TestRegisterType.from_index(0))
+    block = Block(
+        (InoutOp(operands=[a], result_types=[TestRegisterType.from_index(1)]),)
+    )
 
-    allocator = BlockNaiveAllocator(RegisterStack.get(), TestRegister)
+    allocator = BlockNaiveAllocator(RegisterStack.get(), TestRegisterType)
 
     with pytest.raises(
         DiagnosticException,
@@ -464,7 +453,7 @@ def test_fail_error_message():
 def test_out_of_registers():
     register_stack = RegisterStack()
     with pytest.raises(OutOfRegisters, match="Out of registers."):
-        register_stack.pop(TestRegister)
+        register_stack.pop(TestRegisterType)
 
 
 def test_reserved_aliased_register():

--- a/tests/backend/test_register_type.py
+++ b/tests/backend/test_register_type.py
@@ -4,27 +4,14 @@ from xdsl import ir, irdl
 from xdsl.backend.register_type import (
     RegisterAllocatedMemoryEffect,
     RegisterResource,
-    RegisterType,
 )
+from xdsl.dialects.test import TestRegisterType
 from xdsl.traits import (
     EffectInstance,
     MemoryEffectKind,
     get_effects,
     is_side_effect_free,
 )
-
-
-@irdl.irdl_attr_definition
-class TestRegister(RegisterType):
-    name = "test.reg"
-
-    @classmethod
-    def index_by_name(cls) -> dict[str, int]:
-        return {"x0": 0, "x1": 1, "a0": 0, "a1": 1}
-
-    @classmethod
-    def infinite_register_prefix(cls):
-        return "y"
 
 
 @irdl.irdl_op_definition
@@ -55,14 +42,14 @@ class TestAllocatableOp(irdl.IRDLOperation):
 
 def test_register_resource_name():
     """Test that RegisterResource returns a descriptive name."""
-    reg = TestRegister.from_name("x0")
+    reg = TestRegisterType.from_name("x0")
     resource = RegisterResource(reg)
     assert "<Register !test.reg<x0>>" == resource.name()
 
 
 def test_no_effects_for_unallocated_registers():
     """Test that unallocated registers produce no memory effects."""
-    op = TestAllocatableOp([], [], [TestRegister.unallocated()], [])
+    op = TestAllocatableOp([], [], [TestRegisterType.unallocated()], [])
     effects = get_effects(op)
     assert effects == set()
     assert is_side_effect_free(op)
@@ -70,7 +57,7 @@ def test_no_effects_for_unallocated_registers():
 
 def test_write_effect_for_allocated_result():
     """Test that allocated register results produce WRITE effects."""
-    allocated_reg = TestRegister.from_name("x0")
+    allocated_reg = TestRegisterType.from_name("x0")
     op = TestAllocatableOp([], [], [allocated_reg], [])
     effects = get_effects(op)
 
@@ -82,7 +69,7 @@ def test_write_effect_for_allocated_result():
 def test_read_effect_for_allocated_operand():
     """Test that allocated register operands produce READ effects."""
     # Create an op that produces an allocated register to use as operand
-    allocated_reg = TestRegister.from_name("x1")
+    allocated_reg = TestRegisterType.from_name("x1")
     producer = TestAllocatableOp([], [], [allocated_reg], [])
 
     # Use the result as an operand
@@ -96,8 +83,8 @@ def test_read_effect_for_allocated_operand():
 
 def test_mixed_read_write_effects():
     """Test an op with both allocated operands and results."""
-    reg_x0 = TestRegister.from_name("x0")
-    reg_x1 = TestRegister.from_name("x1")
+    reg_x0 = TestRegisterType.from_name("x0")
+    reg_x1 = TestRegisterType.from_name("x1")
 
     # Producer for operand
     producer = TestAllocatableOp([], [], [reg_x0], [])

--- a/xdsl/dialects/test.py
+++ b/xdsl/dialects/test.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 
+from xdsl.backend.register_type import RegisterType
 from xdsl.dialect_interfaces.op_asm import OpAsmDialectInterface
 from xdsl.dialects.builtin import IntegerAttr, IntegerType, SymbolNameConstraint
 from xdsl.interfaces import HasFolderInterface
@@ -327,6 +328,19 @@ class TestSymbolOp(IRDLOperation):
         )
 
 
+@irdl_attr_definition
+class TestRegisterType(RegisterType):
+    name = "test.reg"
+
+    @classmethod
+    def index_by_name(cls) -> dict[str, int]:
+        return {"x0": 0, "x1": 1, "a0": 0, "a1": 1}
+
+    @classmethod
+    def infinite_register_prefix(cls):
+        return "y"
+
+
 Test = Dialect(
     "test",
     [
@@ -339,6 +353,7 @@ Test = Dialect(
     ],
     [
         TestType,
+        TestRegisterType,
     ],
     [OpAsmDialectInterface()],
 )


### PR DESCRIPTION
We already use the same one everywhere in tests, this brings the definition to one place.