### PR TITLE
CI: enable RUF012 lint rule

### DIFF
--- a/benchmarks/microbenchmarks.py
+++ b/benchmarks/microbenchmarks.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+from typing import ClassVar
+
 from benchmarks.bench_utils import BenchmarkClass, safe_to_repeat
 from xdsl.dialects.arith import ConstantOp
 from xdsl.dialects.builtin import IntAttr, IntegerAttr, ModuleOp, i32
@@ -67,8 +69,8 @@ class IRTraversal(BenchmarkClass):
     """Benchmark the time to traverse xDSL IR."""
 
     EXAMPLE_BLOCK_NUM_OPS = 1_000
-    EXAMPLE_OPS = [EmptyOp() for _ in range(EXAMPLE_BLOCK_NUM_OPS)]
-    EXAMPLE_BLOCK = Block(ops=EXAMPLE_OPS)
+    EXAMPLE_OPS: ClassVar = [EmptyOp() for _ in range(EXAMPLE_BLOCK_NUM_OPS)]
+    EXAMPLE_BLOCK: ClassVar = Block(ops=EXAMPLE_OPS)
 
     @safe_to_repeat
     def time_iterate_ops(self) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,6 @@ lint.ignore = [
   # https://github.com/xdslproject/xdsl/issues/5927
   "RUF002", # https://docs.astral.sh/ruff/rules/ambiguous-unicode-character-docstring
   "RUF005", # https://docs.astral.sh/ruff/rules/collection-literal-concatenation
-  "RUF012", # https://docs.astral.sh/ruff/rules/mutable-class-default
   "RUF043", # https://docs.astral.sh/ruff/rules/pytest-raises-ambiguous-pattern
 ]
 lint.per-file-ignores."**/filecheck/*" = [ "E501", "F811", "F841" ]

--- a/tests/backend/wgsl/test_wgsl_printer.py
+++ b/tests/backend/wgsl/test_wgsl_printer.py
@@ -9,6 +9,16 @@ lhs_op = test.TestOp(result_types=[IndexType()])
 rhs_op = test.TestOp(result_types=[IndexType()])
 
 
+def test_printer_name_state_is_isolated():
+    first = WGSLPrinter()
+    second = WGSLPrinter()
+
+    first.wgsl_name(lhs_op.res[0])
+
+    assert lhs_op.res[0] in first.name_dict
+    assert lhs_op.res[0] not in second.name_dict
+
+
 def test_gpu_global_id():
     file = StringIO("")
     printer = WGSLPrinter(stream=file)
@@ -150,7 +160,7 @@ def test_memref_load():
     load = memref.LoadOp.get(memref_val, [lhs_op.res[0], rhs_op.res[0]])
     printer.print(load)
 
-    assert "let v1 = v0[10u * v1 + 1u * v2];" in file.getvalue()
+    assert "let v1 = v0[10u * v2 + 1u * v3];" in file.getvalue()
 
 
 def test_memref_store():
@@ -163,4 +173,4 @@ def test_memref_store():
     store = memref.StoreOp.get(load.res, memref_val, [lhs_op.res[0], rhs_op.res[0]])
     printer.print(store)
 
-    assert "v1[10u * v1 + 1u * v2] = v0;" in file.getvalue()
+    assert "v1[10u * v2 + 1u * v3] = v0;" in file.getvalue()

--- a/tests/irdl/test_operation_definition.py
+++ b/tests/irdl/test_operation_definition.py
@@ -167,7 +167,7 @@ def test_invalid_irdl_options():
 
 class MutableIRDLOpts(IRDLOperation):
     name = "test.mutable_irdl_options_field"
-    irdl_options = [AttrSizedRegionSegments()]
+    irdl_options = [AttrSizedRegionSegments()]  # noqa: RUF012
 
 
 def test_list_irdl_options():

--- a/tests/irdl/test_operation_definition.py
+++ b/tests/irdl/test_operation_definition.py
@@ -167,6 +167,7 @@ def test_invalid_irdl_options():
 
 class MutableIRDLOpts(IRDLOperation):
     name = "test.mutable_irdl_options_field"
+    # Intentionally exercise the deprecated mutable-list input below.
     irdl_options = [AttrSizedRegionSegments()]  # noqa: RUF012
 
 

--- a/tests/test_dialect_interfaces.py
+++ b/tests/test_dialect_interfaces.py
@@ -43,3 +43,13 @@ def test_op_asm_interface():
     assert interf.build_resources(["some_key", "non_assigned_key"]) == {
         "some_key": "0x0800000001"
     }
