### PR TITLE
CI: enable RUF003 lint rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,6 @@ lint.ignore = [
   # https://github.com/xdslproject/xdsl/issues/5927
   "RUF001", # https://docs.astral.sh/ruff/rules/ambiguous-unicode-character-string
   "RUF002", # https://docs.astral.sh/ruff/rules/ambiguous-unicode-character-docstring
-  "RUF003", # https://docs.astral.sh/ruff/rules/ambiguous-unicode-character-comment
   "RUF005", # https://docs.astral.sh/ruff/rules/collection-literal-concatenation
   "RUF012", # https://docs.astral.sh/ruff/rules/mutable-class-default
   "RUF018", # https://docs.astral.sh/ruff/rules/assignment-in-assert

--- a/tests/analysis/test_sparse_analysis.py
+++ b/tests/analysis/test_sparse_analysis.py
@@ -530,12 +530,12 @@ def test_lattice_multiple_operations():
     other1 = TestLattice(anchor, value=TestLatticeValue(10))
     other2 = TestLattice(anchor, value=TestLatticeValue(3))
 
-    # First join: 5 ∨ 10 = 10
+    # First join: join(5, 10) = 10
     result1 = lattice.join(other1)
     assert result1 == ChangeResult.CHANGE
     assert lattice.value.value == 10
 
-    # Second join: 10 ∨ 3 = 10 (no change)
+    # Second join: join(10, 3) = 10 (no change)
     result2 = lattice.join(other2)
     assert result2 == ChangeResult.NO_CHANGE
     assert lattice.value.value == 10

--- a/xdsl/dialects/emitc.py
+++ b/xdsl/dialects/emitc.py
@@ -440,7 +440,7 @@ class EmitC_CallOpaqueOp(IRDLOperation):
     callee = prop_def(StringAttr)
     args = opt_prop_def(ArrayAttr)
     template_args = opt_prop_def(ArrayAttr)
-    # The SSA‐value operands of the call
+    # The SSA-value operands of the call
     call_args = var_operand_def()
     res = var_result_def()
 

--- a/xdsl/dialects/hw.py
+++ b/xdsl/dialects/hw.py
@@ -179,7 +179,7 @@ class InnerSymbolTableTrait(OpTrait):
             )
 
         # InnerSymbolTable's must be directly nested within an InnerRefNamespaceTrait (or similar),
-        # however don’t test InnerRefNamespace’s symbol lookups
+        # however don't test InnerRefNamespace's symbol lookups
         parent = op.parent_op()
         if parent is None or not parent.has_trait(trait := InnerRefNamespaceLike):
             raise VerifyException(

--- a/xdsl/dialects/math_xdsl.py
+++ b/xdsl/dialects/math_xdsl.py
@@ -22,13 +22,13 @@ from xdsl.utils.str_enum import StrEnum
 
 
 class Constant(StrEnum):
-    E = auto()  # 𝑒
+    E = auto()  # e
     PI = auto()  # π
     M_2_SQRTPI = auto()  # 2/sqrt(π)
-    LOG2E = auto()  # log2(𝑒)
+    LOG2E = auto()  # log2(e)
     PI_2 = auto()  # π/2
     SQRT2 = auto()  # sqrt(2)
-    LOG10E = auto()  # log10(𝑒)
+    LOG10E = auto()  # log10(e)
     PI_4 = auto()  # π/4
     SQRT1_2 = auto()  # sqrt(1/2)
     LN2 = auto()  # ln(2)

--- a/xdsl/transforms/test_constant_folding.py
+++ b/xdsl/transforms/test_constant_folding.py
@@ -170,7 +170,7 @@ class TestSpecialisedConstantFoldingPass(ModulePass):
                     old_result = old_op.results[0]
                     ## There are no callbacks, so can elide `self.handle_operation_modification(use.operation)`
                     for use in tuple(old_result.uses):
-                        ## Inline `use.operation.operands.__setitem__(...)`
+                        ## Inline `use.operation.operands.__setitem__(...)`
                         operands = use.operation._operands  # pyright: ignore[reportPrivateUsage]
                         ## Inline `operands[use.index].remove_use(Use(use.operation, use.index))`
                         old_use = use.operation._operand_uses[use.index]  # pyright: ignore[reportPrivateUsage]


### PR DESCRIPTION
Fixes the RUF003 item in #5927.

This enables Ruff's ambiguous Unicode character check for comments. The nine existing findings are normalized to unambiguous ASCII text while preserving the meaning of the affected comments.

Validation:

- `ruff format --check` on all changed Python files
- `ruff check` on all changed Python files
- `ruff check --select RUF003 .`
- 154 affected analysis and dialect tests
