### PR TITLE
CI: enable RUF018 lint rule

### DIFF
--- a/docs/Toy/toy/rewrites/lower_toy.py
+++ b/docs/Toy/toy/rewrites/lower_toy.py
@@ -414,7 +414,8 @@ class FuncOpLowering(RewritePattern):
 class PrintOpLowering(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: toy.PrintOp, rewriter: PatternRewriter):
-        assert isinstance(shaped_type := op.input.type, ShapedType)
+        shaped_type = op.input.type
+        assert isinstance(shaped_type, ShapedType)
         shape = shaped_type.get_shape()
 
         format_str = "{}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,6 @@ lint.ignore = [
   "RUF003", # https://docs.astral.sh/ruff/rules/ambiguous-unicode-character-comment
   "RUF005", # https://docs.astral.sh/ruff/rules/collection-literal-concatenation
   "RUF012", # https://docs.astral.sh/ruff/rules/mutable-class-default
-  "RUF018", # https://docs.astral.sh/ruff/rules/assignment-in-assert
   "RUF043", # https://docs.astral.sh/ruff/rules/pytest-raises-ambiguous-pattern
 ]
 lint.per-file-ignores."**/filecheck/*" = [ "E501", "F811", "F841" ]

--- a/tests/test_folder.py
+++ b/tests/test_folder.py
@@ -64,7 +64,8 @@ def test_insert_with_fold():
     # Should successfully fold
     assert folded_values is not None
     assert len(folded_values) == 1
-    assert isinstance(folded_value := folded_values[0], OpResult)
+    folded_value = folded_values[0]
+    assert isinstance(folded_value, OpResult)
     defining_op = folded_value.owner
     assert isinstance(defining_op, ConstantOp)
     assert isinstance(defining_op.value, IntegerAttr)
@@ -123,7 +124,8 @@ def test_replace_with_fold():
     # Should successfully fold
     assert folded_values is not None
     assert len(folded_values) == 1
-    assert isinstance(folded_value := folded_values[0], OpResult)
+    folded_value = folded_values[0]
+    assert isinstance(folded_value, OpResult)
     defining_op = folded_value.owner
     assert isinstance(defining_op, ConstantOp)
     assert isinstance(defining_op.value, IntegerAttr)

--- a/tests/transforms/test_convert_pdl_to_pdl_interp.py
+++ b/tests/transforms/test_convert_pdl_to_pdl_interp.py
@@ -122,10 +122,11 @@ def test_extract_tree_predicates():
 
     predicates = p.extract_tree_predicates(root, root_pos, {})
 