+
+
+def test_op_asm_interface_storage_is_isolated():
+    first = OpAsmDialectInterface()
+    second = OpAsmDialectInterface()
+
+    first.declare_resource("some_key")
+
+    assert second.lookup("some_key") is None
+    assert second.declare_resource("some_key") == "some_key"

--- a/tests/test_dialect_interfaces.py
+++ b/tests/test_dialect_interfaces.py
@@ -46,6 +46,7 @@ def test_op_asm_interface():
 
 
 def test_op_asm_interface_storage_is_isolated():
+    """Resource storage belongs to each interface instance."""
     first = OpAsmDialectInterface()
     second = OpAsmDialectInterface()
 

--- a/xdsl/backend/wgsl/wgsl_printer.py
+++ b/xdsl/backend/wgsl/wgsl_printer.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import singledispatchmethod
 from typing import IO, cast
 
@@ -13,9 +13,12 @@ from xdsl.utils.hints import isa
 from xdsl.utils.target import Target
 
 
+@dataclass(eq=False, repr=False)
 class WGSLPrinter(BasePrinter):
-    name_dict: dict[SSAValue, str] = dict()
-    count = 0
+    name_dict: dict[SSAValue, str] = field(
+        default_factory=dict[SSAValue, str], init=False
+    )
+    count: int = field(default=0, init=False)
 
     def wgsl_name(self, v: SSAValue):
         if v not in self.name_dict:

--- a/xdsl/backend/x86/arch.py
+++ b/xdsl/backend/x86/arch.py
@@ -153,7 +153,10 @@ class AVX2Arch(X86Arch):
     def name() -> str:
         return "avx2"
 
-    VECTOR_TYPES_BY_BITWIDTH = {128: SSERegisterType, 256: AVX2RegisterType}
+    VECTOR_TYPES_BY_BITWIDTH: ClassVar[dict[int, type[X86VectorRegisterType]]] = {
+        128: SSERegisterType,
+        256: AVX2RegisterType,
+    }
 
 
 AVX2 = AVX2Arch()
@@ -164,7 +167,7 @@ class AVX512Arch(X86Arch):
     def name() -> str:
         return "avx512"
 
