### PR TITLE
CI: use per-commit checkout of llvm backend test

### DIFF
--- a/benchmarks/bench_utils.py
+++ b/benchmarks/bench_utils.py
@@ -3,6 +3,7 @@
 
 import cProfile
 import subprocess
+import sys
 import time
 from argparse import ArgumentParser, Namespace
 from collections.abc import Callable
@@ -28,6 +29,20 @@ class Benchmark(NamedTuple):
 
     body: Callable[[], Any]
     setup: Callable[[], Any] | None = None
+
+
+def benchmark_root_directory() -> Path:
+    """
+    Resolve the path for this test fixture.
+
+    Prefer the ASV per-commit checkout (<env>/project) so benchmark inputs match
+    the commit under test, and fall back to the benchmark checkout for local runs.
+    """
+    asv_project_path = Path(sys.executable).parents[1] / "project"
+    asv_file = asv_project_path
+    if asv_file.exists():
+        return asv_file
+    return Path(__file__).parents[1]
 
 
 def parse_arguments(benchmark_names: list[str]) -> ArgumentParser:

--- a/benchmarks/llvm_backend.py
+++ b/benchmarks/llvm_backend.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
-from pathlib import Path
-
+from benchmarks.bench_utils import benchmark_root_directory
 from xdsl.context import Context
 from xdsl.dialects.builtin import Builtin, ModuleOp
 from xdsl.dialects.llvm import LLVM
@@ -8,13 +7,16 @@ from xdsl.dialects.vector import Vector
 from xdsl.parser import Parser
 
 FILECHECK_TEST = (
-    Path(__file__).parents[1]
+    benchmark_root_directory()
     / "tests"
     / "filecheck"
     / "backend"
     / "llvm"
     / "convert_op.mlir"
 )
+"""
+Root directory of the benchmark, handling running under ASV or directly.
+"""
 
 
 def _parse_module() -> ModuleOp:


### PR DESCRIPTION
ASV checks out two versions of xDSL, one is always main, and contains the benchmarks, and the other is per-commit. That way it's possible to catch regressions in behaviour even if it's only main that has the benchmark for the thing being tested. It effectively allows you to backport the benchmark. The problem is that for some of our tests, like the llvmlite one, we add functionality which is reflected in the test, and I actually care more about the time it takes to convert a module per-commit, than the trendline. This PR adds the functionality to resolve the test input per-commit instead of always from main.