### PR TITLE
core: (SymbolTable) add cached lookup methods for symbol table

### DIFF
--- a/tests/utils/test_symbol_table.py
+++ b/tests/utils/test_symbol_table.py
@@ -373,30 +373,46 @@ def test_symbol_table_collection_init():
 
 
 def test_symbol_table_collection_lookup_symbol_in():
-    """Test SymbolTableCollection.lookup_symbol_in static method."""
-    test_op = TestOp()
-    symbol = StringAttr("test_symbol")
+    """Test SymbolTableCollection.lookup_symbol_in method."""
+    op_a = TestSymbolOp(properties={"sym_name": StringAttr("a")})
+    nested_symbol = TestSymbolOp(properties={"sym_name": StringAttr("nested")})
+    nested_table = ModuleOp([nested_symbol], sym_name=StringAttr("nested_table"))
+    module = ModuleOp([op_a, nested_table])
+    collection = SymbolTableCollection()
 
-    # This will raise NotImplementedError until implemented
-    with pytest.raises(NotImplementedError):
-        SymbolTableCollection.lookup_symbol_in(test_op, symbol, all_symbols=False)
+    assert collection.lookup_symbol_in(module, "a") is op_a
+    cached_module_table = collection.symbol_tables[module]
+    assert collection.lookup_symbol_in(module, StringAttr("a")) is op_a
+    assert collection.symbol_tables[module] is cached_module_table
+
+    assert (
+        collection.lookup_symbol_in(module, SymbolRefAttr("nested_table", ["nested"]))
+        is nested_symbol
+    )
+    assert collection.lookup_symbol_in(
+        module, SymbolRefAttr("nested_table", ["nested"]), all_symbols=True
+    ) == [nested_table, nested_symbol]
+    assert nested_table in collection.symbol_tables
 
 
 def test_symbol_table_collection_lookup_nearest_symbol_from():
-    """Test SymbolTableCollection.lookup_nearest_symbol_from static method."""
-    test_op = TestOp()
-    symbol = StringAttr("test_symbol")
+    """Test SymbolTableCollection.lookup_nearest_symbol_from method."""
+    collection = SymbolTableCollection()
+    symbol = TestSymbolOp(properties={"sym_name": StringAttr("nearest_symbol")})
+    from_op = TestOp()
+    ModuleOp([symbol, TestOp(regions=[Region(Block([from_op]))])])
 
-    # This will raise NotImplementedError until implemented
-    with pytest.raises(NotImplementedError):
-        SymbolTableCollection.lookup_nearest_symbol_from(test_op, symbol)
+    assert collection.lookup_nearest_symbol_from(from_op, "nearest_symbol") is symbol
+    assert collection.lookup_nearest_symbol_from(TestOp(), "nearest_symbol") is None
 
 
 def test_symbol_table_collection_get_symbol_table():
     """Test SymbolTableCollection.get_symbol_table method."""
     collection = SymbolTableCollection()
-    test_op = TestOp()
+    module = ModuleOp([])
 
-    # This will raise NotImplementedError until implemented
-    with pytest.raises(NotImplementedError):
-        collection.get_symbol_table(test_op)
+    symbol_table = collection.get_symbol_table(module)
+
+    assert isinstance(symbol_table, SymbolTable)
+    assert collection.get_symbol_table(module) is symbol_table
+    assert collection.symbol_tables[module] is symbol_table

--- a/tests/utils/test_symbol_table.py
+++ b/tests/utils/test_symbol_table.py
@@ -1,6 +1,6 @@
 import pytest
 
