### PR TITLE
core: (AnyOf) Split off equality constraint logic from AnyOf

### DIFF
--- a/tests/irdl/test_attr_constraint.py
+++ b/tests/irdl/test_attr_constraint.py
@@ -425,21 +425,21 @@ def test_param_attr_merge_failure():
             BaseAttr(AttrA) | BaseAttr(AttrB),
             BaseAttr(AttrA),
             re.escape(
-                "Constraint BaseAttr(AttrA) shares a base with a non-equality constraint in {AnyOf(attr_constrs=(BaseAttr(AttrA), BaseAttr(AttrB)))} in `AnyOf` constraint."
+                "Constraint BaseAttr(AttrA) shares a base with a constraint in {AnyOf(attr_constrs=(BaseAttr(AttrA), BaseAttr(AttrB)))} in `AnyOf` constraint."
             ),
         ),
         (
             BaseAttr(AttrA),
             EqAttrConstraint(AttrA()),
             re.escape(
-                "Constraint EqAttrConstraint(attr=AttrA()) shares a base with a non-equality constraint in {BaseAttr(AttrA)} in `AnyOf` constraint."
+                "Constraint EqAttrConstraint(attr=AttrA()) shares a base with a constraint in {BaseAttr(AttrA)} in `AnyOf` constraint."
             ),
         ),
         (
             EqAttrConstraint(AttrA()),
             BaseAttr(AttrA),
             re.escape(
-                "Non-equality constraint BaseAttr(AttrA) shares a base with a constraint in {EqAttrConstraint(attr=AttrA())} in `AnyOf` constraint."
+                "Constraint BaseAttr(AttrA) shares a base with a constraint in {EqAttrConstraint(attr=AttrA())} in `AnyOf` constraint."
             ),
         ),
         (
@@ -453,14 +453,14 @@ def test_param_attr_merge_failure():
             BaseAttr(Base),
             BaseAttr(AttrA),
             re.escape(
-                "Non-equality constraint BaseAttr(AttrA) overlaps with the constraint BaseAttr(Base) in `AnyOf` constraint."
+                "Constraint BaseAttr(AttrA) overlaps with the constraint BaseAttr(Base) in `AnyOf` constraint."
             ),
         ),
         (
             BaseAttr(Base),
             EqAttrConstraint(AttrA()),
             re.escape(
-                "Equality constraint EqAttrConstraint(attr=AttrA()) overlaps with the constraint BaseAttr(Base) in `AnyOf` constraint."
+                "Constraint EqAttrConstraint(attr=AttrA()) overlaps with the constraint BaseAttr(Base) in `AnyOf` constraint."
             ),
         ),
     ],
@@ -478,14 +478,9 @@ def test_any_of_overlapping(c1: AttrConstraint, c2: AttrConstraint, msg: str):
             BaseAttr(AttrA),
         ),
         (
-            EqAttrConstraint(AttrD(AttrA())),
-            EqAttrConstraint(AttrD(AttrC())),
-        ),
-        (
-            EqAttrConstraint(AttrD(AttrA())),
+            BaseAttr(AttrD),
             BaseAttr(AttrA),
             BaseAttr(AttrC),
-            EqAttrConstraint(AttrD(AttrC())),
         ),
     ],
 )
@@ -571,8 +566,8 @@ def test_constraint_get(constr: AttrConstraint, expected: AttrConstraint):
         (VarConstraint("A", EqAttrConstraint(i32)), {}, i32),
         (EqAttrConstraint(i32), {}, i32),
         (BaseAttr(type(i32)), {}, None),
