### PR TITLE
dialects: add `riscv_cf.bnez` op

### DIFF
--- a/tests/filecheck/dialects/riscv_cf/assembly_emission.mlir
+++ b/tests/filecheck/dialects/riscv_cf/assembly_emission.mlir
@@ -26,7 +26,7 @@ riscv_func.func @main() {
     riscv_cf.bgeu %0 : !riscv.reg<a0>, %1 : !riscv.reg<a1>, ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^else5(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>)
   ^else5(%e50: !riscv.reg<a2>, %e51: !riscv.reg<a3>):
     riscv.label "else5"
-    riscv_cf.bnez %0 : !riscv.reg<a0>, ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^else6(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>) {test_attr}
+    riscv_cf.bnez %0 : !riscv.reg<a0>, ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^else6(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>)
   ^else6(%e60: !riscv.reg<a2>, %e61: !riscv.reg<a3>):
     riscv.label "else6"
     riscv_cf.branch ^dummy0(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>)

--- a/tests/filecheck/dialects/riscv_cf/assembly_emission.mlir
+++ b/tests/filecheck/dialects/riscv_cf/assembly_emission.mlir
@@ -26,6 +26,9 @@ riscv_func.func @main() {
     riscv_cf.bgeu %0 : !riscv.reg<a0>, %1 : !riscv.reg<a1>, ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^else5(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>)
   ^else5(%e50: !riscv.reg<a2>, %e51: !riscv.reg<a3>):
     riscv.label "else5"
+    riscv_cf.bnez %0 : !riscv.reg<a0>, ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^else6(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>)
+  ^else6(%e60: !riscv.reg<a2>, %e61: !riscv.reg<a3>):
+    riscv.label "else6"
     riscv_cf.branch ^dummy0(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>)
   ^dummy0(%d00: !riscv.reg<a2>, %d01: !riscv.reg<a3>):
     riscv.label "dummy0"
@@ -51,6 +54,8 @@ riscv_func.func @main() {
 // CHECK-NEXT:  else4:
 // CHECK-NEXT:      bgeu a0, a1, then
 // CHECK-NEXT:  else5:
+// CHECK-NEXT:      bnez a0, then
+// CHECK-NEXT:  else6:
 // CHECK-NEXT:  dummy0:
 // CHECK-NEXT:      # comment
 // CHECK-NEXT:  dummy1:

--- a/tests/filecheck/dialects/riscv_cf/assembly_emission.mlir
+++ b/tests/filecheck/dialects/riscv_cf/assembly_emission.mlir
@@ -26,7 +26,7 @@ riscv_func.func @main() {
     riscv_cf.bgeu %0 : !riscv.reg<a0>, %1 : !riscv.reg<a1>, ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^else5(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>)
   ^else5(%e50: !riscv.reg<a2>, %e51: !riscv.reg<a3>):
     riscv.label "else5"
-    riscv_cf.bnez %0 : !riscv.reg<a0>, ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^else6(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>)
+    riscv_cf.bnez %0 : !riscv.reg<a0>, ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^else6(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>) {test_attr}
   ^else6(%e60: !riscv.reg<a2>, %e61: !riscv.reg<a3>):
     riscv.label "else6"
     riscv_cf.branch ^dummy0(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>)

--- a/tests/filecheck/dialects/riscv_cf/assembly_emission.mlir
+++ b/tests/filecheck/dialects/riscv_cf/assembly_emission.mlir
@@ -26,7 +26,7 @@ riscv_func.func @main() {
     riscv_cf.bgeu %0 : !riscv.reg<a0>, %1 : !riscv.reg<a1>, ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^else5(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>)
   ^else5(%e50: !riscv.reg<a2>, %e51: !riscv.reg<a3>):
     riscv.label "else5"
-    riscv_cf.bnez %0 : !riscv.reg<a0>, ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^else6(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>)
+    riscv_cf.bnez %0 : !riscv.reg<a0>, ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^else6(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>) attributes {"comment" = "comment"}
   ^else6(%e60: !riscv.reg<a2>, %e61: !riscv.reg<a3>):
     riscv.label "else6"
     riscv_cf.branch ^dummy0(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>)
@@ -54,7 +54,7 @@ riscv_func.func @main() {
 // CHECK-NEXT:  else4:
 // CHECK-NEXT:      bgeu a0, a1, then
 // CHECK-NEXT:  else5:
-// CHECK-NEXT:      bnez a0, then
+// CHECK-NEXT:      bnez a0, then                                # comment
 // CHECK-NEXT:  else6:
 // CHECK-NEXT:  dummy0:
 // CHECK-NEXT:      # comment

--- a/tests/filecheck/dialects/riscv_cf/ops.mlir
+++ b/tests/filecheck/dialects/riscv_cf/ops.mlir
@@ -20,8 +20,8 @@
     riscv.label "else4"
     riscv_cf.bgeu %0 : !riscv.reg<a0>, %1 : !riscv.reg<a1>, ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^else5(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>)
   ^else5(%e50: !riscv.reg<a2>, %e51: !riscv.reg<a3>):
-    riscv.label "else5"
-    riscv_cf.bnez %0 : !riscv.reg<a0>, ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^else6(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>)
+    riscv.label "else5" 
+    riscv_cf.bnez %0 : !riscv.reg<a0>, ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^else6(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>) attributes {"comment" = "comment"}
   ^else6(%e60: !riscv.reg<a2>, %e61: !riscv.reg<a3>):
     riscv.label "else6"
     riscv_cf.branch ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>) attributes {"hello" = "world"}
@@ -51,7 +51,7 @@
 // CHECK-NEXT:      riscv_cf.bgeu %0 : !riscv.reg<a0>, %1 : !riscv.reg<a1>, ^{{.+}}(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^{{.+}}(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>)
 // CHECK-NEXT:    ^{{.+}}(%{{.+}}: !riscv.reg<a2>, %{{.+}}: !riscv.reg<a3>):
 // CHECK-NEXT:      riscv.label "else5"
-// CHECK-NEXT:      riscv_cf.bnez %0 : !riscv.reg<a0>, ^{{.+}}(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^{{.+}}(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>)
+// CHECK-NEXT:      riscv_cf.bnez %0 : !riscv.reg<a0>, ^{{.+}}(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^{{.+}}(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>) attributes {"comment" = "comment"}
 // CHECK-NEXT:    ^{{.+}}(%{{.+}}: !riscv.reg<a2>, %{{.+}}: !riscv.reg<a3>):
 // CHECK-NEXT:      riscv.label "else6"
 // CHECK-NEXT:      riscv_cf.branch ^{{.+}}(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>) attributes {hello = "world"}

--- a/tests/filecheck/dialects/riscv_cf/ops.mlir
+++ b/tests/filecheck/dialects/riscv_cf/ops.mlir
@@ -21,6 +21,9 @@
     riscv_cf.bgeu %0 : !riscv.reg<a0>, %1 : !riscv.reg<a1>, ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^else5(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>)
   ^else5(%e50: !riscv.reg<a2>, %e51: !riscv.reg<a3>):
     riscv.label "else5"
+    riscv_cf.bnez %0 : !riscv.reg<a0>, ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^else6(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>)
+  ^else6(%e60: !riscv.reg<a2>, %e61: !riscv.reg<a3>):
+    riscv.label "else6"
     riscv_cf.branch ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>) attributes {"hello" = "world"}
   ^then(%t0: !riscv.reg<a2>, %t1: !riscv.reg<a3>):
     riscv.label "then"
@@ -48,6 +51,9 @@
 // CHECK-NEXT:      riscv_cf.bgeu %0 : !riscv.reg<a0>, %1 : !riscv.reg<a1>, ^{{.+}}(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^{{.+}}(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>)
 // CHECK-NEXT:    ^{{.+}}(%{{.+}}: !riscv.reg<a2>, %{{.+}}: !riscv.reg<a3>):
 // CHECK-NEXT:      riscv.label "else5"
+// CHECK-NEXT:      riscv_cf.bnez %0 : !riscv.reg<a0>, ^{{.+}}(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^{{.+}}(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>)
+// CHECK-NEXT:    ^{{.+}}(%{{.+}}: !riscv.reg<a2>, %{{.+}}: !riscv.reg<a3>):
+// CHECK-NEXT:      riscv.label "else6"
 // CHECK-NEXT:      riscv_cf.branch ^{{.+}}(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>) attributes {hello = "world"}
 // CHECK-NEXT:    ^{{.+}}(%{{.+}}: !riscv.reg<a2>, %{{.+}}: !riscv.reg<a3>):
 // CHECK-NEXT:      riscv.label "then"

--- a/tests/filecheck/dialects/riscv_cf/ops.mlir
+++ b/tests/filecheck/dialects/riscv_cf/ops.mlir
@@ -51,7 +51,7 @@
 // CHECK-NEXT:      riscv_cf.bgeu %0 : !riscv.reg<a0>, %1 : !riscv.reg<a1>, ^{{.+}}(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^{{.+}}(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>)
 // CHECK-NEXT:    ^{{.+}}(%{{.+}}: !riscv.reg<a2>, %{{.+}}: !riscv.reg<a3>):
 // CHECK-NEXT:      riscv.label "else5"
-// CHECK-NEXT:      riscv_cf.bnez %0 : !riscv.reg<a0>, ^{{.+}}(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^{{.+}}(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>) attributes {"comment" = "comment"}
+// CHECK-NEXT:      riscv_cf.bnez %0 : !riscv.reg<a0>, ^{{.+}}(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^{{.+}}(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>) attributes {comment = "comment"}
 // CHECK-NEXT:    ^{{.+}}(%{{.+}}: !riscv.reg<a2>, %{{.+}}: !riscv.reg<a3>):
 // CHECK-NEXT:      riscv.label "else6"
 // CHECK-NEXT:      riscv_cf.branch ^{{.+}}(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>) attributes {hello = "world"}

--- a/tests/filecheck/dialects/riscv_cf/verification.mlir
+++ b/tests/filecheck/dialects/riscv_cf/verification.mlir
@@ -121,7 +121,7 @@
     riscv_cf.j ^then(%1 : !riscv.reg<a2>, %2 : !riscv.reg<a3>)
 }) : () -> ()
 
-// CHECK: Operation does not verify: riscv_cf branch op then block first op must be a label
+// CHECK: Operation does not verify: riscv_cf.bnez operation then block must have a riscv.label operation as a first argument, found
 
 // -----
 
@@ -169,4 +169,4 @@
     riscv_cf.j ^then(%1 : !riscv.reg<a2>, %2 : !riscv.reg<a3>)
 }) : () -> ()
 
