### PR TITLE
transformations: (x86-regalloc-verify-liveness) rename from verify-register-allocation

### DIFF
--- a/tests/filecheck/backend/x86/x86_regalloc_verify_liveness.mlir
+++ b/tests/filecheck/backend/x86/x86_regalloc_verify_liveness.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -p verify-register-allocation --verify-diagnostics --split-input-file %s | filecheck %s
+// RUN: xdsl-opt -p x86-regalloc-verify-liveness --verify-diagnostics --split-input-file %s | filecheck %s
 
 // CHECK-LABEL:    @inc
 x86_func.func @inc(%ptr: !x86.reg64<rax>) {

--- a/xdsl/backend/register_allocatable.py
+++ b/xdsl/backend/register_allocatable.py
@@ -101,7 +101,7 @@ class HasRegisterConstraints(RegisterAllocatableOperation, abc.ABC):
     Abstract superclass for operations corresponding to assembly, with registers used
     as in, out, or inout registers.
     The use of a register value as inout must be its last use (externally verified,
-    e.g. for x86 see pass verify-register-allocation).
+    e.g. for x86 see pass x86-regalloc-verify-liveness).
     """
 
     traits = traits_def(HasRegisterConstraintsTrait())

--- a/xdsl/transforms/__init__.py
+++ b/xdsl/transforms/__init__.py
@@ -657,25 +657,25 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
 
         return x86_allocate_registers.X86AllocateRegisters
 
-    def get_x86_prologue_epilogue_insertion():
-        from xdsl.backend.x86 import prologue_epilogue_insertion
+    def get_x86_infer_broadcast():
+        from xdsl.transforms import x86_infer_broadcast
 
-        return prologue_epilogue_insertion.X86PrologueEpilogueInsertion
+        return x86_infer_broadcast.X86InferBroadcast
 
     def get_x86_legalize_for_regalloc():
         from xdsl.transforms import x86_legalize_for_regalloc
 
         return x86_legalize_for_regalloc.X86LegalizeForRegallocPass
 
-    def get_x86_infer_broadcast():
-        from xdsl.transforms import x86_infer_broadcast
+    def get_x86_prologue_epilogue_insertion():
+        from xdsl.backend.x86 import prologue_epilogue_insertion
 
-        return x86_infer_broadcast.X86InferBroadcast
+        return prologue_epilogue_insertion.X86PrologueEpilogueInsertion
 
-    def get_verify_register_allocation():
-        from xdsl.transforms import verify_register_allocation
+    def get_x86_regalloc_verify_liveness():
+        from xdsl.transforms import x86_regalloc_verify_liveness
 
-        return verify_register_allocation.VerifyRegisterAllocationPass
+        return x86_regalloc_verify_liveness.X86RegallocVerifyLiveness
 
     # Please insert pass and `get_` function in alphabetical order
 
@@ -809,8 +809,8 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
         "varith-fuse-repeated-operands": get_varith_fuse_repeated_operands,
         "vector-split-load-extract": get_vector_split_load_extract,
         "x86-allocate-registers": get_x86_allocate_registers,
-        "x86-prologue-epilogue-insertion": get_x86_prologue_epilogue_insertion,
-        "x86-legalize-for-regalloc": get_x86_legalize_for_regalloc,
         "x86-infer-broadcast": get_x86_infer_broadcast,
-        "verify-register-allocation": get_verify_register_allocation,
+        "x86-legalize-for-regalloc": get_x86_legalize_for_regalloc,
+        "x86-prologue-epilogue-insertion": get_x86_prologue_epilogue_insertion,
+        "x86-regalloc-verify-liveness": get_x86_regalloc_verify_liveness,
     }

--- a/xdsl/transforms/__init__.py
+++ b/xdsl/transforms/__init__.py
@@ -675,7 +675,7 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
     def get_x86_regalloc_verify_liveness():
         from xdsl.transforms import x86_regalloc_verify_liveness
 
-        return x86_regalloc_verify_liveness.X86RegallocVerifyLiveness
+        return x86_regalloc_verify_liveness.X86RegallocVerifyLivenessPass
 
     # Please insert pass and `get_` function in alphabetical order
 

--- a/xdsl/transforms/x86_regalloc_verify_liveness.py
+++ b/xdsl/transforms/x86_regalloc_verify_liveness.py
@@ -10,7 +10,7 @@ from xdsl.utils.exceptions import VerifyException
 
 
 @dataclass(frozen=True)
-class X86RegallocVerifyLiveness(ModulePass):
+class X86RegallocVerifyLivenessPass(ModulePass):
     """
     Verify that, assuming the dominance property is respected, the
     use of a register value as inout is its last use.

--- a/xdsl/transforms/x86_regalloc_verify_liveness.py
+++ b/xdsl/transforms/x86_regalloc_verify_liveness.py
@@ -10,15 +10,15 @@ from xdsl.utils.exceptions import VerifyException
 
 
 @dataclass(frozen=True)
-class VerifyRegisterAllocationPass(ModulePass):
+class X86RegallocVerifyLiveness(ModulePass):
     """
     Verify that, assuming the dominance property is respected, the
     use of a register value as inout is its last use.
     """
 
-    name = "verify-register-allocation"
+    name = "x86-regalloc-verify-liveness"
 
-    def _process_region(self, region: Region, alive: set[SSAValue] = set()) -> None:
+    def _process_region(self, region: Region, alive: set[SSAValue]) -> None:
         alive_card = len(alive)
         if not region.blocks:
             return
@@ -46,4 +46,4 @@ class VerifyRegisterAllocationPass(ModulePass):
         assert alive_card == len(alive)
 
     def apply(self, ctx: Context, op: builtin.ModuleOp) -> None:
-        self._process_region(op.body)
+        self._process_region(op.body, set())


### PR DESCRIPTION
I'd like to make the naming of passes more consistent so that they're easier to find. This also fixes a bug I'll comment on in the diff.