### PR TITLE
testing: use substitution for mlir-translate in lit

### DIFF
--- a/.github/workflows/ci-mlir.yml
+++ b/.github/workflows/ci-mlir.yml
@@ -23,6 +23,7 @@ jobs:
     env:
       LLVM_SYMBOLIZER_PATH: /usr/lib/llvm-11/bin/llvm-symbolizer
       COLLECT_COVERAGE: ${{ matrix.python-version == '3.13' }}
+      XDSL_MLIR_TRANSLATE: /usr/bin/mlir-translate
       XDSL_LLVM_DIFF: /usr/bin/llvm-diff-22
     steps:
       - uses: actions/checkout@v6
@@ -58,7 +59,7 @@ jobs:
         run: |
           # Add decoy executables that should be XDSL_ env vars in tests instead
           FAKE_BIN=$(mktemp -d)
-          for tool in llvm-diff; do
+          for tool in mlir-translate llvm-diff; do
             printf '%s\n' '#!/bin/sh' "echo \"bare $tool on PATH forbidden; use lit substitution\" >&2" 'exit 1' > "$FAKE_BIN/$tool"
             chmod +x "$FAKE_BIN/$tool"
           done

--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,7 @@
                 llvmPackages_22.mlir
                 llvmPackages_22.tblgen
               ];
+              XDSL_MLIR_TRANSLATE = "${llvmPackages_22.mlir}/bin/mlir-translate";
               XDSL_LLVM_DIFF = "${llvmPackages_22.llvm}/bin/llvm-diff";
             };
           }

--- a/tests/filecheck/mlir-conversion/with-mlir/backend/llvm/convert_op.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/backend/llvm/convert_op.mlir
@@ -1,1 +1,2 @@
-// RUN: xdsl-opt %S/../../../../backend/llvm/convert_op.mlir | mlir-translate --mlir-to-llvmir > /dev/null
+// REQUIRES: MLIR_TRANSLATE
+// RUN: xdsl-opt %S/../../../../backend/llvm/convert_op.mlir | $XDSL_MLIR_TRANSLATE --mlir-to-llvmir > /dev/null

--- a/tests/filecheck/mlir-conversion/with-mlir/backend/llvm/lit.local.cfg
+++ b/tests/filecheck/mlir-conversion/with-mlir/backend/llvm/lit.local.cfg
@@ -1,7 +1,0 @@
-import os
-import re
-
-llvm_diff = os.environ.get("XDSL_LLVM_DIFF")
-if llvm_diff:
-    config.available_features.add("LLVM_DIFF")
-    config.substitutions.append((re.escape("$XDSL_LLVM_DIFF"), llvm_diff))

--- a/tests/filecheck/mlir-conversion/with-mlir/backend/llvm/mlir_translate_convert_op_llvmdiff.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/backend/llvm/mlir_translate_convert_op_llvmdiff.mlir
@@ -1,4 +1,4 @@
-// REQUIRES: LLVM_DIFF
+// REQUIRES: MLIR_TRANSLATE, LLVM_DIFF
 // RUN: xdsl-opt -t llvm %S/../../../../backend/llvm/convert_op.mlir > %t.xdsl.ll
-// RUN: mlir-translate --mlir-to-llvmir %S/../../../../backend/llvm/convert_op.mlir > %t.mlir.ll
+// RUN: $XDSL_MLIR_TRANSLATE --mlir-to-llvmir %S/../../../../backend/llvm/convert_op.mlir > %t.mlir.ll
 // RUN: $XDSL_LLVM_DIFF %t.xdsl.ll %t.mlir.ll