-// CHECK: Operation does not verify: riscv_cf branch op else block must be immediately after op
+// CHECK: Operation does not verify: riscv_cf.bnez operation else block must be immediately after op

--- a/tests/filecheck/dialects/riscv_cf/verification.mlir
+++ b/tests/filecheck/dialects/riscv_cf/verification.mlir
@@ -107,3 +107,66 @@
 }) : () -> ()
 
 // CHECK: Operation does not verify: riscv_cf.j operation successor must have a riscv.label operation as a first argument, found JOp(riscv_cf.j ^bb0(%0 : !riscv.reg<a0>, %1 : !riscv.reg<a1>))
+
+// -----
+
+%0, %1, %2, %3, %4 = "test.op"() : () -> (!riscv.reg<a0>, !riscv.reg<a2>, !riscv.reg<a3>, !riscv.reg<a2>, !riscv.reg<a3>)
+
+"test.op"() ({
+    riscv_cf.bnez %0 : !riscv.reg<a0>, ^then(%1 : !riscv.reg<a2>, %2 : !riscv.reg<a3>), ^else(%3 : !riscv.reg<a2>, %4 : !riscv.reg<a3>)
+  ^else(%e0: !riscv.reg<a2>, %e1: !riscv.reg<a3>):
+    riscv.label "else"
+    riscv_cf.j ^then(%1 : !riscv.reg<a2>, %2 : !riscv.reg<a3>)
+  ^then(%t0: !riscv.reg<a2>, %t1: !riscv.reg<a3>):
+    riscv_cf.j ^then(%1 : !riscv.reg<a2>, %2 : !riscv.reg<a3>)
+}) : () -> ()
+
+// CHECK: Operation does not verify: riscv_cf branch op then block first op must be a label
+
+// -----
+
+%0, %1, %2, %3, %4 = "test.op"() : () -> (!riscv.reg<a0>, !riscv.reg<a2>, !riscv.reg<a3>, !riscv.reg<a2>, !riscv.reg<a3>)
+
+"test.op"() ({
+    riscv_cf.bnez %0 : !riscv.reg<a0>, ^then(%2 : !riscv.reg<a3>, %2 : !riscv.reg<a3>), ^else(%3 : !riscv.reg<a2>, %4 : !riscv.reg<a3>)
+  ^else(%e0: !riscv.reg<a2>, %e1: !riscv.reg<a3>):
+    riscv.label "else"
+    riscv_cf.j ^then(%1 : !riscv.reg<a2>, %2 : !riscv.reg<a3>)
+  ^then(%t0: !riscv.reg<a2>, %t1: !riscv.reg<a3>):
+    riscv.label "then"
+    riscv_cf.j ^then(%1 : !riscv.reg<a2>, %2 : !riscv.reg<a3>)
+}) : () -> ()
+
+// CHECK: Operation does not verify: Block arg types must match !riscv.reg<a3> !riscv.reg<a2>
+
+// -----
+
+%0, %1, %2, %3, %4 = "test.op"() : () -> (!riscv.reg<a0>, !riscv.reg<a2>, !riscv.reg<a3>, !riscv.reg<a2>, !riscv.reg<a3>)
+
+"test.op"() ({
+    riscv_cf.bnez %0 : !riscv.reg<a0>, ^then(%1 : !riscv.reg<a2>, %2 : !riscv.reg<a3>), ^else(%0 : !riscv.reg<a0>, %4 : !riscv.reg<a3>)
+  ^else(%e0: !riscv.reg<a2>, %e1: !riscv.reg<a3>):
+    riscv.label "else"
+    riscv_cf.j ^then(%1 : !riscv.reg<a2>, %2 : !riscv.reg<a3>)
+  ^then(%t0: !riscv.reg<a2>, %t1: !riscv.reg<a3>):
+    riscv.label "then"
+    riscv_cf.j ^then(%1 : !riscv.reg<a2>, %2 : !riscv.reg<a3>)
+}) : () -> ()
+
+// CHECK: Operation does not verify: Block arg types must match !riscv.reg<a0> !riscv.reg<a2>
+
+// -----
+
+%0, %1, %2, %3, %4 = "test.op"() : () -> (!riscv.reg<a0>, !riscv.reg<a2>, !riscv.reg<a3>, !riscv.reg<a2>, !riscv.reg<a3>)
+
+"test.op"() ({
+    riscv_cf.bnez %0 : !riscv.reg<a0>, ^then(%1 : !riscv.reg<a2>, %2 : !riscv.reg<a3>), ^else(%3 : !riscv.reg<a2>, %4 : !riscv.reg<a3>)
+  ^then(%t0: !riscv.reg<a2>, %t1: !riscv.reg<a3>):
+    riscv.label "then"
+    riscv_cf.j ^then(%1 : !riscv.reg<a2>, %2 : !riscv.reg<a3>)
+  ^else(%e0: !riscv.reg<a2>, %e1: !riscv.reg<a3>):
+    riscv.label "else"
+    riscv_cf.j ^then(%1 : !riscv.reg<a2>, %2 : !riscv.reg<a3>)
+}) : () -> ()
+
+// CHECK: Operation does not verify: riscv_cf branch op else block must be immediately after op

