### PR TITLE
core: make _ThreadLocalBuilder not a dataclass

### DIFF
--- a/xdsl/builder.py
+++ b/xdsl/builder.py
@@ -290,14 +290,14 @@ class Builder(BuilderListener):
 # Implicit builders
 
 
-@dataclass
 class _ThreadLocalBuilder(threading.local):
     """
     Stores the implicit builder for use in ImplicitBuilder, None by default.
     There is a builder per thread, guaranteed by inheriting from `threading.local`.
     """
 
-    builder: Builder | None = None
+    def __init__(self) -> None:
+        self.builder: Builder | None = None
 
 
 _current_builder = _ThreadLocalBuilder()

--- a/xdsl/builder.py
+++ b/xdsl/builder.py
@@ -296,8 +296,10 @@ class _ThreadLocalBuilder(threading.local):
     There is a builder per thread, guaranteed by inheriting from `threading.local`.
     """
 
+    builder: Builder | None
+
     def __init__(self) -> None:
-        self.builder: Builder | None = None
+        self.builder = None
 
 
 _current_builder = _ThreadLocalBuilder()


### PR DESCRIPTION
Marimo's WASM `threading.local` patch registers instances in a WeakSet, and dataclass subclasses of that shim are not weakly referenceable, which breaks importing `xdsl/builder.py` in browser notebooks.

Unfortunately there's not really a good way to unit-test this, but in my local branch that fixes the wasm Marimo notebooks this fix is necessary.