### PR TITLE
dialects: (ub) Unreachable operator

### DIFF
--- a/tests/filecheck/dialects/ub/ops.mlir
+++ b/tests/filecheck/dialects/ub/ops.mlir
@@ -10,10 +10,13 @@
 // default `#ub.poison`, it is re-printed in the elided short form.
 // CHECK-NEXT:   %{{.*}} = ub.poison : f32
 %2 = ub.poison <#ub.poison> : f32
+// CHECK-NEXT:   ub.unreachable
+ub.unreachable
 // CHECK-NEXT: }
 
 // CHECK-GENERIC:      "builtin.module"() ({
 // CHECK-GENERIC-NEXT:   %{{.*}} = "ub.poison"() <{value = #ub.poison}> : () -> i32
 // CHECK-GENERIC-NEXT:   %{{.*}} = "ub.poison"() <{value = #ub.poison}> : () -> vector<4xi64>
 // CHECK-GENERIC-NEXT:   %{{.*}} = "ub.poison"() <{value = #ub.poison}> : () -> f32
+// CHECK-GENERIC-NEXT:   "ub.unreachable"() : () -> ()
 // CHECK-GENERIC-NEXT: }) : () -> ()

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/ub/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/ub/ops.mlir
@@ -17,4 +17,7 @@ builtin.module {
   // upstream to produce a non-elided spelling).
   // CHECK: %{{.*}} = ub.poison : f32
   %2 = ub.poison <#ub.poison> : f32
+
+  // CHECK: ub.unreachable
+  ub.unreachable
 }

--- a/xdsl/dialects/ub.py
+++ b/xdsl/dialects/ub.py
@@ -17,7 +17,7 @@ from xdsl.irdl import (
     result_def,
     traits_def,
 )
-from xdsl.traits import ConstantLike, Pure
+from xdsl.traits import ConstantLike, IsTerminator, Pure
 
 
 @irdl_attr_definition
@@ -79,10 +79,30 @@ class PoisonOp(IRDLOperation):
         )
 
 
+@irdl_op_definition
+class UnreachableOp(IRDLOperation):
+    """
+    Triggers immediate undefined behavior if executed.
+
+    Example:
+
+    ```mlir
+    ub.unreachable
+    ```
+    """
+
+    name = "ub.unreachable"
+
+    traits = traits_def(IsTerminator())
+
+    assembly_format = "attr-dict"
+
+
 UB = Dialect(
     "ub",
     [
         PoisonOp,
+        UnreachableOp,
     ],
     [
         PoisonAttr,


### PR DESCRIPTION
Adds the unreachable operator to the UB dialect. This is the second, and last, operator in the dialect so with this the dialect's operations and attribute now matches MLIR's (with the exception of the attrinterface)
