### PR TITLE
dialects: (llvm) Stackrestore operation

### DIFF
--- a/tests/dialects/test_llvm.py
+++ b/tests/dialects/test_llvm.py
@@ -769,6 +769,13 @@ def test_stacksave_op():
     assert isinstance(op.res.type.addr_space, builtin.NoneAttr)
 
 
+def test_stackrestore_op():
+    ptr = create_ssa_value(llvm.LLVMPointerType())
+    op = llvm.StackRestoreOp(ptr)
+    assert op.ptr is ptr
+    assert not op.results
+
+
 def test_cond_br_op():
     cond = create_ssa_value(builtin.i1)
     then_block = Block()

--- a/tests/filecheck/dialects/llvm/llvm_intrinsics.mlir
+++ b/tests/filecheck/dialects/llvm/llvm_intrinsics.mlir
@@ -216,3 +216,6 @@ llvm.intr.masked.store %vec_val, %ptr, %vec_mask {alignment = 32 : i32} : vector
 
 %stack = llvm.intr.stacksave : !llvm.ptr
 // CHECK: %stack = llvm.intr.stacksave : !llvm.ptr
+
+llvm.intr.stackrestore %stack : !llvm.ptr
+// CHECK: llvm.intr.stackrestore %stack : !llvm.ptr

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/llvm_intrinsics.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/llvm_intrinsics.mlir
@@ -154,3 +154,6 @@ llvm.intr.masked.store %vec_val, %ptr, %vec_mask {alignment = 32 : i32} : vector
 
 %stack = llvm.intr.stacksave : !llvm.ptr
 // CHECK: llvm.intr.stacksave : !llvm.ptr
+
+llvm.intr.stackrestore %stack : !llvm.ptr
+// CHECK: llvm.intr.stackrestore %{{.*}} : !llvm.ptr

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -3725,6 +3725,18 @@ class StackSaveOp(IRDLOperation):
 
 
 @irdl_op_definition
+class StackRestoreOp(IRDLOperation):
+    name = "llvm.intr.stackrestore"
+
+    ptr = operand_def(LLVMPointerType)
+
+    assembly_format = "$ptr attr-dict `:` type($ptr)"
+
+    def __init__(self, ptr: Operation | SSAValue):
+        super().__init__(operands=[ptr])
+
+
+@irdl_op_definition
 class UnreachableOp(IRDLOperation):
     name = "llvm.unreachable"
 
@@ -3790,6 +3802,7 @@ LLVM = Dialect(
         SRemOp,
         ShlOp,
         ShuffleVectorOp,
+        StackRestoreOp,
         StackSaveOp,
         StoreOp,
         SubOp,


### PR DESCRIPTION
This PR adds the llvm.intr.stackrestore operation to the LLVM dialect, includes filecheck tests and python test to exercise constructor
