### PR TITLE
dialects: (builtin) Fix TensorType.constr type hint

### DIFF
--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -1668,7 +1668,7 @@ class TensorType(
     @staticmethod
     def constr(
         element_type: IRDLAttrConstraint[AttributeInvT] | None = None,
-        shape: IRDLAttrConstraint[AttributeInvT] | None = None,
+        shape: IRDLAttrConstraint[ArrayAttr[IntAttr]] | None = None,
     ) -> AttrConstraint[TensorType[AttributeInvT]]:
         return cast(
             AttrConstraint[TensorType[AttributeInvT]],

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -1668,7 +1668,7 @@ class TensorType(
     @staticmethod
     def constr(
         element_type: IRDLAttrConstraint[AttributeInvT] | None = None,
-        shape: IRDLAttrConstraint[ArrayAttr[IntAttr]] | None = None,
+        shape: IRDLAttrConstraint | None = None,
     ) -> AttrConstraint[TensorType[AttributeInvT]]:
         return cast(
             AttrConstraint[TensorType[AttributeInvT]],


### PR DESCRIPTION
This was incorrectly giving the type inference:
`TensorType.constr(i64, ArrayOfConstraint(RangeOf(IntAttr).of_length(4)))` -> `AttrConstraint[TensorType[I64 | ArrayAttr[IntAttr[int]]]]`
instead of just `AttrConstraint[TensorType[I64]]` as it should be.