### PR TITLE
core: (PassPipeline) refactor callback

### DIFF
--- a/docs/marimo/mlir_introduction.py
+++ b/docs/marimo/mlir_introduction.py
@@ -69,7 +69,7 @@ def _(mo, xmo):
             module = to_mlir(code_editor.value)
         else:
             module = parse_mlir(code_editor.value)
-        module_list = [module.clone()]
+        module_list = []
         def callback(pass1, module, pass2):
             module_list.append(module.clone())
         all_passes = get_all_passes()
@@ -80,7 +80,6 @@ def _(mo, xmo):
         labels = ["Initial IR"] + ["IR after " + t for t in titles]
         ctx = get_ctx()
         pipeline.apply(ctx, module)
-        module_list.append(module.clone())
         if result == "md":
             return [(label, xmo.module_md(module)) for label, module in zip(labels, module_list, strict=True)]
         return [(label, module) for label, module in zip(labels, module_list, strict=True)]

--- a/xdsl/frontend/pyast/context.py
+++ b/xdsl/frontend/pyast/context.py
@@ -20,7 +20,7 @@ from xdsl.frontend.pyast.utils.type_conversion import (
     TypeRegistry,
 )
 from xdsl.ir import Dialect, Operation, TypeAttribute
-from xdsl.passes import ModulePass, PassPipeline
+from xdsl.passes import ModulePass, PassPipeline, PassPipelineCallbackType
 from xdsl.transforms.desymref import FrontendDesymrefyPass
 
 
@@ -38,10 +38,11 @@ class FuncInfo(NamedTuple):
 
 
 def default_pipeline_callback(
-    _previous_pass: ModulePass, module: ModuleOp, _next_pass: ModulePass
+    previous_pass: ModulePass | None, module: ModuleOp, next_pass: ModulePass | None
 ) -> None:
     """Default callback to verify the module after each transformation pass."""
-    module.verify()
+    if previous_pass and next_pass:
+        module.verify()
 
 
 @dataclass
@@ -62,9 +63,7 @@ class PyASTContext:
     )
     """An ordered list of passes to apply to the built module."""
 
