### PR TITLE
dialects: (ub) Initial ub dialect with poison operator

### DIFF
--- a/tests/dialects/test_ub.py
+++ b/tests/dialects/test_ub.py
@@ -1,0 +1,17 @@
+from xdsl.dialects.builtin import VectorType, i32, i64
+from xdsl.dialects.ub import PoisonAttr, PoisonOp
+
+
+def test_poison_default_value():
+    """Constructing without a value defaults to the empty `#ub.poison` attr."""
+    op = PoisonOp(i32)
+    assert op.result.type == i32
+    assert op.value == PoisonAttr()
+
+
+def test_poison_explicit_value():
+    """An explicit poison attribute is stored verbatim on the `value` prop."""
+    value = PoisonAttr()
+    op = PoisonOp(VectorType(i64, [4]), value)
+    assert op.result.type == VectorType(i64, [4])
+    assert op.value is value

--- a/tests/filecheck/dialects/ub/ops.mlir
+++ b/tests/filecheck/dialects/ub/ops.mlir
@@ -3,15 +3,14 @@
 
 // CHECK:      builtin.module {
 // CHECK-NEXT:   %{{.*}} = ub.poison : i32
+%0 = ub.poison : i32
 // CHECK-NEXT:   %{{.*}} = ub.poison : vector<4xi64>
+%1 = ub.poison : vector<4xi64>
 // The long form is accepted on parse; since the only poison attribute is the
 // default `#ub.poison`, it is re-printed in the elided short form.
 // CHECK-NEXT:   %{{.*}} = ub.poison : f32
-// CHECK-NEXT: }
-
-%0 = ub.poison : i32
-%1 = ub.poison : vector<4xi64>
 %2 = ub.poison <#ub.poison> : f32
+// CHECK-NEXT: }
 
 // CHECK-GENERIC:      "builtin.module"() ({
 // CHECK-GENERIC-NEXT:   %{{.*}} = "ub.poison"() <{value = #ub.poison}> : () -> i32

--- a/tests/filecheck/dialects/ub/ops.mlir
+++ b/tests/filecheck/dialects/ub/ops.mlir
@@ -1,0 +1,20 @@
+// RUN: XDSL_ROUNDTRIP
+// RUN: XDSL_GENERIC_ROUNDTRIP
+
+// CHECK:      builtin.module {
+// CHECK-NEXT:   %{{.*}} = ub.poison : i32
+// CHECK-NEXT:   %{{.*}} = ub.poison : vector<4xi64>
+// The long form is accepted on parse; since the only poison attribute is the
+// default `#ub.poison`, it is re-printed in the elided short form.
+// CHECK-NEXT:   %{{.*}} = ub.poison : f32
+// CHECK-NEXT: }
+
+%0 = ub.poison : i32
+%1 = ub.poison : vector<4xi64>
+%2 = ub.poison <#ub.poison> : f32
+
+// CHECK-GENERIC:      "builtin.module"() ({
+// CHECK-GENERIC-NEXT:   %{{.*}} = "ub.poison"() <{value = #ub.poison}> : () -> i32
+// CHECK-GENERIC-NEXT:   %{{.*}} = "ub.poison"() <{value = #ub.poison}> : () -> vector<4xi64>
+// CHECK-GENERIC-NEXT:   %{{.*}} = "ub.poison"() <{value = #ub.poison}> : () -> f32
+// CHECK-GENERIC-NEXT: }) : () -> ()

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/ub/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/ub/ops.mlir
@@ -1,0 +1,13 @@
+// RUN: MLIR_ROUNDTRIP
+// RUN: MLIR_GENERIC_ROUNDTRIP
+
+// Proves xDSL emits `ub.poison` in a form that upstream `mlir-opt`
+// accepts and re-emits identically, in both the pretty and generic forms.
+
+builtin.module {
+  // CHECK: %{{.*}} = ub.poison : i32
+  %0 = ub.poison : i32
+
+  // CHECK: %{{.*}} = ub.poison : vector<4xi64>
+  %1 = ub.poison : vector<4xi64>
+}

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/ub/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/ub/ops.mlir
@@ -10,4 +10,11 @@ builtin.module {
 
   // CHECK: %{{.*}} = ub.poison : vector<4xi64>
   %1 = ub.poison : vector<4xi64>
+
+  // The long form with an explicit value is accepted on parse, but since
+  // `#ub.poison` is the default value, both xDSL and mlir-opt elide it back to
+  // the short form (there is no non-default `PoisonAttrInterface` attribute
+  // upstream to produce a non-elided spelling).
+  // CHECK: %{{.*}} = ub.poison : f32
+  %2 = ub.poison <#ub.poison> : f32
 }

