### PR TITLE
core: (attr assembly fmt) add keyword directive

### DIFF
--- a/tests/irdl/test_attr_declarative_assembly_format.py
+++ b/tests/irdl/test_attr_declarative_assembly_format.py
@@ -44,30 +44,25 @@ def test_empty_format_produces_empty_program():
 
 
 @pytest.mark.parametrize(
-    "format_str, printed",
-    [("", ""), ("` `", " "), ("``", ""), ("`\\n`", "\n")],
+    "format_str, body, printed",
+    [
+        ("", "", ""),
+        ("` `", "", " "),
+        ("``", "", ""),
+        ("`\\n`", "", "\n"),
+        ("`hello`", "hello", "hello"),
+        ("`foo``bar`", "foo bar", "foo bar"),
+    ],
 )
-def test_prints_and_parses_nothing(format_str: str, printed: str):
+def test_print_and_parse(format_str: str, body: str, printed: str):
     assert _print(format_str) == printed
-    assert _parse(format_str, "") == []
+    assert _parse(format_str, body) == []
 
 
 def test_parse_attribute_end_to_end():
     ctx = Context()
     ctx.load_attr_or_type(EmptyType)
     assert Parser(ctx, "!test_af.empty").parse_type() == EmptyType()
-
-
-@pytest.mark.parametrize(
-    "format_str, printed",
-    [("`hello`", "hello"), ("`foo``bar`", "foo bar")],
-)
-def test_keyword_print(format_str: str, printed: str):
-    assert _print(format_str) == printed
-
-
-def test_keyword_parse():
-    assert _parse("`kw`", "kw") == []
 
 
 @pytest.mark.parametrize(

--- a/tests/irdl/test_attr_declarative_assembly_format.py
+++ b/tests/irdl/test_attr_declarative_assembly_format.py
@@ -59,11 +59,23 @@ def test_parse_attribute_end_to_end():
 
 
 @pytest.mark.parametrize(
+    "format_str, printed",
+    [("`hello`", "hello"), ("`foo``bar`", "foo bar")],
+)
+def test_keyword_print(format_str: str, printed: str):
+    assert _print(format_str) == printed
+
+
+def test_keyword_parse():
+    assert _parse("`kw`", "kw") == []
+
+
+@pytest.mark.parametrize(
     "format_str, error",
     [
         ("$foo", "unexpected token"),
         ("`  `", "unexpected whitespace in directive"),
-        ("`+`", "expected a whitespace directive"),
+        ("`+`", "punctuation or identifier expected"),
     ],
 )
 def test_error(format_str: str, error: str):

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -1371,6 +1371,14 @@ def _print_whitespace(printer: Printer, state: PrintingState, whitespace: str) -
     state.should_emit_space = False
 
 
+def _print_keyword(printer: Printer, state: PrintingState, keyword: str) -> None:
+    if state.should_emit_space:
+        printer.print_string(" ")
+    state.should_emit_space = True
+    state.last_was_punctuation = False
+    printer.print_string(keyword)
+
+
 @dataclass(frozen=True)
 class WhitespaceDirective(FormatDirective):
     """
@@ -1446,12 +1454,7 @@ class KeywordDirective(FormatDirective):
         return parser.parse_optional_keyword(self.keyword) is not None
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
-        if state.should_emit_space:
-            printer.print_string(" ")
-        state.should_emit_space = True
-        state.last_was_punctuation = False
-
-        printer.print_string(self.keyword)
+        _print_keyword(printer, state, self.keyword)
 
     def is_optional_like(self) -> bool:
         return True
@@ -1568,6 +1571,27 @@ class AttrWhitespaceDirective(AttrFormatDirective):
         self, printer: Printer, state: PrintingState, attr: ParametrizedAttribute, /
     ) -> None:
         _print_whitespace(printer, state, self.whitespace)
+
+
+@dataclass(frozen=True)
+class AttrKeywordDirective(AttrFormatDirective):
+    """
+    A keyword directive for attribute/type assembly format.
+
+    Mirrors the op-side KeywordDirective: expects a specific identifier and
+    requests a space to be printed after.
+    """
+
+    keyword: str
+    """The identifier that should be printed."""
+
+    def parse(self, parser: AttrParser, state: AttrParsingState) -> bool:
+        return parser.parse_optional_keyword(self.keyword) is not None
+
+    def print(
+        self, printer: Printer, state: PrintingState, attr: ParametrizedAttribute, /
+    ) -> None:
+        _print_keyword(printer, state, self.keyword)
 
 
 @dataclass(frozen=True)

--- a/xdsl/irdl/declarative_assembly_format_parser.py
+++ b/xdsl/irdl/declarative_assembly_format_parser.py
@@ -49,6 +49,7 @@ from xdsl.irdl.declarative_assembly_format import (
     AttrFormatDirective,
     AttrFormatProgram,
     AttributeVariable,
+    AttrKeywordDirective,
     AttrWhitespaceDirective,
     DenseArrayAttributeVariable,
     Directive,
@@ -949,4 +950,10 @@ class AttrFormatParser(BaseParser):
                 )
             return AttrWhitespaceDirective(whitespace)
 
-        self.raise_error("expected a whitespace directive")
+        # Identifier case
+        ident = self.parse_optional_identifier()
+        if ident is None or ident == "`":
+            self.raise_error("punctuation or identifier expected")
+
+        self.parse_characters("`")
+        return AttrKeywordDirective(ident)


### PR DESCRIPTION
Adds `AttrKeywordDirective` to declarative assembly format for attributes.

WIP:
* #5907 