### PR TITLE
dialects: (riscv) add canonicalization pattern (x^a)^b=x^(a^b)

### DIFF
--- a/tests/filecheck/backend/riscv/canonicalize.mlir
+++ b/tests/filecheck/backend/riscv/canonicalize.mlir
@@ -189,6 +189,16 @@ builtin.module {
   %xori_self_inverse_multi = riscv.xori %xori_tmp_multi, 42 : (!riscv.reg) -> !riscv.reg<a0>
   "test.op"(%xori_tmp_multi, %xori_self_inverse_multi) : (!riscv.reg, !riscv.reg<a0>) -> ()
 
+  // (x ^ a) ^ b -> x ^ (a ^ b), intermediate has one use
+  %xori_combine_tmp = riscv.xori %i2, 5 : (!riscv.reg) -> !riscv.reg
+  %xori_combine = riscv.xori %xori_combine_tmp, 3 : (!riscv.reg) -> !riscv.reg<a0>
+  "test.op"(%xori_combine) : (!riscv.reg<a0>) -> ()
+
+  // (x ^ a) ^ b -> x ^ (a ^ b), intermediate preserved when it has other uses
+  %xori_combine_tmp_multi = riscv.xori %i2, 10 : (!riscv.reg) -> !riscv.reg
+  %xori_combine_multi = riscv.xori %xori_combine_tmp_multi, 9 : (!riscv.reg) -> !riscv.reg<a0>
+  "test.op"(%xori_combine_tmp_multi, %xori_combine_multi) : (!riscv.reg, !riscv.reg<a0>) -> ()
+
   %shift_left_zero_r0 = rv32.slli %i2, 0 : (!riscv.reg) -> !riscv.reg<a0>
   "test.op"(%shift_left_zero_r0) : (!riscv.reg<a0>) -> ()
 
@@ -385,6 +395,13 @@ builtin.module {
 // CHECK-NEXT:   %xori_tmp_multi = riscv.xori %i2, 42 : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:   %xori_self_inverse_multi = riscv.mv %i2 : (!riscv.reg) -> !riscv.reg<a0>
 // CHECK-NEXT:   "test.op"(%xori_tmp_multi, %xori_self_inverse_multi) : (!riscv.reg, !riscv.reg<a0>) -> ()
+
+// CHECK-NEXT:   %xori_combine = riscv.xori %i2, 6 : (!riscv.reg) -> !riscv.reg<a0>
+// CHECK-NEXT:   "test.op"(%xori_combine) : (!riscv.reg<a0>) -> ()
+
+// CHECK-NEXT:   %xori_combine_tmp_multi = riscv.xori %i2, 10 : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:   %xori_combine_multi = riscv.xori %i2, 3 : (!riscv.reg) -> !riscv.reg<a0>
+// CHECK-NEXT:   "test.op"(%xori_combine_tmp_multi, %xori_combine_multi) : (!riscv.reg, !riscv.reg<a0>) -> ()
 
 // CHECK-NEXT:   %shift_left_zero_r0 = riscv.mv %i2 : (!riscv.reg) -> !riscv.reg<a0>
 // CHECK-NEXT:   "test.op"(%shift_left_zero_r0) : (!riscv.reg<a0>) -> ()

--- a/xdsl/dialects/riscv/ops.py
+++ b/xdsl/dialects/riscv/ops.py
@@ -218,12 +218,13 @@ class XoriOpHasCanonicalizationPatternsTrait(HasCanonicalizationPatternsTrait):
     @classmethod
     def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
         from xdsl.transforms.canonicalization_patterns.riscv import (
+            XoriCombineImmediates,
             XoriImmediate,
             XoriSelfInverse,
             XoriZero,
         )
 
-        return (XoriZero(), XoriSelfInverse(), XoriImmediate())
+        return (XoriZero(), XoriSelfInverse(), XoriImmediate(), XoriCombineImmediates())
 
 
 @irdl_op_definition

--- a/xdsl/transforms/canonicalization_patterns/riscv.py
+++ b/xdsl/transforms/canonicalization_patterns/riscv.py
@@ -316,6 +316,34 @@ class XoriImmediate(RewritePattern):
             )
 
 
+class XoriCombineImmediates(RewritePattern):
+    """
+    (x ^ a) ^ b -> x ^ (a ^ b)
+    """
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: riscv.XoriOp, rewriter: PatternRewriter) -> None:
+        if (
+            isinstance(op.rs1, OpResult)
+            and isinstance(op.rs1.op, riscv.XoriOp)
+            and isinstance(op.immediate, IntegerAttr)
+            and isinstance(op.rs1.op.immediate, IntegerAttr)
+        ):
+            rd = op.rd.type
+            can_erase = op.rs1.op.rd.has_one_use()
+            rewriter.replace_op(
+                op,
+                riscv.XoriOp(
+                    op.rs1.op.rs1,
+                    op.rs1.op.immediate.value.data ^ op.immediate.value.data,
+                    rd=rd,
+                    comment=op.comment,
+                ),
+            )
+            if can_erase:
+                rewriter.erase_op(op.rs1.op)
+
+
 class ShiftbyZero(RewritePattern, Generic[IWidth]):
     """
     shift(x, 0) -> x


### PR DESCRIPTION
## Summary

This PR adds a canonicalization pattern for consecutive `riscv.xori` operations:

```text
(x ^ a) ^ b -> x ^ (a ^ b)
```

The intermediate `riscv.xori` operation is erased when it has no remaining uses.

## Tests

Added FileCheck tests covering:

- intermediate has one use
- intermediate has multiple uses