### PR TITLE
CI: enable Ruff RUF005

### DIFF
--- a/benchmarks/bench_utils.py
+++ b/benchmarks/bench_utils.py
@@ -92,7 +92,7 @@ def parse_arguments(benchmark_names: list[str]) -> ArgumentParser:
 
     parser.add_argument(
         "test",
-        choices=benchmark_names + ["all"],
+        choices=[*benchmark_names, "all"],
         help="the name of the benchmark to run, `all` to run all benchmarks",
     )
     parser.add_argument(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,7 @@ lint.ignore = [
   # Help welcome removing ignores below
   # https://github.com/xdslproject/xdsl/issues/5927
   "RUF002", # https://docs.astral.sh/ruff/rules/ambiguous-unicode-character-docstring
-  "RUF005", # https://docs.astral.sh/ruff/rules/collection-literal-concatenation
+  "RUF003", # https://docs.astral.sh/ruff/rules/ambiguous-unicode-character-comment
   "RUF012", # https://docs.astral.sh/ruff/rules/mutable-class-default
   "RUF043", # https://docs.astral.sh/ruff/rules/pytest-raises-ambiguous-pattern
 ]

--- a/xdsl/backend/llvm/convert_op.py
+++ b/xdsl/backend/llvm/convert_op.py
@@ -127,7 +127,7 @@ class CastInstrWithFlags(instructions.CastInstr):
 
     def descr(self, buf: list[str]) -> None:
         opname = (
-            " ".join([self.opname] + list(self.flags)) if self.flags else self.opname
+            " ".join([self.opname, *self.flags]) if self.flags else self.opname
         )
         op = self.operands[0]
         buf.append(

--- a/xdsl/backend/llvm/convert_op.py
+++ b/xdsl/backend/llvm/convert_op.py
@@ -126,7 +126,7 @@ class CastInstrWithFlags(instructions.CastInstr):
         )
 
     def descr(self, buf: list[str]) -> None:
-        opname = " ".join([self.opname, *self.flags]) if self.flags else self.opname
+        opname = " ".join((self.opname, *self.flags))
         op = self.operands[0]
         buf.append(
             f"{opname} {op.type} {op.get_reference()} to {self.type}{self._stringify_metadata(leading_comma=True)}\n"

--- a/xdsl/backend/llvm/convert_op.py
+++ b/xdsl/backend/llvm/convert_op.py
@@ -126,9 +126,7 @@ class CastInstrWithFlags(instructions.CastInstr):
         )
 
     def descr(self, buf: list[str]) -> None:
-        opname = (
-            " ".join([self.opname, *self.flags]) if self.flags else self.opname
-        )
+        opname = " ".join([self.opname, *self.flags]) if self.flags else self.opname
         op = self.operands[0]
         buf.append(
             f"{opname} {op.type} {op.get_reference()} to {self.type}{self._stringify_metadata(leading_comma=True)}\n"

--- a/xdsl/backend/x86/lowering/convert_func_to_x86_func.py
+++ b/xdsl/backend/x86/lowering/convert_func_to_x86_func.py
@@ -130,7 +130,7 @@ class LowerFuncOp(RewritePattern):
         new_func = x86_func.FuncOp(
             op.sym_name.data,
             new_region,
-            (reg_args_types + (x86.registers.RSP,), outputs_types),
+            ((*reg_args_types, x86.registers.RSP), outputs_types),
             visibility=op.sym_visibility,
         )
 

--- a/xdsl/dialects/csl_stencil.py
+++ b/xdsl/dialects/csl_stencil.py
@@ -430,7 +430,7 @@ class ApplyOp(IRDLOperation):
 
     def add_coeff(self, offset: stencil.IndexAttr, coeff: FloatAttr):
         self.coeffs = builtin.ArrayAttr(
-            list(self.coeffs or []) + [CoeffAttr(offset, coeff)]
+            (*(self.coeffs or ()), CoeffAttr(offset, coeff))
         )
 
 

--- a/xdsl/dialects/tensor.py
+++ b/xdsl/dialects/tensor.py
@@ -831,7 +831,7 @@ class FromElementsOp(IRDLOperation):
         *tail_elements: SSAValue,
         result_type: Attribute | None = None,
     ):
-        elements = (head_element,) + tail_elements
+        elements = (head_element, *tail_elements)
 
         if result_type is None:
             result_type = TensorType(head_element.type, (len(elements),))

--- a/xdsl/parser/attribute_parser.py
+++ b/xdsl/parser/attribute_parser.py
@@ -1299,7 +1299,7 @@ class AttrParser(BaseParser):
                 self.raise_error(
                     "Tensor literal has inconsistent ranks between elements"
                 )
-            shape = [len(res)] + sub_literal_shape
+            shape = [len(res), *sub_literal_shape]
             values = [elem for sub_list in res for elem in sub_list[0]]
             return values, shape
         else:

--- a/xdsl/rewriting/composable_rewriting/immutable_ir/immutable_ir.py
+++ b/xdsl/rewriting/composable_rewriting/immutable_ir/immutable_ir.py
@@ -170,9 +170,11 @@ class IRegion:
                             op,
                             "successors",
                             IList(
-                                op.successors[:dummy_index]
-                                + [imm_block]
-                                + op.successors[dummy_index + 1 :]
+                                [
+                                    *op.successors[:dummy_index],
+                                    imm_block,
+                                    *op.successors[dummy_index + 1 :],
+                                ]
                             ),
                         )
 

--- a/xdsl/transforms/convert_pdl_to_pdl_interp/conversion.py
+++ b/xdsl/transforms/convert_pdl_to_pdl_interp/conversion.py
@@ -937,7 +937,7 @@ class OperationPositionTree:
 
             child_paths: dict[int, list[int]] = {}
             for idx in indices:
