### PR TITLE
core: (symbolTable) implement nearest symbol table helper

### DIFF
--- a/tests/utils/test_symbol_table.py
+++ b/tests/utils/test_symbol_table.py
@@ -234,11 +234,13 @@ def test_symbol_table_set_symbol_visibility():
 
 def test_symbol_table_get_nearest_symbol_table():
     """Test SymbolTable.get_nearest_symbol_table static method."""
-    test_op = TestOp()
+    detached_op = TestOp()
+    nested_op = TestOp()
+    module = ModuleOp([nested_op])
 
-    # This will raise NotImplementedError until implemented
-    with pytest.raises(NotImplementedError):
-        SymbolTable.get_nearest_symbol_table(test_op)
+    assert SymbolTable.get_nearest_symbol_table(detached_op) is None
+    assert SymbolTable.get_nearest_symbol_table(module) is module
+    assert SymbolTable.get_nearest_symbol_table(nested_op) is module
 
 
 def test_symbol_table_walk_symbol_tables():

--- a/xdsl/utils/symbol_table.py
+++ b/xdsl/utils/symbol_table.py
@@ -174,7 +174,12 @@ class SymbolTable:
         Returns the nearest symbol table from a given operation `from`.
         Returns `None` if no valid parent symbol table could be found.
         """
-        raise NotImplementedError
+        op: Operation | None = from_op
+        while op is not None:
+            if op.has_trait(traits.SymbolTable, value_if_unregistered=False):
+                return op
+            op = op.parent_op()
+        return None
 
     @staticmethod
     def walk_symbol_tables(


### PR DESCRIPTION
Implement `get_nearest_symbol_table`. 

It returns the nearest symbol table from a given operation `from`. This is to support building SymbolTable collection.