### PR TITLE
dialects: add `rv64.ld` and `rv64.sd`

### DIFF
--- a/tests/dialects/test_rv64.py
+++ b/tests/dialects/test_rv64.py
@@ -6,9 +6,17 @@ from xdsl.dialects.builtin import (
     IntegerAttr,
     Signedness,
 )
-from xdsl.traits import ConstantLike, MemoryEffect, NoMemoryEffect, Pure
+from xdsl.traits import (
+    ConstantLike,
+    MemoryEffect,
+    MemoryReadEffect,
+    MemoryWriteEffect,
+    NoMemoryEffect,
+    Pure,
+)
 from xdsl.transforms.canonicalization_patterns.riscv import get_constant_value
 from xdsl.utils.exceptions import VerifyException
+from xdsl.utils.test_value import create_ssa_value
 
 
 def test_immediate_pseudo_inst():
@@ -43,6 +51,44 @@ def test_get_constant_value():
     assert zero_val == IntegerAttr(0, 64)
 
 
+def test_ld_op_construction():
+    lb, ub = Signedness.SIGNLESS.value_range(12)
+    rs1 = create_ssa_value(riscv.Registers.A1)
+
+    with pytest.raises(VerifyException):
+        rv64.LdOp(rs1, ub)
+
+    with pytest.raises(VerifyException):
+        rv64.LdOp(rs1, lb - 1)
+
+    rv64.LdOp(rs1, ub - 1)
+    rv64.LdOp(rs1, lb)
+    rv64.LdOp(rs1, 0)
+
+    ld = rv64.LdOp(rs1, 8, rd=riscv.Registers.A0)
+    assert ld.rd.type == riscv.Registers.A0
+    assert ld.immediate == IntegerAttr(8, 12)
+
+
+def test_sd_op_construction():
+    lb, ub = Signedness.SIGNLESS.value_range(12)
+    rs1 = create_ssa_value(riscv.Registers.A1)
+    rs2 = create_ssa_value(riscv.Registers.A2)
+
+    with pytest.raises(VerifyException):
+        rv64.SdOp(rs1, rs2, ub)
+
+    with pytest.raises(VerifyException):
+        rv64.SdOp(rs1, rs2, lb - 1)
+
+    rv64.SdOp(rs1, rs2, ub - 1)
+    rv64.SdOp(rs1, rs2, lb)
+    rv64.SdOp(rs1, rs2, 0)
+
+    sd = rv64.SdOp(rs1, rs2, 8)
+    assert sd.immediate == IntegerAttr(8, 12)
+
+
 def test_effect_traits():
     """
     Check effects of operations in the rv64 dialect.
@@ -52,7 +98,7 @@ def test_effect_traits():
     unknown_effects_ops = {op for op in operations if op not in effects_ops}
 
     # Sentinels to remind us to update this test when updating the dialect
-    assert len(effects_ops) == 2
+    assert len(effects_ops) == 4
     assert not unknown_effects_ops
 
     all_effects_trait_types = {
@@ -65,12 +111,19 @@ def test_effect_traits():
     assert all_effects_trait_types == {
         Pure,
         RegisterAllocatedMemoryEffect,
+        MemoryReadEffect,
+        MemoryWriteEffect,
     }
 
     register_effects_ops = {
         op for op in effects_ops if op.has_trait(RegisterAllocatedMemoryEffect)
     }
+    read_effects_ops = {op for op in effects_ops if op.has_trait(MemoryReadEffect)}
+    write_effects_ops = {op for op in effects_ops if op.has_trait(MemoryWriteEffect)}
     no_effects_ops = {op for op in effects_ops if op.has_trait(NoMemoryEffect)}
 
-    assert register_effects_ops == {rv64.LiOp}
+    # RISCVInstruction base adds RegisterAllocatedMemoryEffect to all instructions
+    assert register_effects_ops == {rv64.LiOp, rv64.LdOp, rv64.SdOp}
+    assert read_effects_ops == {rv64.LdOp}
+    assert write_effects_ops == {rv64.SdOp}
     assert no_effects_ops == {rv64.GetRegisterOp}

--- a/tests/dialects/test_rv64.py
+++ b/tests/dialects/test_rv64.py
@@ -6,6 +6,7 @@ from xdsl.dialects.builtin import (
     IntegerAttr,
     Signedness,
 )
+from xdsl.dialects.riscv.attrs import si12
 from xdsl.traits import (
     ConstantLike,
     MemoryEffect,
@@ -52,7 +53,7 @@ def test_get_constant_value():
 
 
 def test_ld_op_construction():
-    lb, ub = Signedness.SIGNLESS.value_range(12)
+    lb, ub = Signedness.SIGNED.value_range(12)
     rs1 = create_ssa_value(riscv.Registers.A1)
 
     with pytest.raises(VerifyException):
@@ -67,11 +68,11 @@ def test_ld_op_construction():
 
     ld = rv64.LdOp(rs1, 8, rd=riscv.Registers.A0)
     assert ld.rd.type == riscv.Registers.A0
-    assert ld.immediate == IntegerAttr(8, 12)
+    assert ld.immediate == IntegerAttr(8, si12)
 
 
 def test_sd_op_construction():
-    lb, ub = Signedness.SIGNLESS.value_range(12)
+    lb, ub = Signedness.SIGNED.value_range(12)
     rs1 = create_ssa_value(riscv.Registers.A1)
     rs2 = create_ssa_value(riscv.Registers.A2)
 
@@ -86,7 +87,7 @@ def test_sd_op_construction():
     rv64.SdOp(rs1, rs2, 0)
 
     sd = rv64.SdOp(rs1, rs2, 8)
-    assert sd.immediate == IntegerAttr(8, 12)
+    assert sd.immediate == IntegerAttr(8, si12)
 
 
 def test_effect_traits():

--- a/tests/filecheck/dialects/rv64/rv64_assembly_emission.mlir
+++ b/tests/filecheck/dialects/rv64/rv64_assembly_emission.mlir
@@ -9,7 +9,15 @@ riscv_func.func @main() {
   // Assembler pseudo-instructions
   %li = rv64.li 1 : !riscv.reg<j_0>
   // CHECK-NEXT: li j_0, 1
-  
+
+  // Load 64-bit value: ld rd, offset(rs1)
+  %ld = rv64.ld %1, 8 : (!riscv.reg<j_1>) -> !riscv.reg<j_2>
+  // CHECK-NEXT: ld j_2, 8(j_1)
+
+  // Store 64-bit value: sd rs2, offset(rs1)
+  rv64.sd %1, %ld, 16 : (!riscv.reg<j_1>, !riscv.reg<j_2>) -> ()
+  // CHECK-NEXT: sd j_2, 16(j_1)
+
   // Terminate block
   riscv_func.return
   // CHECK-NEXT: ret

--- a/tests/filecheck/dialects/rv64/rv64_ops.mlir
+++ b/tests/filecheck/dialects/rv64/rv64_ops.mlir
@@ -21,8 +21,8 @@ riscv_func.func @main() {
 // CHECK-GENERIC:       "builtin.module"() ({
 // CHECK-GENERIC-NEXT:    "riscv_func.func"() ({
 // CHECK-GENERIC-NEXT:      %li = "rv64.li"() {immediate = 1 : i64} : () -> !riscv.reg
-// CHECK-GENERIC-NEXT:      %ld = "rv64.ld"(%li) {immediate = 8 : i12} : (!riscv.reg) -> !riscv.reg
-// CHECK-GENERIC-NEXT:      "rv64.sd"(%li, %ld) {immediate = 16 : i12} : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-GENERIC-NEXT:      %ld = "rv64.ld"(%li) {immediate = 8 : si12} : (!riscv.reg) -> !riscv.reg
+// CHECK-GENERIC-NEXT:      "rv64.sd"(%li, %ld) {immediate = 16 : si12} : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-GENERIC-NEXT:      "riscv_func.return"() : () -> ()
 // CHECK-GENERIC-NEXT:    }) {sym_name = "main", function_type = () -> ()} : () -> ()
 // CHECK-GENERIC-NEXT:  }) : () -> ()

--- a/tests/filecheck/dialects/rv64/rv64_ops.mlir
+++ b/tests/filecheck/dialects/rv64/rv64_ops.mlir
@@ -7,12 +7,22 @@ riscv_func.func @main() {
   %li = rv64.li 1 : !riscv.reg
   // CHECK: %{{.*}} = rv64.li 1 : !riscv.reg
 
+  // Load 64-bit value from memory
+  %ld = rv64.ld %li, 8 : (!riscv.reg) -> !riscv.reg
+  // CHECK: %{{.*}} = rv64.ld %{{.*}}, 8 : (!riscv.reg) -> !riscv.reg
+
+  // Store 64-bit value to memory
+  rv64.sd %li, %ld, 16 : (!riscv.reg, !riscv.reg) -> ()
+  // CHECK: rv64.sd %{{.*}}, %{{.*}}, 16 : (!riscv.reg, !riscv.reg) -> ()
+
   riscv_func.return
 }
 
 // CHECK-GENERIC:       "builtin.module"() ({
 // CHECK-GENERIC-NEXT:    "riscv_func.func"() ({
 // CHECK-GENERIC-NEXT:      %li = "rv64.li"() {immediate = 1 : i64} : () -> !riscv.reg
+// CHECK-GENERIC-NEXT:      %ld = "rv64.ld"(%li) {immediate = 8 : i12} : (!riscv.reg) -> !riscv.reg
+// CHECK-GENERIC-NEXT:      "rv64.sd"(%li, %ld) {immediate = 16 : i12} : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-GENERIC-NEXT:      "riscv_func.return"() : () -> ()
 // CHECK-GENERIC-NEXT:    }) {sym_name = "main", function_type = () -> ()} : () -> ()
 // CHECK-GENERIC-NEXT:  }) : () -> ()

--- a/xdsl/dialects/riscv/abstract_ops.py
+++ b/xdsl/dialects/riscv/abstract_ops.py
@@ -1523,6 +1523,132 @@ class LiOperation(
         printer.print_attribute(self.rd.type)
 
 
+IOffset = TypeVar("IOffset", bound=I12 | SI12)
+
+
+class LdOperation(
+    RISCVCustomFormatOperation,
+    RISCVInstruction,
+    ABC,
+    Generic[IOffset],
+):
+    """
+    Base class for RISC-V load operations that load a value from memory
+    at address rs1 + sext(immediate) into rd.
+
+    This is an I-Type operation.
+    """
+
+    rd = result_def(IntRegisterType)
+    rs1 = operand_def(IntRegisterType)
+    immediate = attr_def(IntegerAttr[IOffset])
+
+    traits = traits_def(MemoryReadEffect())
+
+    def __init__(
+        self,
+        rs1: Operation | SSAValue,
+        immediate: IntegerAttr[IOffset],
+        *,
+        rd: IntRegisterType = Registers.UNALLOCATED_INT,
+        comment: str | StringAttr | None = None,
+    ):
+        if isinstance(comment, str):
+            comment = StringAttr(comment)
+        super().__init__(
+            operands=[rs1],
+            result_types=[rd],
+            attributes={
+                "immediate": immediate,
+                "comment": comment,
+            },
+        )
+
+    def assembly_line(self) -> str | None:
+        instruction_name = self.assembly_instruction_name()
+        value = assembly_arg_str(self.rd)
+        imm = assembly_arg_str(self.immediate)
+        base = assembly_arg_str(self.rs1)
+        return AssemblyPrinter.assembly_line(
+            instruction_name, f"{value}, {imm}({base})", self.comment
+        )
+
+    def assembly_line_args(self) -> tuple[AssemblyInstructionArg, ...]:
+        return self.rd, self.rs1, self.immediate
+
+    @classmethod
+    def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
+        attributes = dict[str, Attribute]()
+        attributes["immediate"] = parse_immediate_value(parser, i12)
+        return attributes
+
+    def custom_print_attributes(self, printer: Printer) -> AbstractSet[str]:
+        printer.print_string(", ")
+        print_immediate_value(printer, self.immediate)
+        return {"immediate"}
+
+
+class SdOperation(
+    RISCVCustomFormatOperation,
+    RISCVInstruction,
+    ABC,
+    Generic[IOffset],
+):
+    """
+    Base class for RISC-V store operations that store a value from rs2
+    to memory at address rs1 + sext(immediate).
+
+    This is an S-Type operation.
+    """
+
+    rs1 = operand_def(IntRegisterType)
+    rs2 = operand_def(IntRegisterType)
+    immediate = attr_def(IntegerAttr[IOffset])
+
+    traits = traits_def(MemoryWriteEffect())
+
+    def __init__(
+        self,
+        rs1: Operation | SSAValue,
+        rs2: Operation | SSAValue,
+        immediate: IntegerAttr[IOffset],
+        *,
+        comment: str | StringAttr | None = None,
+    ):
+        if isinstance(comment, str):
+            comment = StringAttr(comment)
+        super().__init__(
+            operands=[rs1, rs2],
+            attributes={
+                "immediate": immediate,
+                "comment": comment,
+            },
+        )
+
+    def assembly_line(self) -> str | None:
+        instruction_name = self.assembly_instruction_name()
+        value = assembly_arg_str(self.rs2)
+        imm = assembly_arg_str(self.immediate)
+        base = assembly_arg_str(self.rs1)
+        return AssemblyPrinter.assembly_line(
+            instruction_name, f"{value}, {imm}({base})", self.comment
+        )
+
+    def assembly_line_args(self) -> tuple[AssemblyInstructionArg, ...]:
+        return self.rs1, self.rs2, self.immediate
+
+    @classmethod
+    def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
+        attributes = dict[str, Attribute]()
+        attributes["immediate"] = parse_immediate_value(parser, i12)
+        return attributes
+
+    def custom_print_attributes(self, printer: Printer) -> AbstractSet[str]:
+        printer.print_string(", ")
+        print_immediate_value(printer, self.immediate)
+        return {"immediate"}
+
+
 class GetAnyRegisterOperation(
     RISCVCustomFormatOperation,
     RISCVAsmOperation,

--- a/xdsl/dialects/riscv/abstract_ops.py
+++ b/xdsl/dialects/riscv/abstract_ops.py
@@ -1526,68 +1526,6 @@ class LiOperation(
 IOffset = TypeVar("IOffset", bound=I12 | SI12)
 
 
-class LdOperation(
-    RISCVCustomFormatOperation,
-    RISCVInstruction,
-    ABC,
-    Generic[IOffset],
-):
-    """
-    Base class for RISC-V load operations that load a value from memory
-    at address rs1 + sext(immediate) into rd.
-
-    This is an I-Type operation.
-    """
-
-    rd = result_def(IntRegisterType)
-    rs1 = operand_def(IntRegisterType)
-    immediate = attr_def(IntegerAttr[IOffset])
-
-    traits = traits_def(MemoryReadEffect())
-
-    def __init__(
-        self,
-        rs1: Operation | SSAValue,
-        immediate: IntegerAttr[IOffset],
-        *,
-        rd: IntRegisterType = Registers.UNALLOCATED_INT,
-        comment: str | StringAttr | None = None,
-    ):
-        if isinstance(comment, str):
-            comment = StringAttr(comment)
-        super().__init__(
-            operands=[rs1],
-            result_types=[rd],
-            attributes={
-                "immediate": immediate,
-                "comment": comment,
-            },
-        )
-
-    def assembly_line(self) -> str | None:
-        instruction_name = self.assembly_instruction_name()
-        value = assembly_arg_str(self.rd)
-        imm = assembly_arg_str(self.immediate)
-        base = assembly_arg_str(self.rs1)
-        return AssemblyPrinter.assembly_line(
-            instruction_name, f"{value}, {imm}({base})", self.comment
-        )
-
-    def assembly_line_args(self) -> tuple[AssemblyInstructionArg, ...]:
-        return self.rd, self.rs1, self.immediate
-
-    @classmethod
-    def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
-        attributes = dict[str, Attribute]()
-        attributes["immediate"] = parse_immediate_value(parser, i12)
-        return attributes
-
-    def custom_print_attributes(self, printer: Printer) -> AbstractSet[str]:
-        printer.print_string(", ")
-        print_immediate_value(printer, self.immediate)
-        return {"immediate"}
-
-
 class SdOperation(
     RISCVCustomFormatOperation,
     RISCVInstruction,

--- a/xdsl/dialects/riscv/abstract_ops.py
+++ b/xdsl/dialects/riscv/abstract_ops.py
@@ -1526,67 +1526,6 @@ class LiOperation(
 IOffset = TypeVar("IOffset", bound=I12 | SI12)
 
 
-class SdOperation(
-    RISCVCustomFormatOperation,
-    RISCVInstruction,
-    ABC,
-    Generic[IOffset],
-):
-    """
-    Base class for RISC-V store operations that store a value from rs2
-    to memory at address rs1 + sext(immediate).
-
-    This is an S-Type operation.
-    """
-
-    rs1 = operand_def(IntRegisterType)
-    rs2 = operand_def(IntRegisterType)
-    immediate = attr_def(IntegerAttr[IOffset])
-
-    traits = traits_def(MemoryWriteEffect())
-
-    def __init__(
-        self,
-        rs1: Operation | SSAValue,
-        rs2: Operation | SSAValue,
-        immediate: IntegerAttr[IOffset],
-        *,
-        comment: str | StringAttr | None = None,
-    ):
-        if isinstance(comment, str):
-            comment = StringAttr(comment)
-        super().__init__(
-            operands=[rs1, rs2],
-            attributes={
-                "immediate": immediate,
-                "comment": comment,
-            },
-        )
-
-    def assembly_line(self) -> str | None:
-        instruction_name = self.assembly_instruction_name()
-        value = assembly_arg_str(self.rs2)
-        imm = assembly_arg_str(self.immediate)
-        base = assembly_arg_str(self.rs1)
-        return AssemblyPrinter.assembly_line(
-            instruction_name, f"{value}, {imm}({base})", self.comment
-        )
-
-    def assembly_line_args(self) -> tuple[AssemblyInstructionArg, ...]:
-        return self.rs1, self.rs2, self.immediate
-
-    @classmethod
-    def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
-        attributes = dict[str, Attribute]()
-        attributes["immediate"] = parse_immediate_value(parser, i12)
-        return attributes
-
-    def custom_print_attributes(self, printer: Printer) -> AbstractSet[str]:
-        printer.print_string(", ")
-        print_immediate_value(printer, self.immediate)
-        return {"immediate"}
-
-
 class GetAnyRegisterOperation(
     RISCVCustomFormatOperation,
     RISCVAsmOperation,

--- a/xdsl/dialects/rv64.py
+++ b/xdsl/dialects/rv64.py
@@ -14,15 +14,25 @@ from xdsl.dialects.riscv import (
     Registers,
     parse_immediate_value,
 )
-from xdsl.dialects.riscv.abstract_ops import GetAnyRegisterOperation, LiOperation
+from xdsl.dialects.riscv.abstract_ops import (
+    GetAnyRegisterOperation,
+    LdOperation,
+    LiOperation,
+    SdOperation,
+)
+from xdsl.dialects.riscv.attrs import I12, i12
 from xdsl.ir import (
     Attribute,
     Dialect,
+    Operation,
+    SSAValue,
 )
 from xdsl.irdl import (
     irdl_op_definition,
+    traits_def,
 )
 from xdsl.parser import Parser
+from xdsl.traits import MemoryReadEffect
 
 
 @irdl_op_definition
@@ -56,6 +66,60 @@ class LiOp(LiOperation[I64]):
 
 
 @irdl_op_definition
+class LdOp(LdOperation[I12]):
+    """
+    Loads a 64-bit value from memory into register rd for RV64I.
+    ```C
+    x[rd] = M[x[rs1] + sext(offset)][63:0]
+    ```
+
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/#_ld).
+    """
+
+    name = "rv64.ld"
+
+    traits = traits_def(MemoryReadEffect())
+
+    def __init__(
+        self,
+        rs1: Operation | SSAValue,
+        immediate: int | IntegerAttr[I12],
+        *,
+        rd: IntRegisterType = Registers.UNALLOCATED_INT,
+        comment: str | StringAttr | None = None,
+    ):
+        if isinstance(immediate, int):
+            immediate = IntegerAttr(immediate, i12)
+        super().__init__(rs1, immediate, rd=rd, comment=comment)
+
+
+@irdl_op_definition
+class SdOp(SdOperation[I12]):
+    """
+    Store 64-bit, values from register rs2 to memory.
+    ```C
+    M[x[rs1] + sext(offset)] = x[rs2][63:0]
+    ```
+
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/#_sd).
+    """
+
+    name = "rv64.sd"
+
+    def __init__(
+        self,
+        rs1: Operation | SSAValue,
+        rs2: Operation | SSAValue,
+        immediate: int | IntegerAttr[I12],
+        *,
+        comment: str | StringAttr | None = None,
+    ):
+        if isinstance(immediate, int):
+            immediate = IntegerAttr(immediate, i12)
+        super().__init__(rs1, rs2, immediate, comment=comment)
+
+
+@irdl_op_definition
 class GetRegisterOp(GetAnyRegisterOperation[IntRegisterType]):
     name = "rv64.get_register"
 
@@ -64,6 +128,8 @@ RV64 = Dialect(
     "rv64",
     [
         LiOp,
+        LdOp,
+        SdOp,
         GetRegisterOp,
     ],
     [],

--- a/xdsl/dialects/rv64.py
+++ b/xdsl/dialects/rv64.py
@@ -7,6 +7,7 @@ using 6-bit immediates for 64-bit architectures.
 
 from __future__ import annotations
 
+from xdsl.backend.assembly_printer import AssemblyPrinter
 from xdsl.dialects.builtin import I64, IntegerAttr, StringAttr, i64
 from xdsl.dialects.riscv import (
     IntRegisterType,
@@ -16,16 +17,14 @@ from xdsl.dialects.riscv import (
 )
 from xdsl.dialects.riscv.abstract_ops import (
     GetAnyRegisterOperation,
-    LdOperation,
     LiOperation,
-    SdOperation,
+    RdRsImmIntegerOperation,
+    RsRsImmIntegerOperation,
+    assembly_arg_str,
 )
-from xdsl.dialects.riscv.attrs import I12, i12
 from xdsl.ir import (
     Attribute,
     Dialect,
-    Operation,
-    SSAValue,
 )
 from xdsl.irdl import (
     irdl_op_definition,
@@ -66,7 +65,7 @@ class LiOp(LiOperation[I64]):
 
 
 @irdl_op_definition
-class LdOp(LdOperation[I12]):
+class LdOp(RdRsImmIntegerOperation):
     """
     Loads a 64-bit value from memory into register rd for RV64I.
     ```C
@@ -80,21 +79,18 @@ class LdOp(LdOperation[I12]):
 
     traits = traits_def(MemoryReadEffect())
 
-    def __init__(
-        self,
-        rs1: Operation | SSAValue,
-        immediate: int | IntegerAttr[I12],
-        *,
-        rd: IntRegisterType = Registers.UNALLOCATED_INT,
-        comment: str | StringAttr | None = None,
-    ):
-        if isinstance(immediate, int):
-            immediate = IntegerAttr(immediate, i12)
-        super().__init__(rs1, immediate, rd=rd, comment=comment)
+    def assembly_line(self) -> str | None:
+        instruction_name = self.assembly_instruction_name()
+        value = assembly_arg_str(self.rd)
+        imm = assembly_arg_str(self.immediate)
+        base = assembly_arg_str(self.rs1)
+        return AssemblyPrinter.assembly_line(
+            instruction_name, f"{value}, {imm}({base})", self.comment
+        )
 
 
 @irdl_op_definition
-class SdOp(SdOperation[I12]):
+class SdOp(RsRsImmIntegerOperation):
     """
     Store 64-bit, values from register rs2 to memory.
     ```C
@@ -106,17 +102,14 @@ class SdOp(SdOperation[I12]):
 
     name = "rv64.sd"
 
-    def __init__(
-        self,
-        rs1: Operation | SSAValue,
-        rs2: Operation | SSAValue,
-        immediate: int | IntegerAttr[I12],
-        *,
-        comment: str | StringAttr | None = None,
-    ):
-        if isinstance(immediate, int):
-            immediate = IntegerAttr(immediate, i12)
-        super().__init__(rs1, rs2, immediate, comment=comment)
+    def assembly_line(self) -> str | None:
+        instruction_name = self.assembly_instruction_name()
+        value = assembly_arg_str(self.rs2)
+        imm = assembly_arg_str(self.immediate)
+        base = assembly_arg_str(self.rs1)
+        return AssemblyPrinter.assembly_line(
+            instruction_name, f"{value}, {imm}({base})", self.comment
+        )
 
 
 @irdl_op_definition


### PR DESCRIPTION
Add the `riscv.sd` and `riscv.ld` operations. Because this is only used in i64 afaiu, I added it to `rv64` directly.

Largely assisted by Claude code.