### PR TITLE
CI: enable RUF002 lint rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,6 @@ lint.ignore = [
   "PYI041", # https://docs.astral.sh/ruff/rules/redundant-numeric-union
   # Help welcome removing ignores below
   # https://github.com/xdslproject/xdsl/issues/5927
-  "RUF002", # https://docs.astral.sh/ruff/rules/ambiguous-unicode-character-docstring
   "RUF005", # https://docs.astral.sh/ruff/rules/collection-literal-concatenation
   "RUF012", # https://docs.astral.sh/ruff/rules/mutable-class-default
   "RUF043", # https://docs.astral.sh/ruff/rules/pytest-raises-ambiguous-pattern

--- a/tests/analysis/test_sparse_analysis.py
+++ b/tests/analysis/test_sparse_analysis.py
@@ -554,7 +554,7 @@ def test_lattice_multiple_operations():
 
 @dataclass(frozen=True)
 class KnownLatticeValue(AbstractLatticeValue):
-    """A simple lattice value: Unknown (⊥) < Known < Top (⊤)"""
+    """A simple lattice value: Unknown (bottom) < Known < Top"""
 
     value: Literal["unknown", "top"] | int
 

--- a/tests/analysis/test_sparse_backward_analysis.py
+++ b/tests/analysis/test_sparse_backward_analysis.py
@@ -26,7 +26,7 @@ from xdsl.ir import Block, Operation, Region
 
 @dataclass(frozen=True)
 class LiveValue(AbstractLatticeValue):
-    """Boolean liveness lattice: live (⊤) ⊑ dead (⊥)."""
+    """Boolean liveness lattice: live (top) ⊑ dead (bottom)."""
 
     state: Literal["dead", "live"]
 

--- a/xdsl/analysis/sparse_analysis.py
+++ b/xdsl/analysis/sparse_analysis.py
@@ -28,7 +28,7 @@ class AbstractLatticeValue(Protocol):
     Protocol for the mathematical lattice value types used within Lattice wrappers.
     A lattice is a mathematical structure with a partial ordering and two operations:
 
-    - join (∨): computes the least upper bound (union of information)
+    - join: computes the least upper bound (union of information)
     - meet (∧): computes the greatest lower bound (intersection of information)
 
     Classes implementing this protocol should provide implementations for the `meet`
@@ -38,7 +38,7 @@ class AbstractLatticeValue(Protocol):
     This protocol represents the actual lattice element (the abstract value being
     tracked), separate from the propagation infrastructure. For example:
 
-    - In constant propagation: the lattice value might be `⊥ (bottom) | Constant(n) | ⊤ (top)`
+    - In constant propagation: the lattice value might be `bottom | Constant(n) | top`
     - In sign analysis: the lattice value might be `Positive | Negative | Zero | Unknown`
     - In range analysis: the lattice value might be `Interval(min, max)`
     """
@@ -74,7 +74,7 @@ class AbstractLatticeValue(Protocol):
         """
         Computes the least upper bound (union of information) of two lattice values.
 
-        `a.join(b)` (or `a ∨ b`) produces the least precise value that is greater than or
+        `a.join(b)` produces the least precise value that is greater than or
         equal to both `a` and `b` in the lattice ordering. It represents the merging of
         two abstract values where we keep any information that could hold in either.
 
@@ -82,9 +82,9 @@ class AbstractLatticeValue(Protocol):
 
         Examples:
 
-        - In constant propagation: `Constant(3) ∨ Constant(4) = ⊤ (top)`
-        - In sign analysis: `Positive ∨ Negative = Unknown`
-        - In range analysis: `[0, 10] ∨ [5, 15] = [0, 15]`
+        - In constant propagation: `join(Constant(3), Constant(4)) = top`
+        - In sign analysis: `join(Positive, Negative) = Unknown`
+        - In range analysis: `join([0, 10], [5, 15]) = [0, 15]`
         """
         ...
 

--- a/xdsl/backend/riscv/targets.py
+++ b/xdsl/backend/riscv/targets.py
@@ -8,7 +8,7 @@ Based on:
       Clarke, RISC-V International, November 2022.
       https://github.com/riscv-non-isa/riscv-elf-psabi-doc/releases/tag/v1.0
  [2]: “The RISC-V Instruction Set Manual, Volume I: User-Level ISA, Document Version
-      20191213”, Editors Andrew Waterman and Krste Asanovi´c, RISC-V Foundation,
+      20191213”, Editors Andrew Waterman and Krste Asanovic, RISC-V Foundation,
       December 2019.
       https://github.com/riscv/riscv-isa-manual/releases/download/Ratified-IMAFDQC/riscv-spec-20191213.pdf
 

--- a/xdsl/dialects/hw.py
+++ b/xdsl/dialects/hw.py
@@ -1,5 +1,5 @@
 """
-This is a stub of CIRCT’s hw dialect.
+This is a stub of CIRCT's hw dialect.
 Follows definitions as of CIRCT commit `f8c7faec1e8447521a1ea9a0836b6923a132c79e`.
 
 See [rationale](https://circt.llvm.org/docs/RationaleSymbols/) for symbols.

--- a/xdsl/dialects/riscv/ops.py
+++ b/xdsl/dialects/riscv/ops.py
@@ -457,7 +457,7 @@ class ZextBOp(RdRsIntegerOperation[IntRegisterType]):
 @irdl_op_definition
 class ZextWOp(RdRsIntegerOperation[IntRegisterType]):
     """
-    A pseudo instruction that zero-extends the least-significant word of the source to XLEN by inserting 0’s
+    A pseudo instruction that zero-extends the least-significant word of the source to XLEN by inserting 0's
     into all of the bits more significant than 31.
 
     Equivalent to `add.uw rd, rs1, 0`
@@ -1239,7 +1239,7 @@ class MulOpHasCanonicalizationPatternsTrait(HasCanonicalizationPatternsTrait):
 @irdl_op_definition
 class MulOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
     """
-    Performs an XLEN-bit × XLEN-bit multiplication of signed rs1 by signed rs2
+    Performs an XLEN-bit by XLEN-bit multiplication of signed rs1 by signed rs2
     and places the lower XLEN bits in the destination register.
     x[rd] = x[rs1] * x[rs2]
 
@@ -1254,9 +1254,9 @@ class MulOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
 @irdl_op_definition
 class MulhOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
     """
-    Performs an XLEN-bit × XLEN-bit multiplication of signed rs1 by signed rs2
+    Performs an XLEN-bit by XLEN-bit multiplication of signed rs1 by signed rs2
     and places the upper XLEN bits in the destination register.
-    x[rd] = (x[rs1] s×s x[rs2]) >>s XLEN
+    x[rd] = (x[rs1] s*s x[rs2]) >>s XLEN
 
     See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvm.html#mulh).
     """
@@ -1267,9 +1267,9 @@ class MulhOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
 @irdl_op_definition
 class MulhsuOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
     """
-    Performs an XLEN-bit × XLEN-bit multiplication of signed rs1 by unsigned rs2
+    Performs an XLEN-bit by XLEN-bit multiplication of signed rs1 by unsigned rs2
     and places the upper XLEN bits in the destination register.
-    x[rd] = (x[rs1] s × x[rs2]) >>s XLEN
+    x[rd] = (x[rs1] s * x[rs2]) >>s XLEN
 
     See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvm.html#mulhsu).
     """
@@ -1280,9 +1280,9 @@ class MulhsuOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
 @irdl_op_definition
 class MulhuOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
     """
-    Performs an XLEN-bit × XLEN-bit multiplication of unsigned rs1 by unsigned rs2
+    Performs an XLEN-bit by XLEN-bit multiplication of unsigned rs1 by unsigned rs2
     and places the upper XLEN bits in the destination register.
-    x[rd] = (x[rs1] u × x[rs2]) >>u XLEN
+    x[rd] = (x[rs1] u * x[rs2]) >>u XLEN
 
     See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvm.html#mulhu).
     """
@@ -1293,9 +1293,9 @@ class MulhuOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
 @irdl_op_definition
 class MulwOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
     """
-    Performs an 32-bit × 32-bit multiplication of signed rs1 by signed rs2.
+    Performs a 32-bit by 32-bit multiplication of signed rs1 by signed rs2.
     ```
-    x[rd] = (x[rs1] s × x[rs2]) >>s XLEN
+    x[rd] = (x[rs1] s * x[rs2]) >>s XLEN
     ```
 
     See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvm.html#mulw).
@@ -1485,7 +1485,7 @@ class SextHOp(RdRsIntegerOperation[IntRegisterType]):
 class ZextHOp(RdRsIntegerOperation[IntRegisterType]):
     """
     This instruction zero-extends the least-significant halfword of the source to XLEN by inserting
-    0’s into all of the bits more significant than 15.
+    0's into all of the bits more significant than 15.
     ```
     x[rd] = EXTZ(x[rs][15..0]);
     ```
@@ -1585,7 +1585,7 @@ class BsetOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
 @irdl_op_definition
 class ClzOp(RdRsIntegerOperation[IntRegisterType]):
     """
-    This instruction counts the number of 0’s before the first 1, starting at the most-significant bit
+    This instruction counts the number of 0's before the first 1, starting at the most-significant bit
     (i.e., XLEN-1) and progressing to bit 0. Accordingly, if the input is 0, the output is XLEN, and if
     the most-significant bit of the input is a 1, the output is 0.
 
@@ -1600,7 +1600,7 @@ class ClzOp(RdRsIntegerOperation[IntRegisterType]):
 @irdl_op_definition
 class ClzwOp(RdRsIntegerOperation[IntRegisterType]):
     """
-    This instruction counts the number of 0’s before the first 1 starting at bit 31 and progressing to
+    This instruction counts the number of 0's before the first 1 starting at bit 31 and progressing to
     bit 0. Accordingly, if the least-significant word is 0, the output is 32, and if the most-significant
     bit of the word (i.e., bit 31) is a 1, the output is 0.
 
@@ -1615,7 +1615,7 @@ class ClzwOp(RdRsIntegerOperation[IntRegisterType]):
 @irdl_op_definition
 class CpopOp(RdRsIntegerOperation[IntRegisterType]):
     """
-    This instructions counts the number of 1’s (i.e., set bits) in the source register.
+    This instructions counts the number of 1's (i.e., set bits) in the source register.
 
     See external [documentation](https://docs.riscv.org/reference/isa/v20260120/unpriv/b-st-ext.html#insns-cpop)
     """
@@ -1628,7 +1628,7 @@ class CpopOp(RdRsIntegerOperation[IntRegisterType]):
 @irdl_op_definition
 class CpopwOp(RdRsIntegerOperation[IntRegisterType]):
     """
-    This instructions counts the number of 1’s (i.e., set bits) in the least-significant word of the
+    This instructions counts the number of 1's (i.e., set bits) in the least-significant word of the
     source register.
 
     See external [documentation](https://docs.riscv.org/reference/isa/v20260120/unpriv/b-st-ext.html#insns-cpopw)
@@ -1642,7 +1642,7 @@ class CpopwOp(RdRsIntegerOperation[IntRegisterType]):
 @irdl_op_definition
 class CtzOp(RdRsIntegerOperation[IntRegisterType]):
     """
-    This instruction counts the number of 0’s before the first 1, starting at the least-significant bit
+    This instruction counts the number of 0's before the first 1, starting at the least-significant bit
     (i.e., 0) and progressing to the most-significant bit (i.e., XLEN-1). Accordingly, if the input is 0,
     the output is XLEN, and if the least-significant bit of the input is a 1, the output is 0.
 
@@ -1657,7 +1657,7 @@ class CtzOp(RdRsIntegerOperation[IntRegisterType]):
 @irdl_op_definition
 class CtzwOp(RdRsIntegerOperation[IntRegisterType]):
     """
-    This instruction counts the number of 0’s before the first 1, starting at the least-significant bit
+    This instruction counts the number of 0's before the first 1, starting at the least-significant bit
     (i.e., 0) and progressing to the most-significant bit of the least-significant word (i.e., 31).
     Accordingly, if the least-significant word is 0, the output is 32, and if the least-significant bit
     of the input is a 1, the output is 0.
@@ -2402,7 +2402,7 @@ class FMAddSOp(RdRsRsRsFloatOperation):
     Perform single-precision fused multiply addition.
 
     ```C
-    f[rd] = f[rs1]×f[rs2]+f[rs3]
+    f[rd] = f[rs1]*f[rs2]+f[rs3]
     ```
 
     See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fmadd-s).
@@ -2417,7 +2417,7 @@ class FMSubSOp(RdRsRsRsFloatOperation):
     Perform single-precision fused multiply substraction.
 
     ```C
-    f[rd] = f[rs1]×f[rs2]+f[rs3]
+    f[rd] = f[rs1]*f[rs2]+f[rs3]
     ```
 
     See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fmsub-s).
@@ -2432,7 +2432,7 @@ class FNMSubSOp(RdRsRsRsFloatOperation):
     Perform single-precision fused multiply substraction.
 
     ```C
-    f[rd] = -f[rs1]×f[rs2]+f[rs3]
+    f[rd] = -f[rs1]*f[rs2]+f[rs3]
     ```
 
     See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fnmsub-s).
@@ -2447,7 +2447,7 @@ class FNMAddSOp(RdRsRsRsFloatOperation):
     Perform single-precision fused multiply addition.
 
     ```C
-    f[rd] = -f[rs1]×f[rs2]-f[rs3]
+    f[rd] = -f[rs1]*f[rs2]-f[rs3]
     ```
 
     See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fnmadd-s).
@@ -2494,7 +2494,7 @@ class FMulSOp(RdRsRsFloatOperationWithFastMath):
     Perform single-precision floating-point multiplication.
 
     ```C
-    f[rd] = f[rs1]×f[rs2]
+    f[rd] = f[rs1]*f[rs2]
     ```
 
     See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fmul-s).
@@ -2537,7 +2537,7 @@ class FSqrtSOp(RdRsFloatOperation[FloatRegisterType]):
 class FSgnJSOp(RdRsRsFloatOperation[FloatRegisterType, FloatRegisterType]):
     """
     Produce a result that takes all bits except the sign bit from rs1.
-    The result’s sign bit is rs2’s sign bit.
+    The result's sign bit is rs2's sign bit.
 
     ```C
     f[rd] = {f[rs2][31], f[rs1][30:0]}
@@ -2553,7 +2553,7 @@ class FSgnJSOp(RdRsRsFloatOperation[FloatRegisterType, FloatRegisterType]):
 class FSgnJNSOp(RdRsRsFloatOperation[FloatRegisterType, FloatRegisterType]):
     """
     Produce a result that takes all bits except the sign bit from rs1.
-    The result’s sign bit is opposite of rs2’s sign bit.
+    The result's sign bit is opposite of rs2's sign bit.
 
     ```C
     f[rd] = {~f[rs2][31], f[rs1][30:0]}
@@ -2569,7 +2569,7 @@ class FSgnJNSOp(RdRsRsFloatOperation[FloatRegisterType, FloatRegisterType]):
 class FSgnJXSOp(RdRsRsFloatOperation[FloatRegisterType, FloatRegisterType]):
     """
     Produce a result that takes all bits except the sign bit from rs1.
-    The result’s sign bit is XOR of sign bit of rs1 and rs2.
+    The result's sign bit is XOR of sign bit of rs1 and rs2.
 
     ```C
     f[rd] = {f[rs1][31] ^ f[rs2][31], f[rs1][30:0]}
@@ -2850,7 +2850,7 @@ class FMAddDOp(RdRsRsRsFloatOperation):
     """
     Perform double-precision fused multiply addition.
 
-    f[rd] = f[rs1]×f[rs2]+f[rs3]
+    f[rd] = f[rs1]*f[rs2]+f[rs3]
 
     See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fmadd-d).
     """
@@ -2865,7 +2865,7 @@ class FMSubDOp(RdRsRsRsFloatOperation):
     """
     Perform double-precision fused multiply substraction.
 
-    f[rd] = f[rs1]×f[rs2]+f[rs3]
+    f[rd] = f[rs1]*f[rs2]+f[rs3]
 
     See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fmsub-d).
     """
@@ -2923,7 +2923,7 @@ class FMulDOp(RdRsRsFloatOperationWithFastMath):
     """
     Perform double-precision floating-point multiplication.
 
