### PR TITLE
core: (IR) Improve ParameterizedAttribute verify exception messages

### DIFF
--- a/tests/irdl/test_attribute_definition.py
+++ b/tests/irdl/test_attribute_definition.py
@@ -9,7 +9,7 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from enum import auto
 from io import StringIO
-from typing import Annotated, ClassVar, Generic, TypeAlias
+from typing import Annotated, ClassVar, Generic, TypeAlias, cast
 
 import pytest
 from typing_extensions import TypeVar, override
@@ -473,6 +473,59 @@ def test_typed_attribute_parsing_printing():
     assert attr == TypedAttr(IntAttr(42), i32)
 
     assert str(attr) == "#test.typed<42> : i32"
+
+
+################################################################################
+# Parameterized Attribute
+################################################################################
+
+
+def test_parameterized_attribute_verify_called():
+    """Test that a custom verify method of a ParametrizedAttribute is called."""
+
+    @irdl_attr_definition
+    class MyAttr(ParametrizedAttribute):
+        name = "test.my_attr"
+
+        def verify(self):
+            raise VerifyException("Always fails")
+
+    with pytest.raises(VerifyException, match="Always fails"):
+        MyAttr()
+
+
+def test_parameterized_attribute_verify_constraints():
+    """Test that a ParametrizedAttribute verifies its given child attribute constraints."""
+
+    class FailConstraint(AttrConstraint[NoneAttr]):
+        def verify(self, attr: Attribute, constraint_context: ConstraintContext):
+            raise VerifyException("Always fails")
+
+        def mapping_type_vars(
+            self, type_var_mapping: Mapping[TypeVar, AttrConstraint | IntConstraint]
+        ) -> FailConstraint:
+            return self
+
+    @irdl_attr_definition
+    class MyAttr(ParametrizedAttribute):
+        name = "test.my_attr"
+
+        child_1: NoneAttr
+        child_2: NoneAttr = param_def(FailConstraint())
+
+    with pytest.raises(
+        VerifyException,
+        match=re.escape(
+            "parameter 'child_1' does not verify:\n#builtin.int<1> should be of base attribute none"
+        ),
+    ):
+        MyAttr(cast(NoneAttr, IntAttr(1)), NoneAttr())
+
+    with pytest.raises(
+        VerifyException,
+        match=re.escape("parameter 'child_2' does not verify:\nAlways fails"),
+    ):
+        MyAttr(NoneAttr(), NoneAttr())
 
 
 ################################################################################

--- a/xdsl/irdl/attributes.py
+++ b/xdsl/irdl/attributes.py
@@ -46,7 +46,11 @@ from xdsl.ir import (
     TypedAttribute,
 )
 from xdsl.utils.classvar import is_const_classvar
-from xdsl.utils.exceptions import PyRDLAttrDefinitionError, PyRDLTypeError
+from xdsl.utils.exceptions import (
+    PyRDLAttrDefinitionError,
+    PyRDLTypeError,
+    VerifyException,
+)
 from xdsl.utils.hints import (
     PropertyType,
     get_type_var_from_generic_class,
@@ -281,7 +285,12 @@ class ParamAttrDef:
 
         constraint_context = ConstraintContext()
         for field, param_def in self.parameters:
-            param_def.constr.verify(getattr(attr, field), constraint_context)
+            try:
+                param_def.constr.verify(getattr(attr, field), constraint_context)
+            except VerifyException as e:
+                raise VerifyException(
+                    f"parameter '{field}' does not verify:\n{e}"
+                ) from e
 
 
 _PAttrTT = TypeVar("_PAttrTT", bound=type[ParametrizedAttribute])


### PR DESCRIPTION
Adds some better exception message generation for parameterised attributes to specify which parameter's constraint caused the failure. 

Co-authored by @asb-rvl
