### PR TITLE
core: (symbolTable) add symbol table lookup helper

### DIFF
--- a/tests/utils/test_symbol_table.py
+++ b/tests/utils/test_symbol_table.py
@@ -1,6 +1,6 @@
 import pytest
 
-from xdsl.dialects.builtin import IntegerAttr, ModuleOp, StringAttr
+from xdsl.dialects.builtin import IntegerAttr, ModuleOp, StringAttr, SymbolRefAttr
 from xdsl.dialects.test import TestOp, TestSymbolOp
 from xdsl.ir import Block, Region
 from xdsl.utils.symbol_table import (
@@ -289,12 +289,43 @@ def test_symbol_table_walk_symbol_tables():
 
 def test_symbol_table_lookup_symbol_in():
     """Test SymbolTable.lookup_symbol_in static method."""
-    test_op = TestOp()
-    symbol = StringAttr("test_symbol")
+    op_a = TestSymbolOp(properties={"sym_name": StringAttr("a")})
+    op_b = TestSymbolOp(properties={"sym_name": StringAttr("b")})
+    nested_symbol = TestSymbolOp(properties={"sym_name": StringAttr("nested")})
+    nested_private_symbol = TestSymbolOp(
+        properties={
+            "sym_name": StringAttr("private_nested"),
+            "sym_visibility": StringAttr("private"),
+        }
+    )
+    nested_table = ModuleOp(
+        [nested_symbol, nested_private_symbol], sym_name=StringAttr("nested_table")
+    )
+    non_table_root = TestSymbolOp(properties={"sym_name": StringAttr("non_table")})
+    module = ModuleOp([op_a, op_b, nested_table, non_table_root])
 
-    # This will raise NotImplementedError until implemented
-    with pytest.raises(NotImplementedError):
-        SymbolTable.lookup_symbol_in(test_op, symbol, all_symbols=False)
+    assert SymbolTable.lookup_symbol_in(module, "a") is op_a
+    assert SymbolTable.lookup_symbol_in(module, StringAttr("b")) is op_b
+    assert SymbolTable.lookup_symbol_in(module, "missing") is None
+    assert SymbolTable.lookup_symbol_in(module, "a", all_symbols=True) == [op_a]
+
+    assert (
+        SymbolTable.lookup_symbol_in(module, SymbolRefAttr("nested_table", ["nested"]))
+        is nested_symbol
+    )
+    assert (
+        SymbolTable.lookup_symbol_in(module, SymbolRefAttr("non_table", ["nested"]))
+        is None
+    )
+    assert (
+        SymbolTable.lookup_symbol_in(
+            module, SymbolRefAttr("nested_table", ["private_nested"])
+        )
+        is None
+    )
+    assert SymbolTable.lookup_symbol_in(
+        module, SymbolRefAttr("nested_table", ["nested"]), all_symbols=True
+    ) == [nested_table, nested_symbol]
 
 
 def test_symbol_table_lookup_nearest_symbol_from():

--- a/tests/utils/test_symbol_table.py
+++ b/tests/utils/test_symbol_table.py
@@ -307,6 +307,10 @@ def test_symbol_table_lookup_symbol_in():
     assert SymbolTable.lookup_symbol_in(module, "a") is op_a
     assert SymbolTable.lookup_symbol_in(module, StringAttr("b")) is op_b
     assert SymbolTable.lookup_symbol_in(module, "missing") is None
+    assert (
+        SymbolTable.lookup_symbol_in(module, SymbolRefAttr("missing", ["nested"]))
+        is None
+    )
     assert SymbolTable.lookup_symbol_in(module, "a", all_symbols=True) == [op_a]
 
     assert (

--- a/xdsl/utils/symbol_table.py
+++ b/xdsl/utils/symbol_table.py
@@ -4,7 +4,7 @@ Helper methods and classes to reason about operations that refer to other operat
 
 from __future__ import annotations
 
-from collections.abc import Iterator, Mapping, Sequence
+from collections.abc import Callable, Iterator, Mapping, Sequence
 from typing import Literal, NamedTuple, overload
 
 from xdsl import traits
@@ -215,7 +215,7 @@ class SymbolTable:
         op: Operation,
         symbol: StringAttr | SymbolRefAttr | str,
         *,
-        all_symbols: Literal[False],
+        all_symbols: Literal[False] = False,
     ) -> Operation | None: ...
 
     @staticmethod
@@ -231,7 +231,19 @@ class SymbolTable:
         `op` is required to be an operation with the 'xdsl.traits.SymbolTable' trait.
         If `all_symbols` is `True`, returns all symbols referenced by the symbol.
         """
-        raise NotImplementedError
+        assert op.get_trait(traits.SymbolTable) is not None, (
+            "Expected operation to have SymbolTable trait"
+        )
+        if isinstance(symbol, str | StringAttr):
+            symbol_op = _lookup_symbol_in_direct_children(op, symbol)
+            if all_symbols:
+                return [symbol_op] if symbol_op is not None else None
+            return symbol_op
+
+        symbols = _lookup_symbol_ref_in(op, symbol, _lookup_symbol_in_direct_children)
+        if symbols is None:
+            return None
+        return symbols if all_symbols else symbols[-1]
 
     @staticmethod
     def lookup_nearest_symbol_from(
@@ -287,6 +299,42 @@ class SymbolTable:
         uses are replaced and `False` is returned.
         """
         raise NotImplementedError
+
+
+def _lookup_symbol_in_direct_children(
+    symbol_table_op: Operation, symbol: StringAttr | str
+) -> Operation | None:
+    symbol_name = symbol.data if isinstance(symbol, StringAttr) else symbol
+    block = symbol_table_op.regions[0].blocks[0]
+    for op in block.ops:
+        if get_name_if_symbol(op) == symbol_name:
+            return op
+    return None
+
+
+def _lookup_symbol_ref_in(
+    symbol_table_op: Operation,
+    symbol: SymbolRefAttr,
+    lookup_symbol: Callable[[Operation, StringAttr], Operation | None],
+) -> list[Operation] | None:
+    symbol_op = lookup_symbol(symbol_table_op, symbol.root_reference)
+    if symbol_op is None:
+        return None
+
+    symbols = [symbol_op]
+    for nested_reference in symbol.nested_references.data:
+        if not symbol_op.has_trait(traits.SymbolTable, value_if_unregistered=False):
+            return None
+
+        symbol_op = lookup_symbol(symbol_op, nested_reference)
+        if (
+            symbol_op is None
+            or SymbolTable.get_symbol_visibility(symbol_op) is Visibility.PRIVATE
+        ):
+            return None
+        symbols.append(symbol_op)
+
+    return symbols
 
 
 class SymbolTableCollection:


### PR DESCRIPTION
This PR implements `lookup_symbol_in` method for SymbolTable class. Two helper methods `_lookup_symbol_in_direct_children` and `_lookup_symbol_ref_in` was introduced to make logic flow clearer.

`_lookup_symbol_ref_in` takes a function `lookup_symbol` as a parameter, instead of hardcode to `_lookup_symbol_in_direct_children`. This might seems not neccessary at this stage, but it is needed because in the following patches we will reuse this method for symbolTableCollection.