### PR TITLE
core: Fix MLIR string-literal escape in the printer

### DIFF
--- a/tests/filecheck/backend/riscv/register-allocation/preallocated.mlir
+++ b/tests/filecheck/backend/riscv/register-allocation/preallocated.mlir
@@ -11,7 +11,7 @@ riscv_func.func @main() {
 }
 
 // LIVE-BNAIVE:       builtin.module {
-// LIVE-BNAIVE-NEXT:    riscv.comment {comment = "Regalloc stats: {\"preallocated_float\": [\"ft0\"], \"preallocated_int\": [\"t0\"], \"excluded_float\": [], \"excluded_int\": [], \"allocated_float\": [\"ft0\", \"ft1\"], \"allocated_int\": [\"t0\", \"t1\"]}"} : () -> ()
+// LIVE-BNAIVE-NEXT:    riscv.comment {comment = "Regalloc stats: {\22preallocated_float\22: [\22ft0\22], \22preallocated_int\22: [\22t0\22], \22excluded_float\22: [], \22excluded_int\22: [], \22allocated_float\22: [\22ft0\22, \22ft1\22], \22allocated_int\22: [\22t0\22, \22t1\22]}"} : () -> ()
 // LIVE-BNAIVE-NEXT:    riscv_func.func @main() {
 // LIVE-BNAIVE-NEXT:      %0 = rv32.li 6 : !riscv.reg<t1>
 // LIVE-BNAIVE-NEXT:      %1 = rv32.li 5 : !riscv.reg<t0>

--- a/tests/filecheck/dialects/emitc/emitc_attrs.mlir
+++ b/tests/filecheck/dialects/emitc/emitc_attrs.mlir
@@ -7,6 +7,6 @@
 "test.op"() {
   // CHECK: opaque_attr = #emitc.opaque<"some_value">
   opaque_attr = #emitc.opaque<"some_value">,
-  // CHECK-SAME: quoted_attr = #emitc.opaque<"\"quoted_attr\"">
+  // CHECK-SAME: quoted_attr = #emitc.opaque<"\22quoted_attr\22">
   quoted_attr = #emitc.opaque<"\"quoted_attr\"">
 }: () -> ()