-    post_callback: Callable[[ModulePass, ModuleOp, ModulePass], None] | None = (
-        default_pipeline_callback
-    )
+    post_callback: PassPipelineCallbackType | None = default_pipeline_callback
     """Callback to run between post transforms."""
 
     ir_context: Context = field(

--- a/xdsl/passes.py
+++ b/xdsl/passes.py
@@ -127,6 +127,9 @@ def get_pass_option_infos(
     )
 
 
+Callback = Callable[[ModulePass | None, builtin.ModuleOp, ModulePass | None], None]
+
+
 @dataclass(frozen=True)
 class PassPipeline:
     """
@@ -138,33 +141,41 @@ class PassPipeline:
     """
     These will be executed sequentially during the execution of the pipeline.
     """
-    callback: Callable[[ModulePass, builtin.ModuleOp, ModulePass], None] | None = field(
-        default=None
-    )
+
+    callback: Callback | None = field(default=None)
     """
     Function called in between every pass, taking the pass that just ran, the module,
     and the next pass.
     """
 
+    @staticmethod
+    def _default_callback(
+        before: ModulePass | None, op: builtin.ModuleOp, next: ModulePass | None
+    ):
+        return
+
     def apply(self, ctx: Context, op: builtin.ModuleOp) -> None:
+        callback = self.callback or PassPipeline._default_callback
         if not self.passes:
+            callback(None, op, None)
             # Early exit to avoid fetching a non-existing last pass.
             return
-        callback = self.callback
+
+        callback(None, op, self.passes[0])
 
         for prev, next in zip(self.passes[:-1], self.passes[1:]):
             prev.apply(ctx, op)
-            if callback is not None:
-                callback(prev, op, next)
+            callback(prev, op, next)
 
         self.passes[-1].apply(ctx, op)
+
+        callback(self.passes[-1], op, None)
 
     @staticmethod
     def parse_spec(
         available_passes: dict[str, Callable[[], type[ModulePass]]],
         spec: str,
-        callback: Callable[[ModulePass, builtin.ModuleOp, ModulePass], None]
-        | None = None,
+        callback: Callback | None = None,
     ) -> PassPipeline:
         specs = tuple(parse_pipeline(spec))
         unrecognised_passes = tuple(

--- a/xdsl/passes.py
+++ b/xdsl/passes.py
@@ -127,7 +127,15 @@ def get_pass_option_infos(
     )
 
 
-Callback = Callable[[ModulePass | None, builtin.ModuleOp, ModulePass | None], None]
+PassPipelineCallbackType = Callable[
+    [ModulePass | None, builtin.ModuleOp, ModulePass | None], None
+]
+"""
+Type of callback functions that can be given to a PassPipeline
+The first argument of the function is the previous pass applied (if any).
+The second argument is the current state of the module.
+The third argument is the pass which is about to be applied (if any).
+"""
 
 
 @dataclass(frozen=True)
@@ -142,7 +150,7 @@ class PassPipeline:
     These will be executed sequentially during the execution of the pipeline.
     """
 
-    callback: Callback | None = field(default=None)
+    callback: PassPipelineCallbackType | None = field(default=None)
     """
     Function called in between every pass, taking the pass that just ran, the module,
     and the next pass.
@@ -175,7 +183,7 @@ class PassPipeline:
     def parse_spec(
         available_passes: dict[str, Callable[[], type[ModulePass]]],
         spec: str,
-        callback: Callback | None = None,
+        callback: PassPipelineCallbackType | None = None,
     ) -> PassPipeline:
         specs = tuple(parse_pipeline(spec))
         unrecognised_passes = tuple(

--- a/xdsl/passes.py
+++ b/xdsl/passes.py
@@ -156,28 +156,25 @@ class PassPipeline:
     and the next pass.
     """
 
-    @staticmethod
-    def _default_callback(
-        before: ModulePass | None, op: builtin.ModuleOp, next: ModulePass | None
-    ):
-        return
-
     def apply(self, ctx: Context, op: builtin.ModuleOp) -> None:
-        callback = self.callback or PassPipeline._default_callback
         if not self.passes:
-            callback(None, op, None)
+            if self.callback is not None:
+                self.callback(None, op, None)
             # Early exit to avoid fetching a non-existing last pass.
             return
 
-        callback(None, op, self.passes[0])
+        if self.callback is not None:
+            self.callback(None, op, self.passes[0])
 
         for prev, next in zip(self.passes[:-1], self.passes[1:]):
             prev.apply(ctx, op)
-            callback(prev, op, next)
+            if self.callback is not None:
+                self.callback(prev, op, next)
 
         self.passes[-1].apply(ctx, op)
 
-        callback(self.passes[-1], op, None)
+        if self.callback is not None:
+            self.callback(self.passes[-1], op, None)
 
     @staticmethod
     def parse_spec(

--- a/xdsl/xdsl_opt_main.py
+++ b/xdsl/xdsl_opt_main.py
@@ -99,8 +99,8 @@ class xDSLOptMain(CommandLineTool):
                     module = self.parse_chunk(chunk, file_extension, offset)
 
                     if module is not None:
-                        if self.apply_passes(module):
-                            output_stream.write(self.output_resulting_program(module))
+                        self.apply_passes(module)
+                        output_stream.write(self.output_resulting_program(module))
                     output_stream.flush()
                 except ParseError as e:
                     s = e.span
@@ -271,11 +271,13 @@ class xDSLOptMain(CommandLineTool):
         """
 
         def callback(
-            previous_pass: ModulePass, module: ModuleOp, next_pass: ModulePass
+            previous_pass: ModulePass | None,
+            module: ModuleOp,
+            next_pass: ModulePass | None,
         ) -> None:
             if not self.args.disable_verify:
                 module.verify()
-            if self.args.print_between_passes:
+            if previous_pass and next_pass and self.args.print_between_passes:
                 print(f"IR after {previous_pass.name}:")
                 printer = Printer(stream=sys.stdout)
                 printer.print_op(module)
@@ -325,14 +327,9 @@ class xDSLOptMain(CommandLineTool):
         else:
             return open(self.args.output_file, "w")
 
-    def apply_passes(self, prog: ModuleOp) -> bool:
+    def apply_passes(self, prog: ModuleOp):
         """Apply passes in order."""
-        if not self.args.disable_verify:
-            prog.verify()
         self.pipeline.apply(self.ctx, prog)
-        if not self.args.disable_verify:
-            prog.verify()
-        return True
 
     def output_resulting_program(self, prog: ModuleOp) -> str:
         """Get the resulting program."""


### PR DESCRIPTION
Part 1 of changes for adding timing to passes. Calls the callback before and after the whole pipeline, which will allow a timer to be started/ended in the callback. I think this makes sense independently so split it off. 