--- a/xdsl/dialects/riscv_cf.py
+++ b/xdsl/dialects/riscv_cf.py
@@ -464,6 +464,131 @@ class JOp(RISCVInstruction):
         return (dest_label.label,)
 
 
+@irdl_op_definition
+class BnezOp(RISCVInstruction):
+    """
+    A pseudo-instruction that branches if register rs is not equal to zero.
+    Equivalent to BneOp with rs2 = x0.
+
+    if (x[rs] != 0) pc += sext(offset)
+    """
+
+    name = "riscv_cf.bnez"
+
+    rs = operand_def(IntRegisterType)
+
+    then_arguments = var_operand_def(RISCVRegisterType)
+    else_arguments = var_operand_def(RISCVRegisterType)
+
+    irdl_options = (AttrSizedOperandSegments(),)
+
+    then_block = successor_def()
+    else_block = successor_def()
+
+    traits = traits_def(IsTerminator())
+
+    def __init__(
+        self,
+        rs: Operation | SSAValue,
+        then_arguments: Sequence[SSAValue],
+        else_arguments: Sequence[SSAValue],
+        then_block: Successor,
+        else_block: Successor,
+        *,
+        comment: str | StringAttr | None = None,
+    ):
+        if isinstance(comment, str):
+            comment = StringAttr(comment)
+
+        super().__init__(
+            operands=[rs, then_arguments, else_arguments],
+            attributes={
+                "comment": comment,
+            },
+            successors=(then_block, else_block),
+        )
+
+    def verify_(self) -> None:
+        if not isinstance(self.then_block.first_op, riscv.LabelOp):
+            raise VerifyException(
+                "riscv_cf.bnez operation then block must have a riscv.label operation as a "
+                f"first op, found {self.then_block.first_op}"
+            )
+
+        for op_arg, block_arg in zip(self.then_arguments, self.then_block.args):
+            if op_arg.type != block_arg.type:
+                raise VerifyException(
+                    f"Block arg types must match {op_arg.type} {block_arg.type}"
+                )
+
+        for op_arg, block_arg in zip(self.else_arguments, self.else_block.args):
+            if op_arg.type != block_arg.type:
+                raise VerifyException(
+                    f"Block arg types must match {op_arg.type} {block_arg.type}"
+                )
+
+        parent_block = self.parent
+        if parent_block is None:
+            return
+
+        parent_region = parent_block.parent
+        if parent_region is None:
+            return
+
+        if parent_block.next_block is not self.else_block:
+            raise VerifyException(
+                "riscv_cf.bnez operation else block must be immediately after op"
+            )
+
+    def print(self, printer: Printer) -> None:
+        printer.print_string(" ")
+        _print_type_pair(printer, self.rs)
+        printer.print_string(", ")
+        printer.print_block_name(self.then_block)
+        printer.print_string("(")
+        printer.print_list(
+            self.then_arguments, lambda val: _print_type_pair(printer, val)
+        )
+        printer.print_string("), ")
+        printer.print_block_name(self.else_block)
+        printer.print_string("(")
+        printer.print_list(
+            self.else_arguments, lambda val: _print_type_pair(printer, val)
+        )
+        printer.print_string(")")
+        if self.attributes:
+            printer.print_op_attributes(
+                self.attributes,
+                reserved_attr_names="operandSegmentSizes",
+                print_keyword=True,
+            )
+
+    @classmethod
+    def parse(cls, parser: Parser) -> Self:
+        rs = _parse_type_pair(parser)
+        parser.parse_punctuation(",")
+        then_block = parser.parse_successor()
+        then_args = parser.parse_comma_separated_list(
+            parser.Delimiter.PAREN, lambda: _parse_type_pair(parser)
+        )
+        parser.parse_punctuation(",")
+        else_block = parser.parse_successor()
+        else_args = parser.parse_comma_separated_list(
+            parser.Delimiter.PAREN, lambda: _parse_type_pair(parser)
+        )
+        attrs = parser.parse_optional_attr_dict_with_keyword()
+        op = cls(rs, then_args, else_args, then_block, else_block)
+        if attrs is not None:
+            op.attributes |= attrs.data
+        return op
+
+    def assembly_line_args(self) -> tuple[AssemblyInstructionArg, ...]:
+        then_label = self.then_block.first_op
+        assert isinstance(then_label, riscv.LabelOp)
+        return (self.rs, then_label.label)
+
+
+
 RISCV_Cf = Dialect(
     "riscv_cf",
     [
@@ -475,5 +600,6 @@ RISCV_Cf = Dialect(
         BgeOp,
         BltuOp,
         BgeuOp,
+        BnezOp,
     ],
 )

--- a/xdsl/dialects/riscv_cf.py
+++ b/xdsl/dialects/riscv_cf.py
@@ -508,6 +508,11 @@ class BnezOp(RISCVInstruction):
         )
 
     def verify_(self) -> None:
