### PR TITLE
utils: (Worklist) make generic and move to utils

### DIFF
--- a/benchmarks/rewriting.py
+++ b/benchmarks/rewriting.py
@@ -16,7 +16,7 @@ from xdsl.ir import Region
 from xdsl.ir.post_order import PostOrderIterator
 from xdsl.irdl import VarIRConstruct, verify_variadic_size
 from xdsl.parser import Parser as XdslParser
-from xdsl.pattern_rewriter import PatternRewriter, Worklist
+from xdsl.pattern_rewriter import PatternRewriter
 from xdsl.rewriter import InsertPoint
 from xdsl.traits import (
     HasCanonicalizationPatternsTrait,
@@ -34,6 +34,7 @@ from xdsl.transforms.test_constant_folding import (
     TestConstantFoldingPass,
     TestSpecialisedConstantFoldingPass,
 )
+from xdsl.utils.worklist import Worklist
 
 CTX = Context(allow_unregistered=True)
 CTX.load_dialect(Arith)

--- a/tests/pattern_rewriter/test_worklist.py
+++ b/tests/pattern_rewriter/test_worklist.py
@@ -1,3 +1,5 @@
+import pytest
+
 from xdsl.dialects import test
 from xdsl.pattern_rewriter import Worklist
 
@@ -22,9 +24,9 @@ def test_worklist_push_pop():
     assert worklist.pop() is op4
     assert worklist.pop() is op3
     assert worklist.pop() is op1
-    assert worklist.is_empty()
-    assert worklist.pop() is None
-    assert worklist.is_empty()
+    assert not worklist
+    with pytest.raises(IndexError, match="pop from empty worklist"):
+        worklist.pop()
 
 
 def test_worklist_push_already_inserted():
@@ -41,9 +43,9 @@ def test_worklist_push_already_inserted():
 
     assert worklist.pop() is op2
     assert worklist.pop() is op1
-    assert worklist.is_empty()
-    assert worklist.pop() is None
-    assert worklist.is_empty()
+    assert not worklist
+    with pytest.raises(IndexError, match="pop from empty worklist"):
+        worklist.pop()
 
 
 def test_worklist_remove():
@@ -66,6 +68,37 @@ def test_worklist_remove():
 
     assert worklist.pop() is op4
     assert worklist.pop() is op3
-    assert worklist.is_empty()
+    assert not worklist
+    with pytest.raises(IndexError, match="pop from empty worklist"):
+        worklist.pop()
+
+
+def test_worklist_non_default():
+    worklist = Worklist[int]()
+
+    worklist.push(1)
+    worklist.push(2)
+    assert worklist.pop() == 2
+    assert worklist.pop() == 1
+    assert not worklist
+
+
+def test_worklist_with_none():
+    worklist = Worklist[int | None]()
+
+    worklist.push(None)
+    worklist.push(1)
+    assert worklist.pop() == 1
     assert worklist.pop() is None
-    assert worklist.is_empty()
+
+    with pytest.raises(IndexError, match="pop from empty worklist"):
+        worklist.pop()
+
+    worklist.push(1)
+    worklist.push(None)
+    worklist.push(2)
+    worklist.remove(None)
+
+    assert worklist.pop() == 2
+    assert worklist.pop() == 1
+    assert not worklist

--- a/tests/utils/test_worklist.py
+++ b/tests/utils/test_worklist.py
@@ -1,7 +1,7 @@
 import pytest
 
 from xdsl.dialects import test
-from xdsl.pattern_rewriter import Worklist
+from xdsl.utils.worklist import Worklist
 
 
 def test_worklist_push_pop():

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -6,9 +6,9 @@ from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass, field
 from functools import wraps
 from types import UnionType
-from typing import Union, final, get_args, get_origin
+from typing import Generic, Union, final, get_args, get_origin
 
-from typing_extensions import TypeVar, deprecated
+from typing_extensions import Sentinel, TypeVar, deprecated
 
 from xdsl.builder import Builder, BuilderListener, InsertOpInvT
 from xdsl.context import Context
@@ -602,58 +602,60 @@ class GreedyRewritePatternApplier(RewritePattern):
         return
 
 
+_T = TypeVar("_T", default=Operation)
+
+_MISSING = Sentinel("_MISSING")
+
+
 @dataclass(eq=False)
-class Worklist:
-    _op_stack: list[Operation | None] = field(
-        default_factory=list[Operation | None], init=False
-    )
+class Worklist(Generic[_T]):
+    _stack: list[_T | _MISSING] = field(default_factory=list[_T | _MISSING], init=False)
     """
-    The list of operations to iterate over, used as a last-in-first-out stack.
-    Operations are added and removed at the end of the list.
-    Operation that are `None` are meant to be discarded, and are used to
-    keep removal of operations O(1).
+    The list of items to iterate over, used as a last-in-first-out stack.
+    Items are added and removed at the end of the list.
+    Items that are `_MISSING` are meant to be discarded, and are used to
+    keep removal of items O(1).
     """
 
-    _map: dict[Operation, int] = field(default_factory=dict[Operation, int], init=False)
+    _map: dict[_T, int] = field(default_factory=dict[_T, int], init=False)
     """
-    The map of operations to their index in the stack.
-    It is used to check if an operation is already in the stack, and to
+    The map of items to their index in the stack.
+    It is used to check if an item is already in the stack, and to
     remove it in O(1).
     """
 
-    def is_empty(self) -> bool:
-        """Check if the worklist is empty."""
-        while self._op_stack and self._op_stack[-1] is None:
-            self._op_stack.pop()
-        return not bool(self._op_stack)
+    def __bool__(self) -> bool:
+        """Check if the worklist is non-empty."""
+        while self._stack and self._stack[-1] is _MISSING:
+            self._stack.pop()
+        return bool(self._stack)
 
-    def push(self, op: Operation):
+    def push(self, item: _T):
         """
-        Push an operation to the end of the worklist, if it is not already in it.
+        Push an item to the end of the worklist, if it is not already in it.
         """
-        if op not in self._map:
-            self._map[op] = len(self._op_stack)
-            self._op_stack.append(op)
+        if item not in self._map:
+            self._map[item] = len(self._stack)
+            self._stack.append(item)
 
-    def pop(self) -> Operation | None:
-        """Pop the operation at the end of the worklist."""
-        # All `None` operations at the end of the stack are discarded,
+    def pop(self) -> _T:
+        """Pop the item at the end of the worklist."""
+        # All `_MISSING` items at the end of the stack are discarded,
         # as they were removed previously.
-        # We either return `None` if the stack is empty, or the last operation
-        # that is not `None`.
-        while self._op_stack:
-            op = self._op_stack.pop()
-            if op is not None:
+        # We return the last item that is not `_MISSING`.
+        while self._stack:
+            op = self._stack.pop()
+            if op is not _MISSING:
                 del self._map[op]
                 return op
-        return None
+        raise IndexError("pop from empty worklist")
 
-    def remove(self, op: Operation):
-        """Remove an operation from the worklist."""
-        if op in self._map:
-            index = self._map[op]
-            self._op_stack[index] = None
-            del self._map[op]
+    def remove(self, item: _T):
+        """Remove an item from the worklist."""
+        if item in self._map:
+            index = self._map[item]
+            self._stack[index] = _MISSING
+            del self._map[item]
 
 
 @dataclass(eq=False, repr=False)
@@ -813,9 +815,9 @@ class PatternRewriteWalker:
         rewriter_has_done_action = False
 
         # Handle empty worklist
-        op = self._worklist.pop()
-        if op is None:
+        if not self._worklist:
             return rewriter_has_done_action
+        op = self._worklist.pop()
 
         # Create a rewriter on the first operation
         rewriter = PatternRewriter(op)
@@ -840,6 +842,6 @@ class PatternRewriteWalker:
             rewriter_has_done_action |= rewriter.has_done_action
 
             # If the worklist is empty, we are done
-            op = self._worklist.pop()
-            if op is None:
+            if not self._worklist:
                 return rewriter_has_done_action
+            op = self._worklist.pop()

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -643,12 +643,13 @@ class Worklist(Generic[_T]):
         # All `_MISSING` items at the end of the stack are discarded,
         # as they were removed previously.
         # We return the last item that is not `_MISSING`.
-        while self._stack:
-            op = self._stack.pop()
-            if op is not _MISSING:
-                del self._map[op]
-                return op
-        raise IndexError("pop from empty worklist")
+        try:
+            while (item := self._stack.pop()) is _MISSING:
+                pass
+            del self._map[item]
+            return item
+        except IndexError:
+            raise IndexError("pop from empty worklist")
 
     def remove(self, item: _T):
         """Remove an item from the worklist."""

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -6,9 +6,9 @@ from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass, field
 from functools import wraps
 from types import UnionType
-from typing import Generic, Union, final, get_args, get_origin
+from typing import Union, final, get_args, get_origin
 
-from typing_extensions import Sentinel, TypeVar, deprecated
+from typing_extensions import TypeVar, deprecated
 
 from xdsl.builder import Builder, BuilderListener, InsertOpInvT
 from xdsl.context import Context
@@ -30,6 +30,7 @@ from xdsl.irdl import AttrConstraint, base
 from xdsl.rewriter import BlockInsertPoint, InsertPoint, Rewriter
 from xdsl.traits import ConstantLike, HasFolder
 from xdsl.utils.hints import isa
+from xdsl.utils.worklist import Worklist
 
 
 @dataclass(eq=False)
@@ -600,63 +601,6 @@ class GreedyRewritePatternApplier(RewritePattern):
             if rewriter.has_done_action:
                 return
         return
-
-
-_T = TypeVar("_T", default=Operation)
-
-_MISSING = Sentinel("_MISSING")
-
-
-@dataclass(eq=False)
-class Worklist(Generic[_T]):
-    _stack: list[_T | _MISSING] = field(default_factory=list[_T | _MISSING], init=False)
-    """
-    The list of items to iterate over, used as a last-in-first-out stack.
-    Items are added and removed at the end of the list.
-    Items that are `_MISSING` are meant to be discarded, and are used to
-    keep removal of items O(1).
-    """
-
-    _map: dict[_T, int] = field(default_factory=dict[_T, int], init=False)
-    """
-    The map of items to their index in the stack.
-    It is used to check if an item is already in the stack, and to
-    remove it in O(1).
-    """
-
-    def __bool__(self) -> bool:
-        """Check if the worklist is non-empty."""
-        while self._stack and self._stack[-1] is _MISSING:
-            self._stack.pop()
-        return bool(self._stack)
-
-    def push(self, item: _T):
-        """
-        Push an item to the end of the worklist, if it is not already in it.
-        """
-        if item not in self._map:
-            self._map[item] = len(self._stack)
-            self._stack.append(item)
-
-    def pop(self) -> _T:
-        """Pop the item at the end of the worklist."""
-        # All `_MISSING` items at the end of the stack are discarded,
-        # as they were removed previously.
-        # We return the last item that is not `_MISSING`.
-        try:
-            while (item := self._stack.pop()) is _MISSING:
-                pass
-            del self._map[item]
-            return item
-        except IndexError:
-            raise IndexError("pop from empty worklist")
-
-    def remove(self, item: _T):
-        """Remove an item from the worklist."""
-        if item in self._map:
-            index = self._map[item]
-            self._stack[index] = _MISSING
-            del self._map[item]
 
 
 @dataclass(eq=False, repr=False)

--- a/xdsl/utils/worklist.py
+++ b/xdsl/utils/worklist.py
@@ -1,0 +1,63 @@
+from dataclasses import dataclass, field
+from typing import Generic
+
+from typing_extensions import Sentinel, TypeVar
+
+from xdsl.ir import Operation
+
+_T = TypeVar("_T", default=Operation)
+
+
+_MISSING = Sentinel("_MISSING")
+
+
+@dataclass(eq=False)
+class Worklist(Generic[_T]):
+    _stack: list[_T | _MISSING] = field(default_factory=list[_T | _MISSING], init=False)
+    """
+    The list of items to iterate over, used as a last-in-first-out stack.
+    Items are added and removed at the end of the list.
+    Items that are `_MISSING` are meant to be discarded, and are used to
+    keep removal of items O(1).
+    """
+
+    _map: dict[_T, int] = field(default_factory=dict[_T, int], init=False)
+    """
+    The map of items to their index in the stack.
+    It is used to check if an items is already in the stack, and to
+    remove it in O(1).
+    """
+
+    def __bool__(self) -> bool:
+        """Check if the worklist is non-empty."""
+        while self._stack and self._stack[-1] is _MISSING:
+            self._stack.pop()
+        return bool(self._stack)
+
+    def push(self, item: _T):
+        """
+        Push an item to the end of the worklist, if it is not already in it.
+        """
+        if item not in self._map:
+            self._map[item] = len(self._stack)
+            self._stack.append(item)
+
+    def pop(self) -> _T:
+        """Pop the item at the end of the worklist."""
+        # All `_MISSING` items at the end of the stack are discarded,
+        # as they were removed previously.
+        # We return the last item that is not `_MISSING`.
+        try:
+            while (item := self._stack.pop()) is _MISSING:
+                pass
+            del self._map[item]
+            return item
+        except IndexError:
+            raise IndexError("pop from empty worklist")
+
+    def remove(self, item: _T):
+        """Remove an item from the worklist."""
+        if item in self._map:
+            index = self._map[item]
+            self._stack[index] = _MISSING
+            del self._map[item]


### PR DESCRIPTION
I feel this worklist structure is useful outside of the pattern rewriter, in particular for analysis, where I would like to have a worklist of blocks.

This adds a generic argument for the items stored on the worklist, but makes the default for this `Operation` to maintain the previous behaviour.