### PR TITLE
dialects: (x86) mov op is from GP to GP reg

### DIFF
--- a/xdsl/backend/x86/lowering/convert_func_to_x86_func.py
+++ b/xdsl/backend/x86/lowering/convert_func_to_x86_func.py
@@ -86,6 +86,7 @@ class LowerFuncOp(RewritePattern):
         for i, register_type in enumerate(reg_args_types):
             arg = first_block.args[i]
             register = first_block.insert_arg(register_type, i)
+            assert isinstance(register_type, GeneralRegisterType)
             mov_op = x86.DS_MovOp(
                 source=register, destination=register_type.unallocated()
             )
@@ -169,6 +170,7 @@ class LowerReturnOp(RewritePattern):
             )
 
         ret_unalloc = self.arch.register_type_for_type(return_value.type).unallocated()
+        assert isinstance(ret_unalloc, GeneralRegisterType)
         cast_op = builtin.UnrealizedConversionCastOp.get(
             (return_value,), (ret_unalloc,)
         )

--- a/xdsl/backend/x86/lowering/helpers.py
+++ b/xdsl/backend/x86/lowering/helpers.py
@@ -137,7 +137,7 @@ class Arch(StrEnum):
                         "Float precision must be half, single or double."
                     )
         else:
-            if not isinstance(reg_type := value.type, X86RegisterType):
+            if not isinstance(reg_type := value.type, GeneralRegisterType):
                 raise ValueError(f"Invalid type for move {value_type}")
             mov_op = x86.DS_MovOp(value, destination=type(reg_type).unallocated())
 

--- a/xdsl/dialects/x86/ops.py
+++ b/xdsl/dialects/x86/ops.py
@@ -1577,7 +1577,7 @@ class DS_MovOpHasCanonicalizationPatterns(HasCanonicalizationPatternsTrait):
 
 
 @irdl_op_definition
-class DS_MovOp(DS_Operation[X86RegisterType, GeneralRegisterType]):
+class DS_MovOp(DS_Operation[GeneralRegisterType, GeneralRegisterType]):
     """
     Copies the value of s into r.
     ```C


### PR DESCRIPTION
As far as I know, we can only use the mov op to move from a general-purpose register to another general-purpose register, this change reflects this.