### PR TITLE
backend: (x86) rename Arch to X86Arch

### DIFF
--- a/tests/backend/x86/test_lowering_utils.py
+++ b/tests/backend/x86/test_lowering_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from xdsl.backend.x86.lowering.helpers import Arch
+from xdsl.backend.x86.arch import X86Arch
 from xdsl.builder import Builder
 from xdsl.dialects import ptr
 from xdsl.dialects.builtin import VectorType, f64, i64
@@ -19,14 +19,14 @@ from xdsl.utils.test_value import create_ssa_value
     "arch, reg_type, value_type, expected_op, expected_unallocated_type",
     [
         (
-            Arch.UNKNOWN,
+            X86Arch.UNKNOWN,
             Reg64Type,
             i64,
             DS_MovOp,
             Reg64Type.unallocated(),
         ),
         (
-            Arch.AVX2,
+            X86Arch.AVX2,
             AVX2RegisterType,
             VectorType(f64, (4,)),
             DS_VmovapdOp,
@@ -35,7 +35,7 @@ from xdsl.utils.test_value import create_ssa_value
     ],
 )
 def test_move_value_to_unallocated(
-    arch: Arch,
+    arch: X86Arch,
     reg_type: type[X86RegisterType],
     value_type: Attribute,
     expected_op: type[DS_Operation[X86RegisterType, X86RegisterType]],
@@ -52,7 +52,7 @@ def test_move_value_to_unallocated(
 
 @pytest.mark.parametrize(
     "arch",
-    [Arch.AVX2, Arch.AVX512, Arch.UNKNOWN],
+    [X86Arch.AVX2, X86Arch.AVX512, X86Arch.UNKNOWN],
 )
-def test_register_type_for_ptr_type(arch: Arch):
+def test_register_type_for_ptr_type(arch: X86Arch):
     assert arch.register_type_for_type(ptr.PtrType()) == Reg64Type

--- a/xdsl/backend/x86/arch.py
+++ b/xdsl/backend/x86/arch.py
@@ -25,15 +25,15 @@ from xdsl.utils.hints import isa
 from xdsl.utils.str_enum import StrEnum
 
 
-class Arch(StrEnum):
+class X86Arch(StrEnum):
     UNKNOWN = "unknown"
     AVX2 = "avx2"
     AVX512 = "avx512"
 
     @staticmethod
-    def arch_for_name(name: str | None) -> Arch:
+    def arch_for_name(name: str | None) -> X86Arch:
         if name is None:
-            return Arch.UNKNOWN
+            return X86Arch.UNKNOWN
         try:
             return _ARCH_BY_NAME[name]
         except KeyError:
@@ -52,9 +52,9 @@ class Arch(StrEnum):
         element_size = element_type.bitwidth
         vector_size = vector_num_elements * element_size
         match self, vector_size:
-            case ((Arch.AVX2 | Arch.AVX512), 256):
+            case ((X86Arch.AVX2 | X86Arch.AVX512), 256):
                 return x86.registers.AVX2RegisterType
-            case Arch.AVX512, 512:
+            case X86Arch.AVX512, 512:
                 return x86.registers.AVX512RegisterType
             case _, 128:
                 return x86.registers.SSERegisterType
@@ -140,7 +140,7 @@ class Arch(StrEnum):
         return builder.insert_op(mov_op).results[0]
 
 
-_ARCH_BY_NAME = {str(case): case for case in Arch}
+_ARCH_BY_NAME = {str(case): case for case in X86Arch}
 """
 Handled architectures in x86 backend.
 """

--- a/xdsl/backend/x86/lowering/convert_arith_to_x86.py
+++ b/xdsl/backend/x86/lowering/convert_arith_to_x86.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 
-from xdsl.backend.x86.lowering.helpers import Arch
+from xdsl.backend.x86.arch import X86Arch
 from xdsl.context import Context
 from xdsl.dialects import arith, asm, builtin, x86
 from xdsl.dialects.builtin import IntegerAttr
@@ -20,7 +20,7 @@ from xdsl.utils.hints import isa
 
 @dataclass
 class ArithConstantToX86(RewritePattern):
-    arch: Arch
+    arch: X86Arch
 
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: arith.ConstantOp, rewriter: PatternRewriter):
@@ -47,7 +47,7 @@ X86_OP_BY_ARITH_BINARY_OP = {
 
 @dataclass
 class ArithBinaryToX86(RewritePattern):
-    arch: Arch
+    arch: X86Arch
 
     def match_and_rewrite(self, op: Operation, rewriter: PatternRewriter):
         new_type = X86_OP_BY_ARITH_BINARY_OP.get(type(op))  # pyright: ignore
@@ -76,7 +76,7 @@ class ConvertArithToX86Pass(ModulePass):
     name = "convert-arith-to-x86"
 
     def apply(self, ctx: Context, op: builtin.ModuleOp) -> None:
-        arch = Arch.arch_for_name(None)
+        arch = X86Arch.arch_for_name(None)
         PatternRewriteWalker(
             GreedyRewritePatternApplier(
                 [

--- a/xdsl/backend/x86/lowering/convert_func_to_x86_func.py
+++ b/xdsl/backend/x86/lowering/convert_func_to_x86_func.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 
-from xdsl.backend.x86.lowering.helpers import Arch
+from xdsl.backend.x86.arch import X86Arch
 from xdsl.context import Context
 from xdsl.dialects import asm, builtin, func, x86, x86_func
 from xdsl.dialects.builtin import ModuleOp
@@ -49,7 +49,7 @@ STACK_SLOT_SIZE_BYTES = 8
 
 @dataclass
 class LowerFuncOp(RewritePattern):
-    arch: Arch
+    arch: X86Arch
 
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: func.FuncOp, rewriter: PatternRewriter):
@@ -139,7 +139,7 @@ class LowerFuncOp(RewritePattern):
 
 @dataclass
 class LowerReturnOp(RewritePattern):
-    arch: Arch
+    arch: X86Arch
 
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: func.ReturnOp, rewriter: PatternRewriter):
@@ -182,7 +182,7 @@ class ConvertFuncToX86FuncPass(ModulePass):
     arch: str | None = None
 
     def apply(self, ctx: Context, op: ModuleOp) -> None:
-        arch = Arch.arch_for_name(self.arch)
+        arch = X86Arch.arch_for_name(self.arch)
         PatternRewriteWalker(
             GreedyRewritePatternApplier(
                 [

--- a/xdsl/backend/x86/lowering/convert_ptr_to_x86.py
+++ b/xdsl/backend/x86/lowering/convert_ptr_to_x86.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 
-from xdsl.backend.x86.lowering.helpers import Arch
+from xdsl.backend.x86.arch import X86Arch
 from xdsl.context import Context
 from xdsl.dialects import asm, builtin, ptr, x86
 from xdsl.dialects.builtin import (
@@ -22,7 +22,7 @@ from xdsl.utils.hints import isa
 
 @dataclass
 class PtrAddToX86(RewritePattern):
-    arch: Arch
+    arch: X86Arch
 
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: ptr.PtrAddOp, rewriter: PatternRewriter):
@@ -46,7 +46,7 @@ class PtrAddToX86(RewritePattern):
 
 @dataclass
 class PtrStoreToX86(RewritePattern):
-    arch: Arch
+    arch: X86Arch
 
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: ptr.StoreOp, rewriter: PatternRewriter):
@@ -86,7 +86,7 @@ class PtrStoreToX86(RewritePattern):
 
 @dataclass
 class PtrLoadToX86(RewritePattern):
-    arch: Arch
+    arch: X86Arch
 
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: ptr.LoadOp, rewriter: PatternRewriter):
@@ -131,7 +131,7 @@ class ConvertPtrToX86Pass(ModulePass):
     arch: str
 
     def apply(self, ctx: Context, op: builtin.ModuleOp) -> None:
-        arch = Arch.arch_for_name(self.arch)
+        arch = X86Arch.arch_for_name(self.arch)
         PatternRewriteWalker(
             GreedyRewritePatternApplier(
                 [

--- a/xdsl/backend/x86/lowering/convert_vector_to_x86.py
+++ b/xdsl/backend/x86/lowering/convert_vector_to_x86.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from typing import cast
 
 from xdsl import ir
-from xdsl.backend.x86.lowering.helpers import Arch
+from xdsl.backend.x86.arch import X86Arch
 from xdsl.context import Context
 from xdsl.dialects import asm, builtin, vector, x86
 from xdsl.dialects.builtin import FixedBitwidthType, VectorType
@@ -19,7 +19,7 @@ from xdsl.utils.exceptions import DiagnosticException
 
 @dataclass
 class VectorBroadcastToX86(RewritePattern):
-    arch: Arch
+    arch: X86Arch
 
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: vector.BroadcastOp, rewriter: PatternRewriter):
@@ -55,7 +55,7 @@ class VectorBroadcastToX86(RewritePattern):
 
 @dataclass
 class VectorFMAToX86(RewritePattern):
-    arch: Arch
+    arch: X86Arch
 
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: vector.FMAOp, rewriter: PatternRewriter):
@@ -100,7 +100,7 @@ class ConvertVectorToX86Pass(ModulePass):
     arch: str
 
     def apply(self, ctx: Context, op: builtin.ModuleOp) -> None:
-        arch = Arch.arch_for_name(self.arch)
+        arch = X86Arch.arch_for_name(self.arch)
         PatternRewriteWalker(
             GreedyRewritePatternApplier(
                 [

--- a/xdsl/transforms/convert_scf_to_x86_scf.py
+++ b/xdsl/transforms/convert_scf_to_x86_scf.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
 
 from xdsl.backend.riscv.lowering.utils import cast_op_results
-from xdsl.backend.x86.lowering.helpers import Arch
+from xdsl.backend.x86.arch import X86Arch
 from xdsl.context import Context
 from xdsl.dialects import asm, builtin, scf, x86_scf
 from xdsl.ir import Block
@@ -16,7 +16,7 @@ from xdsl.pattern_rewriter import (
 from xdsl.rewriter import InsertPoint
 
 
-def cast_block_args_to_regs(block: Block, arch: Arch, rewriter: PatternRewriter):
+def cast_block_args_to_regs(block: Block, arch: X86Arch, rewriter: PatternRewriter):
     """
     Change the type of the block arguments to registers and add cast operations just after
     the block entry.
@@ -40,7 +40,7 @@ def cast_block_args_to_regs(block: Block, arch: Arch, rewriter: PatternRewriter)
 
 @dataclass
 class ScfForLowering(RewritePattern):
-    arch: Arch
+    arch: X86Arch
 
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: scf.ForOp, rewriter: PatternRewriter) -> None:
@@ -74,7 +74,7 @@ class ScfForLowering(RewritePattern):
 
 @dataclass
 class ScfYieldLowering(RewritePattern):
-    arch: Arch
+    arch: X86Arch
 
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: scf.YieldOp, rewriter: PatternRewriter) -> None:
@@ -90,7 +90,7 @@ class ConvertScfToX86ScfPass(ModulePass):
     arch: str = field(default="unknown")
 
     def apply(self, ctx: Context, op: builtin.ModuleOp) -> None:
-        arch = Arch.arch_for_name(self.arch)
+        arch = X86Arch.arch_for_name(self.arch)
         PatternRewriteWalker(
             GreedyRewritePatternApplier(
                 [


### PR DESCRIPTION
This is not technically necessary but will make autocomplete more helpful vs risc-v's Arch etc. Also moved location since it's not just a lowering concern.