### PR TITLE
core: Derive low-precision fp bitwidth from semantics

### DIFF
--- a/tests/dialects/test_builtin.py
+++ b/tests/dialects/test_builtin.py
@@ -20,6 +20,7 @@ from xdsl.dialects.builtin import (
     DenseArrayBase,
     DenseIntOrFPElementsAttr,
     FloatAttr,
+    FloatSemantics,
     IndexType,
     IntAttr,
     IntAttrConstraint,
@@ -79,6 +80,27 @@ from xdsl.irdl import (
 )
 from xdsl.printer import Printer
 from xdsl.utils.exceptions import VerifyException
+
+
+@pytest.mark.parametrize(
+    "e",
+    "m",
+    "s",
+    [
+        (5, 3, True),
+        (3, 0, True),
+        (0, 3, True),
+        (1, 3, True),
+        (5, 3, False),
+        (3, 0, False),
+        (0, 1, False),
+        (1, 7, False),
+    ],
+)
+def test_FloatSemantics_bitwidths(e: int, m: int, s: bool):
+    fs = FloatSemantics(exponent_bits=e, mantissa_bits=m, has_sign=s)
+    expected = e + m + int(s)
+    assert fs.bitwidth == expected
 
 
 def test_FloatType_bitwidths():

--- a/tests/dialects/test_builtin.py
+++ b/tests/dialects/test_builtin.py
@@ -83,9 +83,7 @@ from xdsl.utils.exceptions import VerifyException
 
 
 @pytest.mark.parametrize(
-    "e",
-    "m",
-    "s",
+    "e, m, s",
     [
         (5, 3, True),
         (3, 0, True),
@@ -98,7 +96,7 @@ from xdsl.utils.exceptions import VerifyException
     ],
 )
 def test_FloatSemantics_bitwidths(e: int, m: int, s: bool):
-    fs = FloatSemantics(exponent_bits=e, mantissa_bits=m, has_sign=s)
+    fs = FloatSemantics(exponent_bits=e, mantissa_bits=m, exponent_bias=12, has_sign=s)
     expected = e + m + int(s)
     assert fs.bitwidth == expected
 

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -1330,19 +1330,31 @@ class Float128Type(ParametrizedAttribute, _FloatType, StructPackableType[float])
 @irdl_attr_definition
 class FloatTF32Type(ParametrizedAttribute, ReducedPrecisionFloatType):
     name = "tf32"
-    SEMANTICS = FloatSemantics(exponent_bits=8, mantissa_bits=10, exponent_bias=127)
+    SEMANTICS = FloatSemantics(
+        exponent_bits=8,
+        mantissa_bits=10,
+        exponent_bias=127,
+    )
 
 
 @irdl_attr_definition
 class Float8E5M2Type(ParametrizedAttribute, ReducedPrecisionFloatType):
     name = "f8E5M2"
-    SEMANTICS = FloatSemantics(exponent_bits=5, mantissa_bits=2, exponent_bias=15)
+    SEMANTICS = FloatSemantics(
+        exponent_bits=5,
+        mantissa_bits=2,
+        exponent_bias=15,
+    )
 
 
 @irdl_attr_definition
 class Float8E4M3Type(ParametrizedAttribute, ReducedPrecisionFloatType):
     name = "f8E4M3"
-    SEMANTICS = FloatSemantics(exponent_bits=4, mantissa_bits=3, exponent_bias=7)
+    SEMANTICS = FloatSemantics(
+        exponent_bits=4,
+        mantissa_bits=3,
+        exponent_bias=7,
+    )
 
 
 @irdl_attr_definition
@@ -1396,7 +1408,11 @@ class Float8E4M3B11FNUZType(ParametrizedAttribute, ReducedPrecisionFloatType):
 @irdl_attr_definition
 class Float8E3M4Type(ParametrizedAttribute, ReducedPrecisionFloatType):
     name = "f8E3M4"
-    SEMANTICS = FloatSemantics(exponent_bits=3, mantissa_bits=4, exponent_bias=3)
+    SEMANTICS = FloatSemantics(
+        exponent_bits=3,
+        mantissa_bits=4,
+        exponent_bias=3,
+    )
 
 
 @irdl_attr_definition

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -1148,7 +1148,8 @@ class _FloatType(PackableType[float], FixedBitwidthType, BuiltinAttribute, ABC):
 
 
 class FloatNonfiniteBehavior(Enum):
-    """How a reduced-precision float format represents infinities and NaNs.
+    """
+    How a reduced-precision float format represents infinities and NaNs.
 
     Mirrors LLVM APFloat's `fltNonfiniteBehavior`.
     """
@@ -1162,7 +1163,9 @@ class FloatNonfiniteBehavior(Enum):
 
 
 class FloatNanEncoding(Enum):
-    """Which bit pattern encodes NaN. Mirrors LLVM APFloat's `fltNanEncoding`."""
+    """
+    Which bit pattern encodes NaN. Mirrors LLVM APFloat's `fltNanEncoding`.
+    """
 
     IEEE = auto()
     """All-ones exponent with a non-zero mantissa."""
@@ -1174,7 +1177,8 @@ class FloatNanEncoding(Enum):
 
 @dataclass(frozen=True)
 class FloatSemantics:
-    """The parameters that fully define a reduced-precision float format.
+    """
+    The parameters that fully define a reduced-precision float format.
 
     Modelled on LLVM's `fltSemantics`. This describes the bit layout; the codec that
     encodes and decodes values from this descriptor is added separately.
@@ -1188,9 +1192,14 @@ class FloatSemantics:
     has_zero: bool = True
     has_sign: bool = True
 
+    @property
+    def bitwidth(self) -> int:
+        return int(self.has_sign) + self.exponent_bits + self.mantissa_bits
+
 
 class ReducedPrecisionFloatType(_FloatType, StructPackableType[float], ABC):
-    """Base for reduced-precision float types, described by a `FloatSemantics`.
+    """
+    Base for reduced-precision float types, described by a `FloatSemantics`.
 
     Concrete subclasses set only `SEMANTICS`. This carries the type structure; the packing
     codec that consumes the semantics is added separately, so packing is not yet supported
@@ -1201,10 +1210,7 @@ class ReducedPrecisionFloatType(_FloatType, StructPackableType[float], ABC):
 
     @property
     def bitwidth(self) -> int:
-        semantics = self.SEMANTICS
-        return (
-            int(semantics.has_sign) + semantics.exponent_bits + semantics.mantissa_bits
-        )
+        return self.SEMANTICS.bitwidth
 
     @property
     def format(self) -> str:

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -6,11 +6,12 @@ from abc import ABC, abstractmethod
 from collections.abc import Iterable, Iterator, Mapping, Sequence
 from collections.abc import Set as AbstractSet
 from dataclasses import dataclass
-from enum import Enum
+from enum import Enum, auto
 from math import prod
 from typing import (
     TYPE_CHECKING,
     Annotated,
+    ClassVar,
     Generic,
     Literal,
     TypeAlias,
@@ -1146,6 +1147,70 @@ class _FloatType(PackableType[float], FixedBitwidthType, BuiltinAttribute, ABC):
         printer.print_string(self.name)
 
 
+class FloatNonfiniteBehavior(Enum):
+    """How a reduced-precision float format represents infinities and NaNs.
+
+    Mirrors LLVM APFloat's `fltNonfiniteBehavior`.
+    """
+
+    IEEE = auto()
+    """The all-ones exponent encodes infinities (zero mantissa) and NaNs."""
+    NAN_ONLY = auto()
+    """No infinities; a NaN is present (see `FloatNanEncoding`)."""
+    FINITE_ONLY = auto()
+    """No infinities or NaNs; overflow saturates to the largest finite value."""
+
+
+class FloatNanEncoding(Enum):
+    """Which bit pattern encodes NaN. Mirrors LLVM APFloat's `fltNanEncoding`."""
+
+    IEEE = auto()
+    """All-ones exponent with a non-zero mantissa."""
+    ALL_ONES = auto()
+    """All-ones exponent and mantissa."""
+    NEGATIVE_ZERO = auto()
+    """The sign-bit-only pattern; the format has no negative zero."""
+
+
+@dataclass(frozen=True)
+class FloatSemantics:
+    """The parameters that fully define a reduced-precision float format.
+
+    Modelled on LLVM's `fltSemantics`. This describes the bit layout; the codec that
+    encodes and decodes values from this descriptor is added separately.
+    """
+
+    exponent_bits: int
+    mantissa_bits: int
+    exponent_bias: int
+    nonfinite: FloatNonfiniteBehavior = FloatNonfiniteBehavior.IEEE
+    nan_encoding: FloatNanEncoding = FloatNanEncoding.IEEE
+    has_zero: bool = True
+    has_sign: bool = True
+
+
+class ReducedPrecisionFloatType(_FloatType, StructPackableType[float], ABC):
+    """Base for reduced-precision float types, described by a `FloatSemantics`.
+
+    Concrete subclasses set only `SEMANTICS`. This carries the type structure; the packing
+    codec that consumes the semantics is added separately, so packing is not yet supported
+    (`format` raises, as these types have no `struct` format string).
+    """
+
+    SEMANTICS: ClassVar[FloatSemantics]
+
+    @property
+    def bitwidth(self) -> int:
+        semantics = self.SEMANTICS
+        return (
+            int(semantics.has_sign) + semantics.exponent_bits + semantics.mantissa_bits
+        )
+
+    @property
+    def format(self) -> str:
+        raise NotImplementedError()
+
+
 @irdl_attr_definition
 class BFloat16Type(ParametrizedAttribute, _FloatType):
     name = "bf16"
@@ -1263,161 +1328,122 @@ class Float128Type(ParametrizedAttribute, _FloatType, StructPackableType[float])
 
 
 @irdl_attr_definition
-class FloatTF32Type(ParametrizedAttribute, _FloatType, StructPackableType[float]):
+class FloatTF32Type(ParametrizedAttribute, ReducedPrecisionFloatType):
     name = "tf32"
-
-    @property
-    def bitwidth(self) -> int:
-        return 19
-
-    @property
-    def format(self) -> str:
-        raise NotImplementedError()
+    SEMANTICS = FloatSemantics(exponent_bits=8, mantissa_bits=10, exponent_bias=127)
 
 
 @irdl_attr_definition
-class Float8E5M2Type(ParametrizedAttribute, _FloatType, StructPackableType[float]):
+class Float8E5M2Type(ParametrizedAttribute, ReducedPrecisionFloatType):
     name = "f8E5M2"
-
-    @property
-    def bitwidth(self) -> int:
-        return 8
-
-    @property
-    def format(self) -> str:
-        raise NotImplementedError()
+    SEMANTICS = FloatSemantics(exponent_bits=5, mantissa_bits=2, exponent_bias=15)
 
 
 @irdl_attr_definition
-class Float8E4M3Type(ParametrizedAttribute, _FloatType, StructPackableType[float]):
+class Float8E4M3Type(ParametrizedAttribute, ReducedPrecisionFloatType):
     name = "f8E4M3"
-
-    @property
-    def bitwidth(self) -> int:
-        return 8
-
-    @property
-    def format(self) -> str:
-        raise NotImplementedError()
+    SEMANTICS = FloatSemantics(exponent_bits=4, mantissa_bits=3, exponent_bias=7)
 
 
 @irdl_attr_definition
-class Float8E4M3FNType(ParametrizedAttribute, _FloatType, StructPackableType[float]):
+class Float8E4M3FNType(ParametrizedAttribute, ReducedPrecisionFloatType):
     name = "f8E4M3FN"
-
-    @property
-    def bitwidth(self) -> int:
-        return 8
-
-    @property
-    def format(self) -> str:
-        raise NotImplementedError()
+    SEMANTICS = FloatSemantics(
+        exponent_bits=4,
+        mantissa_bits=3,
+        exponent_bias=7,
+        nonfinite=FloatNonfiniteBehavior.NAN_ONLY,
+        nan_encoding=FloatNanEncoding.ALL_ONES,
+    )
 
 
 @irdl_attr_definition
-class Float8E5M2FNUZType(ParametrizedAttribute, _FloatType, StructPackableType[float]):
+class Float8E5M2FNUZType(ParametrizedAttribute, ReducedPrecisionFloatType):
     name = "f8E5M2FNUZ"
-
-    @property
-    def bitwidth(self) -> int:
-        return 8
-
-    @property
-    def format(self) -> str:
-        raise NotImplementedError()
+    SEMANTICS = FloatSemantics(
+        exponent_bits=5,
+        mantissa_bits=2,
+        exponent_bias=16,
+        nonfinite=FloatNonfiniteBehavior.NAN_ONLY,
+        nan_encoding=FloatNanEncoding.NEGATIVE_ZERO,
+    )
 
 
 @irdl_attr_definition
-class Float8E4M3FNUZType(ParametrizedAttribute, _FloatType, StructPackableType[float]):
+class Float8E4M3FNUZType(ParametrizedAttribute, ReducedPrecisionFloatType):
     name = "f8E4M3FNUZ"
-
-    @property
-    def bitwidth(self) -> int:
-        return 8
-
-    @property
-    def format(self) -> str:
-        raise NotImplementedError()
+    SEMANTICS = FloatSemantics(
+        exponent_bits=4,
+        mantissa_bits=3,
+        exponent_bias=8,
+        nonfinite=FloatNonfiniteBehavior.NAN_ONLY,
+        nan_encoding=FloatNanEncoding.NEGATIVE_ZERO,
+    )
 
 
 @irdl_attr_definition
-class Float8E4M3B11FNUZType(
-    ParametrizedAttribute, _FloatType, StructPackableType[float]
-):
+class Float8E4M3B11FNUZType(ParametrizedAttribute, ReducedPrecisionFloatType):
     name = "f8E4M3B11FNUZ"
-
-    @property
-    def bitwidth(self) -> int:
-        return 8
-
-    @property
-    def format(self) -> str:
-        raise NotImplementedError()
+    SEMANTICS = FloatSemantics(
+        exponent_bits=4,
+        mantissa_bits=3,
+        exponent_bias=11,
+        nonfinite=FloatNonfiniteBehavior.NAN_ONLY,
+        nan_encoding=FloatNanEncoding.NEGATIVE_ZERO,
+    )
 
 
 @irdl_attr_definition
-class Float8E3M4Type(ParametrizedAttribute, _FloatType, StructPackableType[float]):
+class Float8E3M4Type(ParametrizedAttribute, ReducedPrecisionFloatType):
     name = "f8E3M4"
-
-    @property
-    def bitwidth(self) -> int:
-        return 8
-
-    @property
-    def format(self) -> str:
-        raise NotImplementedError()
+    SEMANTICS = FloatSemantics(exponent_bits=3, mantissa_bits=4, exponent_bias=3)
 
 
 @irdl_attr_definition
-class Float8E8M0FNUType(ParametrizedAttribute, _FloatType, StructPackableType[float]):
+class Float8E8M0FNUType(ParametrizedAttribute, ReducedPrecisionFloatType):
     name = "f8E8M0FNU"
-
-    @property
-    def bitwidth(self) -> int:
-        return 8
-
-    @property
-    def format(self) -> str:
-        raise NotImplementedError()
+    SEMANTICS = FloatSemantics(
+        exponent_bits=8,
+        mantissa_bits=0,
+        exponent_bias=127,
+        nonfinite=FloatNonfiniteBehavior.NAN_ONLY,
+        nan_encoding=FloatNanEncoding.ALL_ONES,
+        has_zero=False,
+        has_sign=False,
+    )
 
 
 @irdl_attr_definition
-class Float6E2M3FNType(ParametrizedAttribute, _FloatType, StructPackableType[float]):
+class Float6E2M3FNType(ParametrizedAttribute, ReducedPrecisionFloatType):
     name = "f6E2M3FN"
-
-    @property
-    def bitwidth(self) -> int:
-        return 6
-
-    @property
-    def format(self) -> str:
-        raise NotImplementedError()
+    SEMANTICS = FloatSemantics(
+        exponent_bits=2,
+        mantissa_bits=3,
+        exponent_bias=1,
+        nonfinite=FloatNonfiniteBehavior.FINITE_ONLY,
+    )
 
 
 @irdl_attr_definition
-class Float6E3M2FNType(ParametrizedAttribute, _FloatType, StructPackableType[float]):
+class Float6E3M2FNType(ParametrizedAttribute, ReducedPrecisionFloatType):
     name = "f6E3M2FN"
-
-    @property
-    def bitwidth(self) -> int:
-        return 6
-
-    @property
-    def format(self) -> str:
-        raise NotImplementedError()
+    SEMANTICS = FloatSemantics(
+        exponent_bits=3,
+        mantissa_bits=2,
+        exponent_bias=3,
+        nonfinite=FloatNonfiniteBehavior.FINITE_ONLY,
+    )
 
 
 @irdl_attr_definition
-class Float4E2M1FNType(ParametrizedAttribute, _FloatType, StructPackableType[float]):
+class Float4E2M1FNType(ParametrizedAttribute, ReducedPrecisionFloatType):
     name = "f4E2M1FN"
-
-    @property
-    def bitwidth(self) -> int:
-        return 4
-
-    @property
-    def format(self) -> str:
-        raise NotImplementedError()
+    SEMANTICS = FloatSemantics(
+        exponent_bits=2,
+        mantissa_bits=1,
+        exponent_bias=1,
+        nonfinite=FloatNonfiniteBehavior.FINITE_ONLY,
+    )
 
 
 AnyFloat: TypeAlias = (


### PR DESCRIPTION
This PR introduces the FloatSemantics class based on MLIR's `fltSemantics` concept (alongside `fltNonfiniteBehavior` and `fltNanEncoding`). This is used to calculate the `bitwidth` of reduced-precision floats.

WIP:
* #6254 