-    f[rd] = f[rs1]×f[rs2]
+    f[rd] = f[rs1]*f[rs2]
 
     See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fmul-d).
     """

--- a/xdsl/dialects/seq.py
+++ b/xdsl/dialects/seq.py
@@ -1,5 +1,5 @@
 """
-CIRCT’s seq dialect.
+CIRCT's seq dialect.
 
 See external [documentation](https://circt.llvm.org/docs/Dialects/Seq/).
 """

--- a/xdsl/dialects/smt.py
+++ b/xdsl/dialects/smt.py
@@ -268,7 +268,7 @@ class ApplyFuncOp(IRDLOperation):
 class ConstantBoolOp(IRDLOperation, HasFolderInterface):
     """
     This operation represents a constant boolean value. The semantics are
-    equivalent to the ‘true’ and ‘false’ keywords in the Core theory of the
+    equivalent to the 'true' and 'false' keywords in the Core theory of the
     SMT-LIB Standard 2.7.
     """
 
@@ -297,7 +297,7 @@ class ConstantBoolOp(IRDLOperation, HasFolderInterface):
 class NotOp(IRDLOperation):
     """
     This operation performs a boolean negation. The semantics are equivalent
-    to the ’not’ operator in the Core theory of the SMT-LIB Standard 2.7.
+    to the 'not' operator in the Core theory of the SMT-LIB Standard 2.7.
     """
 
     name = "smt.not"
@@ -334,7 +334,7 @@ class VariadicBoolOp(IRDLOperation):
 class AndOp(VariadicBoolOp):
     """
     This operation performs a boolean conjunction. The semantics are equivalent
-    to the ‘and’ operator in the Core theory of the SMT-LIB Standard 2.7.
+    to the 'and' operator in the Core theory of the SMT-LIB Standard 2.7.
 
     It supports a variadic number of operands, but requires at least two.
     """
@@ -346,7 +346,7 @@ class AndOp(VariadicBoolOp):
 class OrOp(VariadicBoolOp):
     """
     This operation performs a boolean disjunction. The semantics are equivalent
-    to the ‘or’ operator in the Core theory of the SMT-LIB Standard 2.7.
+    to the 'or' operator in the Core theory of the SMT-LIB Standard 2.7.
 
     It supports a variadic number of operands, but requires at least two.
     """
@@ -358,7 +358,7 @@ class OrOp(VariadicBoolOp):
 class XOrOp(VariadicBoolOp):
     """
     This operation performs a boolean exclusive or. The semantics are equivalent
-    to the ‘xor’ operator in the Core theory of the SMT-LIB Standard 2.7.
+    to the 'xor' operator in the Core theory of the SMT-LIB Standard 2.7.
 
     It supports a variadic number of operands, but requires at least two.
     """
@@ -609,7 +609,7 @@ class AssertOp(IRDLOperation):
 class BvConstantOp(IRDLOperation, HasFolderInterface):
     """
     This operation produces an SSA value equal to the bitvector constant specified
-    by the ‘value’ attribute.
+    by the 'value' attribute.
     """
 
     name = "smt.bv.constant"

--- a/xdsl/dialects/tensor.py
+++ b/xdsl/dialects/tensor.py
@@ -543,7 +543,7 @@ class ExtractSliceOp(IRDLOperation):
     """
     Extract slice operation.
 
-    Extracts a tensor from another tensor as specified by the operation’s
+    Extracts a tensor from another tensor as specified by the operation's
     offsets, sizes and strides arguments.
 
     https://mlir.llvm.org/docs/Dialects/TensorOps/#tensorextract_slice-tensorextractsliceop
@@ -601,7 +601,7 @@ class InsertSliceOp(IRDLOperation):
     Insert_slice operation.
 
     The insert_slice operation insert a tensor, source, into another tensor, dest,
-    as specified by the operation’s offsets, sizes and strides arguments. It
+    as specified by the operation's offsets, sizes and strides arguments. It
     returns a copy of dest with the proper slice updated with the value of source.
 
     https://mlir.llvm.org/docs/Dialects/TensorOps/#tensorinsert_slice-tensorinsertsliceop
@@ -755,7 +755,7 @@ class InsertOp(IRDLOperation):
     Element insertion operation.
 
     The tensor.insert op inserts a scalar into a ranked tensor, dest, as
-    specified by the operation’s indices. It returns a copy of dest with the
+    specified by the operation's indices. It returns a copy of dest with the
     indexed position updated to the value of scalar.
 
     https://mlir.llvm.org/docs/Dialects/TensorOps/#tensorinsert-tensorinsertop

--- a/xdsl/utils/mlir_lexer.py
+++ b/xdsl/utils/mlir_lexer.py
@@ -490,7 +490,7 @@ class MLIRLexer(Lexer[MLIRTokenKind]):
     def _lex_string_literal(self, start_pos: Position) -> MLIRToken:
         """
         Lex a string literal. Return STRING_LIT when the payload can be decoded
-        as UTF‑8, otherwise BYTES_LIT.
+        as UTF-8, otherwise BYTES_LIT.
         """
         m = self._unescaped_characters_regex.match(self.input.content, start_pos)
         if m is None:


### PR DESCRIPTION
Fixes the RUF002 item in #5927.

This enables Ruff's ambiguous Unicode character check for docstrings. The existing findings are normalized to clear ASCII punctuation and notation, including spelling out lattice joins where that is easier to read than a look-alike mathematical glyph.

Validation:

- `ruff format --check` on all changed Python files
- `ruff check` on all changed Python files
- `ruff check --select RUF002 .`
- 113 affected analysis, dialect, and lexer tests
