### PR TITLE
core: (SymbolTableCollection) add cached symbol table lookup helper

### DIFF
--- a/tests/utils/test_symbol_table.py
+++ b/tests/utils/test_symbol_table.py
@@ -412,13 +412,33 @@ def test_symbol_table_collection_init():
 
 
 def test_symbol_table_collection_lookup_symbol_in():
-    """Test SymbolTableCollection.lookup_symbol_in static method."""
-    test_op = TestOp()
-    symbol = StringAttr("test_symbol")
+    """Test SymbolTableCollection.lookup_symbol_in method."""
+    op_a = TestSymbolOp(properties={"sym_name": StringAttr("a")})
+    nested_symbol = TestSymbolOp(properties={"sym_name": StringAttr("nested")})
+    nested_table = ModuleOp([nested_symbol], sym_name=StringAttr("nested_table"))
+    module = ModuleOp([op_a, nested_table])
+    collection = SymbolTableCollection()
 
-    # This will raise NotImplementedError until implemented
-    with pytest.raises(NotImplementedError):
-        SymbolTableCollection.lookup_symbol_in(test_op, symbol, all_symbols=False)
+    assert collection.lookup_symbol_in(module, "a") is op_a
+    cached_module_table = collection.symbol_tables[module]
+    assert collection.lookup_symbol_in(module, StringAttr("a")) is op_a
+    assert collection.lookup_symbol_in(module, "missing") is None
+    assert collection.lookup_symbol_in(module, "a", all_symbols=True) == [op_a]
+    assert collection.lookup_symbol_in(module, "missing", all_symbols=True) is None
+    assert collection.symbol_tables[module] is cached_module_table
+
+    assert (
+        collection.lookup_symbol_in(module, SymbolRefAttr("missing", ["nested"]))
+        is None
+    )
+    assert (
+        collection.lookup_symbol_in(module, SymbolRefAttr("nested_table", ["nested"]))
+        is nested_symbol
+    )
+    assert collection.lookup_symbol_in(
+        module, SymbolRefAttr("nested_table", ["nested"]), all_symbols=True
+    ) == [nested_table, nested_symbol]
+    assert nested_table in collection.symbol_tables
 
 
 def test_symbol_table_collection_lookup_nearest_symbol_from():

--- a/xdsl/utils/symbol_table.py
+++ b/xdsl/utils/symbol_table.py
@@ -358,8 +358,8 @@ class SymbolTableCollection:
         return self._symbol_tables
 
     @overload
-    @staticmethod
     def lookup_symbol_in(
+        self,
         op: Operation,
         symbol: StringAttr | SymbolRefAttr | str,
         *,
@@ -367,16 +367,16 @@ class SymbolTableCollection:
     ) -> list[Operation] | None: ...
 
     @overload
-    @staticmethod
     def lookup_symbol_in(
+        self,
         op: Operation,
         symbol: StringAttr | SymbolRefAttr | str,
         *,
-        all_symbols: Literal[False],
+        all_symbols: Literal[False] = False,
     ) -> Operation | None: ...
 
-    @staticmethod
     def lookup_symbol_in(
+        self,
         op: Operation,
         symbol: StringAttr | SymbolRefAttr | str,
         *,
@@ -389,7 +389,22 @@ class SymbolTableCollection:
         `op` is required to be an operation with the 'xdsl.traits.SymbolTable' trait.
         If `all_symbols` is `True`, returns all symbols referenced by the symbol.
         """
-        raise NotImplementedError
+        if isinstance(symbol, str | StringAttr):
+            symbol_op = self.get_symbol_table(op).lookup(symbol)
+            if all_symbols:
+                return [symbol_op] if symbol_op is not None else None
+            return symbol_op
+
+        symbols = _lookup_symbol_ref_in(
+            op,
+            symbol,
+            lambda symbol_table_op, name: self.get_symbol_table(symbol_table_op).lookup(
+                name
+            ),
+        )
+        if symbols is None:
+            return None
+        return symbols if all_symbols else symbols[-1]
 
     @staticmethod
     def lookup_nearest_symbol_from(


### PR DESCRIPTION
This PR implements the cached symbol table lookup method `lookup_symbol_in` for SymbolTableCollection.