-                child_paths[idx] = current_paths.get(idx, []) + [child_index]
+                child_paths[idx] = [*current_paths.get(idx, []), child_index]
                 pattern_paths[idx] = child_paths[idx]
             OperationPositionTree._build_subtree(
                 child,

--- a/xdsl/transforms/experimental/hls_convert_stencil_to_ll_mlir.py
+++ b/xdsl/transforms/experimental/hls_convert_stencil_to_ll_mlir.py
@@ -471,9 +471,11 @@ def transform_apply_into_loop(
     p.body.block.insert_op_after(chunk_size_y_1, call_get_chunk_size)
 
     old_operands_lst = [old_operand for old_operand in y_for_op.operands]
-    y_for_op.operands = (
-        [old_operands_lst[0]] + [chunk_size_y_1.results[0]] + old_operands_lst[2:]
-    )
+    y_for_op.operands = [
+        old_operands_lst[0],
+        chunk_size_y_1.results[0],
+        *old_operands_lst[2:],
+    ]
 
     p.attributes["compute_loop"] = IntAttr(1)
 
@@ -550,8 +552,9 @@ class ApplyOpToHLS(RewritePattern):
                 else:
                     new_operands_lst.append(operand)
 
-            apply_clone.operands = new_operands_lst + [
-                self.out_data_streams[k].results[0]
+            apply_clone.operands = [
+                *new_operands_lst,
+                self.out_data_streams[k].results[0],
             ]
 
         indices_stream_to_read: list[int] = []
@@ -821,7 +824,7 @@ class StencilAccessOpToReadBlockOp(RewritePattern):
             for idx in op.offset.array.data:
                 access_idx.append(idx.data + 1)
 
-            access_idx_array = DenseArrayBase.from_list(i64, [0] + access_idx)
+            access_idx_array = DenseArrayBase.from_list(i64, [0, *access_idx])
 
             assert isinstance(result_hls_read, OpResult)
             stencil_value = HLSExtractStencilValueOp(

--- a/xdsl/transforms/memref_stream_interleave.py
+++ b/xdsl/transforms/memref_stream_interleave.py
@@ -180,20 +180,20 @@ class PipelineGenericPattern(RewritePattern):
             AffineMapAttr(
                 m.data.replace_dims_and_symbols(
                     (
-                        tuple(
-                            AffineExpr.dimension(i)
-                            for i in range(interleave_bound_index)
-                        )
-                        + (
+                        (
+                            *tuple(
+                                AffineExpr.dimension(i)
+                                for i in range(interleave_bound_index)
+                            ),
                             AffineExpr.dimension(interleave_bound_index)
                             * interleave_factor
                             + AffineExpr.dimension(m.data.num_dims),
-                        )
-                        + tuple(
-                            AffineExpr.dimension(i)
-                            for i in range(
-                                interleave_bound_index + 1, m.data.num_dims + 2
-                            )
+                            *tuple(
+                                AffineExpr.dimension(i)
+                                for i in range(
+                                    interleave_bound_index + 1, m.data.num_dims + 2
+                                )
+                            ),
                         )
                     ),
                     (),
@@ -221,8 +221,10 @@ class PipelineGenericPattern(RewritePattern):
                 new_region,
                 new_indexing_maps,
                 ArrayAttr(
-                    op.iterator_types.data
-                    + (memref_stream.IteratorTypeAttr.interleaved(),)
+                    (
+                        *op.iterator_types.data,
+                        memref_stream.IteratorTypeAttr.interleaved(),
+                    )
                 ),
                 ArrayAttr(new_bounds),
                 op.init_indices,

--- a/xdsl/transforms/printf_to_llvm.py
+++ b/xdsl/transforms/printf_to_llvm.py
@@ -135,9 +135,9 @@ class PrintlnOpToPrintfCall(RewritePattern):
 
         rewriter.replace(
             op,
-            casts
-            + [
-                ptr := llvm.AddressOfOp(globl.sym_name, llvm.LLVMPointerType()),
+            [
+                *casts,
+                (ptr := llvm.AddressOfOp(globl.sym_name, llvm.LLVMPointerType())),
                 llvm.CallOp("printf", ptr.result, *args, variadic_args=len(args)),
             ],
         )

--- a/xdsl/transforms/stencil_bufferize.py
+++ b/xdsl/transforms/stencil_bufferize.py
@@ -330,9 +330,11 @@ class ApplyStoreFoldPattern(RewritePattern):
             rewriter.replace(
                 op,
                 [new_apply, load],
-                new_apply.results[:temp_index]
-                + (load.res,)
-                + new_apply.results[temp_index:],
+                (
+                    *new_apply.results[:temp_index],
+                    load.res,
+                    *new_apply.results[temp_index:],
+                ),
             )
             for store in stores:
                 rewriter.erase(store)
@@ -534,7 +536,7 @@ class CombineStoreFold(RewritePattern):
             rewriter.replace(
                 op,
                 new_combine,
-                new_results=new_combine.results[:i] + (None,) + new_combine.results[i:],
+                new_results=(*new_combine.results[:i], None, *new_combine.results[i:]),
             )
             return
 


### PR DESCRIPTION
## Summary

- replace all 16 collection-literal concatenations reported by RUF005 with behavior-preserving iterable unpacking
- preserve each original collection type and element order
- remove only the RUF005 ignore so future concatenations are rejected by CI

Progresses #5927 (RUF005 slice).

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .` (729 files)
- `uv run pyright` (0 errors)
- `make pytest` (5050 passed, 1 skipped)
- `make filecheck` (494 passed, 110 unsupported because external MLIR tools are not configured)