+        if not isinstance(self.then_block.first_op, riscv.LabelOp):
+            raise VerifyException(
+                "riscv_cf.bnez operation then block must have a riscv.label operation as a "
+                f"first argument, found {self.then_block.first_op}"
+            )
 
         for op_arg, block_arg in zip(self.then_arguments, self.then_block.args):
             if op_arg.type != block_arg.type:

--- a/xdsl/dialects/riscv_cf.py
+++ b/xdsl/dialects/riscv_cf.py
@@ -97,7 +97,6 @@ class ConditionalBranchOperation(
             )
 
         # Types of arguments must match arg types of blocks
-
         for op_arg, block_arg in zip(self.then_arguments, self.then_block.args):
             if op_arg.type != block_arg.type:
                 raise VerifyException(
@@ -508,38 +507,6 @@ class BnezOp(RISCVInstruction):
             successors=(then_block, else_block),
         )
 
-    def verify_(self) -> None:
-        if not isinstance(self.then_block.first_op, riscv.LabelOp):
-            raise VerifyException(
-                "riscv_cf.bnez operation then block must have a riscv.label operation as a "
-                f"first op, found {self.then_block.first_op}"
-            )
-
-        for op_arg, block_arg in zip(self.then_arguments, self.then_block.args):
-            if op_arg.type != block_arg.type:
-                raise VerifyException(
-                    f"Block arg types must match {op_arg.type} {block_arg.type}"
-                )
-
-        for op_arg, block_arg in zip(self.else_arguments, self.else_block.args):
-            if op_arg.type != block_arg.type:
-                raise VerifyException(
-                    f"Block arg types must match {op_arg.type} {block_arg.type}"
-                )
-
-        parent_block = self.parent
-        if parent_block is None:
-            return
-
-        parent_region = parent_block.parent
-        if parent_region is None:
-            return
-
-        if parent_block.next_block is not self.else_block:
-            raise VerifyException(
-                "riscv_cf.bnez operation else block must be immediately after op"
-            )
-
     def print(self, printer: Printer) -> None:
         printer.print_string(" ")
         _print_type_pair(printer, self.rs)