+    root_pos = OperationPosition(None, depth=0)
     assert predicates[0] == PositionalPredicate(
         OperationNameQuestion(),
         StringAnswer("op1"),
-        root_pos := OperationPosition(None, depth=0),
+        root_pos,
     )
     assert predicates[1] == PositionalPredicate(
         OperandCountQuestion(),
@@ -288,12 +289,13 @@ def test_operation_with_multiple_results():
     root_pos = OperationPosition(depth=0)
     predicates = p.extract_tree_predicates(root, root_pos, {})
 
+    root_pos = OperationPosition(None, depth=0)
     assert len(predicates) == 7
     assert (
         PositionalPredicate(
             ResultCountQuestion(),
             UnsignedAnswer(2),
-            root_pos := OperationPosition(None, depth=0),
+            root_pos,
         )
         in predicates
     )

--- a/xdsl/backend/riscv/lowering/convert_memref_to_riscv.py
+++ b/xdsl/backend/riscv/lowering/convert_memref_to_riscv.py
@@ -42,7 +42,8 @@ from xdsl.utils.exceptions import DiagnosticException
 class ConvertMemRefAllocOp(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: memref.AllocOp, rewriter: PatternRewriter) -> None:
-        assert isinstance(op_memref_type := op.memref.type, memref.MemRefType)
+        op_memref_type = op.memref.type
+        assert isinstance(op_memref_type, memref.MemRefType)
         op_memref_type = cast(memref.MemRefType[Any], op_memref_type)
         assert isinstance(op_memref_type.element_type, FixedBitwidthType)
         width_in_bytes = op_memref_type.element_type.size
@@ -165,7 +166,8 @@ def get_strided_pointer(
 class ConvertMemRefStoreOp(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: memref.StoreOp, rewriter: PatternRewriter):
-        assert isinstance(op_memref_type := op.memref.type, memref.MemRefType)
+        op_memref_type = op.memref.type
+        assert isinstance(op_memref_type, memref.MemRefType)
         memref_type = cast(memref.MemRefType[Any], op_memref_type)
 
         value, mem, *indices = cast_operands_to_regs(rewriter, op)
@@ -208,9 +210,8 @@ class ConvertMemRefStoreOp(RewritePattern):
 class ConvertMemRefLoadOp(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: memref.LoadOp, rewriter: PatternRewriter):
-        assert isinstance(op_memref_type := op.memref.type, memref.MemRefType), (
-            f"{op.memref.type}"
-        )
+        op_memref_type = op.memref.type
+        assert isinstance(op_memref_type, memref.MemRefType), f"{op.memref.type}"
         memref_type = cast(memref.MemRefType[Any], op_memref_type)
 
         mem, *indices = cast_operands_to_regs(rewriter, op)

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -3196,15 +3196,16 @@ class DenseIntOrFPElementsAttr(
         self, val: float | tuple[int, int] | tuple[float, float], printer: Printer
     ):
         if isinstance(val, int):
-            assert isinstance(
-                element_type := self.get_element_type(), IntegerType | IndexType
-            )
+            element_type = self.get_element_type()
+            assert isinstance(element_type, IntegerType | IndexType)
             printer.print_int(val, element_type)
         elif isinstance(val, float):
-            assert isinstance(element_type := self.get_element_type(), AnyFloat)
+            element_type = self.get_element_type()
+            assert isinstance(element_type, AnyFloat)
             printer.print_float(val, element_type)
         else:  # complex
-            assert isinstance(element_type := self.get_element_type(), ComplexType)
+            element_type = self.get_element_type()
+            assert isinstance(element_type, ComplexType)
             printer.print_complex(val, element_type)
 
     def _print_dense_list(

--- a/xdsl/dialects/gpu.py
+++ b/xdsl/dialects/gpu.py
@@ -157,7 +157,8 @@ class AllocOp(IRDLOperation):
 
     def verify_(self) -> None:
         ndyn = len(self.dynamicSizes)
-        assert isinstance(res_type := self.result.type, memref.MemRefType)
+        res_type = self.result.type
+        assert isinstance(res_type, memref.MemRefType)
         ndyn_type = len([i for i in res_type.get_shape() if i == DYNAMIC_INDEX])
         if ndyn != ndyn_type:
             raise VerifyException(

--- a/xdsl/dialects/linalg/ops.py
+++ b/xdsl/dialects/linalg/ops.py
@@ -918,8 +918,10 @@ class TransposeOp(LinalgStructuredOperation):
         )
 
     def verify_(self) -> None:
-        assert isinstance(input_type := self.inputs[0].type, TensorType | MemRefType)
-        assert isinstance(init_type := self.outputs[0].type, TensorType | MemRefType)
+        input_type = self.inputs[0].type
+        assert isinstance(input_type, TensorType | MemRefType)
+        init_type = self.outputs[0].type
+        assert isinstance(init_type, TensorType | MemRefType)
 
         input_shape = input_type.get_shape()
         init_shape = init_type.get_shape()
@@ -1267,8 +1269,10 @@ class BroadcastOp(IRDLOperation):
         )
 
     def verify_(self) -> None:
-        assert isinstance(input_type := self.input.type, TensorType | MemRefType)
-        assert isinstance(init_type := self.init.type, TensorType | MemRefType)
+        input_type = self.input.type
+        assert isinstance(input_type, TensorType | MemRefType)
+        init_type = self.init.type
+        assert isinstance(init_type, TensorType | MemRefType)
 
         dimensions_shape = self.dimensions.get_values()
 
@@ -1377,8 +1381,10 @@ class ReduceOp(IRDLOperation):
         )
 
     def verify_(self) -> None:
-        assert isinstance(input_type := self.input.type, TensorType | MemRefType)
-        assert isinstance(init_type := self.init.type, TensorType | MemRefType)
+        input_type = self.input.type
+        assert isinstance(input_type, TensorType | MemRefType)
+        init_type = self.init.type
+        assert isinstance(init_type, TensorType | MemRefType)
 
         if input_type.get_element_type() != init_type.get_element_type():
             raise VerifyException(

--- a/xdsl/dialects/memref_stream.py
+++ b/xdsl/dialects/memref_stream.py
@@ -249,7 +249,8 @@ class ReadOp(IRDLOperation):
 
     def __init__(self, stream_val: SSAValue, result_type: Attribute | None = None):
         if result_type is None:
-            assert isinstance(stream_type := stream_val.type, ReadableStreamType)
+            stream_type = stream_val.type
+            assert isinstance(stream_type, ReadableStreamType)
             stream_type = cast(ReadableStreamType[Attribute], stream_type)
             result_type = stream_type.element_type
         super().__init__(operands=[stream_val], result_types=[result_type])

--- a/xdsl/dialects/omp.py
+++ b/xdsl/dialects/omp.py
@@ -270,7 +270,8 @@ class LoopWrapper(NoTerminator):
             raise VerifyException(
                 f"{op.name} is not a LoopWrapper: has {num_ops} ops, expected 1"
             )
-        assert (inner := op.regions[0].block.first_op) is not None
+        inner = op.regions[0].block.first_op
+        assert inner is not None
         if not (inner.has_trait(LoopWrapper()) or isinstance(inner, LoopNestOp)):
             raise VerifyException(
                 f"{op.name} is not a LoopWrapper: "
@@ -1033,7 +1034,8 @@ class TargetUpdateOp(TargetTaskBasedDataOp):
         mapped = defaultdict[Operand, set[ClauseMapFlags]](lambda: set())
         one_of = {ClauseMapFlags.TO, ClauseMapFlags.FROM}
         for var in self.mapped_vars:
-            assert isinstance(owner := var.owner, MapInfoOp)
+            owner = var.owner
+            assert isinstance(owner, MapInfoOp)
 
             mapped[owner.var_ptr] |= owner.map_type.data
             if len(mapped[owner.var_ptr] & one_of) != 1:

--- a/xdsl/dialects/pdl.py
+++ b/xdsl/dialects/pdl.py
@@ -491,10 +491,12 @@ def _visit_pdl_ops(op: Operation, visited: set[Operation]):
     # Traverse the operands
     if isinstance(op, OperationOp):
         for value in op.operand_values:
-            assert isinstance(owner := value.owner, Operation)
+            owner = value.owner
+            assert isinstance(owner, Operation)
             _visit_pdl_ops(owner, visited)
     elif isinstance(op, ResultOp | ResultsOp):
-        assert isinstance(owner := op.parent_.owner, Operation)
+        owner = op.parent_.owner
+        assert isinstance(owner, Operation)
         _visit_pdl_ops(owner, visited)
 
     # Traverse the users

--- a/xdsl/dialects/riscv_snitch.py
+++ b/xdsl/dialects/riscv_snitch.py
@@ -194,7 +194,8 @@ class ReadOp(RISCVAsmOperation, RISCVRegallocOperation):
 
     def __init__(self, stream_val: SSAValue, result_type: Attribute | None = None):
         if result_type is None:
-            assert isinstance(stream_type := stream_val.type, snitch.ReadableStreamType)
+            stream_type = stream_val.type
+            assert isinstance(stream_type, snitch.ReadableStreamType)
             stream_type = cast(snitch.ReadableStreamType[Attribute], stream_type)
             result_type = stream_type.element_type
         super().__init__(operands=[stream_val], result_types=[result_type])

--- a/xdsl/dialects/smt.py
+++ b/xdsl/dialects/smt.py
@@ -550,8 +550,10 @@ class QuantifierOp(IRDLOperation, ABC):
         This function will asserts if the region is not correctly terminated by
         an `smt.yield` operation with a single boolean operand.
         """
-        assert isinstance(yield_op := self.body.block.last_op, YieldOp)
-        assert isa(ret_value := yield_op.values[0], SSAValue[BoolType])
+        yield_op = self.body.block.last_op
+        assert isinstance(yield_op, YieldOp)
+        ret_value = yield_op.values[0]
+        assert isa(ret_value, SSAValue[BoolType])
         return ret_value
 
 

--- a/xdsl/folder.py
+++ b/xdsl/folder.py
@@ -47,7 +47,8 @@ class Folder:
                 interface = dialect.get_interface(ConstantMaterializationInterface)
                 if interface is None:
                     return None
-                assert isinstance(type := original_result.type, TypeAttribute)
+                type = original_result.type
+                assert isinstance(type, TypeAttribute)
                 new_op = interface.materialize_constant(val, type)
                 if new_op is None:
                     return None

--- a/xdsl/interpreters/eqsat_pdl_interp.py
+++ b/xdsl/interpreters/eqsat_pdl_interp.py
@@ -545,18 +545,22 @@ class EqsatPDLInterpFunctions(InterpreterFunctions):
                 # the corresponding eclasses need to be merged.
                 op2 = unique_parents[op1]
 
-                assert (op1_use := op1.results[0].first_use), (
+                op1_use = op1.results[0].first_use
+                assert op1_use, (
                     "Modification handler currently only supports operations with a single (ClassOp) use"
                 )
-                assert isinstance(eclass1 := op1_use.operation, equivalence.AnyClassOp)
+                eclass1 = op1_use.operation
+                assert isinstance(eclass1, equivalence.AnyClassOp)
 
                 assert len(op2.results) == 1, (
                     "Expected a single result for the operation being modified."
                 )
-                assert (op2_use := op2.results[0].first_use), (
+                op2_use = op2.results[0].first_use
+                assert op2_use, (
                     "Modification handler currently only supports operations with a single (ClassOp) use"
                 )
-                assert isinstance(eclass2 := op2_use.operation, equivalence.AnyClassOp)
+                eclass2 = op2_use.operation
+                assert isinstance(eclass2, equivalence.AnyClassOp)
 
                 # This temporarily breaks the invariant since eclass2 will now contain the result of op2 twice.
                 # Callling `eclass_union` will deduplicate this operand.
@@ -595,12 +599,12 @@ class EqsatPDLInterpFunctions(InterpreterFunctions):
 
                 changed = result.meet(type(result)(result.anchor, original_state))
                 if changed == ChangeResult.CHANGE:
-                    assert (op_use := op.results[0].first_use), (
+                    op_use = op.results[0].first_use
+                    assert op_use, (
                         "Dataflow analysis currently only supports operations with a single (ClassOp) use"
                     )
-                    assert isinstance(
-                        eclass_op := op_use.operation, equivalence.AnyClassOp
-                    )
+                    eclass_op = op_use.operation
+                    assert isinstance(eclass_op, equivalence.AnyClassOp)
                     self.worklist.append(eclass_op)
 
     def rebuild(self, interpreter: Interpreter):

--- a/xdsl/transforms/apply_eqsat_pdl.py
+++ b/xdsl/transforms/apply_eqsat_pdl.py
@@ -122,8 +122,9 @@ class ApplyEqsatPDLPass(ModulePass):
             matcher, rewriter_func = self._extract_matcher_and_rewriters(temp_module)
 
             assert matcher.body.last_block is not None
+            recordmatch = matcher.body.last_block.last_op
             assert isinstance(
-                recordmatch := matcher.body.last_block.last_op,
+                recordmatch,
                 eqsat_pdl_interp.RecordMatchOp,
             )
             name = (

--- a/xdsl/transforms/apply_eqsat_pdl_interp.py
+++ b/xdsl/transforms/apply_eqsat_pdl_interp.py
@@ -30,7 +30,8 @@ class EqsatConstraintFunctions(InterpreterFunctions):
     def run_is_not_unsound(
         self, interp: Interpreter, _op: Operation, args: PythonValues
     ):
-        assert isinstance(op := args[0], Operation)
+        op = args[0]
+        assert isinstance(op, Operation)
         return "unsound" not in op.attributes, ()
 
 

--- a/xdsl/transforms/convert_memref_to_ptr.py
+++ b/xdsl/transforms/convert_memref_to_ptr.py
@@ -206,7 +206,8 @@ def build_target_ptr(
 class ConvertStorePattern(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: memref.StoreOp, rewriter: PatternRewriter, /):
-        assert isa(memref_type := op.memref.type, memref.MemRefType)
+        memref_type = op.memref.type
+        assert isa(memref_type, memref.MemRefType)
         target_ptr = build_target_ptr(op.memref, memref_type, op.indices, rewriter)
         rewriter.replace_op(op, ptr.StoreOp(target_ptr, op.value))
 
@@ -215,7 +216,8 @@ class ConvertStorePattern(RewritePattern):
 class ConvertLoadPattern(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: memref.LoadOp, rewriter: PatternRewriter, /):
-        assert isa(memref_type := op.memref.type, memref.MemRefType)
+        memref_type = op.memref.type
+        assert isa(memref_type, memref.MemRefType)
         target_ptr = build_target_ptr(op.memref, memref_type, op.indices, rewriter)
         rewriter.replace_op(op, ptr.LoadOp(target_ptr, memref_type.element_type))
 

--- a/xdsl/transforms/convert_ml_program_to_memref.py
+++ b/xdsl/transforms/convert_ml_program_to_memref.py
@@ -26,7 +26,8 @@ class ConvertGlobalPattern(RewritePattern):
             raise NotImplementedError(
                 "Converting ml_program.global with no value not implemented"
             )
-        assert isinstance(op_type := op.type, TensorType)
+        op_type = op.type
+        assert isinstance(op_type, TensorType)
         op_type = cast(TensorType[Any], op_type)
         new_type = memref.MemRefType(op_type.element_type, op_type.shape)
         rewriter.replace_op(
@@ -48,7 +49,8 @@ class ConvertGlobalLoadConst(RewritePattern):
     def match_and_rewrite(
         self, op: ml_program.GlobalLoadConstantOp, rewriter: PatternRewriter
     ) -> None:
-        assert isinstance(op_type := op.result.type, TensorType)
+        op_type = op.result.type
+        assert isinstance(op_type, TensorType)
         op_type = cast(TensorType[Any], op_type)
         new_type = memref.MemRefType(op_type.element_type, op_type.shape)
         rewriter.replace_op(

--- a/xdsl/transforms/convert_pdl_to_pdl_interp/conversion.py
+++ b/xdsl/transforms/convert_pdl_to_pdl_interp/conversion.py
@@ -1298,7 +1298,8 @@ class PredicateTreeBuilder:
             # the parent SwitchNode (`parent`) that leads to the ChooseNode and insert the
             # predicate as a new node (`replacement_node`) in place of the ChooseNode.
             # The failure path of the new node then points to the ChooseNode.
-            assert isinstance(parent := node.parent, SwitchNode)
+            parent = node.parent
+            assert isinstance(parent, SwitchNode)
             replacement_node = SwitchNode(
                 position=current_predicate.position,
                 question=current_predicate.question,

--- a/xdsl/transforms/convert_pdl_to_pdl_interp/predicate.py
+++ b/xdsl/transforms/convert_pdl_to_pdl_interp/predicate.py
@@ -413,13 +413,15 @@ This is used to decide which question to branch on first when evaluating predica
 
 def get_position_cost(position: Position) -> int:
     """Get cost for a position type, with fallback for unknown types."""
-    assert (t := type(position)) in POSITION_COSTS
+    t = type(position)
+    assert t in POSITION_COSTS
     return POSITION_COSTS[t]
 
 
 def get_question_cost(question: Question) -> int:
     """Get cost for a question type, with fallback for unknown types."""
-    assert (t := type(question)) in QUESTION_COSTS
+    t = type(question)
+    assert t in QUESTION_COSTS
     return QUESTION_COSTS[t]
 
 

--- a/xdsl/transforms/convert_stencil_to_csl_stencil.py
+++ b/xdsl/transforms/convert_stencil_to_csl_stencil.py
@@ -177,9 +177,8 @@ class ConvertSwapToPrefetchPattern(RewritePattern):
         assert (MemRefType.constr() | stencil.StencilTypeConstr).verifies(
             op.input_stencil.type
         )
-        assert isa(
-            t_type := op.input_stencil.type.get_element_type(), TensorType[Attribute]
-        )
+        t_type = op.input_stencil.type.get_element_type()
+        assert isa(t_type, TensorType[Attribute])
         assert op.strategy.comm_layout() is not None, (
             f"topology on {type(op)} is not given"
         )

--- a/xdsl/transforms/convert_vector_to_ptr.py
+++ b/xdsl/transforms/convert_vector_to_ptr.py
@@ -18,7 +18,8 @@ from xdsl.utils.hints import isa
 class VectorStoreToPtr(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: vector.StoreOp, rewriter: PatternRewriter):
-        assert isa(memref_type := op.base.type, memref.MemRefType)
+        memref_type = op.base.type
+        assert isa(memref_type, memref.MemRefType)
         target_ptr = build_target_ptr(op.base, memref_type, op.indices, rewriter)
         rewriter.replace_op(op, ptr.StoreOp(addr=target_ptr, value=op.vector))
 
@@ -27,7 +28,8 @@ class VectorStoreToPtr(RewritePattern):
 class VectorLoadToPtr(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: vector.LoadOp, rewriter: PatternRewriter):
-        assert isa(memref_type := op.base.type, memref.MemRefType)
+        memref_type = op.base.type
+        assert isa(memref_type, memref.MemRefType)
         target_ptr = build_target_ptr(op.base, memref_type, op.indices, rewriter)
         rewriter.replace_op(op, ptr.LoadOp(target_ptr, op.result.type))
 

--- a/xdsl/transforms/csl_stencil_bufferize.py
+++ b/xdsl/transforms/csl_stencil_bufferize.py
@@ -167,7 +167,8 @@ class ApplyOpBufferize(RewritePattern):
             else:
                 done_exchange_arg_mapping.append(arg)
 
-        assert isa(typ := op.receive_chunk.block.args[0].type, TensorType[Attribute])
+        typ = op.receive_chunk.block.args[0].type
+        assert isa(typ, TensorType[Attribute])
         chunk_type = TensorType(typ.get_element_type(), typ.get_shape()[1:])
 
         # inline blocks from old into new regions
@@ -267,7 +268,8 @@ class ApplyOpBufferize(RewritePattern):
         """
 
         # this is the unbufferized `tensor<(neighbours)x(ZDim)x(type)>` value
-        assert isa(typ := op.receive_chunk.block.args[0].type, TensorType[Attribute])
+        typ = op.receive_chunk.block.args[0].type
+        assert isa(typ, TensorType[Attribute])
 
         return tensor.ExtractSliceOp(
             operands=[to_tensor.tensor, [offset], [], []],

--- a/xdsl/transforms/csl_stencil_handle_async_flow.py
+++ b/xdsl/transforms/csl_stencil_handle_async_flow.py
@@ -71,7 +71,8 @@ class HandleCslStencilApplyAsyncCF(RewritePattern):
             return
 
         # case 3: apply is followed by other code, split it off into a different func, call it from second callback of apply
-        assert (parent_block := op.parent_block()) is not None
+        parent_block = op.parent_block()
+        assert parent_block is not None
         next_block = parent_block.split_before(op.next_op)
         rewriter.insert_op(csl.ReturnOp(), InsertPoint.after(op))
         next_func = csl.FuncOp(f"step{self.counter}", FunctionType.from_lists([], []))

--- a/xdsl/transforms/csl_stencil_materialize_stores.py
+++ b/xdsl/transforms/csl_stencil_materialize_stores.py
@@ -26,7 +26,8 @@ class MaterializeInApplyDest(RewritePattern):
     def match_and_rewrite(self, op: csl_stencil.YieldOp, rewriter: PatternRewriter, /):
         if not len(op.arguments) > 0:
             return
-        assert isinstance(apply := op.parent_op(), csl_stencil.ApplyOp)
+        apply = op.parent_op()
+        assert isinstance(apply, csl_stencil.ApplyOp)
 
         if op.parent_region() != apply.done_exchange:
             return

--- a/xdsl/transforms/experimental/convert_stencil_to_ll_mlir.py
+++ b/xdsl/transforms/experimental/convert_stencil_to_ll_mlir.py
@@ -344,8 +344,10 @@ class BufferOpToMemRef(RewritePattern):
 
 
 def field_subview(field: SSAValue):
-    assert isa(field_type := field.type, FieldType[Attribute])
-    assert isinstance(bounds := field_type.bounds, StencilBoundsAttr)
+    field_type = field.type
+    assert isa(field_type, FieldType[Attribute])
+    bounds = field_type.bounds
+    assert isinstance(bounds, StencilBoundsAttr)
     offsets = [i for i in -bounds.lb]
     sizes = [i for i in field_type.get_shape()]
     strides = [1] * len(sizes)

--- a/xdsl/transforms/experimental/stencil_tensorize_z_dimension.py
+++ b/xdsl/transforms/experimental/stencil_tensorize_z_dimension.py
@@ -140,7 +140,8 @@ class AccessOpTensorize(RewritePattern):
         #     rewriter.replace_op(op, a)
         #     return
         assert isa(op.temp.type, TempType[Attribute])
-        assert is_tensor(element_t := op.temp.type.get_element_type())
+        element_t = op.temp.type.get_element_type()
+        assert is_tensor(element_t)
         extract = ExtractSliceOp.from_static_parameters(
             a, [z_offset], element_t.get_shape()
         )
@@ -198,7 +199,8 @@ class ArithOpTensorize(RewritePattern):
         If it is not a constant, create an empty tensor and `linalg.fill` it with the scalar value.
         """
         if isinstance(scalar_op, OpResult) and isinstance(scalar_op.op, ConstantOp):
-            assert isinstance(float_attr := scalar_op.op.value, FloatAttr)
+            float_attr = scalar_op.op.value
+            assert isinstance(float_attr, FloatAttr)
             scalar_value = float_attr.value.data
             tens_const = ConstantOp(
                 DenseIntOrFPElementsAttr.from_list(dest_typ, [scalar_value])
@@ -276,7 +278,8 @@ class LoadOpTensorize(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: LoadOp, rewriter: PatternRewriter, /):
         assert isa(op.res.type, TempType[Attribute])
-        assert isinstance(bounds := op.res.type.bounds, StencilBoundsAttr)
+        bounds = op.res.type.bounds
+        assert isinstance(bounds, StencilBoundsAttr)
         rewriter.replace_op(
             op,
             LoadOp(

--- a/xdsl/transforms/lower_csl_stencil.py
+++ b/xdsl/transforms/lower_csl_stencil.py
@@ -425,9 +425,8 @@ class FullStencilAccessImmediateReductionOptimization(RewritePattern):
             rewriter.erase_op(e, safe_erase=False)
 
         # housekeeping: this strategy requires zeroing out the accumulator iff the apply is inside a loop
-        assert isinstance(
-            (elem_t := accumulator.type.get_element_type()), Float16Type | Float32Type
-        )
+        elem_t = accumulator.type.get_element_type()
+        assert isinstance(elem_t, Float16Type | Float32Type)
         zero = arith.ConstantOp(FloatAttr(0.0, elem_t))
         mov_op = csl.FmovsOp if elem_t == f32 else csl.FmovhOp
         rewriter.insert_op(

--- a/xdsl/transforms/lower_csl_wrapper.py
+++ b/xdsl/transforms/lower_csl_wrapper.py
@@ -124,7 +124,8 @@ class ExtractCslModules(RewritePattern):
         y = inner_loop_block.args[0]
         y.name_hint = "y"
 
-        assert isa(yield_op := op.layout_module.block.last_op, csl_wrapper.YieldOp)
+        yield_op = op.layout_module.block.last_op
+        assert isa(yield_op, csl_wrapper.YieldOp)
         rewriter.erase_op(yield_op)
 
         with ImplicitBuilder(module_block):
@@ -186,7 +187,8 @@ class ExtractCslModules(RewritePattern):
     def _collect_yield_args(yield_op: csl_wrapper.YieldOp) -> list[csl.ParamOp]:
         params = list[csl.ParamOp]()
         for s, v in yield_op.items():
-            assert csl.ParamOpAttrConstr.verifies(ty := v.type)
+            ty = v.type
+            assert csl.ParamOpAttrConstr.verifies(ty)
             params.append(csl.ParamOp(s, ty))
         return params
 
@@ -211,10 +213,12 @@ class ExtractCslModules(RewritePattern):
         with ImplicitBuilder(module_block):
             param_width, param_height, params_from_block_args = self._collect_params(op)
 
-        assert isa(yield_op := op.layout_module.block.last_op, csl_wrapper.YieldOp)
+        yield_op = op.layout_module.block.last_op
+        assert isa(yield_op, csl_wrapper.YieldOp)
         yield_args = self._collect_yield_args(yield_op)
         module_block.add_ops(yield_args)
-        assert isa(yield_op := op.program_module.block.last_op, csl_wrapper.YieldOp)
+        yield_op = op.program_module.block.last_op
+        assert isa(yield_op, csl_wrapper.YieldOp)
         rewriter.erase_op(yield_op)
 
         rewriter.inline_block(
@@ -251,7 +255,8 @@ class LowerImport(RewritePattern):
 
         if isinstance(op, csl.CslModuleOp):
             return op
-        assert (parent := op.parent_op()) is not None
+        parent = op.parent_op()
+        assert parent is not None
         return self._get_csl_mod(parent)
 
     def _collect_ops(self, op: Operation, ops: list[Operation]) -> list[Operation]:

--- a/xdsl/transforms/lower_mpi.py
+++ b/xdsl/transforms/lower_mpi.py
@@ -204,7 +204,8 @@ class _MPIToLLVMRewriteBase(RewritePattern, ABC):
         It then returns a list of operations calculating that size, and
         an OpResult containing the calculated value.
         """
-        assert isinstance(ssa_val_type := ssa_val.type, memref.MemRefType)
+        ssa_val_type = ssa_val.type
+        assert isinstance(ssa_val_type, memref.MemRefType)
 
         # Note: we only allow MemRef, not UnrankedMemRef!
         # TODO: handle -1 in sizes

--- a/xdsl/transforms/memref_stream_generalize_fill.py
+++ b/xdsl/transforms/memref_stream_generalize_fill.py
@@ -33,7 +33,8 @@ class GeneralizeFillPattern(RewritePattern):
         with ImplicitBuilder(block) as (arg0, _):
             memref_stream.YieldOp(arg0)
 
-        assert isinstance(memref_type := op.memref.type, memref.MemRefType)
+        memref_type = op.memref.type
+        assert isinstance(memref_type, memref.MemRefType)
 
         memref_type = cast(MemRefType, memref_type)
 

--- a/xdsl/transforms/memref_stream_tile_outer_loops.py
+++ b/xdsl/transforms/memref_stream_tile_outer_loops.py
@@ -72,7 +72,8 @@ def insert_subview(
         raise DiagnosticException("Cannot create subview from non-memref type")
     source_type = cast(MemRefType, source_type)
     layout_attr = source_type.layout
-    assert (strides := source_type.get_strides())
+    strides = source_type.get_strides()
+    assert strides
     strides = tuple(strides)
     match layout_attr:
         case NoneAttr():

--- a/xdsl/transforms/memref_to_dsd.py
+++ b/xdsl/transforms/memref_to_dsd.py
@@ -37,10 +37,11 @@ class LowerAllocOpPass(RewritePattern):
 
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: memref.AllocOp, rewriter: PatternRewriter, /):
+        memref_type = op.memref.type
         assert (
             MemRefType[csl.ZerosOpAttr]
             .constr(csl.ZerosOpAttrConstr)
-            .verifies(memref_type := op.memref.type)
+            .verifies(memref_type)
         )
         zeros_op = csl.ZerosOp(memref_type)
 

--- a/xdsl/transforms/shape_inference_patterns/stencil.py
+++ b/xdsl/transforms/shape_inference_patterns/stencil.py
@@ -201,7 +201,8 @@ class ApplyOpShapeInference(RewritePattern):
             if isa(arg.type, TempType[Attribute]) and isinstance(
                 arg.type.bounds, StencilBoundsAttr
             ):
-                assert isa(ot := op.operands[i].type, TempType[Attribute])
+                ot = op.operands[i].type
+                assert isa(ot, TempType[Attribute])
                 new_bounds = arg.type.bounds | ot.bounds
                 if new_bounds != ot.bounds:
                     update_result_size(op.operands[i], new_bounds, rewriter)


### PR DESCRIPTION
Fixes RUF018 in #5927.

This enables Ruff's `RUF018` rule and moves assignments out of assert statements. Besides satisfying the lint rule, this prevents those assignments from disappearing when Python runs with optimizations enabled.

Validation:

- `ruff format --check` on all changed Python files
- `ruff check` on all changed Python files
- `ruff check --select RUF018 .`
- 496 focused tests covering the affected modules
- Pyright on the changed production modules (0 errors)
