### PR TITLE
core: (irdl) don't use type.__new__ for attributes

### DIFF
--- a/xdsl/interpreters/irdl.py
+++ b/xdsl/interpreters/irdl.py
@@ -25,7 +25,6 @@ from xdsl.irdl import (
     ResultDef,
     VarConstraint,
     get_accessors_from_op_def,
-    get_accessors_from_param_attr_def,
 )
 from xdsl.traits import SymbolTable
 
@@ -163,9 +162,12 @@ class IRDLFunctions(InterpreterFunctions):
 
         attr = self.get_attr(interpreter, name)
         attr_def = self._get_attr_def(interpreter, name)
-        to_inject = get_accessors_from_param_attr_def(attr_def)
-        for k, v in to_inject.items():
-            setattr(attr, k, v)
+
+        @classmethod
+        def get_irdl_definition(cls: type[ParametrizedAttribute]):
+            return attr_def
+
+        setattr(attr, "get_irdl_definition", get_irdl_definition)
         return ()
 
     @impl(irdl.OperandsOp)

--- a/xdsl/irdl/attributes.py
+++ b/xdsl/irdl/attributes.py
@@ -296,19 +296,16 @@ class ParamAttrDef:
 _PAttrTT = TypeVar("_PAttrTT", bound=type[ParametrizedAttribute])
 
 
-def get_accessors_from_param_attr_def(attr_def: ParamAttrDef) -> dict[str, Any]:
-    @classmethod
-    def get_irdl_definition(cls: type[ParametrizedAttribute]):
-        return attr_def
-
-    return {"get_irdl_definition": get_irdl_definition}
-
-
 def irdl_param_attr_definition(cls: _PAttrTT) -> _PAttrTT:
     """Decorator used on classes to define a new attribute definition."""
 
     attr_def = ParamAttrDef.from_pyrdl(cls)
-    new_fields = get_accessors_from_param_attr_def(attr_def)
+
+    @classmethod
+    def get_irdl_definition(cls: type[ParametrizedAttribute]):
+        return attr_def
+
+    cls.get_irdl_definition = get_irdl_definition
 
     if issubclass(cls, TypedAttribute):
         type_indexes = tuple(
@@ -324,18 +321,9 @@ def irdl_param_attr_definition(cls: _PAttrTT) -> _PAttrTT:
         def get_type_index(cls: Any) -> int:
             return type_index
 
-        new_fields["get_type_index"] = get_type_index
+        setattr(cls, "get_type_index", get_type_index)
 
-    return runtime_final(
-        dataclass(frozen=True, init=False)(
-            type.__new__(
-                type(cls),
-                cls.__name__,
-                (cls,),
-                {**cls.__dict__, **new_fields},
-            )
-        )
-    )
+    return runtime_final(dataclass(frozen=True, init=False)(cls))
 
 
 TypeAttributeInvT = TypeVar("TypeAttributeInvT", bound=type[Attribute])


### PR DESCRIPTION
It's been bugging me for a long time, I think we can get away with just updating fields of the decorated classes, which will make the code a little less spooky and hopefully also more performant.

I'm doing this now due to a bug @osmanyasar05 hit in the operation creation where the mro of a class contains a plain generic (#5589, https://github.com/xdslproject/xdsl/pull/5589/changes/BASE..47ca258b6d9df0867dd167ad285eade5e6435916#r3412999735). If everyone is happy with this I'll try to do the same for operations also.