### PR TITLE
CI: enable RUF033

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,6 @@ lint.ignore = [
   "RUF005", # https://docs.astral.sh/ruff/rules/collection-literal-concatenation
   "RUF012", # https://docs.astral.sh/ruff/rules/mutable-class-default
   "RUF018", # https://docs.astral.sh/ruff/rules/assignment-in-assert
-  "RUF033", # https://docs.astral.sh/ruff/rules/post-init-default
   "RUF043", # https://docs.astral.sh/ruff/rules/pytest-raises-ambiguous-pattern
 ]
 lint.per-file-ignores."**/filecheck/*" = [ "E501", "F811", "F841" ]

--- a/xdsl/dialects/hw.py
+++ b/xdsl/dialects/hw.py
@@ -195,7 +195,7 @@ class InnerSymbolTable:
         default_factory=dict[StringAttr, InnerSymTarget]
     )
 
-    def __post_init__(self, op: Operation | None = None) -> None:
+    def __post_init__(self, op: Operation | None) -> None:
         pass
         # Here will populate self.symbol_table
 
@@ -209,7 +209,7 @@ class InnerSymbolTableCollection:
     )
     op: InitVar[Operation | None] = None
 
-    def __post_init__(self, op: Operation | None = None) -> None:
+    def __post_init__(self, op: Operation | None) -> None:
         if op is None:
             return
         if not op.has_trait(trait := InnerRefNamespaceTrait):


### PR DESCRIPTION
Enable Ruff rule RUF033 by removing redundant defaults from the two `__post_init__` parameters in the HW dialect. The defaults already live on their corresponding `InitVar` fields, so dataclass construction behavior is unchanged.

Part of #5927.

Tests:
- `make tests-functional LIT_OPTIONS="-q --order=smart" PYTEST_OPTIONS="-q --tb=short"`
- `uv run prek run --files pyproject.toml xdsl/dialects/hw.py`
- `uv run pyright xdsl/dialects/hw.py`
- `uv run ruff check --select RUF033 .`