### PR TITLE
CI: enable PYI041 lint rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ lint.ignore = [
   "E741",   # https://beta.ruff.rs/docs/rules/ambiguous-variable-name/
   "PT006",  # https://beta.ruff.rs/docs/rules/pytest-parametrize-names-wrong-type/
   "PT012",  # https://beta.ruff.rs/docs/rules/pytest-raises-with-multiple-statements/
-  "PYI041", # https://docs.astral.sh/ruff/rules/redundant-numeric-union
+  # PYI041 enabled: https://docs.astral.sh/ruff/rules/redundant-numeric-union
   # Help welcome removing ignores below
   # https://github.com/xdslproject/xdsl/issues/5927
   "RUF002", # https://docs.astral.sh/ruff/rules/ambiguous-unicode-character-docstring

--- a/tests/filecheck/dialects/irdl/pyrdl-to-irdl/cmath-conversion.py
+++ b/tests/filecheck/dialects/irdl/pyrdl-to-irdl/cmath-conversion.py
@@ -1,7 +1,6 @@
 # RUN: python %s | filecheck %s
 
 from xdsl.dialects.cmath import Cmath
-
 from xdsl.dialects.irdl.pyrdl_to_irdl import dialect_to_irdl
 
 print(dialect_to_irdl(Cmath, "cmath"))

--- a/tests/filecheck/dialects/irdl/pyrdl-to-irdl/cmath-conversion.py
+++ b/tests/filecheck/dialects/irdl/pyrdl-to-irdl/cmath-conversion.py
@@ -1,6 +1,7 @@
 # RUN: python %s | filecheck %s
 
 from xdsl.dialects.cmath import Cmath
+
 from xdsl.dialects.irdl.pyrdl_to_irdl import dialect_to_irdl
 
 print(dialect_to_irdl(Cmath, "cmath"))

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -897,9 +897,7 @@ def test_parse_optional_int_error(text: str, allow_boolean: bool, allow_negative
         ("0.2", True, 0.2),
     ],
 )
-def test_parse_number(
-    text: str, allow_boolean: bool, expected_value: int | float | None
-):
+def test_parse_number(text: str, allow_boolean: bool, expected_value: float | None):
     parser = Parser(Context(), text)
     assert parser.parse_optional_number(allow_boolean=allow_boolean) == expected_value
 


### PR DESCRIPTION
## What changed

Enables Ruff's PYI041 rule and removes the single redundant numeric union it reported.

This also includes one import-order cleanup needed for the full Ruff check to pass on this branch.

## Validation

- `uv run --no-sync ruff check .`
- `uv run --no-sync ruff format --check .`
- `pytest tests/test_parser.py -q` using an existing local xdsl test environment: 447 passed
