### PR TITLE
dialects: (x86) add broadcasting flag on AVX512 RSM operations

### DIFF
--- a/tests/filecheck/dialects/x86/x86_assembly_emission.mlir
+++ b/tests/filecheck/dialects/x86/x86_assembly_emission.mlir
@@ -402,6 +402,12 @@ x86_func.func @funcyasm() {
 // CHECK: vfmadd231pd zmm0, zmm1, [rdx]
 %rrm_vfmadd231ps_avx512 = x86.rsm.vfmadd231ps %rrm_vfmadd231pd_avx512_no_offset, %zmm1, [%1 + 1] : (!x86.avx512reg<zmm0>, !x86.avx512reg<zmm1>, !x86.reg64<rdx>) -> !x86.avx512reg<zmm0>
 // CHECK: vfmadd231ps zmm0, zmm1, [rdx+1]
+
+%rrm_vfmadd231pd_avx512_fsdbcst = x86.rsm.vfmadd231pd %rrm_vfmadd231ps_avx512, %zmm1, [%1 + 512] {broadcast} : (!x86.avx512reg<zmm0>, !x86.avx512reg<zmm1>, !x86.reg64<rdx>) -> !x86.avx512reg<zmm0>
+// CHECK: vfmadd231pd zmm0, zmm1, [rdx+512]{1to8}
+%rrm_vfmadd231ps_avx512_fsdbcst = x86.rsm.vfmadd231ps %rrm_vfmadd231pd_avx512_fsdbcst, %zmm1, [%1 + 4] {broadcast} : (!x86.avx512reg<zmm0>, !x86.avx512reg<zmm1>, !x86.reg64<rdx>) -> !x86.avx512reg<zmm0>
+// CHECK: vfmadd231ps zmm0, zmm1, [rdx+4]{1to16}
+
 %dss_addpd_avx512 = x86.dss.addpd %zmm1, %zmm2 : (!x86.avx512reg<zmm1>, !x86.avx512reg<zmm2>) -> !x86.avx512reg<zmm0>
 // CHECK-NEXT: addpd zmm0, zmm1, zmm2
 %dss_addps_avx512 = x86.dss.addps %zmm1, %zmm2 : (!x86.avx512reg<zmm1>, !x86.avx512reg<zmm2>) -> !x86.avx512reg<zmm0>

--- a/tests/filecheck/dialects/x86/x86_assembly_emission.mlir
+++ b/tests/filecheck/dialects/x86/x86_assembly_emission.mlir
@@ -403,9 +403,9 @@ x86_func.func @funcyasm() {
 %rrm_vfmadd231ps_avx512 = x86.rsm.vfmadd231ps %rrm_vfmadd231pd_avx512_no_offset, %zmm1, [%1 + 1] : (!x86.avx512reg<zmm0>, !x86.avx512reg<zmm1>, !x86.reg64<rdx>) -> !x86.avx512reg<zmm0>
 // CHECK: vfmadd231ps zmm0, zmm1, [rdx+1]
 
-%rrm_vfmadd231pd_avx512_fsdbcst = x86.rsm.vfmadd231pd %rrm_vfmadd231ps_avx512, %zmm1, [%1 + 512] {broadcast} : (!x86.avx512reg<zmm0>, !x86.avx512reg<zmm1>, !x86.reg64<rdx>) -> !x86.avx512reg<zmm0>
+%rrm_vfmadd231pd_avx512_broadcast = x86.rsm.vfmadd231pd %rrm_vfmadd231ps_avx512, %zmm1, [%1 + 512] {broadcast} : (!x86.avx512reg<zmm0>, !x86.avx512reg<zmm1>, !x86.reg64<rdx>) -> !x86.avx512reg<zmm0>
 // CHECK: vfmadd231pd zmm0, zmm1, [rdx+512]{1to8}
-%rrm_vfmadd231ps_avx512_fsdbcst = x86.rsm.vfmadd231ps %rrm_vfmadd231pd_avx512_fsdbcst, %zmm1, [%1 + 4] {broadcast} : (!x86.avx512reg<zmm0>, !x86.avx512reg<zmm1>, !x86.reg64<rdx>) -> !x86.avx512reg<zmm0>
+%rrm_vfmadd231ps_avx512_broadcast = x86.rsm.vfmadd231ps %rrm_vfmadd231pd_avx512_broadcast, %zmm1, [%1 + 4] {broadcast} : (!x86.avx512reg<zmm0>, !x86.avx512reg<zmm1>, !x86.reg64<rdx>) -> !x86.avx512reg<zmm0>
 // CHECK: vfmadd231ps zmm0, zmm1, [rdx+4]{1to16}
 
 %dss_addpd_avx512 = x86.dss.addpd %zmm1, %zmm2 : (!x86.avx512reg<zmm1>, !x86.avx512reg<zmm2>) -> !x86.avx512reg<zmm0>

--- a/tests/filecheck/dialects/x86/x86_ops.mlir
+++ b/tests/filecheck/dialects/x86/x86_ops.mlir
@@ -410,6 +410,11 @@ func.func @funcyasm() {
 // CHECK: %{{.*}} = x86.rsm.vfmadd231pd %{{.*}}, %{{.*}}, [%{{.*}}] : (!x86.avx512reg, !x86.avx512reg, !x86.reg64) -> !x86.avx512reg
 %rrm_vfmadd231ps_avx512 = x86.rsm.vfmadd231ps %rrm_vfmadd231pd_avx512_no_offset, %zmm1, [%1 + 6] : (!x86.avx512reg, !x86.avx512reg, !x86.reg64) -> !x86.avx512reg
 // CHECK: %{{.*}} = x86.rsm.vfmadd231ps %{{.*}}, %{{.*}}, [%{{.*}} + 6] : (!x86.avx512reg, !x86.avx512reg, !x86.reg64) -> !x86.avx512reg
+%rrm_vfmadd231pd_avx512_broadcast = x86.rsm.vfmadd231pd %rrm_vfmadd231ps_avx512, %zmm1, [%1 + 512] {broadcast} : (!x86.avx512reg, !x86.avx512reg, !x86.reg64) -> !x86.avx512reg
+// CHECK: %{{.*}} = x86.rsm.vfmadd231pd %{{.*}}, %{{.*}}, [%{{.*}} + 512] {broadcast} : (!x86.avx512reg, !x86.avx512reg, !x86.reg64) -> !x86.avx512reg
+%rrm_vfmadd231ps_avx512_broadcast = x86.rsm.vfmadd231ps %rrm_vfmadd231pd_avx512_broadcast, %zmm1, [%1 + 8] {broadcast} : (!x86.avx512reg, !x86.avx512reg, !x86.reg64) -> !x86.avx512reg
+// CHECK: %{{.*}} = x86.rsm.vfmadd231ps %{{.*}}, %{{.*}}, [%{{.*}} + 8] {broadcast} : (!x86.avx512reg, !x86.avx512reg, !x86.reg64) -> !x86.avx512reg
+
 %dss_addpd_avx512 = x86.dss.addpd %zmm1, %zmm2 : (!x86.avx512reg, !x86.avx512reg) -> !x86.avx512reg
 // CHECK-NEXT: %dss_addpd_avx512 = x86.dss.addpd %zmm1, %zmm2 : (!x86.avx512reg, !x86.avx512reg) -> !x86.avx512reg
 %dss_addps_avx512 = x86.dss.addps %zmm1, %zmm2 : (!x86.avx512reg, !x86.avx512reg) -> !x86.avx512reg

--- a/xdsl/dialects/x86/assembly.py
+++ b/xdsl/dialects/x86/assembly.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TypeAlias
+from typing import Literal, TypeAlias
 
 from xdsl.backend.assembly_printer import reg
 from xdsl.dialects.builtin import IntegerAttr, StringAttr, UnitAttr
@@ -27,6 +27,15 @@ def memory_access_str(register: SSAValue, offset: IntegerAttr) -> str:
     else:
         mem_acc_str = f"[{register_str}]"
     return mem_acc_str
+
+
+def broadcast_memory_access_str(
+    register: SSAValue,
+    offset: IntegerAttr,
+    broadcast: Literal["1to8", "1to16"],
+) -> str:
+    """e.g. ``[rsi+512]{1to8}``"""
+    return f"{memory_access_str(register, offset)}{{{broadcast}}}"
 
 
 def print_type_pair(printer: Printer, value: SSAValue) -> None:

--- a/xdsl/dialects/x86/ops.py
+++ b/xdsl/dialects/x86/ops.py
@@ -98,6 +98,7 @@ from xdsl.utils.target import Target
 from .assembly import (
     AssemblyInstructionArg,
     assembly_arg_str,
+    broadcast_memory_access_str,
     masked_memory_access_str,
     masked_source_str,
     memory_access_str,
@@ -1387,6 +1388,84 @@ class RSM_Operation(X86Instruction, ABC, Generic[R1InvT, R2InvT, R4InvT]):
         src1 = reg(self.source1)
         destination = reg(self.register_in)
         return destination, src1, memory_access
+
+    def get_register_constraints(self) -> RegisterConstraints:
+        return RegisterConstraints(
+            (self.source1, self.memory), (), ((self.register_in, self.register_out),)
+        )
+
+
+class RSMB_Operation(X86Instruction, ABC, Generic[R1InvT, R2InvT, R4InvT]):
+    """
+    A base class for x86 operations that have one register that is read and written to,
+    one source register, and one memory source operand. When the broadcast attribute is
+    set, the memory operand uses EVEX broadcast encoding.
+    """
+
+    register_in = operand_def(R1InvT)
+    register_out: OpResult[R1InvT] = result_def(R1InvT)
+    source1 = operand_def(R2InvT)
+    memory = operand_def(R4InvT)
+    memory_offset = attr_def(IntegerAttr[SI64], default_value=IntegerAttr(0, si64))
+    broadcast = opt_attr_def(UnitAttr)
+
+    traits = traits_def(MemoryReadEffect())
+
+    assembly_format = (
+        "$register_in `,` $source1 `,` `[` $memory (`+` $memory_offset^)? `]` attr-dict `:` "
+        "`(` type($register_in) `,` type($source1) `,` type($memory) `)` "
+        "`->` type($register_out)"
+    )
+
+    def __init__(
+        self,
+        register_in: SSAValue[R1InvT],
+        source1: Operation | SSAValue,
+        memory: Operation | SSAValue,
+        memory_offset: int | IntegerAttr[SI64],
+        *,
+        broadcast: bool = False,
+        comment: str | StringAttr | None = None,
+        register_out: R1InvT | None = None,
+    ):
+        if isinstance(memory_offset, int):
+            memory_offset = IntegerAttr(memory_offset, si64)
+        if isinstance(comment, str):
+            comment = StringAttr(comment)
+
+        if register_out is None:
+            register_out = register_in.type
+
+        super().__init__(
+            operands=[register_in, source1, memory],
+            attributes={
+                "memory_offset": memory_offset,
+                "broadcast": UnitAttr() if broadcast else None,
+                "comment": comment,
+            },
+            result_types=[register_out],
+        )
+
+    @classmethod
+    @abstractmethod
+    def broadcast_modifier(cls) -> Literal["1to8", "1to16"]:
+        """
+        If broadcasting, specifies whether the operation broadcasts to 8 or 16 lanes.
+        This will be determined by the bitwidth of the lanes of the vector this
+        operation operates on.
+        """
+        raise NotImplementedError()
+
+    def assembly_line_args(self) -> tuple[AssemblyInstructionArg | None, ...]:
+        if self.broadcast:
+            memory_access = broadcast_memory_access_str(
+                self.memory,
+                self.memory_offset,
+                self.broadcast_modifier(),
+            )
+        else:
+            memory_access = memory_access_str(self.memory, self.memory_offset)
+        return reg(self.register_in), reg(self.source1), memory_access
 
     def get_register_constraints(self) -> RegisterConstraints:
         return RegisterConstraints(
@@ -3366,7 +3445,7 @@ class RSSK_Vfmadd231pdOp(RSSK_Operation):
 
 @irdl_op_definition
 class RSM_Vfmadd231pdOp(
-    RSM_Operation[X86VectorRegisterType, X86VectorRegisterType, GeneralRegisterType]
+    RSMB_Operation[X86VectorRegisterType, X86VectorRegisterType, GeneralRegisterType]
 ):
     """
     Multiply packed double-precision floating-point elements in s1 and at specified memory location, add the
@@ -3376,6 +3455,10 @@ class RSM_Vfmadd231pdOp(
     """
 
     name = "x86.rsm.vfmadd231pd"
+
+    @classmethod
+    def broadcast_modifier(cls) -> Literal["1to8"]:
+        return "1to8"
 
 
 @irdl_op_definition
@@ -3394,7 +3477,7 @@ class RSS_Vfmadd231psOp(
 
 @irdl_op_definition
 class RSM_Vfmadd231psOp(
-    RSM_Operation[X86VectorRegisterType, X86VectorRegisterType, GeneralRegisterType]
+    RSMB_Operation[X86VectorRegisterType, X86VectorRegisterType, GeneralRegisterType]
 ):
     """
     Multiply packed single-precision floating-point elements in s1 and at specified memory location, add the
@@ -3404,6 +3487,10 @@ class RSM_Vfmadd231psOp(
     """
 
     name = "x86.rsm.vfmadd231ps"
+
+    @classmethod
+    def broadcast_modifier(cls) -> Literal["1to16"]:
+        return "1to16"
 
 
 @irdl_op_definition


### PR DESCRIPTION
This is only supported on AVX512, so I added a new abstract op instead of extending the existing `RSM_Operation`.