### PR TITLE
bench: (Worklist) catch exception to allow warmup

### DIFF
--- a/benchmarks/rewriting.py
+++ b/benchmarks/rewriting.py
@@ -163,7 +163,10 @@ class PatternRewriting(RewritingMicrobenchmarks):
         relying on operation's `__hash__` function. This is used to process
         items sequentially from the worklist as a stack.
         """
-        self.worklist.pop()
+        try:
+            self.worklist.pop()
+        except IndexError:
+            pass
 
     def time_get_trait(self) -> None:
         """Time `Operation.get_trait`.


### PR DESCRIPTION
Alternative to #6229 . Allows us to keep the warmup, but does add a try statement. Not sure what is cleaner (feels like the cleaner option is that asv runs setup while warming up but there seems to be no option for this which has made a lot of people angry in the issues)