### PR TITLE
[codex] CI: enable E741 lint rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,7 @@ exclude = [ ".venv", "docs/notebooks" ]
 format.exclude = [ "docs/notebooks/**/*.py" ]
 lint.select = [ "D213", "E", "F", "I", "INP", "PT", "PYI", "RUF", "TID251", "UP", "W" ]
 lint.ignore = [
-  "E741",   # https://beta.ruff.rs/docs/rules/ambiguous-variable-name/
+  # E741 enabled: https://beta.ruff.rs/docs/rules/ambiguous-variable-name/
   "PT006",  # https://beta.ruff.rs/docs/rules/pytest-parametrize-names-wrong-type/
   "PT012",  # https://beta.ruff.rs/docs/rules/pytest-raises-with-multiple-statements/
   "PYI041", # https://docs.astral.sh/ruff/rules/redundant-numeric-union


### PR DESCRIPTION
Enable Ruff E741 now that its violations are resolved.

Validation: the full local hook run is blocked because Bazel is unavailable on this Windows environment while building heir-py. CI will provide the authoritative check.