### PR TITLE
core: (Constraints) add relax_constraint

### DIFF
--- a/tests/irdl/test_attr_constraint.py
+++ b/tests/irdl/test_attr_constraint.py
@@ -610,6 +610,11 @@ def test_constraint_inference(
             ParamAttrConstraint.get(AttrF, AttrC, AttrC),
             None,
         ),
+        (
+            ParamAttrConstraint.get(AttrD, AttrA),
+            VarConstraint("A", AnyAttr()),
+            None,
+        ),
     ],
 )
 def test_relax_constaint(

--- a/tests/irdl/test_attr_constraint.py
+++ b/tests/irdl/test_attr_constraint.py
@@ -565,3 +565,54 @@ def test_constraint_inference(
     else:
         assert constr.can_infer(var_dict.keys())
         assert constr.infer(ConstraintContext(var_dict)) == inferred
+
+
+@pytest.mark.parametrize(
+    "constr1, constr2, result",
+    [
+        (AnyAttr(), AnyAttr(), AnyAttr()),
+        (
+            VarConstraint("A", AnyAttr()),
+            VarConstraint("A", AnyAttr()),
+            VarConstraint("A", AnyAttr()),
+        ),
+        (VarConstraint("A", AnyAttr()), VarConstraint("B", AnyAttr()), None),
+        (BaseAttr(AttrB), BaseAttr(AttrB), BaseAttr(AttrB)),
+        (BaseAttr(AttrB), BaseAttr(AttrA), None),
+        (BaseAttr(AttrB), ParamAttrConstraint(AttrB, (AnyAttr(),)), BaseAttr(AttrB)),
+        (ParamAttrConstraint(AttrB, (AnyAttr(),)), BaseAttr(AttrB), BaseAttr(AttrB)),
+        (ParamAttrConstraint.get(AttrD, AttrA), BaseAttr(AttrB), None),
+        (BaseAttr(AttrB), ParamAttrConstraint.get(AttrD, AttrA), None),
+        (ParamAttrConstraint.get(AttrD, AttrA), BaseAttr(AttrD), BaseAttr(AttrD)),
+        (BaseAttr(AttrD), ParamAttrConstraint.get(AttrD, AttrA), BaseAttr(AttrD)),
+        (
+            ParamAttrConstraint.get(AttrD, AttrA),
+            ParamAttrConstraint.get(AttrD, AttrC),
+            ParamAttrConstraint.get(AttrD, AttrA | AttrC),
+        ),
+        (
+            ParamAttrConstraint.get(AttrF, AttrA, AttrA),
+            ParamAttrConstraint.get(AttrF, AttrA, AttrC),
+            ParamAttrConstraint.get(AttrF, AttrA, AttrA | AttrC),
+        ),
+        (
+            ParamAttrConstraint.get(AttrF, AttrA, AttrA),
+            ParamAttrConstraint.get(AttrF, AttrC, AttrA),
+            ParamAttrConstraint.get(AttrF, AttrA | AttrC, AttrA),
+        ),
+        (
+            ParamAttrConstraint.get(AttrF, AttrA, AttrA),
+            ParamAttrConstraint.get(AttrF, AttrC, AttrC),
+            None,
+        ),
+        (
+            ParamAttrConstraint.get(AttrD, AttrA),
+            ParamAttrConstraint.get(AttrF, AttrC, AttrC),
+            None,
+        ),
+    ],
+)
+def test_relax_constaint(
+    constr1: AttrConstraint, constr2: AttrConstraint, result: AttrConstraint | None
+):
+    assert constr1.relax_constraint(constr2) == result

--- a/xdsl/irdl/constraints.py
+++ b/xdsl/irdl/constraints.py
@@ -148,6 +148,15 @@ class AttrConstraint(ABC, Generic[AttributeCovT]):
         """
         return None
 
+    def relax_constraint(
+        self, other: AttrConstraint[AttributeCovT]
+    ) -> AttrConstraint[AttributeCovT] | None:
+        """
+        Attempt to relax this constraint by merging it with `other`,
+        returning the result if successful.
+        """
+        return self if self == other else None
+
     def __or__(
         self, value: AttrConstraint[_AttributeCovT], /
     ) -> AttrConstraint[AttributeCovT | _AttributeCovT]:
@@ -369,6 +378,15 @@ class BaseAttr(AttrConstraint[AttributeCovT], Generic[AttributeCovT]):
         if is_runtime_final(self.attr):
             return {self.attr}
         return None
+
+    def relax_constraint(
+        self, other: AttrConstraint[AttributeCovT]
+    ) -> AttrConstraint[AttributeCovT] | None:
+        if not isinstance(other, BaseAttr):
+            # Trying to match on ParamAttrConstraint does strange things to pyright
+            # so we just appeal to symmetry instead.
+            return other.relax_constraint(self)
+        return super().relax_constraint(other)
 
     def mapping_type_vars(
         self, type_var_mapping: Mapping[TypeVar, AttrConstraint | IntConstraint]
@@ -710,6 +728,30 @@ class ParamAttrConstraint(
                 for l, r in zip(self.param_constrs, value.param_constrs, strict=True)
             ),
         )
+
+    def relax_constraint(
+        self, other: AttrConstraint[ParametrizedAttributeCovT]
+    ) -> AttrConstraint[ParametrizedAttributeCovT] | None:
+        if isinstance(other, BaseAttr):
+            if self.base_attr == other.attr:
+                return other
+            return
+        if not isinstance(other, ParamAttrConstraint):
+            return
+        if self.base_attr != other.base_attr:
+            return
+        seen_difference = False
+        new_params: list[AttrConstraint] = []
+        for x, y in zip(self.param_constrs, other.param_constrs, strict=True):
+            if x == y:
+                new_params.append(x)
+            elif seen_difference:
+                return
+            else:
+                seen_difference = True
+                new_params.append(x | y)
+
+        return ParamAttrConstraint(self.base_attr, tuple(new_params))
 
 
 @dataclass(frozen=True, init=False)


### PR DESCRIPTION
Split off from #6084 

Adds a method which attempts to combine two constraints into a single simpler constraint. At the moment this mainly deals with various permutations of ParamAttrConstraints and BaseAttr, with a default case that merges identical constraints.

This will be used in any_of simplification