### PR TITLE
dialects: (llvm) Stacksave operation

### DIFF
--- a/tests/dialects/test_llvm.py
+++ b/tests/dialects/test_llvm.py
@@ -762,6 +762,13 @@ def test_fpow_op():
     assert op.res.type == builtin.f32
 
 
+def test_stacksave_op():
+    op = llvm.StackSaveOp()
+    assert not op.operands
+    assert isinstance(op.res.type, llvm.LLVMPointerType)
+    assert isinstance(op.res.type.addr_space, builtin.NoneAttr)
+
+
 def test_cond_br_op():
     cond = create_ssa_value(builtin.i1)
     then_block = Block()

--- a/tests/filecheck/dialects/llvm/llvm_intrinsics.mlir
+++ b/tests/filecheck/dialects/llvm/llvm_intrinsics.mlir
@@ -213,3 +213,6 @@
 
 llvm.intr.masked.store %vec_val, %ptr, %vec_mask {alignment = 32 : i32} : vector<4xf32>, vector<4xi1> into !llvm.ptr
 // CHECK: llvm.intr.masked.store %vec_val, %ptr, %vec_mask {alignment = 32 : i32} : vector<4xf32>, vector<4xi1> into !llvm.ptr
+
+%stack = llvm.intr.stacksave : !llvm.ptr
+// CHECK: %stack = llvm.intr.stacksave : !llvm.ptr

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/llvm_intrinsics.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/llvm_intrinsics.mlir
@@ -151,3 +151,6 @@
 
 llvm.intr.masked.store %vec_val, %ptr, %vec_mask {alignment = 32 : i32} : vector<4xf32>, vector<4xi1> into !llvm.ptr
 // CHECK: llvm.intr.masked.store [[vec_val]], [[ptr]], [[vec_mask]] {alignment = 32 : i32} : vector<4xf32>, vector<4xi1> into !llvm.ptr
+
+%stack = llvm.intr.stacksave : !llvm.ptr
+// CHECK: llvm.intr.stacksave : !llvm.ptr

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -3713,6 +3713,18 @@ class FPowOp(IRDLOperation):
 
 
 @irdl_op_definition
+class StackSaveOp(IRDLOperation):
+    name = "llvm.intr.stacksave"
+
+    res = result_def(LLVMPointerType)
+
+    assembly_format = "attr-dict `:` type($res)"
+
+    def __init__(self):
+        super().__init__(result_types=[LLVMPointerType()])
+
+
+@irdl_op_definition
 class UnreachableOp(IRDLOperation):
     name = "llvm.unreachable"
 
@@ -3778,6 +3790,7 @@ LLVM = Dialect(
         SRemOp,
         ShlOp,
         ShuffleVectorOp,
+        StackSaveOp,
         StoreOp,
         SubOp,
         TruncOp,


### PR DESCRIPTION
This PR adds the llvm.intr.stacksave operation to the LLVM dialect. It's a simple operation that simply returns an LLVM pointer. Filecheck tests included.
