### PR TITLE
CI: Enable RUF007 by using itertools.pairwise

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,6 @@ lint.ignore = [
   "RUF002", # https://docs.astral.sh/ruff/rules/ambiguous-unicode-character-docstring
   "RUF003", # https://docs.astral.sh/ruff/rules/ambiguous-unicode-character-comment
   "RUF005", # https://docs.astral.sh/ruff/rules/collection-literal-concatenation
-  "RUF007", # https://docs.astral.sh/ruff/rules/zip-instead-of-pairwise
   "RUF012", # https://docs.astral.sh/ruff/rules/mutable-class-default
   "RUF015", # https://docs.astral.sh/ruff/rules/unnecessary-iterable-allocation-for-first-element
   "RUF018", # https://docs.astral.sh/ruff/rules/assignment-in-assert

--- a/xdsl/dialects/utils/reshape_ops_utils.py
+++ b/xdsl/dialects/utils/reshape_ops_utils.py
@@ -6,6 +6,7 @@ for more details.
 
 from collections.abc import Mapping
 from dataclasses import dataclass
+from itertools import pairwise
 from typing import cast
 
 from typing_extensions import TypeVar
@@ -59,7 +60,7 @@ class ContiguousArrayOfIntArray(AttrConstraint[ArrayOfIntArrayAttr]):
         # Flatten all integer values from all inner arrays
         flat_values = [e.value.data for inner in attr.data for e in inner.data]
         # Check that the flattened list is contiguous
-        for prev, curr in zip(flat_values, flat_values[1:]):
+        for prev, curr in pairwise(flat_values):
             if curr != prev + 1:
                 raise VerifyException(f"All inner arrays must be contiguous: {attr}")
 


### PR DESCRIPTION
## Summary
- replace the remaining successive-pair `zip(..., values[1:])` loop with `itertools.pairwise`
- remove `RUF007` from the Ruff ignore list

## Verification
- `uvx ruff==0.15.14 check --select RUF007 .`
- `PYTHONPATH=. /tmp/kvlq-xdsl-venv/bin/python -m pytest tests/interpreters/test_tensor_interpreter.py`