--- a/tests/filecheck/mlir-conversion/with-mlir/backend/llvm/module.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/backend/llvm/module.mlir
@@ -1,1 +1,2 @@
-// RUN: xdsl-opt %S/../../../../backend/llvm/module.mlir | mlir-translate --mlir-to-llvmir > /dev/null
+// REQUIRES: MLIR_TRANSLATE
+// RUN: xdsl-opt %S/../../../../backend/llvm/module.mlir | $XDSL_MLIR_TRANSLATE --mlir-to-llvmir > /dev/null

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/func.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/func.mlir
@@ -1,7 +1,8 @@
+// REQUIRES: MLIR_TRANSLATE
 // RUN: MLIR_ROUNDTRIP
 // RUN: MLIR_GENERIC_ROUNDTRIP
 // RUN: xdsl-opt %s --print-debuginfo | mlir-opt --allow-unregistered-dialect --mlir-print-local-scope | xdsl-opt --print-debuginfo | filecheck %s --check-prefix=CHECK-DEBUG-INFO
-// RUN: xdsl-opt %s | mlir-translate --mlir-to-llvmir > /dev/null
+// RUN: xdsl-opt %s | $XDSL_MLIR_TRANSLATE --mlir-to-llvmir > /dev/null
 
 // This test checks that the llvm.func operation can be parse the following
 // properties.

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/func_props.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/func_props.mlir
@@ -1,8 +1,9 @@
+// REQUIRES: MLIR_TRANSLATE
 // RUN: XDSL_ROUNDTRIP
 // RUN: MLIR_ROUNDTRIP
 // RUN: XDSL_GENERIC_ROUNDTRIP
 // RUN: MLIR_GENERIC_ROUNDTRIP
-// RUN: xdsl-opt %s | mlir-translate --mlir-to-llvmir > /dev/null
+// RUN: xdsl-opt %s | $XDSL_MLIR_TRANSLATE --mlir-to-llvmir > /dev/null
 
 llvm.func @func_vis0_unnameaddr0()
 

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/global.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/global.mlir
@@ -1,6 +1,7 @@
+// REQUIRES: MLIR_TRANSLATE
 // RUN: MLIR_ROUNDTRIP
 // RUN: MLIR_GENERIC_ROUNDTRIP
-// RUN: xdsl-opt %s | mlir-translate --mlir-to-llvmir > /dev/null
+// RUN: xdsl-opt %s | $XDSL_MLIR_TRANSLATE --mlir-to-llvmir > /dev/null
 builtin.module {
   llvm.mlir.global internal constant @str0("Hello world!") {addr_space = 0 : i32} : !llvm.array<12 x i8>
   llvm.mlir.global internal constant @data(0 : i32) {addr_space = 0 : i32} : i32

--- a/tests/filecheck/mlir-conversion/with-mlir/lit.local.cfg
+++ b/tests/filecheck/mlir-conversion/with-mlir/lit.local.cfg
@@ -1,7 +1,18 @@
 import shutil
+import os
+import re
 
 config.substitutions.append(('MLIR_ROUNDTRIP', "xdsl-opt %s | mlir-opt --allow-unregistered-dialect | xdsl-opt | filecheck %s"))
 config.substitutions.append(("MLIR_GENERIC_ROUNDTRIP", "xdsl-opt %s --print-op-generic | mlir-opt --mlir-print-op-generic --allow-unregistered-dialect --mlir-print-local-scope | xdsl-opt | filecheck %s"))
 
 if not shutil.which("mlir-opt"):
     config.unsupported = True
+mlir_translate = os.environ.get("XDSL_MLIR_TRANSLATE")
+if mlir_translate:
+    config.available_features.add("MLIR_TRANSLATE")
+    config.substitutions.append((re.escape("$XDSL_MLIR_TRANSLATE"), mlir_translate))
+
+llvm_diff = os.environ.get("XDSL_LLVM_DIFF")
+if llvm_diff:
+    config.available_features.add("LLVM_DIFF")
+    config.substitutions.append((re.escape("$XDSL_LLVM_DIFF"), llvm_diff))


### PR DESCRIPTION
Uses same mechanism as for llvm-diff (#6168), and similarly adds decoy mlir-translate executable to CI.
