### PR TITLE
backend: (llvm) target triple in conversion call is fallback

### DIFF
--- a/benchmarks/llvm_backend.py
+++ b/benchmarks/llvm_backend.py
@@ -35,7 +35,7 @@ class LLVMBackend:
     def time_convert_module(self) -> None:
         from xdsl.backend.llvm.convert import convert_module
 
-        convert_module(LLVMBackend.MODULE)
+        convert_module(LLVMBackend.MODULE, fallback_target_triple=None)
 
 
 if __name__ == "__main__":

--- a/tests/backend/llvm/test_convert.py
+++ b/tests/backend/llvm/test_convert.py
@@ -6,12 +6,14 @@ from xdsl.dialects.test import TestOp
 from xdsl.ir import Block, Region
 
 ir = pytest.importorskip("llvmlite.ir")
+from llvmlite import binding  # noqa: E402
+
 from xdsl.backend.llvm.convert import convert_module  # noqa: E402
 
 
 def test_convert_empty_module():
     module = ModuleOp([])
-    llvm_module = convert_module(module)
+    llvm_module = convert_module(module, fallback_target_triple=None)
     assert isinstance(llvm_module, ir.Module)
     assert llvm_module.name == ""
 
@@ -23,28 +25,29 @@ def test_convert_module_with_op_raises():
     with pytest.raises(
         NotImplementedError, match="Conversion not implemented for op: test.op"
     ):
-        convert_module(module)
+        convert_module(module, fallback_target_triple=None)
 
 
 @pytest.mark.parametrize(
-    "module_triple,arg_triple,expected",
+    "module_triple,fallback_triple,expected",
     [
-        # neither the module nor the call specifies a triple: llvmlite default
-        (None, "", "unknown-unknown-unknown"),
-        # only the call specifies a triple
+        # neither the module nor the call specifies a triple: host default is used
+        (None, None, binding.get_default_triple()),
+        # only the call specifies a fallback triple
         (None, "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-gnu"),
         # only the module specifies a triple
-        ("aarch64-unknown-linux-gnu", "", "aarch64-unknown-linux-gnu"),
-        # both specify a triple: the call argument overrides the module attribute
+        ("aarch64-unknown-linux-gnu", None, "aarch64-unknown-linux-gnu"),
+        # both specify a triple: the module attribute takes precedence over the
+        # fallback passed by the caller
         (
             "aarch64-unknown-linux-gnu",
             "x86_64-unknown-linux-gnu",
-            "x86_64-unknown-linux-gnu",
+            "aarch64-unknown-linux-gnu",
         ),
     ],
 )
 def test_convert_module_target_triple(
-    module_triple: str | None, arg_triple: str, expected: str
+    module_triple: str | None, fallback_triple: str | None, expected: str
 ):
     attributes = (
         {"llvm.target_triple": StringAttr(module_triple)}
@@ -53,7 +56,7 @@ def test_convert_module_target_triple(
     )
     module = ModuleOp([], attributes)
 
-    llvm_module = convert_module(module, target_triple=arg_triple)
+    llvm_module = convert_module(module, fallback_target_triple=fallback_triple)
 
     assert llvm_module.triple == expected
 
@@ -62,7 +65,9 @@ def test_convert_module_data_layout():
     module = ModuleOp([])
 
     llvm_module = convert_module(
-        module, data_layout="e-m:e-p270:32:32-p271:32:32-p272:64:64"
+        module,
+        fallback_target_triple=None,
+        data_layout="e-m:e-p270:32:32-p271:32:32-p272:64:64",
     )
 
     assert llvm_module.data_layout == "e-m:e-p270:32:32-p271:32:32-p272:64:64"
@@ -73,7 +78,7 @@ def test_convert_module_target_config_combined():
 
     llvm_module = convert_module(
         module,
-        target_triple="x86_64-unknown-linux-gnu",
+        fallback_target_triple="x86_64-unknown-linux-gnu",
         data_layout="e-m:e-p270:32:32-p271:32:32-p272:64:64",
     )
 
@@ -87,7 +92,7 @@ def test_convert_module_declaration():
     func = llvm.FuncOp("my_decl", ft)
     module = ModuleOp([func])
 
-    llvm_module = convert_module(module)
+    llvm_module = convert_module(module, fallback_target_triple=None)
     fn = llvm_module.get_global("my_decl")
     assert fn is not None
     assert not fn.basic_blocks
@@ -117,7 +122,7 @@ def test_convert_module_forward_reference():
 
     # caller defined before callee
     module = ModuleOp([caller, callee])
-    llvm_module = convert_module(module)
+    llvm_module = convert_module(module, fallback_target_triple=None)
 
     caller_fn = llvm_module.get_global("caller")
     callee_fn = llvm_module.get_global("callee")

--- a/tests/filecheck/projects/pyjit/two_plus_two.py
+++ b/tests/filecheck/projects/pyjit/two_plus_two.py
@@ -95,7 +95,7 @@ class JITContext:
         self, func: Callable[[float, float], float]
     ) -> McJitKeepalive[[float, float], float]:
         parsed_program = self.pyast_ctx.parse_program(func)