@@ -586,7 +553,6 @@ class BnezOp(RISCVInstruction):
         then_label = self.then_block.first_op
         assert isinstance(then_label, riscv.LabelOp)
         return (self.rs, then_label.label)
-
 
 
 RISCV_Cf = Dialect(

--- a/xdsl/dialects/riscv_cf.py
+++ b/xdsl/dialects/riscv_cf.py
@@ -507,6 +507,33 @@ class BnezOp(RISCVInstruction):
             successors=(then_block, else_block),
         )
 
+    def verify_(self) -> None:
+
+        for op_arg, block_arg in zip(self.then_arguments, self.then_block.args):
+            if op_arg.type != block_arg.type:
+                raise VerifyException(
+                    f"Block arg types must match {op_arg.type} {block_arg.type}"
+                )
+
+        for op_arg, block_arg in zip(self.else_arguments, self.else_block.args):
+            if op_arg.type != block_arg.type:
+                raise VerifyException(
+                    f"Block arg types must match {op_arg.type} {block_arg.type}"
+                )
+
+        parent_block = self.parent
+        if parent_block is None:
+            return
+
+        parent_region = parent_block.parent
+        if parent_region is None:
+            return
+
+        if parent_block.next_block is not self.else_block:
+            raise VerifyException(
+                "riscv_cf.bnez operation else block must be immediately after op"
+            )
+
     def print(self, printer: Printer) -> None:
         printer.print_string(" ")
         _print_type_pair(printer, self.rs)


### PR DESCRIPTION
We add the pseudo op `bnez` for riscv. 

Assisted by Claude code - I have checked the code and tried to add meaningful tests, but am unsure whether the `verify` methods suffice.  