### PR TITLE
backend: (llvm) add create_constant helper

### DIFF
--- a/tests/backend/llvm/test_convert_op.py
+++ b/tests/backend/llvm/test_convert_op.py
@@ -4,11 +4,16 @@ from unittest.mock import MagicMock
 import pytest
 from llvmlite import ir
 
-from xdsl.backend.llvm.convert_op import convert_op, declare_intrinsic, intrinsic_suffix
+from xdsl.backend.llvm.convert_op import (
+    convert_op,
+    create_constant,
+    declare_intrinsic,
+    intrinsic_suffix,
+)
 from xdsl.dialects import llvm
-from xdsl.dialects.builtin import i32
+from xdsl.dialects.builtin import FloatAttr, IntegerAttr, f32, f64, i32, i64
 from xdsl.dialects.utils import FastMathFlag
-from xdsl.ir import Block, SSAValue
+from xdsl.ir import Attribute, Block, SSAValue
 
 
 def test_convert_indirect_call_raises():
@@ -100,3 +105,26 @@ def test_convert_zero():
     convert_op(op, MagicMock(), val_map)
 
     assert str(val_map[op.res]) == "ptr null"
+
+
+@pytest.mark.parametrize(
+    "xdsl_type, attr, llvmlite_type, value",
+    [
+        (i32, IntegerAttr(1, i32), ir.IntType(32), 1),
+        (
+            i64,
+            IntegerAttr(123, i64),
+            ir.IntType(64),
+            123,
+        ),
+        (f32, FloatAttr(3.0, f32), ir.FloatType(), 3.0),
+        (f64, FloatAttr(-42.5, f64), ir.DoubleType(), -42.5),
+    ],
+)
+def test_create_constant(
+    xdsl_type: Attribute,
+    attr: Attribute,
+    llvmlite_type: ir.Type,
+    value: object,
+) -> None:
+    assert create_constant(xdsl_type, attr) == ir.Constant(llvmlite_type, value)

--- a/tests/backend/llvm/test_convert_op.py
+++ b/tests/backend/llvm/test_convert_op.py
@@ -11,9 +11,10 @@ from xdsl.backend.llvm.convert_op import (
     intrinsic_suffix,
 )
 from xdsl.dialects import llvm
-from xdsl.dialects.builtin import FloatAttr, IntegerAttr, f32, f64, i32, i64
+from xdsl.dialects.builtin import FloatAttr, IntegerAttr, UnitAttr, f32, f64, i32, i64
 from xdsl.dialects.utils import FastMathFlag
 from xdsl.ir import Attribute, Block, SSAValue
+from xdsl.utils.exceptions import LLVMTranslationException
 
 
 def test_convert_indirect_call_raises():
@@ -128,3 +129,10 @@ def test_create_constant(
     value: object,
 ) -> None:
     assert create_constant(xdsl_type, attr) == ir.Constant(llvmlite_type, value)
+
+
+def test_create_constant_invalid():
+    with pytest.raises(
+        LLVMTranslationException, match="Unsupported constant attribute type"
+    ):
+        create_constant(i32, UnitAttr())

--- a/xdsl/backend/llvm/convert_op.py
+++ b/xdsl/backend/llvm/convert_op.py
@@ -17,6 +17,7 @@ from xdsl.dialects.builtin import (
     IntegerAttr,
 )
 from xdsl.ir import Attribute, Block, Operation, SSAValue
+from xdsl.utils.exceptions import LLVMTranslationException
 from xdsl.utils.type import get_element_type_or_self
 
 _BINARY_OP_MAP: dict[
@@ -487,25 +488,20 @@ def _convert_shuffle_vector(
 
 
 _CONSTANT_VALUE_MAP: dict[type[Attribute], Callable[[Attribute], object]] = {
-    DenseIntOrFPElementsAttr: lambda v: list(
-        cast(DenseIntOrFPElementsAttr, v).iter_values()
-    ),
+    DenseIntOrFPElementsAttr: lambda v: cast(DenseIntOrFPElementsAttr, v).get_values(),
     IntegerAttr: lambda v: cast(IntegerAttr, v).value.data,
     FloatAttr: lambda v: cast(FloatAttr, v).value.data,
 }
 
 
-def _convert_constant(
-    op: llvm.ConstantOp, builder: ir.IRBuilder, val_map: dict[SSAValue, ir.Value]
-):
-    value = op.value
+def create_constant(result_type: Attribute, value: Attribute) -> ir.Constant:
     try:
         handler = _CONSTANT_VALUE_MAP[type(value)]
     except KeyError:
-        raise NotImplementedError(
+        raise LLVMTranslationException(
             f"Unsupported constant attribute type: {type(value)}"
         ) from None
-    val_map[op.result] = ir.Constant(convert_type(op.result.type), handler(value))
+    return ir.Constant(convert_type(result_type), handler(value))
 
 
 def convert_op(
@@ -600,6 +596,6 @@ def convert_op(
         case llvm.FMAOp():
             _convert_fma(op, builder, val_map)
         case llvm.ConstantOp():
-            _convert_constant(op, builder, val_map)
+            val_map[op.result] = create_constant(op.result.type, op.value)
         case _:
             raise NotImplementedError(f"Conversion not implemented for op: {op.name}")


### PR DESCRIPTION
It'll be useful for the llvm.global conversion.