### PR TITLE
[codex] CI: enable PT012 lint rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ lint.select = [ "D213", "E", "F", "I", "INP", "PT", "PYI", "RUF", "TID251", "UP"
 lint.ignore = [
   "E741",   # https://beta.ruff.rs/docs/rules/ambiguous-variable-name/
   "PT006",  # https://beta.ruff.rs/docs/rules/pytest-parametrize-names-wrong-type/
-  "PT012",  # https://beta.ruff.rs/docs/rules/pytest-raises-with-multiple-statements/
+  # PT012 enabled: https://beta.ruff.rs/docs/rules/pytest-raises-with-multiple-statements/
   "PYI041", # https://docs.astral.sh/ruff/rules/redundant-numeric-union
   # Help welcome removing ignores below
   # https://github.com/xdslproject/xdsl/issues/5927


### PR DESCRIPTION
Enable Ruff PT012 after cleaning the remaining pytest.raises blocks. The change removes PT012 from the ignore list while retaining the rule's existing documentation link.\n\nLocal validation is limited by the missing Bazel executable required to build heir-py; CI is the authoritative full check.