### PR TITLE
dialects: (asm) add verifiers for to/from reg ops

### DIFF
--- a/tests/filecheck/dialects/asm/asm_ops_invalid.mlir
+++ b/tests/filecheck/dialects/asm/asm_ops_invalid.mlir
@@ -10,3 +10,19 @@
 %v1 = asm.to_reg %v {attr} : i32 -> i64
 
 // CHECK: i64 should be of attribute subclassing `RegisterType`
+
+// -----
+
+%v0 = "test.op"() : () -> i32
+%r = asm.to_reg %v0 {attr} : i32 -> !test.reg
+%v1 = asm.from_reg %r {attr} : !test.reg -> i64
+
+// CHECK: Expected original value type i32 to be equal to own value type i64.
+
+// -----
+
+%r = "test.op"() : () -> !test.reg<x0>
+%v = asm.from_reg %r {attr} : !test.reg<x0> -> i32
+%r2 = asm.to_reg %v {attr} : i32 -> !test.reg<x1>
+
+// CHECK: Expected original register type !test.reg<x0> to be equal to own register type !test.reg<x1>.

--- a/xdsl/dialects/asm.py
+++ b/xdsl/dialects/asm.py
@@ -5,6 +5,7 @@ The `asm` dialect provides utilities for embedding assembly-level abstractions i
 from xdsl import ir, irdl
 from xdsl.backend.register_type import RegisterType
 from xdsl.traits import Pure
+from xdsl.utils.exceptions import VerifyException
 
 
 @irdl.irdl_op_definition
@@ -25,6 +26,16 @@ class FromRegOp(irdl.IRDLOperation):
     def __init__(self, register: ir.SSAValue | ir.Operation, result_type: ir.Attribute):
         super().__init__(operands=(register,), result_types=(result_type,))
 
+    def verify_(self) -> None:
+        if (
+            isinstance(to_reg_op := self.register.owner, ToRegOp)
+            and to_reg_op.value.type != self.value.type
+        ):
+            raise VerifyException(
+                f"Expected original value type {to_reg_op.value.type} to be "
+                f"equal to own value type {self.value.type}."
+            )
+
 
 @irdl.irdl_op_definition
 class ToRegOp(irdl.IRDLOperation):
@@ -43,6 +54,16 @@ class ToRegOp(irdl.IRDLOperation):
 
     def __init__(self, value: ir.SSAValue | ir.Operation, result_type: RegisterType):
         super().__init__(operands=(value,), result_types=(result_type,))
+
+    def verify_(self) -> None:
+        if (
+            isinstance(from_reg_op := self.value.owner, FromRegOp)
+            and from_reg_op.register.type != self.register.type
+        ):
+            raise VerifyException(
+                f"Expected original register type {from_reg_op.register.type} to be "
+                f"equal to own register type {self.register.type}."
+            )
 
 
 ASM = ir.Dialect(


### PR DESCRIPTION
To/from regs are supposed to resolve to the same register or value, this adds the verification for this.