-from xdsl.dialects.builtin import ModuleOp, StringAttr
+from xdsl.dialects.builtin import ModuleOp, StringAttr, SymbolRefAttr
 from xdsl.dialects.test import TestOp, TestSymbolOp
 from xdsl.ir import Block, Region
 from xdsl.utils.symbol_table import (
@@ -272,22 +272,67 @@ def test_symbol_table_walk_symbol_tables():
 
 def test_symbol_table_lookup_symbol_in():
     """Test SymbolTable.lookup_symbol_in static method."""
-    test_op = TestOp()
-    symbol = StringAttr("test_symbol")
+    op_a = TestSymbolOp(properties={"sym_name": StringAttr("a")})
+    op_b = TestSymbolOp(properties={"sym_name": StringAttr("b")})
+    nested_symbol = TestSymbolOp(properties={"sym_name": StringAttr("nested")})
+    nested_private_symbol = TestSymbolOp(
+        properties={
+            "sym_name": StringAttr("private_nested"),
+            "sym_visibility": StringAttr("private"),
+        }
+    )
+    nested_table = ModuleOp(
+        [nested_symbol, nested_private_symbol], sym_name=StringAttr("nested_table")
+    )
+    non_table_root = TestSymbolOp(properties={"sym_name": StringAttr("non_table")})
+    module = ModuleOp([op_a, op_b, nested_table, non_table_root])
 
-    # This will raise NotImplementedError until implemented
-    with pytest.raises(NotImplementedError):
-        SymbolTable.lookup_symbol_in(test_op, symbol, all_symbols=False)
+    assert SymbolTable.lookup_symbol_in(module, "a") is op_a
+    assert SymbolTable.lookup_symbol_in(module, StringAttr("b")) is op_b
+    assert SymbolTable.lookup_symbol_in(module, "missing") is None
+    assert SymbolTable.lookup_symbol_in(module, "a", all_symbols=True) == [op_a]
+
+    assert (
+        SymbolTable.lookup_symbol_in(module, SymbolRefAttr("nested_table", ["nested"]))
+        is nested_symbol
+    )
+    assert (
+        SymbolTable.lookup_symbol_in(module, SymbolRefAttr("non_table", ["nested"]))
+        is None
+    )
+    assert (
+        SymbolTable.lookup_symbol_in(
+            module, SymbolRefAttr("nested_table", ["private_nested"])
+        )
+        is None
+    )
+    assert SymbolTable.lookup_symbol_in(
+        module, SymbolRefAttr("nested_table", ["nested"]), all_symbols=True
+    ) == [nested_table, nested_symbol]
 
 
 def test_symbol_table_lookup_nearest_symbol_from():
     """Test SymbolTable.lookup_nearest_symbol_from static method."""
-    test_op = TestOp()
-    symbol = StringAttr("test_symbol")
+    module_symbol = TestSymbolOp(properties={"sym_name": StringAttr("module_symbol")})
+    nested_from_op = TestOp()
+    ModuleOp([module_symbol, TestOp(regions=[Region(Block([nested_from_op]))])])
 
-    # This will raise NotImplementedError until implemented
-    with pytest.raises(NotImplementedError):
-        SymbolTable.lookup_nearest_symbol_from(test_op, symbol)
+    assert (
+        SymbolTable.lookup_nearest_symbol_from(nested_from_op, "module_symbol")
+        is module_symbol
+    )
+    assert SymbolTable.lookup_nearest_symbol_from(nested_from_op, "missing") is None
+
+    outer_symbol = TestSymbolOp(properties={"sym_name": StringAttr("scoped_symbol")})
+    inner_symbol = TestSymbolOp(properties={"sym_name": StringAttr("scoped_symbol")})
+    inner_from_op = TestOp()
+    inner_module = ModuleOp([inner_symbol, inner_from_op], sym_name=StringAttr("inner"))
+    ModuleOp([outer_symbol, inner_module])
+
+    assert (
+        SymbolTable.lookup_nearest_symbol_from(inner_from_op, "scoped_symbol")
+        is inner_symbol
+    )
 
 
 def test_symbol_table_get_symbol_uses():

--- a/tests/utils/test_symbol_table.py
+++ b/tests/utils/test_symbol_table.py
@@ -215,11 +215,30 @@ def test_symbol_table_set_symbol_name():
 
 def test_symbol_table_get_symbol_visibility():
     """Test SymbolTable.get_symbol_visibility static method."""
-    test_op = TestOp()
+    public_op = TestSymbolOp(properties={"sym_name": StringAttr("public_symbol")})
+    explicit_public_op = TestSymbolOp(
+        properties={
+            "sym_name": StringAttr("explicit_public_symbol"),
+            "sym_visibility": StringAttr("public"),
+        }
+    )
+    private_op = TestSymbolOp(
+        properties={
+            "sym_name": StringAttr("private_symbol"),
+            "sym_visibility": StringAttr("private"),
+        }
+    )
+    nested_op = TestSymbolOp(
+        properties={
+            "sym_name": StringAttr("nested_symbol"),
+            "sym_visibility": StringAttr("nested"),
+        }
+    )
 
-    # This will raise NotImplementedError until implemented
-    with pytest.raises(NotImplementedError):
-        SymbolTable.get_symbol_visibility(test_op)
+    assert SymbolTable.get_symbol_visibility(public_op) is Visibility.PUBLIC
+    assert SymbolTable.get_symbol_visibility(explicit_public_op) is Visibility.PUBLIC
+    assert SymbolTable.get_symbol_visibility(private_op) is Visibility.PRIVATE
+    assert SymbolTable.get_symbol_visibility(nested_op) is Visibility.NESTED
 
 
 def test_symbol_table_set_symbol_visibility():
@@ -234,11 +253,12 @@ def test_symbol_table_set_symbol_visibility():
 
 def test_symbol_table_get_nearest_symbol_table():
     """Test SymbolTable.get_nearest_symbol_table static method."""
-    test_op = TestOp()
+    nested_op = TestOp()
+    module = ModuleOp([TestOp(regions=[Region(Block([nested_op]))])])
 
-    # This will raise NotImplementedError until implemented
-    with pytest.raises(NotImplementedError):
-        SymbolTable.get_nearest_symbol_table(test_op)
+    assert SymbolTable.get_nearest_symbol_table(nested_op) is module
+    assert SymbolTable.get_nearest_symbol_table(module) is module
+    assert SymbolTable.get_nearest_symbol_table(TestOp()) is None
 
 
 def test_symbol_table_walk_symbol_tables():

--- a/xdsl/utils/symbol_table.py
+++ b/xdsl/utils/symbol_table.py
@@ -161,7 +161,12 @@ class SymbolTable:
     @staticmethod
     def get_symbol_visibility(symbol: Operation) -> Visibility:
         """Returns the visibility of the given symbol operation."""
-        raise NotImplementedError
+        visibility = symbol.get_attr_or_prop("sym_visibility")
+        if visibility is None:
+            return Visibility.PUBLIC
+        if not isinstance(visibility, StringAttr):
+            raise ValueError("Expected 'sym_visibility' to be a StringAttr")
+        return Visibility(visibility.data)
 
     @staticmethod
     def set_symbol_visibility(symbol: Operation, vis: Visibility) -> None:
@@ -174,7 +179,12 @@ class SymbolTable:
         Returns the nearest symbol table from a given operation `from`.
         Returns `None` if no valid parent symbol table could be found.
         """
-        raise NotImplementedError
+        op: Operation | None = from_op
+        while op is not None:
+            if op.has_trait(traits.SymbolTable, value_if_unregistered=False):
+                return op
+            op = op.parent_op()
+        return None
 
     @staticmethod
     def walk_symbol_tables(

--- a/xdsl/utils/symbol_table.py
+++ b/xdsl/utils/symbol_table.py
@@ -215,7 +215,7 @@ class SymbolTable:
         op: Operation,
         symbol: StringAttr | SymbolRefAttr | str,
         *,
-        all_symbols: Literal[False],
+        all_symbols: Literal[False] = False,
     ) -> Operation | None: ...
 
     @staticmethod
@@ -358,8 +358,8 @@ class SymbolTableCollection:
         return self._symbol_tables
 
     @overload
-    @staticmethod
     def lookup_symbol_in(
+        self,
         op: Operation,
         symbol: StringAttr | SymbolRefAttr | str,
         *,
@@ -367,16 +367,16 @@ class SymbolTableCollection:
     ) -> list[Operation] | None: ...
 
     @overload
-    @staticmethod
     def lookup_symbol_in(
+        self,
         op: Operation,
         symbol: StringAttr | SymbolRefAttr | str,
         *,
-        all_symbols: Literal[False],
+        all_symbols: Literal[False] = False,
     ) -> Operation | None: ...
 
-    @staticmethod
     def lookup_symbol_in(
+        self,
         op: Operation,
         symbol: StringAttr | SymbolRefAttr | str,
         *,
@@ -389,11 +389,25 @@ class SymbolTableCollection:
         `op` is required to be an operation with the 'xdsl.traits.SymbolTable' trait.
         If `all_symbols` is `True`, returns all symbols referenced by the symbol.
         """
-        raise NotImplementedError
+        if isinstance(symbol, str | StringAttr):
+            symbol_op = self.get_symbol_table(op).lookup(symbol)
+            if all_symbols:
+                return [symbol_op] if symbol_op is not None else None
+            return symbol_op
 
-    @staticmethod
+        symbols = _lookup_symbol_ref_in(
+            op,
+            symbol,
+            lambda symbol_table_op, name: self.get_symbol_table(symbol_table_op).lookup(
+                name
+            ),
+        )
+        if symbols is None:
+            return None
+        return symbols if all_symbols else symbols[-1]
+
     def lookup_nearest_symbol_from(
-        from_op: Operation, symbol: StringAttr | SymbolRefAttr
+        self, from_op: Operation, symbol: StringAttr | SymbolRefAttr | str
     ) -> Operation | None:
         """
         Returns the operation registered with the given symbol name within the closest
@@ -401,13 +415,20 @@ class SymbolTableCollection:
         [`SymbolTable`][xdsl.traits.SymbolTable] trait.
         Returns `None` if no valid symbol was found.
         """
-        raise NotImplementedError
+        symbol_table_op = SymbolTable.get_nearest_symbol_table(from_op)
+        if symbol_table_op is None:
+            return None
+        return self.lookup_symbol_in(symbol_table_op, symbol)
 
     def get_symbol_table(self, op: Operation) -> SymbolTable:
         """
         Lookup, or create, a symbol table for an operation.
         """
-        raise NotImplementedError
+        symbol_table = self._symbol_tables.get(op)
+        if symbol_table is None:
+            symbol_table = SymbolTable(op)
+            self._symbol_tables[op] = symbol_table
+        return symbol_table
 
 
 def walk_symbol_table(op: Operation) -> Iterator[Operation]:

--- a/xdsl/utils/symbol_table.py
+++ b/xdsl/utils/symbol_table.py
@@ -4,7 +4,7 @@ Helper methods and classes to reason about operations that refer to other operat
 
 from __future__ import annotations
 
-from collections.abc import Iterator, Mapping, Sequence
+from collections.abc import Callable, Iterator, Mapping, Sequence
 from typing import Literal, NamedTuple, overload
 
 from xdsl import traits
@@ -231,11 +231,23 @@ class SymbolTable:
         `op` is required to be an operation with the 'xdsl.traits.SymbolTable' trait.
         If `all_symbols` is `True`, returns all symbols referenced by the symbol.
         """
-        raise NotImplementedError
+        assert op.get_trait(traits.SymbolTable) is not None, (
+            "Expected operation to have SymbolTable trait"
+        )
+        if isinstance(symbol, str | StringAttr):
+            symbol_op = _lookup_symbol_in_direct_children(op, symbol)
+            if all_symbols:
+                return [symbol_op] if symbol_op is not None else None
+            return symbol_op
+
+        symbols = _lookup_symbol_ref_in(op, symbol, _lookup_symbol_in_direct_children)
+        if symbols is None:
+            return None
+        return symbols if all_symbols else symbols[-1]
 
     @staticmethod
     def lookup_nearest_symbol_from(
-        from_op: Operation, symbol: StringAttr | SymbolRefAttr
+        from_op: Operation, symbol: StringAttr | SymbolRefAttr | str
     ) -> Operation | None:
         """
         Returns the operation registered with the given symbol name within the closest
@@ -243,7 +255,10 @@ class SymbolTable:
         [`SymbolTable`][xdsl.traits.SymbolTable] trait.
         Returns `None` if no valid symbol was found.
         """
-        raise NotImplementedError
+        symbol_table_op = SymbolTable.get_nearest_symbol_table(from_op)
+        if symbol_table_op is None:
+            return None
+        return SymbolTable.lookup_symbol_in(symbol_table_op, symbol)
 
     @staticmethod
     def get_symbol_uses(
@@ -287,6 +302,42 @@ class SymbolTable:
         uses are replaced and `False` is returned.
         """
         raise NotImplementedError
+
+
+def _lookup_symbol_in_direct_children(
+    symbol_table_op: Operation, symbol: StringAttr | str
+) -> Operation | None:
+    symbol_name = symbol.data if isinstance(symbol, StringAttr) else symbol
+    block = symbol_table_op.regions[0].blocks[0]
+    for op in block.ops:
+        if get_name_if_symbol(op) == symbol_name:
+            return op
+    return None
+
+
+def _lookup_symbol_ref_in(
+    symbol_table_op: Operation,
+    symbol: SymbolRefAttr,
+    lookup_symbol: Callable[[Operation, StringAttr], Operation | None],
+) -> list[Operation] | None:
+    symbol_op = lookup_symbol(symbol_table_op, symbol.root_reference)
+    if symbol_op is None:
+        return None
+
+    symbols = [symbol_op]
+    for nested_reference in symbol.nested_references.data:
+        if not symbol_op.has_trait(traits.SymbolTable, value_if_unregistered=False):
+            return None
+
+        symbol_op = lookup_symbol(symbol_op, nested_reference)
+        if (
+            symbol_op is None
+            or SymbolTable.get_symbol_visibility(symbol_op) is Visibility.PRIVATE
+        ):
+            return None
+        symbols.append(symbol_op)
+
+    return symbols
 
 
 class SymbolTableCollection:


### PR DESCRIPTION
This PR implements the lookup/collection follow-up for the SymbolTable helper.

It adds:
- SymbolTable.get_nearest_symbol_table
- SymbolTable.lookup_symbol_in
- SymbolTable.lookup_nearest_symbol_from
- SymbolTableCollection.get_symbol_table
- cached SymbolTableCollection.lookup_symbol_in
- cached SymbolTableCollection.lookup_nearest_symbol_from
- nested SymbolRefAttr lookup tests
