### PR TITLE
CI: use SHA dependencies for precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,6 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
+# See https://docs.renovatebot.com/modules/manager/pre-commit/ for Renovate updates to frozen rev pins
 repos:
   - repo: local
     hooks:
@@ -10,13 +11,13 @@ repos:
         pass_filenames: false
         always_run: true
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v6.0.0
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c # frozen: v6.0.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: mixed-line-ending
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.20
+    rev: c59bba8fb259db0fec2bbb77ad8ba51ea7341b56 # frozen: v0.15.20
     hooks:
       - id: ruff-check
         types_or: [python, pyi, jupyter]
@@ -24,11 +25,11 @@ repos:
       - id: ruff-format
         types_or: [python, pyi, jupyter]
   - repo: https://github.com/rbubley/mirrors-prettier
-    rev: 515f543f5718ebfd6ce22e16708bb32c68ff96e1
+    rev: 515f543f5718ebfd6ce22e16708bb32c68ff96e1 # frozen: v3.8.3
     hooks:
       - id: prettier
         types_or: [yaml]
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: "v2.25.0"
+    rev: f073523dfd27b01ec7997cc970a2a7b36c303460 # frozen: v2.25.0
     hooks:
       - id: pyproject-fmt

--- a/renovate.json
+++ b/renovate.json
@@ -17,5 +17,18 @@
   "rangeStrategy": "replace",
   "lockFileMaintenance": {
     "enabled": true
-  }
+  },
+  "packageRules": [
+    {
+      "description": "Only major and minor updates for pre-commit hooks",
+      "matchManagers": [
+        "pre-commit"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "digest"
+      ],
+      "enabled": false
+    }
+  ]
 }


### PR DESCRIPTION
Also only update major and minor versions, I don't think we need to update patches for precommit hooks.