### PR TITLE
fix: core verify() does not check that operation operands are defined in the IR

### DIFF
--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -1041,9 +1041,10 @@ class CustomVerifyOp(IRDLOperation):
         raise Exception("Custom Verification Check")
 
 
-def test_op_custom_verify_is_called():
+def test_detached_op_custom_verify_is_called():
     a = ConstantOp.from_int_and_width(1, i64)
     b = CustomVerifyOp.get(a.result)
+    assert b.parent is None
     with pytest.raises(Exception, match="Custom Verification Check"):
         b.verify()
 
@@ -1091,7 +1092,7 @@ def test_verify_operand_defined_in_ancestor_region():
     consumer.verify()
 
 
-def test_verify_operand_defined_by_detached_operation():
+def test_verify_attached_operation_operand_defined_by_detached_operation():
     producer = test.TestOp(result_types=[i32])
     consumer = test.TestOp(operands=[producer])
     Region(Block([consumer]))
@@ -1122,9 +1123,11 @@ def test_verify_operand_defined_in_unrelated_region():
         consumer.verify()
 
 
-def test_verify_detached_operation_operand():
+def test_verify_detached_operation_with_detached_operand():
     producer = test.TestOp(result_types=[i32])
     consumer = test.TestOp(operands=[producer])
+    assert producer.parent is None
+    assert consumer.parent is None
 
     consumer.verify()
 

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -1073,6 +1073,62 @@ def test_verify_erased_ssa_value():
         b.verify()
 
 
+def test_verify_operand_defined_in_same_region():
+    producer = test.TestOp(result_types=[i32])
+    consumer = test.TestOp(operands=[producer])
+    Region(Block([producer, consumer]))
+
+    consumer.verify()
+
+
+def test_verify_operand_defined_in_ancestor_region():
+    outer_block = Block(arg_types=[i32])
+    consumer = test.TestOp(operands=[outer_block.args[0]])
+    inner_block = Block([consumer, test.TestTermOp()])
+    outer_block.add_op(test.TestOp(regions=[Region(inner_block)]))
+    Region(outer_block)
+
+    consumer.verify()
+
+
+def test_verify_operand_defined_by_detached_operation():
+    producer = test.TestOp(result_types=[i32])
+    consumer = test.TestOp(operands=[producer])
+    Region(Block([consumer]))
+
+    with pytest.raises(
+        VerifyException,
+        match=(
+            "Operation test.op contains operand at index 0 whose value is used but "
+            "not defined in the IR"
+        ),
+    ):
+        consumer.verify()
+
+
+def test_verify_operand_defined_in_unrelated_region():
+    producer = test.TestOp(result_types=[i32])
+    consumer = test.TestOp(operands=[producer])
+    Region(Block([producer]))
+    Region(Block([consumer]))
+
+    with pytest.raises(
+        VerifyException,
+        match=(
+            "Operation test.op contains operand at index 0 whose value is used but "
+            "not defined in the IR"
+        ),
+    ):
+        consumer.verify()
+
+
+def test_verify_detached_operation_operand():
+    producer = test.TestOp(result_types=[i32])
+    consumer = test.TestOp(operands=[producer])
+
+    consumer.verify()
+
+
 def test_block_walk():
     a = ConstantOp.from_int_and_width(1, 32)
     b = ConstantOp.from_int_and_width(2, 32)

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -1253,6 +1253,20 @@ class Operation(_IRNode):
         parent_block = self.parent
         parent_region = None if parent_block is None else parent_block.parent
 
+        if parent_region is not None:
+            ancestor_regions = set[Region]()
+            ancestor: Region | None = parent_region
+            while ancestor is not None:
+                ancestor_regions.add(ancestor)
+                ancestor = ancestor.parent_region()
+
+            for operand_index, operand in enumerate(self.operands):
+                if operand.owner.parent_region() not in ancestor_regions:
+                    raise VerifyException(
+                        f"Operation {self.name} contains operand at index "
+                        f"{operand_index} whose value is used but not defined in the IR"
+                    )
+
         if self.successors:
             if parent_block is None or parent_region is None:
                 raise VerifyException(


### PR DESCRIPTION
# PR Template

Please add a short description of your changes, and the motivation behind them.

Make sure your PR title follows the [guidelines](https://github.com/xdslproject/xdsl/wiki#commit-and-pr-message-formatting)

Fixes #4023
