### PR TITLE
CI: enable ruff RUF015 rule

### DIFF
--- a/benchmarks/rewriting.py
+++ b/benchmarks/rewriting.py
@@ -123,7 +123,7 @@ class RewritingMicrobenchmarks:
         self.add_op_def = AddiOp.get_irdl_definition()
         self.add_op_construct = VarIRConstruct.OPERAND
         self.add_op_result = self.add_op.result
-        self.add_op_result_use = list(self.add_op_result.uses)[0]
+        self.add_op_result_use = next(iter(self.add_op_result.uses))
         self.sub_op = SubiOp(self.const_1, self.const_0)
         self.sub_op_result = self.sub_op.result
         self.insert_point = InsertPoint.before(self.add_op)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,6 @@ lint.ignore = [
   "RUF003", # https://docs.astral.sh/ruff/rules/ambiguous-unicode-character-comment
   "RUF005", # https://docs.astral.sh/ruff/rules/collection-literal-concatenation
   "RUF012", # https://docs.astral.sh/ruff/rules/mutable-class-default
-  "RUF015", # https://docs.astral.sh/ruff/rules/unnecessary-iterable-allocation-for-first-element
   "RUF018", # https://docs.astral.sh/ruff/rules/assignment-in-assert
   "RUF033", # https://docs.astral.sh/ruff/rules/post-init-default
   "RUF043", # https://docs.astral.sh/ruff/rules/pytest-raises-ambiguous-pattern

--- a/xdsl/interactive/add_arguments_screen.py
+++ b/xdsl/interactive/add_arguments_screen.py
@@ -57,11 +57,13 @@ class AddArguments(Screen[ModulePass | None]):
         concatenated_arg_val = self.argument_text_area.text
 
         try:
-            parsed_spec = list(
-                parse_pipeline(
-                    f"{self.selected_pass_type.name}{{{concatenated_arg_val}}}"
+            parsed_spec = next(
+                iter(
+                    parse_pipeline(
+                        f"{self.selected_pass_type.name}{{{concatenated_arg_val}}}"
+                    )
                 )
-            )[0]
+            )
         except ArgSpecParseError:
             self.selected_pass_value = None
             return


### PR DESCRIPTION
Towards #5927 ("Help welcome removing ignores below") — removes `RUF015` from `lint.ignore` and fixes the two flagged single-element-slice patterns to `next(iter(...))`.

RUF015 (`unnecessary-iterable-allocation-for-first-element`) is clean locally with no new violations.

Supersedes #5932, which couldn't be reopened after the rebase onto current main.