### PR TITLE
core: (SymbolTableCollection) add cached nearest symbol lookup helper

### DIFF
--- a/tests/utils/test_symbol_table.py
+++ b/tests/utils/test_symbol_table.py
@@ -442,13 +442,29 @@ def test_symbol_table_collection_lookup_symbol_in():
 
 
 def test_symbol_table_collection_lookup_nearest_symbol_from():
-    """Test SymbolTableCollection.lookup_nearest_symbol_from static method."""
-    test_op = TestOp()
-    symbol = StringAttr("test_symbol")
+    """Test SymbolTableCollection.lookup_nearest_symbol_from method."""
+    collection = SymbolTableCollection()
+    symbol = TestSymbolOp(properties={"sym_name": StringAttr("nearest_symbol")})
+    from_op = TestOp()
+    module = ModuleOp([symbol, TestOp(regions=[Region(Block([from_op]))])])
 
-    # This will raise NotImplementedError until implemented
-    with pytest.raises(NotImplementedError):
-        SymbolTableCollection.lookup_nearest_symbol_from(test_op, symbol)
+    assert collection.lookup_nearest_symbol_from(from_op, "nearest_symbol") is symbol
+    cached_module_table = collection.symbol_tables[module]
+    assert collection.lookup_nearest_symbol_from(from_op, "nearest_symbol") is symbol
+    assert collection.symbol_tables[module] is cached_module_table
+    assert collection.lookup_nearest_symbol_from(from_op, "missing") is None
+    assert collection.lookup_nearest_symbol_from(TestOp(), "nearest_symbol") is None
+
+    outer_symbol = TestSymbolOp(properties={"sym_name": StringAttr("scoped_symbol")})
+    inner_symbol = TestSymbolOp(properties={"sym_name": StringAttr("scoped_symbol")})
+    inner_from_op = TestOp()
+    inner_module = ModuleOp([inner_symbol, inner_from_op], sym_name=StringAttr("inner"))
+    ModuleOp([outer_symbol, inner_module])
+
+    assert (
+        collection.lookup_nearest_symbol_from(inner_from_op, "scoped_symbol")
+        is inner_symbol
+    )
 
 
 def test_symbol_table_collection_get_symbol_table():

--- a/xdsl/utils/symbol_table.py
+++ b/xdsl/utils/symbol_table.py
@@ -406,9 +406,8 @@ class SymbolTableCollection:
             return None
         return symbols if all_symbols else symbols[-1]
 
-    @staticmethod
     def lookup_nearest_symbol_from(
-        from_op: Operation, symbol: StringAttr | SymbolRefAttr
+        self, from_op: Operation, symbol: StringAttr | SymbolRefAttr | str
     ) -> Operation | None:
         """
         Returns the operation registered with the given symbol name within the closest
@@ -416,7 +415,10 @@ class SymbolTableCollection:
         [`SymbolTable`][xdsl.traits.SymbolTable] trait.
         Returns `None` if no valid symbol was found.
         """
-        raise NotImplementedError
+        symbol_table_op = SymbolTable.get_nearest_symbol_table(from_op)
+        if symbol_table_op is None:
+            return None
+        return self.lookup_symbol_in(symbol_table_op, symbol)
 
     def get_symbol_table(self, op: Operation) -> SymbolTable:
         """


### PR DESCRIPTION
This PR implemented `lookup_nearest_symbol_from` for SymbolTableCollection.