### PR TITLE
backend: (llvm) add vector.reduce.fadd and fmul backend conversion

### DIFF
--- a/tests/filecheck/backend/llvm/convert_op.mlir
+++ b/tests/filecheck/backend/llvm/convert_op.mlir
@@ -1115,4 +1115,52 @@ builtin.module {
   // CHECK-NEXT: {{.[0-9]+}}:
   // CHECK-NEXT:   ret <4 x i32> <i32 1, i32 2, i32 3, i32 4>
   // CHECK-NEXT: }
+
+  llvm.func @reduce_fadd_f32(%arg0: f32, %arg1: vector<4xf32>) -> f32 {
+    %0 = "llvm.intr.vector.reduce.fadd"(%arg0, %arg1) <{fastmathFlags = #llvm.fastmath<none>}> : (f32, vector<4xf32>) -> f32
+    llvm.return %0 : f32
+  }
+
+  // CHECK: define float @"reduce_fadd_f32"(float %".1", <4 x float> %".2")
+  // CHECK-NEXT: {
+  // CHECK-NEXT: [[ENTRY:.\d+]]:
+  // CHECK-NEXT:   %"[[RES:.\d+]]" = call float @"llvm.vector.reduce.fadd.v4f32"(float %".1", <4 x float> %".2")
+  // CHECK-NEXT:   ret float %"[[RES]]"
+  // CHECK-NEXT: }
+
+  llvm.func @reduce_fadd_f64(%arg0: f64, %arg1: vector<2xf64>) -> f64 {
+    %0 = "llvm.intr.vector.reduce.fadd"(%arg0, %arg1) <{fastmathFlags = #llvm.fastmath<none>}> : (f64, vector<2xf64>) -> f64
+    llvm.return %0 : f64
+  }
+
+  // CHECK: define double @"reduce_fadd_f64"(double %".1", <2 x double> %".2")
+  // CHECK-NEXT: {
+  // CHECK-NEXT: [[ENTRY:.\d+]]:
+  // CHECK-NEXT:   %"[[RES:.\d+]]" = call double @"llvm.vector.reduce.fadd.v2f64"(double %".1", <2 x double> %".2")
+  // CHECK-NEXT:   ret double %"[[RES]]"
+  // CHECK-NEXT: }
+
+  llvm.func @reduce_fmul_f32(%arg0: f32, %arg1: vector<4xf32>) -> f32 {
+    %0 = "llvm.intr.vector.reduce.fmul"(%arg0, %arg1) <{fastmathFlags = #llvm.fastmath<none>}> : (f32, vector<4xf32>) -> f32
+    llvm.return %0 : f32
+  }
+
+  // CHECK: define float @"reduce_fmul_f32"(float %".1", <4 x float> %".2")
+  // CHECK-NEXT: {
+  // CHECK-NEXT: [[ENTRY:.\d+]]:
+  // CHECK-NEXT:   %"[[RES:.\d+]]" = call float @"llvm.vector.reduce.fmul.v4f32"(float %".1", <4 x float> %".2")
+  // CHECK-NEXT:   ret float %"[[RES]]"
+  // CHECK-NEXT: }
+
+  llvm.func @reduce_fmul_f64(%arg0: f64, %arg1: vector<2xf64>) -> f64 {
+    %0 = "llvm.intr.vector.reduce.fmul"(%arg0, %arg1) <{fastmathFlags = #llvm.fastmath<none>}> : (f64, vector<2xf64>) -> f64
+    llvm.return %0 : f64
+  }
+
+  // CHECK: define double @"reduce_fmul_f64"(double %".1", <2 x double> %".2")
+  // CHECK-NEXT: {
+  // CHECK-NEXT: [[ENTRY:.\d+]]:
+  // CHECK-NEXT:   %"[[RES:.\d+]]" = call double @"llvm.vector.reduce.fmul.v2f64"(double %".1", <2 x double> %".2")
+  // CHECK-NEXT:   ret double %"[[RES]]"
+  // CHECK-NEXT: }
 }

--- a/xdsl/backend/llvm/convert_op.py
+++ b/xdsl/backend/llvm/convert_op.py
@@ -398,6 +398,27 @@ def declare_intrinsic(
     return ir.Function(module, fnty, name=full_name)
 
 
+_VECTOR_REDUCE_INTRINSIC_MAP: dict[type[Operation], str] = {
+    llvm.VectorReduceFAddOp: "llvm.vector.reduce.fadd",
+    llvm.VectorReduceFMulOp: "llvm.vector.reduce.fmul",
+}
+
+
+def _convert_vector_reduce(
+    op: Operation, builder: ir.IRBuilder, val_map: dict[SSAValue, ir.Value]
+):
+    start = val_map[op.operands[0]]
+    vector = val_map[op.operands[1]]
+    vec_type = vector.type
+    assert isinstance(vec_type, ir.VectorType)
+    elt_type = vec_type.element
+    fn_type = ir.FunctionType(elt_type, [elt_type, vec_type])
+    intrinsic = declare_intrinsic(
+        builder.module, _VECTOR_REDUCE_INTRINSIC_MAP[type(op)], vec_type, fn_type
+    )
+    val_map[op.results[0]] = builder.call(intrinsic, [start, vector])
+
+
 def _convert_fma(
     op: llvm.FMAOp,
     builder: ir.IRBuilder,
@@ -522,6 +543,8 @@ def convert_op(
             _convert_unary_intrinsic(op, builder, val_map)
         case op if type(op) in _BINARY_INTRINSIC_MAP:
             _convert_binary_intrinsic(op, builder, val_map)
+        case op if type(op) in _VECTOR_REDUCE_INTRINSIC_MAP:
+            _convert_vector_reduce(op, builder, val_map)
         case llvm.FNegOp():
             _convert_fneg(op, builder, val_map)
         case llvm.CallOp():


### PR DESCRIPTION
Add llvmlite backend conversion for llvm.intr.vector.reduce.fadd and llvm.intr.vector.reduce.fmul.

Depends on #6131.

Refs:
- LLVM LangRef fadd: https://llvm.org/docs/LangRef.html#llvm-vector-reduce-fadd-intrinsic
- LLVM LangRef fmul: https://llvm.org/docs/LangRef.html#llvm-vector-reduce-fmul-intrinsic