### PR TITLE
dialects: (asm) add folding for to/from reg roundtrip

### DIFF
--- a/tests/filecheck/dialects/asm/asm_ops_canonicalize.mlir
+++ b/tests/filecheck/dialects/asm/asm_ops_canonicalize.mlir
@@ -1,0 +1,17 @@
+// RUN: xdsl-opt -p canonicalize %s | filecheck %s
+
+%r0 = "test.op"() : () -> !test.reg
+%v = asm.from_reg %r0 : !test.reg -> i32
+%r1 = asm.to_reg %v: i32 -> !test.reg
+"test.op"(%r1) : (!test.reg) -> ()
+
+//      CHECK: %r0 = "test.op"() : () -> !test.reg
+// CHECK-NEXT: "test.op"(%r0) : (!test.reg) -> ()
+
+%v0 = "test.op"() : () -> i32
+%r = asm.to_reg %v0 : i32 -> !test.reg
+%v1 = asm.from_reg %r : !test.reg -> i32
+"test.op"(%v1) : (i32) -> ()
+
+//      CHECK: %v0 = "test.op"() : () -> i32
+// CHECK-NEXT: "test.op"(%v0) : (i32) -> ()

--- a/xdsl/dialects/asm.py
+++ b/xdsl/dialects/asm.py
@@ -2,14 +2,17 @@
 The `asm` dialect provides utilities for embedding assembly-level abstractions in higher-level functions.
 """
 
+from collections.abc import Sequence
+
 from xdsl import ir, irdl
 from xdsl.backend.register_type import RegisterType
+from xdsl.interfaces import HasFolderInterface
 from xdsl.traits import Pure
 from xdsl.utils.exceptions import VerifyException
 
 
 @irdl.irdl_op_definition
-class FromRegOp(irdl.IRDLOperation):
+class FromRegOp(irdl.IRDLOperation, HasFolderInterface):
     """
     Get the value stored in a given register.
     """
@@ -36,9 +39,13 @@ class FromRegOp(irdl.IRDLOperation):
                 f"equal to own value type {self.value.type}."
             )
 
+    def fold(self) -> Sequence[ir.SSAValue | ir.Attribute] | None:
+        if isinstance(to_reg_op := self.register.owner, ToRegOp):
+            return (to_reg_op.value,)
+
 
 @irdl.irdl_op_definition
-class ToRegOp(irdl.IRDLOperation):
+class ToRegOp(irdl.IRDLOperation, HasFolderInterface):
     """
     Get the register holding a given value.
     """
@@ -64,6 +71,10 @@ class ToRegOp(irdl.IRDLOperation):
                 f"Expected original register type {from_reg_op.register.type} to be "
                 f"equal to own register type {self.register.type}."
             )
+
+    def fold(self) -> Sequence[ir.SSAValue | ir.Attribute] | None:
+        if isinstance(from_reg_op := self.value.owner, FromRegOp):
+            return (from_reg_op.register,)
 
 
 ASM = ir.Dialect(


### PR DESCRIPTION
The folders allow us to eagerly remove them as they're inserted, when they're added by patterns in a GreedyPatternRewriter. In the future we might want a dedicated pass to remove them but for now they disappear on their own.