### PR TITLE
tools: (xdsl-opt) add time-passes argument

### DIFF
--- a/tests/xdsl_opt/test_xdsl_opt.py
+++ b/tests/xdsl_opt/test_xdsl_opt.py
@@ -168,6 +168,25 @@ def test_print_between_passes():
     assert len([l for l in output.split("\n") if "builtin.module" in l]) == len(passes)
 
 
+def test_time_passes():
+    filename_in = "tests/xdsl_opt/empty_program.mlir"
+    passes = ["canonicalize", "cse", "dce"]
+    flags = ["--time-passes", "-p", ",".join(passes)]
+
+    f = StringIO("")
+
+    opt = xDSLOptMain(args=[*flags, filename_in])
+
+    with redirect_stdout(f):
+        opt.run()
+
+    output = f.getvalue()
+    lines = output.split("\n")
+    assert lines[0].startswith("Pass canonicalize took ")
+    assert lines[1].startswith("Pass cse took ")
+    assert lines[2].startswith("Pass dce took ")
+
+
 def test_verify_diagnostics_output():
     """
     Diagnostic exceptions raised when printing output should be redirected to stdout if

--- a/xdsl/xdsl_opt_main.py
+++ b/xdsl/xdsl_opt_main.py
@@ -2,6 +2,7 @@ import argparse
 import dataclasses
 import inspect
 import sys
+import time
 from collections.abc import Callable, Sequence
 from importlib.metadata import version
 from io import StringIO
@@ -173,6 +174,13 @@ class xDSLOptMain(CommandLineTool):
         )
 
         arg_parser.add_argument(
+            "--time-passes",
+            default=False,
+            action="store_true",
+            help="Print timing information for each pass",
+        )
+
+        arg_parser.add_argument(
             "--verify-diagnostics",
             default=False,
             action="store_true",
@@ -270,11 +278,19 @@ class xDSLOptMain(CommandLineTool):
         Fails, if not all passes are registered.
         """
 
+        start_timer = time.perf_counter()
+
         def callback(
             previous_pass: ModulePass | None,
             module: ModuleOp,
             next_pass: ModulePass | None,
         ) -> None:
+            nonlocal start_timer
+            if self.args.time_passes and previous_pass is not None:
+                end_timer = time.perf_counter()
+                duration = end_timer - start_timer
+                print(f"Pass {previous_pass.name} took {duration} seconds")
+
             if not self.args.disable_verify:
                 module.verify()
             if previous_pass and next_pass and self.args.print_between_passes:
@@ -282,6 +298,9 @@ class xDSLOptMain(CommandLineTool):
                 printer = Printer(stream=sys.stdout)
                 printer.print_op(module)
                 print("\n\n\n")
+
+            if self.args.time_passes and next_pass is not None:
+                start_timer = time.perf_counter()
 
         self.pipeline = PassPipeline.parse_spec(
             self.available_passes,


### PR DESCRIPTION
Adds a time passes flag which outputs the time taken by each pass