--- a/tests/filecheck/dialects/llvm/global.mlir
+++ b/tests/filecheck/dialects/llvm/global.mlir
@@ -1,6 +1,6 @@
 // RUN: XDSL_ROUNDTRIP
 builtin.module {
-  llvm.mlir.global internal constant @str0("Hello world!\n") {addr_space = 0 : i32} : !llvm.array<13 x i8>
+  llvm.mlir.global internal constant @str0("Hello world!\0A") {addr_space = 0 : i32} : !llvm.array<13 x i8>
   llvm.mlir.global external @x() {addr_space = 0 : i32} : i32
   llvm.mlir.global private @y(42 : i32) {addr_space = 0 : i32} : i32
   llvm.mlir.global external thread_local @tl() {addr_space = 0 : i32} : i32
@@ -17,7 +17,7 @@ builtin.module {
 }
 
 // CHECK: builtin.module {
-// CHECK-NEXT:   llvm.mlir.global internal constant @str0("Hello world!\n") {addr_space = 0 : i32} : !llvm.array<13 x i8>
+// CHECK-NEXT:   llvm.mlir.global internal constant @str0("Hello world!\0A") {addr_space = 0 : i32} : !llvm.array<13 x i8>
 // CHECK-NEXT:   llvm.mlir.global external @x() {addr_space = 0 : i32} : i32
 // CHECK-NEXT:   llvm.mlir.global private @y(42 : i32) {addr_space = 0 : i32} : i32
 // CHECK-NEXT:   llvm.mlir.global external thread_local @tl() {addr_space = 0 : i32} : i32

--- a/tests/filecheck/dialects/printf/printf_basics.mlir
+++ b/tests/filecheck/dialects/printf/printf_basics.mlir
@@ -1,24 +1,24 @@
 // RUN: XDSL_ROUNDTRIP
 builtin.module {
-    printf.print_format "Hello world!\n"
+    printf.print_format "Hello world!\0A"
 
     %144 = "test.op"() : () -> i32
     %12 = "test.op"() : () -> i32
     %byte = "test.op"() : () -> i8
 
-    printf.print_format "Uses vals twice {} {} {} {}\n", %12 : i32, %144 : i32, %12 : i32, %144 : i32
-    printf.print_format "{}\n", %144 : i32
-    printf.print_format "{}\n", %144 : i32 {unit}
+    printf.print_format "Uses vals twice {} {} {} {}\0A", %12 : i32, %144 : i32, %12 : i32, %144 : i32
+    printf.print_format "{}\0A", %144 : i32
+    printf.print_format "{}\0A", %144 : i32 {unit}
     "printf.print_char"(%byte) : (i8) -> ()
     "printf.print_int"(%12) : (i32) -> ()
 }
 
-// CHECK:       printf.print_format "Hello world!\n"
+// CHECK:       printf.print_format "Hello world!\0A"
 // CHECK-NEXT:  %0 = "test.op"() : () -> i32
 // CHECK-NEXT:  %1 = "test.op"() : () -> i32
 // CHECK-NEXT:  %byte = "test.op"() : () -> i8
-// CHECK-NEXT:  printf.print_format "Uses vals twice {} {} {} {}\n", %1 : i32, %0 : i32, %1 : i32, %0 : i32
-// CHECK-NEXT:  printf.print_format "{}\n", %0 : i32
-// CHECK-NEXT:  printf.print_format "{}\n", %0 : i32 {unit}
+// CHECK-NEXT:  printf.print_format "Uses vals twice {} {} {} {}\0A", %1 : i32, %0 : i32, %1 : i32, %0 : i32
+// CHECK-NEXT:  printf.print_format "{}\0A", %0 : i32
+// CHECK-NEXT:  printf.print_format "{}\0A", %0 : i32 {unit}
 // CHECK-NEXT:  "printf.print_char"(%{{.*}}) : (i8) -> ()
 // CHECK-NEXT:  "printf.print_int"(%{{.*}}) : (i32) -> ()

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/emitc/emitc_attrs.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/emitc/emitc_attrs.mlir
@@ -8,6 +8,6 @@
 "test.op"() {
   // CHECK: opaque_attr = #emitc.opaque<"some_value">
   opaque_attr = #emitc.opaque<"some_value">,
-  // CHECK-SAME: quoted_attr = #emitc.opaque<"\"quoted_attr\"">
+  // CHECK-SAME: quoted_attr = #emitc.opaque<"\22quoted_attr\22">
   quoted_attr = #emitc.opaque<"\"quoted_attr\"">
 }: () -> ()

--- a/tests/filecheck/mlir-conversion/with-mlir/parser-printer/escaped_characters.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/parser-printer/escaped_characters.mlir
@@ -24,4 +24,15 @@
   "test.op"() {name = "\202"} : () -> ()
   // CHECK-NEXT: "test.op"() {name = " 2"} : () -> ()
 
+  // ASCII-only string with control bytes — exercises the StringAttr print path.
+  // Pre-fix this emitted "\uXXXX" escapes that mlir-opt rejects.
+  "test.op"() {name = "NUL:\00 BEL:\07 ESC:\1B DEL:\7F end"} : () -> ()
+  // CHECK-NEXT: "test.op"() {name = "NUL:\00 BEL:\07 ESC:\1B DEL:\7F end"} : () -> ()
+
+  "test.op"() {name = "Hello\00\00"} : () -> ()
+  // CHECK-NEXT: "test.op"() {name = "Hello\00\00"} : () -> ()
+
+  "test.op"() {name = "CR\0Dhere"} : () -> ()
+  // CHECK-NEXT: "test.op"() {name = "CR\0Dhere"} : () -> ()
+
 }) : () -> ()