--- a/xdsl/dialects/__init__.py
+++ b/xdsl/dialects/__init__.py
@@ -368,6 +368,11 @@ def get_all_dialects() -> dict[str, Callable[[], Dialect]]:
 
         return Transform
 
+    def get_ub():
+        from xdsl.dialects.ub import UB
+
+        return UB
+
     def get_varith():
         from xdsl.dialects.varith import Varith
 
@@ -475,6 +480,7 @@ def get_all_dialects() -> dict[str, Callable[[], Dialect]]:
         "tensor": get_tensor,
         "test": get_test,
         "tosa": get_tosa,
+        "ub": get_ub,
         "varith": get_varith,
         "vector": get_vector,
         "wasm": get_wasm,

--- a/xdsl/dialects/ub.py
+++ b/xdsl/dialects/ub.py
@@ -1,0 +1,86 @@
+"""
+The `ub` (undefined behavior) dialect.
+
+Mirrors MLIR's
+[UB dialect](https://mlir.llvm.org/docs/Dialects/UBOps/), which provides
+operations and attributes for representing deferred undefined behavior.
+"""
+
+from __future__ import annotations
+
+from xdsl.ir import Attribute, Dialect, ParametrizedAttribute
+from xdsl.irdl import (
+    IRDLOperation,
+    irdl_attr_definition,
+    irdl_op_definition,
+    prop_def,
+    result_def,
+    traits_def,
+)
+from xdsl.traits import ConstantLike, Pure
+
+
+@irdl_attr_definition
+class PoisonAttr(ParametrizedAttribute):
+    """
+    Attribute carrying poison semantics for `ub.poison`.
+
+    A default (empty) `#ub.poison` indicates a fully poisoned result. Other
+    attributes (e.g. partially poisoned vectors) may be used to indicate
+    additional poison semantics; in MLIR this is modelled via the
+    `PoisonAttrInterface`.
+    """
+
+    name = "ub.poison"
+
+
+@irdl_op_definition
+class PoisonOp(IRDLOperation):
+    """
+    Materializes a compile-time poisoned constant value to indicate deferred
+    undefined behavior.
+
+    The `value` attribute indicates optional additional poison semantics (e.g.
+    partially poisoned vectors); the default value indicates the result is
+    fully poisoned.
+
+    Examples:
+
+    ```mlir
+    // Short form (fully poisoned)
+    %0 = ub.poison : i32
+    // Long form (additional poison semantics)
+    %1 = ub.poison <#custom_poison_elements_attr> : vector<4xi64>
+    ```
+    """
+
+    name = "ub.poison"
+
+    value = prop_def(Attribute, default_value=PoisonAttr())
+
+    result = result_def()
+
+    traits = traits_def(ConstantLike(), Pure())
+
+    assembly_format = "attr-dict (`<` $value^ `>`)? `:` type($result)"
+
+    def __init__(
+        self,
+        result_type: Attribute,
+        value: Attribute | None = None,
+    ):
+        super().__init__(
+            result_types=[result_type],
+            properties={"value": value if value is not None else PoisonAttr()},
+        )
+
+
+UB = Dialect(
+    "ub",
+    [
+        PoisonOp,
+    ],
+    [
+        PoisonAttr,
+    ],
+)

--- a/xdsl/dialects/ub.py
+++ b/xdsl/dialects/ub.py
@@ -56,6 +56,10 @@ class PoisonOp(IRDLOperation):
 
     name = "ub.poison"
 
+    # MLIR constrains this to `PoisonAttrInterface` (an attribute interface).
+    # xDSL does not model that interface yet, so we accept any `Attribute` for
+    # now; this should be tightened to a `PoisonAttrInterface` check once the
+    # interface is available.
     value = prop_def(Attribute, default_value=PoisonAttr())
 
     result = result_def()

--- a/xdsl/dialects/ub.py
+++ b/xdsl/dialects/ub.py
@@ -75,7 +75,7 @@ class PoisonOp(IRDLOperation):
     ):
         super().__init__(
             result_types=[result_type],
-            properties={"value": value} if value is not None else {},
+            properties={"value": value},
         )
 
 

--- a/xdsl/dialects/ub.py
+++ b/xdsl/dialects/ub.py
@@ -71,7 +71,7 @@ class PoisonOp(IRDLOperation):
     ):
         super().__init__(
             result_types=[result_type],
-            properties={"value": value if value is not None else PoisonAttr()},
+            properties={"value": value} if value is not None else {},
         )
 
 


### PR DESCRIPTION
Adds an initial version of MLIR's ub (undefined behaviour) dialect with the poison operator and associated attribute.
