### PR TITLE
CI: enable RUF001 lint rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,6 @@ lint.ignore = [
   "PYI041", # https://docs.astral.sh/ruff/rules/redundant-numeric-union
   # Help welcome removing ignores below
   # https://github.com/xdslproject/xdsl/issues/5927
-  "RUF001", # https://docs.astral.sh/ruff/rules/ambiguous-unicode-character-string
   "RUF002", # https://docs.astral.sh/ruff/rules/ambiguous-unicode-character-docstring
   "RUF003", # https://docs.astral.sh/ruff/rules/ambiguous-unicode-character-comment
   "RUF005", # https://docs.astral.sh/ruff/rules/collection-literal-concatenation

--- a/tests/pattern_rewriter/test_pattern_rewriter.py
+++ b/tests/pattern_rewriter/test_pattern_rewriter.py
@@ -1423,7 +1423,7 @@ def test_inline_region_before():
     %1 = "test.op"() : () -> f32
     ^bb2:
     %2 = "test.op"() : () -> f64
-  }) {label = "а"} : () -> ()
+  }) {label = "a"} : () -> ()
   %2 = "test.op"() : () -> i64
 }) : () -> ()
 """
@@ -1443,7 +1443,7 @@ def test_inline_region_before():
     class Rewrite(RewritePattern):
         @op_type_rewrite_pattern
         def match_and_rewrite(self, op: test.TestOp, rewriter: PatternRewriter):
-            if op.attributes.get("label") != StringAttr("а"):
+            if op.attributes.get("label") != StringAttr("a"):
                 return
             if op.parent is None:
                 return
@@ -1469,7 +1469,7 @@ def test_inline_region_after():
     %1 = "test.op"() : () -> f32
     ^bb2:
     %2 = "test.op"() : () -> f64
-  }) {label = "а"} : () -> ()
+  }) {label = "a"} : () -> ()
 ^bb0:
   %2 = "test.op"() : () -> i64
 }) : () -> ()
@@ -1490,7 +1490,7 @@ def test_inline_region_after():
     class Rewrite(RewritePattern):
         @op_type_rewrite_pattern
         def match_and_rewrite(self, op: test.TestOp, rewriter: PatternRewriter):
-            if op.attributes.get("label") != StringAttr("а"):
+            if op.attributes.get("label") != StringAttr("a"):
                 return
             if op.parent is None:
                 return
@@ -1517,7 +1517,7 @@ def test_inline_region_at_start():
     %1 = "test.op"() : () -> f32
     ^bb2:
     %2 = "test.op"() : () -> f64
-  }) {label = "а"} : () -> ()
+  }) {label = "a"} : () -> ()
   %2 = "test.op"() : () -> i64
 }) : () -> ()
 """
@@ -1537,7 +1537,7 @@ def test_inline_region_at_start():
     class Rewrite(RewritePattern):
         @op_type_rewrite_pattern
         def match_and_rewrite(self, op: test.TestOp, rewriter: PatternRewriter):
-            if op.attributes.get("label") != StringAttr("а"):
+            if op.attributes.get("label") != StringAttr("a"):
                 return
             parent_region = op.parent_region()
             if parent_region is None:
@@ -1567,7 +1567,7 @@ def test_inline_region_at_end():
     %1 = "test.op"() : () -> f32
     ^bb2:
     %2 = "test.op"() : () -> f64
-  }) {label = "а"} : () -> ()
+  }) {label = "a"} : () -> ()
   %2 = "test.op"() : () -> i64
 }) : () -> ()
 """
@@ -1587,7 +1587,7 @@ def test_inline_region_at_end():
     class Rewrite(RewritePattern):
         @op_type_rewrite_pattern
         def match_and_rewrite(self, op: test.TestOp, rewriter: PatternRewriter):
-            if op.attributes.get("label") != StringAttr("а"):
+            if op.attributes.get("label") != StringAttr("a"):
                 return
             parent_region = op.parent_region()
             if parent_region is None:

--- a/xdsl/backend/riscv/targets.py
+++ b/xdsl/backend/riscv/targets.py
@@ -85,7 +85,7 @@ class ABISpec:
     abi_flen: Literal[0, 32, 64, 128]
     """
     ABI_FLEN refers to the width of a floating-point register in the ABI. The ABI_FLEN
-    must be no wider than the ISA’s FLEN. The ISA might have wider floating-point
+    must be no wider than the ISA's FLEN. The ISA might have wider floating-point
     registers than the ABI.
 
     (cited from section 2.2 [1], p. 10)


### PR DESCRIPTION
Fixes the RUF001 item in #5927.

This enables Ruff's ambiguous Unicode character check for string literals. The existing findings were resolved by replacing a Cyrillic `а` used as a test label with ASCII `a`, and normalizing one typographic apostrophe in the RISC-V target documentation.

Validation:

- `ruff format --check` on the changed Python files
- `ruff check` on the changed Python files
- `ruff check --select RUF001 .`
- 49 pattern-rewriter tests
- Pyright on `xdsl/backend/riscv/targets.py` (0 errors)