-    VECTOR_TYPES_BY_BITWIDTH = {
+    VECTOR_TYPES_BY_BITWIDTH: ClassVar[dict[int, type[X86VectorRegisterType]]] = {
         128: SSERegisterType,
         256: AVX2RegisterType,
         512: AVX512RegisterType,

--- a/xdsl/dialect_interfaces/op_asm.py
+++ b/xdsl/dialect_interfaces/op_asm.py
@@ -30,7 +30,8 @@ class OpAsmDialectInterface(DialectInterface):
     compared to keeping these resources tied to ir objects.
     """
 
-    _blob_storage: dict[str, str] = {}
+    def __init__(self) -> None:
+        self._blob_storage: dict[str, str] = {}
 
     def declare_resource(self, key: str) -> str:
         """

--- a/xdsl/dialect_interfaces/op_asm.py
+++ b/xdsl/dialect_interfaces/op_asm.py
@@ -30,8 +30,10 @@ class OpAsmDialectInterface(DialectInterface):
     compared to keeping these resources tied to ir objects.
     """
 
+    _blob_storage: dict[str, str] = {}  # noqa: RUF012
+
     def __init__(self) -> None:
-        self._blob_storage: dict[str, str] = {}
+        self._blob_storage = {}
 
     def declare_resource(self, key: str) -> str:
         """

--- a/xdsl/dialect_interfaces/op_asm.py
+++ b/xdsl/dialect_interfaces/op_asm.py
@@ -30,7 +30,7 @@ class OpAsmDialectInterface(DialectInterface):
     compared to keeping these resources tied to ir objects.
     """
 
-    _blob_storage: dict[str, str] = {}  # noqa: RUF012
+    _blob_storage: dict[str, str]
 
     def __init__(self) -> None:
         self._blob_storage = {}

--- a/xdsl/dialects/acc.py
+++ b/xdsl/dialects/acc.py
@@ -11,7 +11,7 @@ See external [documentation](https://mlir.llvm.org/docs/Dialects/OpenACCDialect/
 
 from abc import ABC
 from collections.abc import Hashable, Iterable, Sequence
-from typing import cast
+from typing import ClassVar, cast
 
 from typing_extensions import TypeVar
 
@@ -1807,12 +1807,12 @@ class CombinedConstructsLoop(CustomDirective):
     combined: AttributeVariable
 
     _KEYWORDS = ("kernels", "parallel", "serial")
-    _BY_KEYWORD = {
+    _BY_KEYWORD: ClassVar = {
         "kernels": CombinedConstructsType.KERNELS_LOOP,
         "parallel": CombinedConstructsType.PARALLEL_LOOP,
         "serial": CombinedConstructsType.SERIAL_LOOP,
     }
-    _BY_VALUE = {v: k for k, v in _BY_KEYWORD.items()}
+    _BY_VALUE: ClassVar = {v: k for k, v in _BY_KEYWORD.items()}
 
     def is_anchorable(self) -> bool:
         return True

--- a/xdsl/interactive/app.py
+++ b/xdsl/interactive/app.py
@@ -64,7 +64,7 @@ class InputApp(App[None]):
 
     CSS_PATH = "app.tcss"
 
-    BINDINGS = [
+    BINDINGS: ClassVar = [
         ("d", "toggle_dark", "Toggle dark mode"),
         ("q", "quit_app", "Quit"),
     ]

--- a/xdsl/interpreters/riscv.py
+++ b/xdsl/interpreters/riscv.py
@@ -53,7 +53,7 @@ STACK_KEY = "stack"
 
 @register_impls
 class RiscvFunctions(InterpreterFunctions):
-    custom_instructions: dict[str, CustomInstructionFn] = {}
+    custom_instructions: dict[str, CustomInstructionFn]
     bitwidth: int
 
     def __init__(

--- a/xdsl/parser/affine_parser.py
+++ b/xdsl/parser/affine_parser.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Sequence
+from typing import ClassVar
 
 from xdsl.ir.affine import (
     AffineConstraintExpr,
@@ -17,7 +18,7 @@ from .generic_parser import ParserState  # noqa: TID251
 
 
 class AffineParser(BaseParser):
-    _BINOP_PRECEDENCE = {
+    _BINOP_PRECEDENCE: ClassVar = {
         "+": 10,
         "-": 10,
         "*": 20,

--- a/xdsl/parser/attribute_parser.py
+++ b/xdsl/parser/attribute_parser.py
@@ -4,7 +4,7 @@ import math
 import re
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
-from typing import Any, Literal, NoReturn, cast, overload
+from typing import Any, ClassVar, Literal, NoReturn, cast, overload
 
 from immutabledict import immutabledict
 
@@ -1570,7 +1570,7 @@ class AttrParser(BaseParser):
         )
 
     _builtin_integer_type_regex = re.compile(r"^[su]?i(\d+)$")
-    _builtin_float_types = {
+    _builtin_float_types: ClassVar = {
         "bf16": bf16,
         "f16": f16,
         "f32": f32,

--- a/xdsl/transforms/lower_mpi.py
+++ b/xdsl/transforms/lower_mpi.py
@@ -2,7 +2,7 @@ from abc import ABC
 from collections.abc import Sequence
 from dataclasses import dataclass
 from math import prod
-from typing import cast
+from typing import ClassVar, cast
 
 from xdsl.context import Context
 from xdsl.dialects import arith, builtin, func, llvm, memref, mpi
@@ -119,7 +119,7 @@ class _MPIToLLVMRewriteBase(RewritePattern, ABC):
     the MpiLibraryInfo class.
     """
 
-    MPI_SYMBOL_NAMES = {
+    MPI_SYMBOL_NAMES: ClassVar[dict[str, str]] = {
         "mpi.init": "MPI_Init",
         "mpi.finalize": "MPI_Finalize",
         "mpi.irecv": "MPI_Irecv",


### PR DESCRIPTION
## Summary

- enable Ruff's `RUF012` mutable class default rule
- annotate intentional class-level constants with `ClassVar`
- give each `WGSLPrinter` its own SSA name state
- give each `OpAsmDialectInterface` its own resource storage
- retain the deliberately mutable `irdl_options` test case with a targeted exemption

## Why

Most reported values are intentional class constants and should be explicit. The WGSL name map and operation assembly resource storage were mutable class attributes even though their state belongs to individual instances, allowing state to leak between otherwise independent objects.

Closes the RUF012 item in #5927.

## Validation

- `ruff check --select RUF012 .`
- Ruff check and format validation for every changed Python file
- Pyright on the affected production modules: 0 errors
- 58 directly affected tests
- 682 x86, OpenACC, parser, MPI, and RISC-V tests
- 13 interactive application tests
