### PR TITLE
dialects: (riscv_scf, x86_scf) generate for loop body if missing

### DIFF
--- a/tests/dialects/test_riscv_scf.py
+++ b/tests/dialects/test_riscv_scf.py
@@ -3,9 +3,10 @@ from collections.abc import Callable
 import pytest
 
 from xdsl import ir
+from xdsl.builder import ImplicitBuilder
 from xdsl.dialects import riscv, riscv_scf, test
 from xdsl.dialects.builtin import IntegerAttr
-from xdsl.dialects.riscv.attrs import i12
+from xdsl.dialects.riscv.attrs import I12, i12
 from xdsl.traits import (
     EffectInstance,
     MemoryEffect,
@@ -18,39 +19,48 @@ from xdsl.utils.test_value import create_ssa_value
 
 
 @pytest.mark.parametrize("loop_cls", [riscv_scf.ForOp, riscv_scf.RofOp])
-def test_for_rof_step(
+@pytest.mark.parametrize(
+    "step", [IntegerAttr(1, i12), create_ssa_value(riscv.Registers.A2)]
+)
+@pytest.mark.parametrize("iter_arg_types", [(), (riscv.Registers.T0,)])
+@pytest.mark.parametrize("gen_block", [True, False])
+def test_for_rof_init(
     loop_cls: type[riscv_scf.ForOp | riscv_scf.RofOp],
+    step: IntegerAttr[I12] | ir.SSAValue,
+    iter_arg_types: tuple[ir.Attribute, ...],
+    gen_block: bool,
 ):
     lb = create_ssa_value(riscv.Registers.A0)
     ub = create_ssa_value(riscv.Registers.A1)
-    step_val = create_ssa_value(riscv.Registers.A2)
-    step_attr = IntegerAttr(1, i12)
+    operands = tuple(create_ssa_value(t) for t in iter_arg_types)
+
+    if gen_block:
+        body = ir.Block(
+            arg_types=[riscv.Registers.A0, *iter_arg_types],
+        )
+    else:
+        body = None
 
     op = loop_cls(
         lb,
         ub,
-        step_val,
-        (),
-        ir.Block((riscv_scf.YieldOp(),), arg_types=[riscv.Registers.UNALLOCATED_INT]),
+        step,
+        operands,
+        body,
     )
+    assert op.body.block.arg_types == (riscv.Registers.A0, *iter_arg_types)
+    with ImplicitBuilder(op.body) as (_i, *args):
+        riscv_scf.YieldOp(*args)
     op.verify()
 
-    assert op.step_attr is None
-    assert op.step_val is step_val
-    assert op.step is step_val
+    if isinstance(step, ir.SSAValue):
+        assert op.step_attr is None
+        assert op.step_val is step
+    else:
+        assert op.step_attr is step
+        assert op.step_val is None
 
-    op = loop_cls(
-        lb,
-        ub,
-        step_attr,
-        (),
-        ir.Block((riscv_scf.YieldOp(),), arg_types=[riscv.Registers.UNALLOCATED_INT]),
-    )
-    op.verify()
-
-    assert op.step_attr is step_attr
-    assert op.step_val is None
-    assert op.step is step_attr
+    assert op.step is step
 
 
 @pytest.mark.parametrize("loop_cls", [riscv_scf.ForOp, riscv_scf.RofOp])

--- a/tests/dialects/test_x86_scf.py
+++ b/tests/dialects/test_x86_scf.py
@@ -3,6 +3,7 @@ from collections.abc import Callable
 import pytest
 
 from xdsl import ir
+from xdsl.builder import ImplicitBuilder
 from xdsl.dialects import test, x86, x86_scf
 from xdsl.traits import (
     EffectInstance,
@@ -13,6 +14,41 @@ from xdsl.traits import (
     get_effects,
 )
 from xdsl.utils.test_value import create_ssa_value
+
+
+@pytest.mark.parametrize("loop_cls", [x86_scf.ForOp, x86_scf.RofOp])
+@pytest.mark.parametrize("iter_arg_types", [(), (x86.registers.R11,)])
+@pytest.mark.parametrize("gen_block", [True, False])
+def test_for_rof_init(
+    loop_cls: type[x86_scf.ForOp | x86_scf.RofOp],
+    iter_arg_types: tuple[ir.Attribute, ...],
+    gen_block: bool,
+):
+    lb = create_ssa_value(x86.registers.R12)
+    ub = create_ssa_value(x86.registers.R13)
+    step = create_ssa_value(x86.registers.R10)
+    operands = tuple(create_ssa_value(t) for t in iter_arg_types)
+
+    if gen_block:
+        body = ir.Block(
+            arg_types=[x86.registers.R12, *iter_arg_types],
+        )
+    else:
+        body = None
+
+    op = loop_cls(
+        lb,
+        ub,
+        step,
+        operands,
+        body,
+    )
+    assert op.body.block.arg_types == (x86.registers.R12, *iter_arg_types)
+    with ImplicitBuilder(op.body) as (_i, *args):
+        x86_scf.YieldOp(*args)
+    op.verify()
+
+    assert op.step is step
 
 
 @pytest.mark.parametrize("loop_cls", [x86_scf.ForOp, x86_scf.RofOp])

--- a/tests/interpreters/test_riscv_scf_interpreter.py
+++ b/tests/interpreters/test_riscv_scf_interpreter.py
@@ -33,18 +33,17 @@ def sum_to_for_op():
     with ImplicitBuilder(func.FuncOp("sum_to", ((register,), (register,))).body) as (
         ub,
     ):
-        lb = rv32.LiOp(0)
-        step = rv32.LiOp(1)
-        initial = rv32.LiOp(0)
+        lb = rv32.LiOp(0).rd
+        step = rv32.LiOp(1).rd
+        initial = rv32.LiOp(0).rd
 
-        @Builder.implicit_region((register, register))
-        def for_loop_region(args: tuple[BlockArgument, ...]):
-            (i, acc) = args
+        func_op = riscv_scf.ForOp(lb, ub, step, (initial,))
+
+        with ImplicitBuilder(func_op.body) as (i, acc):
             res = riscv.AddOp(i, acc)
             riscv_scf.YieldOp(res)
 
-        result = riscv_scf.ForOp(lb, ub, step, (initial,), for_loop_region)
-        func.ReturnOp(result)
+        func.ReturnOp(*func_op.results)
 
 
 # Python implementation of `sum_to_while_op`

--- a/xdsl/dialects/riscv_scf.py
+++ b/xdsl/dialects/riscv_scf.py
@@ -94,9 +94,15 @@ class ForRofOperation(RegisterAllocatableOperation, IRDLOperation, ABC):
         lb: SSAValue | Operation,
         ub: SSAValue | Operation,
         step: SSAValue | Operation | IntegerAttr,
-        iter_args: Sequence[SSAValue | Operation],
-        body: Region | Sequence[Operation] | Sequence[Block] | Block,
+        iter_args: Sequence[SSAValue],
+        body: Region | Sequence[Operation] | Sequence[Block] | Block | None = None,
     ):
+        lb = SSAValue.get(lb)
+        if body is None:
+            body = Region(
+                Block(arg_types=(lb.type, *(iter_arg.type for iter_arg in iter_args)))
+            )
+
         if isinstance(body, Block):
             body = [body]
 

--- a/xdsl/dialects/x86_scf.py
+++ b/xdsl/dialects/x86_scf.py
@@ -73,9 +73,15 @@ class ForRofOperation(RegisterAllocatableOperation, IRDLOperation, ABC):
         lb: SSAValue | Operation,
         ub: SSAValue | Operation,
         step: SSAValue | Operation,
-        iter_args: Sequence[SSAValue | Operation],
-        body: Region | Sequence[Operation] | Sequence[Block] | Block,
+        iter_args: Sequence[SSAValue],
+        body: Region | Sequence[Operation] | Sequence[Block] | Block | None = None,
     ):
+        lb = SSAValue.get(lb)
+        if body is None:
+            body = Region(
+                Block(arg_types=(lb.type, *(iter_arg.type for iter_arg in iter_args)))
+            )
+
         if isinstance(body, Block):
             body = [body]
 


### PR DESCRIPTION
I've just hit a footgun in our current setup, where I forgot to pass in the type of the induction variable when creating the loop body's op. If we generate the body automatically, we can guarantee correctness of block arguments.
