### PR TITLE
core: (Constraints) make IntSetConstraint deterministic

### DIFF
--- a/tests/filecheck/dialects/emitc/emitc_types_invalid.mlir
+++ b/tests/filecheck/dialects/emitc/emitc_types_invalid.mlir
@@ -9,7 +9,7 @@
 
 // -----
 
-// CHECK: Invalid value 0, expected one of {32, 1, 64, 16, 8}
+// CHECK: Invalid value 0, expected one of {1, 8, 16, 32, 64}
 "test.op"() {
   bad_type = !emitc.array<1xi0>>
 }: ()->()
@@ -93,7 +93,7 @@
 
 // -----
 
-// CHECK: Invalid value 17, expected one of {32, 1, 64, 16, 8}
+// CHECK: Invalid value 17, expected one of {1, 8, 16, 32, 64}
 "test.op"() {
   illegal_lvalue_type_3 = !emitc.lvalue<i17>
 }: ()->()

--- a/xdsl/irdl/constraints.py
+++ b/xdsl/irdl/constraints.py
@@ -919,14 +919,18 @@ class IntSetConstraint(IntConstraint):
 
     values: frozenset[int]
 
+    def __repr__(self) -> str:
+        return f"IntSetConstraint({{{', '.join(str(x) for x in sorted(self.values))}}})"
+
     def verify(
         self,
         i: int,
         constraint_context: ConstraintContext,
     ) -> None:
         if i not in self.values:
-            set_str = set(self.values) if self.values else "{}"
-            raise VerifyException(f"Invalid value {i}, expected one of {set_str}")
+            raise VerifyException(
+                f"Invalid value {i}, expected one of {{{', '.join(str(x) for x in sorted(self.values))}}}"
+            )
 
     def can_infer(self, var_constraint_names: AbstractSet[str]) -> bool:
         return len(self.values) == 1


### PR DESCRIPTION
After making #6280, I got worried that the error strings generated by iterating over sets would not be deterministic. Although everything seems to work fine at the moment, it's possible a future python version could start making tests mysteriously fail, so this change tries to safeguard against that.

I'll implement a similar change to #6280 if this one seems reasonable.