-        (AnyOf((EqAttrConstraint(i32), EqAttrConstraint(i64))), {}, None),
-        (AnyOf((EqAttrConstraint(i32), EqAttrConstraint(i32))), {}, None),
+        (AnyOf.get(EqAttrConstraint(i32), EqAttrConstraint(i64)), {}, None),
+        (AnyOf.get(EqAttrConstraint(i32), EqAttrConstraint(i32)), {}, i32),
         (
             AllOf(
                 (

--- a/xdsl/irdl/constraints.py
+++ b/xdsl/irdl/constraints.py
@@ -454,7 +454,6 @@ class AnyOf(AttrConstraint[AttributeCovT], Generic[AttributeCovT]):
     This abstract attribute type is not runtime-final (i.e., does not have the `@irdl_attr_definition` decorator).
     """
 
-    _eq_constrs: set[Attribute] = field(hash=False, repr=False)
     _based_constrs: dict[type[Attribute], AttrConstraint[AttributeCovT]] = field(
         hash=False, repr=False
     )
@@ -497,10 +496,7 @@ class AnyOf(AttrConstraint[AttributeCovT], Generic[AttributeCovT]):
         self,
         attr_constrs: tuple[AttrConstraint[AttributeCovT], ...],
     ):
-        eq_constrs = set[Attribute]()
         based_constrs = dict[type[Attribute], AttrConstraint[AttributeCovT]]()
-
-        eq_bases = set[type[Attribute]]()
         abstr_constr: AttrConstraint[AttributeCovT] | None = None
         for i, c in enumerate(attr_constrs):
             b = c.get_bases()
@@ -520,36 +516,20 @@ class AnyOf(AttrConstraint[AttributeCovT], Generic[AttributeCovT]):
 
             if not b.isdisjoint(based_constrs.keys()):
                 raise PyRDLError(
-                    f"Constraint {c} shares a base with a non-equality constraint "
+                    f"Constraint {c} shares a base with a constraint "
                     f"in {set(attr_constrs[0:i])} in `AnyOf` constraint."
                 )
 
-            if isinstance(c, EqAttrConstraint):
-                eq_constrs.add(c.attr)
-                eq_bases |= b
-            else:
-                if not b.isdisjoint(eq_bases):
-                    raise PyRDLError(
-                        f"Non-equality constraint {c} shares a base with a constraint "
-                        f"in {set(attr_constrs[0:i])} in `AnyOf` constraint."
-                    )
-                for base in b:
-                    based_constrs[base] = c
+            for base in b:
+                based_constrs[base] = c
 
         # check for overlaps with the abstract constraint
         if abstr_constr is not None:
-            # equality constraints should not overlap
-            for attr in eq_constrs:
-                if isinstance(attr, abstr_constr.attr):
-                    raise PyRDLError(
-                        f"Equality constraint {EqAttrConstraint(attr)} overlaps with the "
-                        f"constraint {abstr_constr} in `AnyOf` constraint."
-                    )
             # bases should not overlap via issubclass
             for base in based_constrs.keys():
                 if issubclass(base, abstr_constr.attr):
                     raise PyRDLError(
-                        f"Non-equality constraint {based_constrs[base]} overlaps with "
+                        f"Constraint {based_constrs[base]} overlaps with "
                         f"the constraint {abstr_constr} in `AnyOf` constraint."
                     )
 
@@ -560,19 +540,12 @@ class AnyOf(AttrConstraint[AttributeCovT], Generic[AttributeCovT]):
         )
         object.__setattr__(
             self,
-            "_eq_constrs",
-            eq_constrs,
-        )
-        object.__setattr__(
-            self,
             "_based_constrs",
             based_constrs,
         )
         object.__setattr__(self, "_abstr_constr", abstr_constr)
 
     def verify(self, attr: Attribute, constraint_context: ConstraintContext) -> None:
-        if attr in self._eq_constrs:
-            return
         constr = self._based_constrs.get(attr.__class__)
         if constr is not None:
             constr.verify(attr, constraint_context)


### PR DESCRIPTION
I've thought for a bit that any of is trying to do too much and is too complicated, and thought that one of the ways to tackle this is to move the custom logic for equality constraints into a separate constraint that just deals with collections of equality constraints.

It turns out that this is really easy after the `relax_constraint` addition. This simply adds:
- `AttrSetConstraint` (naming mirrors `IntSetConstraint`) which verifies that an attribute is in some set
- adds a `get` method, which takes a sequence of attributes, and performs the simplification that making a set of 1 attribute gets converted to a `EqAttrConstraint`.
- adds a `relax_constraint` implementation, which combines `EqAttrConstraint`s and `AttrSetConstraint`s into a single `AttrSetConstraint`
- remove all equality constraint logic from any_of