--- a/tests/filecheck/mlir-conversion/with-mlir/parser-printer/escaped_characters.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/parser-printer/escaped_characters.mlir
@@ -4,13 +4,13 @@
 "builtin.module"() ({
 
   "test.op"() {name = "\""} : () -> ()
-  // CHECK:      "test.op"() {name = "\""} : () -> ()
+  // CHECK:      "test.op"() {name = "\22"} : () -> ()
 
   "test.op"() {name = "\n"} : () -> ()
-  // CHECK-NEXT: "test.op"() {name = "\n"} : () -> ()
+  // CHECK-NEXT: "test.op"() {name = "\0A"} : () -> ()
 
   "test.op"() {name = "\t"} : () -> ()
-  // CHECK-NEXT: "test.op"() {name = "\t"} : () -> ()
+  // CHECK-NEXT: "test.op"() {name = "\09"} : () -> ()
 
   "test.op"() {name = "\\"} : () -> ()
   // CHECK-NEXT: "test.op"() {name = "\\"} : () -> ()
@@ -19,7 +19,7 @@
   // CHECK-NEXT: "test.op"() {name = "\E2\9A\A0\EF\B8\8FP\EDU\BA\01\00\10\00\A0\11\00\00\00\00\00\00\02\00\01\01@\00\00\00(\0D\00\00\00\00\00\00\00\00\00\00\00\00\00\00\07\00\01\00=\00\00\00\00\00\00\00\00\00\00\00\11\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\7FELF\02\01\013\07\00\00\00\00\00\00\00\02\00\BE\00x\00\00\00\00\00\00\00\00\00\00\00\80\0C\00\00\00\00\00\00\80\0A\00\00\00\00\00\00=\05=\00@\008\00\03\00@\00\08\00\01\00\00.shstrtab\00.strtab\00.symtab\00.symtab_shndx\00.nv.uft.entry\00.nv.info\00.text.gpu_kernel_kernel"} : () -> ()
 
   "test.op"() {name = "\22quoted_attr\22"} : () -> ()
-  // CHECK-NEXT: "test.op"() {name = "\"quoted_attr\""} : () -> ()
+  // CHECK-NEXT: "test.op"() {name = "\22quoted_attr\22"} : () -> ()
 
   "test.op"() {name = "\202"} : () -> ()
   // CHECK-NEXT: "test.op"() {name = " 2"} : () -> ()

--- a/tests/filecheck/parser-printer/escaped_characters.mlir
+++ b/tests/filecheck/parser-printer/escaped_characters.mlir
@@ -23,4 +23,16 @@
   "test.op"() {name = "\202"} : () -> ()
   // CHECK-NEXT: "test.op"() {name = " 2"} : () -> ()
 
+  // ASCII-only string with control bytes — exercises the StringAttr print path.
+  // Pre-fix this round-tripped through json.dumps producing "\uXXXX" escapes
+  // that xDSL's (and mlir-opt's) lexer reject.
+  "test.op"() {name = "NUL:\00 BEL:\07 ESC:\1B DEL:\7F end"} : () -> ()
+  // CHECK-NEXT: "test.op"() {name = "NUL:\00 BEL:\07 ESC:\1B DEL:\7F end"} : () -> ()
+
+  "test.op"() {name = "Hello\00\00"} : () -> ()
+  // CHECK-NEXT: "test.op"() {name = "Hello\00\00"} : () -> ()
+
+  "test.op"() {name = "CR\0Dhere"} : () -> ()
+  // CHECK-NEXT: "test.op"() {name = "CR\0Dhere"} : () -> ()
+
 }) : () -> ()

