### PR TITLE
dependencies: don't specify version for dev dependency pytest-asyncio

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ optional-dependencies.dev = [
   "prek~=0.4.0",
   "pyright==1.1.409",
   "pytest<9.1",
-  "pytest-asyncio==1.4.0",
+  "pytest-asyncio",
   "pytest-cov",
   "ruff==0.15.14",
   "sympy==1.14",

--- a/uv.lock
+++ b/uv.lock
@@ -4042,7 +4042,7 @@ requires-dist = [
     { name = "pyclip", marker = "extra == 'gui'", specifier = "==0.7" },
     { name = "pyright", marker = "extra == 'dev'", specifier = "==1.1.409" },
     { name = "pytest", marker = "extra == 'dev'", specifier = "<9.1" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = "==1.4.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'" },
     { name = "pytest-cov", marker = "extra == 'dev'" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.14" },
     { name = "sympy", marker = "extra == 'dev'", specifier = "==1.14" },


### PR DESCRIPTION
Since it's a dev dependency the version used will be defined by the lockfile anyway, I don't see a point of specifying it.

Note that as it stands main is broken due to me not waiting for the CI to finish on the renovate PR CI to finish, sorry about that.