### PR TITLE
dialects: (riscv) add canonicalize consecutive xori op

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -63,7 +63,7 @@ Here are some examples of first PRs from existing contributors:
 The first step is finding a missing optimisation pattern.
 You're welcome to come up with your own, or do one of the following:
 
-- `%y = xori %x, a; %z = xori %y, b`  to `%z = xori %x, a ^ b` ((x ^ a) ^ b = x ^ (a ^ b))
+- `%y = xori %x, -1; %z = and %x, %y`  to `%z = li 0` (x & ~x = 0)
 - `div 0, %x` to `li 0` (%x != 0)
 
 The patterns are defined in

--- a/tests/filecheck/backend/riscv/canonicalize.mlir
+++ b/tests/filecheck/backend/riscv/canonicalize.mlir
@@ -189,6 +189,15 @@ builtin.module {
   %xori_self_inverse_multi = riscv.xori %xori_tmp_multi, 42 : (!riscv.reg) -> !riscv.reg<a0>
   "test.op"(%xori_tmp_multi, %xori_self_inverse_multi) : (!riscv.reg, !riscv.reg<a0>) -> ()
 
+  // (x ^ a) ^ b -> x ^ (a ^ b), intermediate has one use
+  %xori_combine_tmp = riscv.xori %i2, 42 : (!riscv.reg) -> !riscv.reg
+  %xori_combine = riscv.xori %xori_combine_tmp, 7 : (!riscv.reg) -> !riscv.reg<a0>
+  "test.op"(%xori_combine) : (!riscv.reg<a0>) -> ()
+  // (x ^ a) ^ b -> x ^ (a ^ b), intermediate preserved with other uses
+  %xori_combine_tmp_multi = riscv.xori %i2, 42 : (!riscv.reg) -> !riscv.reg
+  %xori_combine_multi = riscv.xori %xori_combine_tmp_multi, 7 : (!riscv.reg) -> !riscv.reg<a0>
+  "test.op"(%xori_combine_tmp_multi, %xori_combine_multi) : (!riscv.reg, !riscv.reg<a0>) -> ()
+
   %shift_left_zero_r0 = rv32.slli %i2, 0 : (!riscv.reg) -> !riscv.reg<a0>
   "test.op"(%shift_left_zero_r0) : (!riscv.reg<a0>) -> ()
 
@@ -385,6 +394,11 @@ builtin.module {
 // CHECK-NEXT:   %xori_tmp_multi = riscv.xori %i2, 42 : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:   %xori_self_inverse_multi = riscv.mv %i2 : (!riscv.reg) -> !riscv.reg<a0>
 // CHECK-NEXT:   "test.op"(%xori_tmp_multi, %xori_self_inverse_multi) : (!riscv.reg, !riscv.reg<a0>) -> ()
+// CHECK-NEXT:   %xori_combine = riscv.xori %i2, 45 : (!riscv.reg) -> !riscv.reg<a0>
+// CHECK-NEXT:   "test.op"(%xori_combine) : (!riscv.reg<a0>) -> ()
+// CHECK-NEXT:   %xori_combine_tmp_multi = riscv.xori %i2, 42 : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:   %xori_combine_multi = riscv.xori %i2, 45 : (!riscv.reg) -> !riscv.reg<a0>
+// CHECK-NEXT:   "test.op"(%xori_combine_tmp_multi, %xori_combine_multi) : (!riscv.reg, !riscv.reg<a0>) -> ()
 
 // CHECK-NEXT:   %shift_left_zero_r0 = riscv.mv %i2 : (!riscv.reg) -> !riscv.reg<a0>
 // CHECK-NEXT:   "test.op"(%shift_left_zero_r0) : (!riscv.reg<a0>) -> ()

--- a/xdsl/dialects/riscv/ops.py
+++ b/xdsl/dialects/riscv/ops.py
@@ -219,11 +219,12 @@ class XoriOpHasCanonicalizationPatternsTrait(HasCanonicalizationPatternsTrait):
     def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
         from xdsl.transforms.canonicalization_patterns.riscv import (
             XoriImmediate,
+            XoriOfXori,
             XoriSelfInverse,
             XoriZero,
         )
 
-        return (XoriZero(), XoriSelfInverse(), XoriImmediate())
+        return (XoriZero(), XoriSelfInverse(), XoriOfXori(), XoriImmediate())
 
 
 @irdl_op_definition

--- a/xdsl/transforms/canonicalization_patterns/riscv.py
+++ b/xdsl/transforms/canonicalization_patterns/riscv.py
@@ -312,23 +312,18 @@ class XoriOfXori(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: riscv.XoriOp, rewriter: PatternRewriter) -> None:
 
-        if not isinstance(op.rs1, OpResult):
-            return
-
-        inner_op = op.rs1.op
         if (
-            not isinstance(inner_op, riscv.XoriOp)
-            or not isinstance(op.immediate, IntegerAttr)
-            or not isinstance(inner_op.immediate, IntegerAttr)
+            isinstance(op.rs1, OpResult)
+            and isinstance(inner_op := op.rs1.op, riscv.XoriOp)
+            and isinstance(op.immediate, IntegerAttr)
+            and isinstance(inner_op.immediate, IntegerAttr)
         ):
-            return
-
-        combined_immediate = inner_op.immediate.value.data ^ op.immediate.value.data
-        new_op = riscv.XoriOp(inner_op.rs1, combined_immediate, rd=op.rd.type)
-        can_erase = inner_op.rd.has_one_use()
-        rewriter.replace_op(op, new_op)
-        if can_erase:
-            rewriter.erase_op(inner_op)
+            combined_immediate = inner_op.immediate.value.data ^ op.immediate.value.data
+            new_op = riscv.XoriOp(inner_op.rs1, combined_immediate, rd=op.rd.type)
+            can_erase = inner_op.rd.has_one_use()
+            rewriter.replace_op(op, new_op)
+            if can_erase:
+                rewriter.erase_op(inner_op)
 
 
 class XoriImmediate(RewritePattern):

--- a/xdsl/transforms/canonicalization_patterns/riscv.py
+++ b/xdsl/transforms/canonicalization_patterns/riscv.py
@@ -304,6 +304,33 @@ class XoriSelfInverse(RewritePattern):
                 rewriter.erase_op(op.rs1.op)
 
 
+class XoriOfXori(RewritePattern):
+    """
+    (x ^ a) ^ b -> x ^ (a ^ b)
+    """
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: riscv.XoriOp, rewriter: PatternRewriter) -> None:
+
+        if not isinstance(op.rs1, OpResult):
+            return
+
+        inner_op = op.rs1.op
+        if (
+            not isinstance(inner_op, riscv.XoriOp)
+            or not isinstance(op.immediate, IntegerAttr)
+            or not isinstance(inner_op.immediate, IntegerAttr)
+        ):
+            return
+
+        combined_immediate = inner_op.immediate.value.data ^ op.immediate.value.data
+        new_op = riscv.XoriOp(inner_op.rs1, combined_immediate, rd=op.rd.type)
+        can_erase = inner_op.rd.has_one_use()
+        rewriter.replace_op(op, new_op)
+        if can_erase:
+            rewriter.erase_op(inner_op)
+
+
 class XoriImmediate(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: riscv.XoriOp, rewriter: PatternRewriter) -> None:


### PR DESCRIPTION
I combined consecutive RISC-V `xori` operations by XORing their immediates.

Then I removed the intermediate operation when it has no other users.

Then I preserved the intermediate operation when it has multiple users and added lit tests for both cases.

## Testing

> make precommit

> make pyright

> make tests

> uv run lit tests/filecheck/backend/riscv/canonicalize.mlir