-        module = convert_module(parsed_program.module)
+        module = convert_module(parsed_program.module, fallback_target_triple=None)
         return mcjit_f64_f64_f64_binary(module, parsed_program.name)
 
 

--- a/typings/llvmlite/binding/targets.pyi
+++ b/typings/llvmlite/binding/targets.pyi
@@ -55,7 +55,7 @@ def get_host_cpu_features():  # -> FeatureMap:
     """
     ...
 
-def get_default_triple():  # -> str:
+def get_default_triple() -> str:
     """
     Return the default target triple LLVM is configured to produce code for.
     """

--- a/xdsl/backend/llvm/convert.py
+++ b/xdsl/backend/llvm/convert.py
@@ -122,7 +122,8 @@ def _convert_func(op: llvm.FuncOp, llvm_module: ir.Module):
 
 def convert_module(
     module: ModuleOp,
-    target_triple: str = "",
+    *,
+    fallback_target_triple: str | None,
     data_layout: str = "",
 ) -> ir.Module:
     """
@@ -136,8 +137,12 @@ def convert_module(
                 f"Unsupported llvm.target_triple attribute: {module_triple}"
             )
         llvm_module.triple = module_triple.data
-    if target_triple:
-        llvm_module.triple = target_triple
+    else:
+        if fallback_target_triple is None:
+            from llvmlite import binding
+
+            fallback_target_triple = binding.get_default_triple()
+        llvm_module.triple = fallback_target_triple
     if data_layout:
         llvm_module.data_layout = data_layout
 
@@ -164,5 +169,5 @@ class LLVMTarget(Target):
     name = "llvm"
 
     def emit(self, ctx: Context, module: ModuleOp, output: IO[str]) -> None:
-        llvm_module = convert_module(module)
+        llvm_module = convert_module(module, fallback_target_triple=None)
         print(llvm_module, file=output)

--- a/xdsl/backend/llvm/convert.py
+++ b/xdsl/backend/llvm/convert.py
@@ -128,6 +128,29 @@ def convert_module(
 ) -> ir.Module:
     """
     Convert an xDSL module to an LLVM module.
+
+    Args:
+        module: The xDSL module to convert.
+        fallback_target_triple: The target triple to use when the module does not
+            carry an ``llvm.target_triple`` attribute. The triple of the resulting
+            module is resolved as follows:
+
+            1. If the module has an ``llvm.target_triple`` attribute, its value is
+               always used and ``fallback_target_triple`` is ignored.
+            2. Otherwise, if ``fallback_target_triple`` is not ``None``, it is used
+               as-is.
+            3. Otherwise (it is ``None``), the host's default triple, as reported by
+               ``llvmlite.binding.get_default_triple()``, is used.
+        data_layout: The data layout to set on the resulting module. If empty, no
+            data layout is set.
+
+    Returns:
+        The corresponding llvmlite IR module.
+
+    Raises:
+        LLVMTranslationException: If the ``llvm.target_triple`` attribute is present
+            but is not a ``StringAttr``.
+        NotImplementedError: If the module contains an op that is not a ``FuncOp``.
     """
     llvm_module = ir.Module()
     module_triple = module.attributes.get("llvm.target_triple")


### PR DESCRIPTION
This is a change of behaviour from it overriding the module's target triple.
