### PR TITLE
installation: (pre-commit) remove pyproject-fmt pin

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,5 +32,3 @@ repos:
     rev: "v2.23.0"
     hooks:
       - id: pyproject-fmt
-        # Pin broken transitive dependency for now
-        additional_dependencies: [toml-fmt-common<1.3.3]


### PR DESCRIPTION
Upstream issue is closed and this seems to work fine locally for me now.