--- a/tests/filecheck/parser-printer/escaped_characters.mlir
+++ b/tests/filecheck/parser-printer/escaped_characters.mlir
@@ -3,13 +3,13 @@
 "builtin.module"() ({
 
   "test.op"() {name = "\""} : () -> ()
-  // CHECK:      "test.op"() {name = "\""} : () -> ()
+  // CHECK:      "test.op"() {name = "\22"} : () -> ()
 
   "test.op"() {name = "\n"} : () -> ()
-  // CHECK-NEXT: "test.op"() {name = "\n"} : () -> ()
+  // CHECK-NEXT: "test.op"() {name = "\0A"} : () -> ()
 
   "test.op"() {name = "\t"} : () -> ()
-  // CHECK-NEXT: "test.op"() {name = "\t"} : () -> ()
+  // CHECK-NEXT: "test.op"() {name = "\09"} : () -> ()
 
   "test.op"() {name = "\\"} : () -> ()
   // CHECK-NEXT: "test.op"() {name = "\\"} : () -> ()
@@ -18,7 +18,7 @@
   // CHECK-NEXT: "test.op"() {name = "\E2\9A\A0\EF\B8\8FP\EDU\BA\01\00\10\00\A0\11\00\00\00\00\00\00\02\00\01\01@\00\00\00(\0D\00\00\00\00\00\00\00\00\00\00\00\00\00\00\07\00\01\00=\00\00\00\00\00\00\00\00\00\00\00\11\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\7FELF\02\01\013\07\00\00\00\00\00\00\00\02\00\BE\00x\00\00\00\00\00\00\00\00\00\00\00\80\0C\00\00\00\00\00\00\80\0A\00\00\00\00\00\00=\05=\00@\008\00\03\00@\00\08\00\01\00\00.shstrtab\00.strtab\00.symtab\00.symtab_shndx\00.nv.uft.entry\00.nv.info\00.text.gpu_kernel_kernel"} : () -> ()
 
   "test.op"() {name = "\22quoted_attr\22"} : () -> ()
-  // CHECK-NEXT: "test.op"() {name = "\"quoted_attr\""} : () -> ()
+  // CHECK-NEXT: "test.op"() {name = "\22quoted_attr\22"} : () -> ()
 
   "test.op"() {name = "\202"} : () -> ()
   // CHECK-NEXT: "test.op"() {name = " 2"} : () -> ()

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -302,26 +302,7 @@ class Printer(BasePrinter):
             self.print_list(params, self.print_attribute)
 
     def print_string_literal(self, string: str):
-        # Emit MLIR string-literal syntax: only \\, \", \n, \t are named
-        # escapes; every other non-printable byte is \HH over the UTF-8
-        # encoding. (Don't delegate to print_bytes_literal — bytes literals
-        # intentionally stay hex-only to keep raw-binary output uniform.)
-        self.print_string('"')
-        for byte in string.encode("utf-8"):
-            match byte:
-                case 0x5C:  # ord("\\")
-                    self.print_string("\\\\")
-                case 0x22:  # ord('"')
-                    self.print_string('\\"')
-                case 0x0A:  # ord("\n")
-                    self.print_string("\\n")
-                case 0x09:  # ord("\t")
-                    self.print_string("\\t")
-                case _ if 0x20 > byte or byte > 0x7E:
-                    self.print_string(f"\\{byte:02X}")
-                case _:
-                    self.print_string(chr(byte))
-        self.print_string('"')
+        self.print_bytes_literal(string.encode("utf-8"))
 
     def print_identifier_or_string_literal(self, string: str):
         """

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import math
 from collections.abc import Callable, Generator, Iterable, Mapping, Sequence
 from contextlib import contextmanager
@@ -303,7 +302,26 @@ class Printer(BasePrinter):
             self.print_list(params, self.print_attribute)
 
     def print_string_literal(self, string: str):
-        self.print_string(json.dumps(string))
+        # Emit MLIR string-literal syntax: only \\, \", \n, \t are named
+        # escapes; every other non-printable byte is \HH over the UTF-8
+        # encoding. (Don't delegate to print_bytes_literal — bytes literals
+        # intentionally stay hex-only to keep raw-binary output uniform.)
+        self.print_string('"')
+        for byte in string.encode("utf-8"):
+            match byte:
+                case 0x5C:  # ord("\\")
+                    self.print_string("\\\\")
+                case 0x22:  # ord('"')
+                    self.print_string('\\"')
+                case 0x0A:  # ord("\n")
+                    self.print_string("\\n")
+                case 0x09:  # ord("\t")
+                    self.print_string("\\t")
+                case _ if 0x20 > byte or byte > 0x7E:
+                    self.print_string(f"\\{byte:02X}")
+                case _:
+                    self.print_string(chr(byte))
+        self.print_string('"')
 
     def print_identifier_or_string_literal(self, string: str):
         """


### PR DESCRIPTION
This PR fixes the printing of strings when they have string literal escapes. What JSON emits (old way) is not compatible with MLIR here. The implementation is similar to the print_bytes_literal, but still pretty prints escape characters that JSON did (e.g. \n, \", \\, \t) as that is beneficial for readability in the IR (print_bytes_literal does not do this, that would print \0A in instead of \n for instance), with this code then correctly handles the other escape characters now.