### PR TITLE
core: fix BaseAttr constraint exceptions for abstract bases

### DIFF
--- a/tests/test_pyrdl.py
+++ b/tests/test_pyrdl.py
@@ -3,7 +3,7 @@
 from collections.abc import Mapping
 from dataclasses import dataclass
 from enum import auto
-from typing import Literal
+from typing import Any, Literal
 
 import pytest
 from typing_extensions import Self, TypeVar
@@ -157,6 +157,20 @@ def test_base_attr_verify_wrong_base_fail():
         VerifyException, match=f"{int_zero} should be of base attribute {BoolData.name}"
     ):
         eq_true_constraint.verify(int_zero, ConstraintContext())
+
+
+def test_base_attr_verify_wrong_abstractbase_fail():
+    """
+    Check that a BaseAttr constraint fails to verify an attribute with a
+    different base attribute.
+    """
+    any_data_constraint = BaseAttr[Data[Any]](Data)
+    parametrized_attr = DoubleParamAttr(IntData(0), IntData(1))
+    with pytest.raises(
+        VerifyException,
+        match=f"{parametrized_attr} should be of attribute subclassing `Data`",
+    ):
+        any_data_constraint.verify(parametrized_attr, ConstraintContext())
 
 
 def test_any_attr_verify():

--- a/xdsl/irdl/constraints.py
+++ b/xdsl/irdl/constraints.py
@@ -358,9 +358,14 @@ class BaseAttr(AttrConstraint[AttributeCovT], Generic[AttributeCovT]):
         constraint_context: ConstraintContext,
     ) -> None:
         if not isinstance(attr, self.attr):
-            raise VerifyException(
-                f"{attr} should be of base attribute {self.attr.name}"
-            )
+            if hasattr(self.attr, "name"):
+                raise VerifyException(
+                    f"{attr} should be of base attribute {self.attr.name}"
+                )
+            else:
+                raise VerifyException(
+                    f"{attr} should be of attribute subclassing `{self.attr.__name__}`"
+                )
 
     def can_infer(self, var_constraint_names: AbstractSet[str]) -> bool:
         return (


### PR DESCRIPTION
I have some changes upcoming that restrict operands/result to be of RegisterType, and we currently crash when trying to get `RegisterType.name`. In the future it would be nice to have some kind of official name situation for attribute interfaces, but for the time being I suggest printing their Python class names instead.