### PR TITLE
core: (assembly format) allow optional group anchored on typed attribute

### DIFF
--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -86,6 +86,7 @@ from xdsl.irdl.declarative_assembly_format import (
     FormatProgram,
     OperandsDirective,
     OperandVariable,
+    OptionalFormatDirective,
     ParsingState,
     PrintingState,
     PunctuationDirective,
@@ -2196,6 +2197,36 @@ def test_functional_type_with_operands_and_results(program: str):
     check_roundtrip(program, ctx)
 
 
+def test_functional_type_rejects_non_parenthesized_operand_types():
+    @irdl_op_definition
+    class FunctionalTypeOp(IRDLOperation):
+        name = "test.functional_type"
+
+        ops = var_operand_def()
+        res = var_result_def()
+
+        assembly_format = "$ops attr-dict `:` functional-type($ops, $res)"
+
+    ctx = Context()
+    ctx.load_op(FunctionalTypeOp)
+    ctx.load_dialect(Test)
+
+    parser = Parser(
+        ctx,
+        textwrap.dedent(
+            """\
+            %input = "test.op"() : () -> i32
+            %output = test.functional_type %input : i32 -> i32"""
+        ),
+    )
+    parser.parse_operation()
+
+    with pytest.raises(ParseError) as exc_info:
+        parser.parse_operation()
+
+    assert "AnyAttr()" not in str(exc_info.value)
+
+
 ################################################################################
 # Regions                                                                     #
 ################################################################################
@@ -3876,9 +3907,8 @@ def test_qualified_attr():
 
 @irdl_custom_directive
 class Hello(CustomDirective):
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState):
         parser.parse_keyword("hello")
-        return True
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
         state.print_whitespace(printer)
@@ -3909,12 +3939,12 @@ def test_custom_directive(program: str):
 
 
 @irdl_custom_directive
-class Bars(CustomDirective):
+class Bars(CustomDirective, OptionalFormatDirective):
     """We print the operands with bars between, because why not."""
 
     var: VariadicOperandVariable
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse_optional(self, parser: Parser, state: ParsingState) -> bool:
         first = parser.parse_optional_unresolved_operand()
         if first is None:
             operands = []
@@ -3966,10 +3996,10 @@ def test_non_upper_classvar():
     ):
 
         @irdl_custom_directive
-        class BadClassVar(CustomDirective):  # pyright: ignore[reportUnusedClass]
+        class BadClassVar(CustomDirective, OptionalFormatDirective):  # pyright: ignore[reportUnusedClass]
             bad: ClassVar
 
-            def parse(self, parser: Parser, state: ParsingState) -> bool:
+            def parse(self, parser: Parser, state: ParsingState) -> None:
                 raise NotImplementedError()
 
             def print(
@@ -3988,7 +4018,7 @@ def test_bad_parameter():
         class BadParam(CustomDirective):  # pyright: ignore[reportUnusedClass]
             int_param: int
 
-            def parse(self, parser: Parser, state: ParsingState) -> bool:
+            def parse(self, parser: Parser, state: ParsingState) -> None:
                 raise NotImplementedError()
 
             def print(
@@ -4010,8 +4040,7 @@ class EmptyDirectiveWithParams(CustomDirective):
     operand_types: TypeDirective
     results: TypeDirective
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
-        return True
+    def parse(self, parser: Parser, state: ParsingState) -> None: ...
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
         pass

--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -3142,6 +3142,39 @@ def test_optional_else_group(
     check_equivalence(program, generic_program, ctx)
 
 
+@pytest.mark.parametrize(
+    "program, generic_program",
+    [
+        (
+            '%0 = "test.op"() : () -> i32\ntest.optional_typed_attr_group 5 of %0',
+            '%0 = "test.op"() : () -> i32\n"test.optional_typed_attr_group"(%0) <{index = 5 : i32}> : (i32) -> ()',
+        ),
+        (
+            '%0 = "test.op"() : () -> i32\ntest.optional_typed_attr_group of %0',
+            '%0 = "test.op"() : () -> i32\n"test.optional_typed_attr_group"(%0) : (i32) -> ()',
+        ),
+    ],
+)
+def test_optional_group_anchored_on_typed_attribute(program: str, generic_program: str):
+    """An optional group anchored on a typed attribute variable must be skippable."""
+
+    @irdl_op_definition
+    class OptionalTypedAttrGroupOp(IRDLOperation):
+        name = "test.optional_typed_attr_group"
+
+        index = opt_prop_def(IntegerAttr[I32])
+        input_op = operand_def(i32)
+
+        assembly_format = "($index^)? `of` $input_op attr-dict"
+
+    ctx = Context()
+    ctx.load_op(OptionalTypedAttrGroupOp)
+    ctx.load_dialect(Test)
+
+    check_roundtrip(program, ctx)
+    check_equivalence(program, generic_program, ctx)
+
+
 def test_impossible_optional_else_group():
     error = "property 'val' is already bound"
     with pytest.raises(

--- a/xdsl/dialects/acc.py
+++ b/xdsl/dialects/acc.py
@@ -922,7 +922,7 @@ class DeviceTypeOperands(CustomDirective):
         self.operands.set(state, ())
         self.operand_types.set(state, ())
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState) -> None:
         triples = parser.parse_comma_separated_list(
             parser.Delimiter.NONE, lambda: _parse_operand_with_dt(parser)
         )
@@ -930,7 +930,6 @@ class DeviceTypeOperands(CustomDirective):
         self.operands.set(state, operands)
         self.operand_types.set(state, types)
         self.device_types.set(state, ArrayAttr(device_types))
-        return True
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
         operands = self.operands.get(op)
@@ -1060,7 +1059,7 @@ class DeviceTypeOperandsWithKeywordOnly(CustomDirective):
         self.operands.set(state, ())
         self.operand_types.set(state, ())
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState) -> None:
         operands, types, device_types, keyword_only = _parse_dt_kw_only_body(parser)
         self.operands.set(state, operands)
         self.operand_types.set(state, types)
@@ -1068,7 +1067,6 @@ class DeviceTypeOperandsWithKeywordOnly(CustomDirective):
             self.device_types.set(state, device_types)
         if keyword_only is not None:
             self.keyword_only.set(state, keyword_only)
-        return True
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
         _print_dt_kw_only_body(
@@ -1105,7 +1103,7 @@ class NumGangs(CustomDirective):
         self.operands.set(state, ())
         self.operand_types.set(state, ())
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState) -> None:
         groups = parser.parse_comma_separated_list(
             parser.Delimiter.NONE, lambda: _parse_num_gangs_group(parser)
         )
@@ -1114,7 +1112,6 @@ class NumGangs(CustomDirective):
         self.operand_types.set(state, types)
         self.device_types.set(state, ArrayAttr(dts))
         self.segments.set(state, DenseArrayBase.from_list(i32, segs))
-        return True
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
         operands = self.operands.get(op)
@@ -1286,7 +1283,7 @@ class WaitClause(CustomDirective):
         self.operands.set(state, ())
         self.operand_types.set(state, ())
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState) -> None:
         operands, types, dts, segs, devnum, kw_only = _parse_wait_body(parser)
         self.operands.set(state, operands)
         self.operand_types.set(state, types)
@@ -1298,7 +1295,6 @@ class WaitClause(CustomDirective):
             self.has_devnum.set(state, devnum)
         if kw_only is not None:
             self.keyword_only.set(state, kw_only)
-        return True
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
         _print_wait_body(
@@ -1349,7 +1345,7 @@ class KernelEnvironmentClauses(CustomDirective):
 
     _CLAUSE_KEYWORDS = ("dataOperands", "async", "wait")
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState) -> None:
         self.set_empty(state)
         seen: set[str] = set()
         while (
@@ -1386,7 +1382,6 @@ class KernelEnvironmentClauses(CustomDirective):
                     self.wait_has_devnum.set(state, devnum)
                 if kw_only is not None:
                     self.wait_only.set(state, kw_only)
-        return True
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
         if data_operands := self.data_clause_operands.get(op):
@@ -1446,17 +1441,16 @@ class OperandWithKeywordOnly(CustomDirective):
         self.operand.set(state, None)
         self.operand_type.set(state, ())
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState) -> None:
         if not parser.parse_optional_punctuation("("):
             self.attr.set(state, UnitAttr())
             self.operand.set(state, None)
             self.operand_type.set(state, ())
-            return True
+            return
         operand, ty = _parse_typed_operand(parser)
         parser.parse_punctuation(")")
         self.operand.set(state, operand)
         self.operand_type.set(state, (ty,))
-        return True
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
         # Mirror upstream's `if (attr) return;`: when the bare-keyword
@@ -1497,12 +1491,12 @@ class OperandsWithKeywordOnly(CustomDirective):
         self.operands.set(state, ())
         self.operand_types.set(state, ())
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState) -> None:
         if not parser.parse_optional_punctuation("("):
             self.attr.set(state, UnitAttr())
             self.operands.set(state, ())
             self.operand_types.set(state, ())
-            return True
+            return
         operands = parser.parse_comma_separated_list(
             parser.Delimiter.NONE, parser.parse_unresolved_operand
         )
@@ -1513,7 +1507,6 @@ class OperandsWithKeywordOnly(CustomDirective):
         parser.parse_punctuation(")")
         self.operands.set(state, operands)
         self.operand_types.set(state, types)
-        return True
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
         if self.attr.get(op) is not None:
@@ -1549,16 +1542,15 @@ class AtomicIfClause(CustomDirective):
         self.if_cond.set(state, None)
         self.if_cond_type.set(state, ())
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState) -> None:
         self.set_empty(state)
         if parser.parse_optional_keyword("if") is None:
-            return True
+            return
         parser.parse_punctuation("(")
         operand = parser.parse_unresolved_operand()
         parser.parse_punctuation(")")
         self.if_cond.set(state, operand)
         self.if_cond_type.set(state, (i1,))
-        return True
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
         if_cond = self.if_cond.get(op)
@@ -1599,7 +1591,7 @@ class AccVar(CustomDirective):
     acc_var: OperandVariable
     acc_var_type: TypeDirective
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState) -> None:
         if parser.parse_optional_keyword("accPtr") is None:
             parser.parse_keyword("accVar")
         with parser.in_parens():
@@ -1608,7 +1600,6 @@ class AccVar(CustomDirective):
             ty = parser.parse_type()
         self.acc_var.set(state, operand)
         self.acc_var_type.set(state, (ty,))
-        return True
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
         state.print_whitespace(printer)
@@ -1638,7 +1629,7 @@ class Var(CustomDirective):
     var_type: TypeDirective
     var_type_attr: AttributeVariable
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState) -> None:
         if parser.parse_optional_keyword("varPtr") is None:
             parser.parse_keyword("var")
         with parser.in_parens():
@@ -1653,7 +1644,6 @@ class Var(CustomDirective):
                 self.var_type_attr.set(state, parser.parse_type())
         else:
             self.var_type_attr.set(state, _default_var_type(ty))
-        return True
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
         state.print_whitespace(printer)
@@ -1704,7 +1694,7 @@ class DataEntryOilist(CustomDirective):
 
     _CLAUSE_KEYWORDS = ("varPtrPtr", "bounds", "async", "recipe")
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState) -> None:
         self.set_empty(state)
         seen: set[str] = set()
         while (
@@ -1737,7 +1727,6 @@ class DataEntryOilist(CustomDirective):
             else:  # recipe
                 with parser.in_parens():
                     self.recipe.set(state, parser.parse_attribute())
-        return True
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
         var_ptr_ptr = self.var_ptr_ptr.get(op)
@@ -1820,13 +1809,13 @@ class CombinedConstructsLoop(CustomDirective):
     def is_present(self, op: IRDLOperation) -> bool:
         return self.combined.get(op) is not None
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState) -> None:
         for kw in self._KEYWORDS:
             if parser.parse_optional_keyword(kw) is not None:
                 self.combined.set(
                     state, CombinedConstructsTypeAttr(self._BY_KEYWORD[kw])
                 )
-                return True
+                return
         parser.raise_error("expected compute construct name")
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
@@ -1862,7 +1851,7 @@ class DeviceTypeOperandsWithSegment(CustomDirective):
         self.operands.set(state, ())
         self.operand_types.set(state, ())
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState) -> None:
         groups = parser.parse_comma_separated_list(
             parser.Delimiter.NONE, lambda: _parse_num_gangs_group(parser)
         )
@@ -1871,7 +1860,7 @@ class DeviceTypeOperandsWithSegment(CustomDirective):
         self.operand_types.set(state, types)
         self.device_types.set(state, ArrayAttr(dts))
         self.segments.set(state, DenseArrayBase.from_list(i32, segs))
-        return True
+        return
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
         # `is_present = bool(self.operands.get(op))` — when this `print` is
@@ -1987,12 +1976,12 @@ class GangClause(CustomDirective):
         self.operands.set(state, ())
         self.operand_types.set(state, ())
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState) -> None:
         if not parser.parse_optional_punctuation("("):
             self.gang_only.set(state, ArrayAttr([DeviceTypeAttr(DeviceType.NONE)]))
             self.operands.set(state, ())
             self.operand_types.set(state, ())
-            return True
+            return
 
         kw_only = parser.parse_optional_comma_separated_list(
             parser.Delimiter.SQUARE, lambda: _parse_device_type_attr(parser)
@@ -2003,7 +1992,7 @@ class GangClause(CustomDirective):
         if parser.parse_optional_punctuation(")"):
             self.operands.set(state, ())
             self.operand_types.set(state, ())
-            return True
+            return
 
         if kw_only is not None:
             parser.parse_punctuation(",")
@@ -2030,7 +2019,6 @@ class GangClause(CustomDirective):
         self.gang_arg_types.set(state, ArrayAttr(arg_types))
         self.device_types.set(state, ArrayAttr(dts))
         self.segments.set(state, DenseArrayBase.from_list(i32, segs))
-        return True
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
         operands = self.operands.get(op)
@@ -2124,7 +2112,7 @@ class LoopControl(CustomDirective):
     step: VariadicOperandVariable
     step_types: TypeDirective
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState) -> None:
         if parser.parse_optional_keyword("control") is None:
             self.lowerbound.set(state, ())
             self.lowerbound_types.set(state, ())
@@ -2133,7 +2121,7 @@ class LoopControl(CustomDirective):
             self.step.set(state, ())
             self.step_types.set(state, ())
             self.region.set(state, parser.parse_region())
-            return True
+            return
 
         with parser.in_parens():
             args = parser.parse_comma_separated_list(
@@ -2153,7 +2141,6 @@ class LoopControl(CustomDirective):
         self.step.set(state, st_ops)
         self.step_types.set(state, st_types)
         self.region.set(state, parser.parse_region(args))
-        return True
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
         region = self.region.get(op)
@@ -2238,7 +2225,7 @@ class BindName(CustomDirective):
             or self.bind_str_name.get(op) is not None
         )
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState) -> None:
         id_names: list[SymbolRefAttr] = []
         str_names: list[StringAttr] = []
         id_dts: list[DeviceTypeAttr] = []
@@ -2266,7 +2253,6 @@ class BindName(CustomDirective):
         if str_names:
             self.bind_str_name.set(state, ArrayAttr(str_names))
             self.bind_str_name_device_type.set(state, ArrayAttr(str_dts))
-        return True
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
         # Concatenate the (id-name, dt) and (str-name, dt) sequences in that
@@ -2320,10 +2306,10 @@ class RoutineGangClause(CustomDirective):
     def is_present(self, op: IRDLOperation) -> bool:
         return self.gang.get(op) is not None or self.gang_dim.get(op) is not None
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState) -> None:
         if not parser.parse_optional_punctuation("("):
             self.gang.set(state, ArrayAttr([DeviceTypeAttr(DeviceType.NONE)]))
-            return True
+            return
 
         kw_only = parser.parse_optional_comma_separated_list(
             parser.Delimiter.SQUARE, lambda: _parse_device_type_attr(parser)
@@ -2331,7 +2317,7 @@ class RoutineGangClause(CustomDirective):
         if kw_only is not None:
             self.gang.set(state, ArrayAttr(kw_only))
             if parser.parse_optional_punctuation(")"):
-                return True
+                return
             parser.parse_punctuation(",")
 
         gang_dim_attrs: list[Attribute] = []
@@ -2350,7 +2336,6 @@ class RoutineGangClause(CustomDirective):
         # one element, so `gang_dim_attrs` is always non-empty here.
         self.gang_dim.set(state, ArrayAttr(gang_dim_attrs))
         self.gang_dim_device_type.set(state, ArrayAttr(gang_dim_dt_attrs))
-        return True
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
         gang = self.gang.get(op)
@@ -2416,10 +2401,10 @@ class DeviceTypeArrayClause(CustomDirective):
         # `hasDeviceTypeValues`-gated emission.
         return isa(attr := self.device_types.get(op), ArrayAttr) and bool(attr.data)
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState) -> None:
         if not parser.parse_optional_punctuation("("):
             self.device_types.set(state, ArrayAttr([DeviceTypeAttr(DeviceType.NONE)]))
-            return True
+            return
 
         attrs = parser.parse_optional_comma_separated_list(
             parser.Delimiter.SQUARE, lambda: _parse_device_type_attr(parser)
@@ -2428,7 +2413,6 @@ class DeviceTypeArrayClause(CustomDirective):
         self.device_types.set(
             state, ArrayAttr(attrs) if attrs is not None else ArrayAttr(())
         )
-        return True
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
         # `is_present` guarantees a non-empty ArrayAttr.

--- a/xdsl/dialects/cf.py
+++ b/xdsl/dialects/cf.py
@@ -222,7 +222,7 @@ class SwitchOpCases(CustomDirective):
         (block, ops, types) = cls._parse_case_body(parser)
         return (i, block, ops, types)
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState) -> None:
         parser.parse_keyword("default")
         (default_block, default_operands, default_operand_types) = (
             self._parse_case_body(parser)
@@ -257,7 +257,6 @@ class SwitchOpCases(CustomDirective):
             self.case_operands.set_empty(state)
             self.case_operand_types.set_empty(state)
             self.case_operand_segments.set(state, DenseArrayBase.from_list(i32, ()))
-        return True
 
     @staticmethod
     def _print_case(

--- a/xdsl/dialects/pdl_interp.py
+++ b/xdsl/dialects/pdl_interp.py
@@ -74,6 +74,7 @@ from xdsl.irdl import (
 )
 from xdsl.irdl.declarative_assembly_format import (
     CustomDirective,
+    OptionalFormatDirective,
     ParsingState,
     PrintingState,
     TypeDirective,
@@ -952,7 +953,7 @@ class CreateOperationOp(IRDLOperation):
 
 
 @irdl_custom_directive
-class RangeTypeDirective(CustomDirective):
+class RangeTypeDirective(CustomDirective, OptionalFormatDirective):
     """
     Custom directive for parsing/printing range types in CreateRangeOp.
     """
@@ -960,7 +961,7 @@ class RangeTypeDirective(CustomDirective):
     arguments_type: TypeDirective
     result_type: TypeDirective
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse_optional(self, parser: Parser, state: ParsingState) -> bool:
         args_inner = self.arguments_type.inner
         assert isinstance(args_inner, VariadicOperandVariable)
 

--- a/xdsl/dialects/utils/dimension_list.py
+++ b/xdsl/dialects/utils/dimension_list.py
@@ -34,15 +34,13 @@ class DimensionList(CustomDirective):
 
     dimensions: AttributeVariable
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState) -> None:
         dims = []
 
         if not parse_empty_dimension_list_directive(parser):
             dims = parser.parse_dimension_list()
 
         self.dimensions.set(state, DenseArrayBase[I64].from_list(i64, dims))
-
-        return True
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
         state.print_whitespace(printer)

--- a/xdsl/dialects/utils/dynamic_index_list.py
+++ b/xdsl/dialects/utils/dynamic_index_list.py
@@ -230,13 +230,12 @@ class DynamicIndexList(CustomDirective):
     dynamic_position: VariadicOperandVariable
     static_position: AttributeVariable
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState) -> None:
         dynamic, static = parse_dynamic_index_list_without_types(
             parser, self.DYNAMIC_INDEX
         )
         self.dynamic_position.set(state, dynamic)
         self.static_position.set(state, DenseArrayBase.from_list(i64, static))
-        return True
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
         state.print_whitespace(printer)

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -298,17 +298,11 @@ class FormatDirective(Directive, ABC):
     """A format directive for operation format."""
 
     @abstractmethod
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState) -> None:
         """
-        Parses the directive, returning True if input was consumed.
+        Parses the directive, raising ParseError if not present.
         """
         ...
-
-    def parse_optional(self, parser: Parser, state: ParsingState) -> bool:
-        """
-        Parses an optional directive, returning False if not present.
-        """
-        return self.parse(parser, state)
 
     @abstractmethod
     def print(
@@ -321,6 +315,20 @@ class FormatDirective(Directive, ABC):
         Used when a variable appears in an optional group which is not parsed.
         """
         return
+
+
+class OptionalFormatDirective(FormatDirective, ABC):
+    @abstractmethod
+    def parse_optional(self, parser: Parser, state: ParsingState) -> bool:
+        """
+        Parses an optional directive, returning False if not present.
+        """
+
+    def parse(self, parser: Parser, state: ParsingState) -> None:
+        self.parse_optional(parser, state)
+
+    def is_optional_like(self) -> bool:
+        return True
 
 
 class CustomDirective(FormatDirective, ABC):
@@ -393,8 +401,8 @@ class TypeDirective(FormatDirective):
     def set(self, state: ParsingState, types: Sequence[Attribute]):
         self.inner.set_types(state, types)
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
-        return self.inner.parse_types(parser, state)
+    def parse(self, parser: Parser, state: ParsingState) -> None:
+        self.inner.parse_types(parser, state)
 
     def get(self, op: IRDLOperation) -> Sequence[Attribute]:
         return self.inner.get_types(op)
@@ -447,19 +455,16 @@ class VariadicVariable(VariableDirective, ABC):
         return True
 
 
-class OptionalVariable(VariableDirective, ABC):
+class OptionalVariable(VariableDirective, OptionalFormatDirective, ABC):
     def is_present(self, op: IRDLOperation) -> bool:
         return getattr(op, self.name) is not None
 
     def is_anchorable(self) -> bool:
         return True
 
-    def is_optional_like(self) -> bool:
-        return True
-
 
 @dataclass(frozen=True)
-class AttrDictDirective(FormatDirective):
+class AttrDictDirective(OptionalFormatDirective):
     """
     An attribute dictionary directive, with the following format:
        attr-dict-directive ::= attr-dict
@@ -484,7 +489,7 @@ class AttrDictDirective(FormatDirective):
     This is used to keep compatibility with MLIR which allows that.
     """
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse_optional(self, parser: Parser, state: ParsingState) -> bool:
         if self.with_keyword:
             res = parser.parse_optional_attr_dict_with_keyword()
             if res is None:
@@ -563,10 +568,9 @@ class OperandVariable(VariableDirective, OperandDirective):
     def set_types(self, state: ParsingState, types: Sequence[Attribute]):
         state.operand_types[self.index] = types
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState) -> None:
         operand = parser.parse_unresolved_operand()
         self.set(state, operand)
-        return True
 
     def parse_types(self, parser: Parser, state: ParsingState) -> bool:
         self.set_types(state, (parser.parse_type(),))
@@ -587,7 +591,9 @@ class OperandVariable(VariableDirective, OperandDirective):
 
 
 @dataclass(frozen=True)
-class VariadicOperandVariable(VariadicVariable, OperandDirective):
+class VariadicOperandVariable(
+    VariadicVariable, OperandDirective, OptionalFormatDirective
+):
     """
     A variadic operand variable, with the following format:
       operand-directive ::= ( percent-ident ( `,` percent-id )* )?
@@ -600,7 +606,7 @@ class VariadicOperandVariable(VariadicVariable, OperandDirective):
     def set_types(self, state: ParsingState, types: Sequence[Attribute]):
         state.operand_types[self.index] = types
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse_optional(self, parser: Parser, state: ParsingState) -> bool:
         operands = parser.parse_optional_undelimited_comma_separated_list(
             parser.parse_optional_unresolved_operand, parser.parse_unresolved_operand
         )
@@ -652,7 +658,7 @@ class OptionalOperandVariable(OptionalVariable, OperandDirective):
     def set_types(self, state: ParsingState, types: Sequence[Attribute]):
         state.operand_types[self.index] = types
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse_optional(self, parser: Parser, state: ParsingState) -> bool:
         operand = parser.parse_optional_unresolved_operand()
         self.set(state, operand)
         return bool(operand)
@@ -722,7 +728,7 @@ class OperandsOrResultDirective(TypeableDirective, ABC):
             field[i] = res
 
 
-class OperandsDirective(OperandsOrResultDirective, FormatDirective):
+class OperandsDirective(OperandsOrResultDirective, OptionalFormatDirective):
     """
     An operands directive, with the following format:
       operands-directive ::= operands
@@ -738,7 +744,7 @@ class OperandsDirective(OperandsOrResultDirective, FormatDirective):
             types,
         )
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse_optional(self, parser: Parser, state: ParsingState) -> bool:
         pos_start = parser.pos
         operands = (
             parser.parse_optional_undelimited_comma_separated_list(
@@ -852,6 +858,21 @@ class OptionalResultVariable(OptionalVariable, TypeableDirective):
     parsing is not handled by the custom operation parser.
     """
 
+    def parse(self, parser: Parser, state: ParsingState) -> None:
+        raise AssertionError(
+            "Optional result variables are parsed by the operation parser"
+        )
+
+    def parse_optional(self, parser: Parser, state: ParsingState) -> bool:
+        raise AssertionError(
+            "Optional result variables are parsed by the operation parser"
+        )
+
+    def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
+        raise AssertionError(
+            "Optional result variables are printed by the operation printer"
+        )
+
     def set_types(self, state: ParsingState, types: Sequence[Attribute]):
         state.result_types[self.index] = types
 
@@ -929,9 +950,8 @@ class FunctionalTypeDirective(FormatDirective):
     operand_typeable_directive: TypeableDirective
     result_typeable_directive: TypeableDirective
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
-        if not parser.parse_optional_punctuation("("):
-            return False
+    def parse(self, parser: Parser, state: ParsingState) -> None:
+        parser.parse_punctuation("(")
         self.operand_typeable_directive.parse_types(parser, state)
         parser.parse_punctuation(")")
         parser.parse_punctuation("->")
@@ -940,7 +960,6 @@ class FunctionalTypeDirective(FormatDirective):
             parser.parse_punctuation(")")
         else:
             self.result_typeable_directive.parse_single_type(parser, state)
-        return True
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
         state.print_whitespace(printer)
@@ -974,17 +993,16 @@ class RegionVariable(RegionDirective, VariableDirective):
     def set(self, state: ParsingState, region: Region):
         state.regions[self.index] = (region,)
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState) -> None:
         self.set(state, parser.parse_region())
-        return True
 
     def parse_optional(self, parser: Parser, state: ParsingState) -> bool:
         region = parser.parse_optional_region()
-        res = region is None
-        if res:
+        present = region is not None
+        if not present:
             region = Region()
         self.set(state, region)
-        return res
+        return present
 
     def get(self, op: IRDLOperation) -> Region:
         return getattr(op, self.name)
@@ -1007,7 +1025,9 @@ class RegionVariable(RegionDirective, VariableDirective):
 
 
 @dataclass(frozen=True)
-class VariadicRegionVariable(RegionDirective, VariadicVariable):
+class VariadicRegionVariable(
+    RegionDirective, VariadicVariable, OptionalFormatDirective
+):
     """
     A variadic region variable, with the following format:
       region-directive ::= dollar-ident
@@ -1018,7 +1038,7 @@ class VariadicRegionVariable(RegionDirective, VariadicVariable):
     def set(self, state: ParsingState, region: Sequence[Region]):
         state.regions[self.index] = region
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse_optional(self, parser: Parser, state: ParsingState) -> bool:
         regions: list[Region] = []
         current_region = parser.parse_optional_region()
         while current_region is not None:
@@ -1027,9 +1047,6 @@ class VariadicRegionVariable(RegionDirective, VariadicVariable):
 
         self.set(state, regions)
         return bool(regions)
-
-    def parse_optional(self, parser: Parser, state: ParsingState) -> bool:
-        return self.parse(parser, state)
 
     def get(self, op: IRDLOperation) -> Sequence[Region]:
         return getattr(op, self.name)
@@ -1055,13 +1072,10 @@ class OptionalRegionVariable(RegionDirective, OptionalVariable):
     def set(self, state: ParsingState, region: Region | None):
         state.regions[self.index] = () if region is None else (region,)
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse_optional(self, parser: Parser, state: ParsingState) -> bool:
         region = parser.parse_optional_region()
         self.set(state, region)
         return region is not None
-
-    def parse_optional(self, parser: Parser, state: ParsingState) -> bool:
-        return self.parse(parser, state)
 
     def get(self, op: IRDLOperation) -> Region | None:
         return getattr(op, self.name)
@@ -1094,12 +1108,9 @@ class SuccessorVariable(VariableDirective, SuccessorDirective):
     def set(self, state: ParsingState, successor: Successor):
         state.successors[self.index] = (successor,)
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState) -> None:
         successor = parser.parse_successor()
-
         self.set(state, successor)
-
-        return True
 
     def get(self, op: IRDLOperation) -> Successor:
         return getattr(op, self.name)
@@ -1109,7 +1120,9 @@ class SuccessorVariable(VariableDirective, SuccessorDirective):
         printer.print_block_name(self.get(op))
 
 
-class VariadicSuccessorVariable(VariadicVariable, SuccessorDirective):
+class VariadicSuccessorVariable(
+    VariadicVariable, SuccessorDirective, OptionalFormatDirective
+):
     """
     A variadic successor variable, with the following format:
       successor-directive ::= dollar-ident
@@ -1119,7 +1132,7 @@ class VariadicSuccessorVariable(VariadicVariable, SuccessorDirective):
     def set(self, state: ParsingState, successors: Sequence[Successor]):
         state.successors[self.index] = successors
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse_optional(self, parser: Parser, state: ParsingState) -> bool:
         successors = (
             parser.parse_optional_undelimited_comma_separated_list(
                 parser.parse_optional_successor, parser.parse_successor
@@ -1155,7 +1168,7 @@ class OptionalSuccessorVariable(OptionalVariable, SuccessorDirective):
     def set(self, state: ParsingState, successor: Successor | None):
         state.successors[self.index] = () if successor is None else (successor,)
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse_optional(self, parser: Parser, state: ParsingState) -> bool:
         successor = parser.parse_optional_successor()
         self.set(state, successor)
         return successor is not None
@@ -1175,7 +1188,7 @@ class OptionalSuccessorVariable(OptionalVariable, SuccessorDirective):
 
 
 @dataclass(frozen=True)
-class AttributeVariable(FormatDirective):
+class AttributeVariable(OptionalFormatDirective):
     """
     An attribute variable, with the following format:
       attribute-variable ::= dollar-ident
@@ -1202,7 +1215,7 @@ class AttributeVariable(FormatDirective):
         else:
             return parser.parse_attribute()
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse_optional(self, parser: Parser, state: ParsingState) -> bool:
         attr = self.parse_attr(parser)
         if attr is None:
             return False
@@ -1261,10 +1274,14 @@ class UniqueBaseAttributeVariable(AttributeVariable):
         # that an optional group anchored on this variable can be skipped.
         pos = parser.pos
         try:
-            return self.parse(parser, state)
+            attr = self.parse_attr(parser)
         except ParseError:
             parser._resume_from(pos)  # pyright: ignore[reportPrivateUsage]
             return False
+        if attr is None:
+            return False
+        self.set(state, attr)
+        return True
 
     def print_attr(self, printer: Printer, attr: Attribute) -> None:
         if isinstance(attr, ParametrizedAttribute):
@@ -1359,7 +1376,7 @@ class OptionalUnitAttrVariable(AttributeVariable):
     def __init__(self, name: str, is_property: bool):
         super().__init__(name, is_property, True, None)
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse_optional(self, parser: Parser, state: ParsingState) -> bool:
         self.set(state, UnitAttr())
         return True
 
@@ -1403,15 +1420,14 @@ class WhitespaceDirective(FormatDirective):
     whitespace: Literal[" ", "\n", ""]
     """The whitespace that should be printed."""
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
-        return False
+    def parse(self, parser: Parser, state: ParsingState) -> None: ...
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
         _print_whitespace(printer, state, self.whitespace)
 
 
 @dataclass(frozen=True)
-class PunctuationDirective(FormatDirective):
+class PunctuationDirective(OptionalFormatDirective):
     """
     A punctuation directive, with the following format:
       punctuation-directive ::= punctuation
@@ -1425,7 +1441,7 @@ class PunctuationDirective(FormatDirective):
     punctuation: PunctuationSpelling
     """The punctuation that should be printed/parsed."""
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse_optional(self, parser: Parser, state: ParsingState) -> bool:
         return parser.parse_optional_punctuation(self.punctuation) is not None
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
@@ -1450,7 +1466,7 @@ class PunctuationDirective(FormatDirective):
 
 
 @dataclass(frozen=True)
-class KeywordDirective(FormatDirective):
+class KeywordDirective(OptionalFormatDirective):
     """
     A keyword directive, with the following format:
       keyword-directive ::= bare-ident
@@ -1461,7 +1477,7 @@ class KeywordDirective(FormatDirective):
     keyword: str
     """The identifier that should be printed."""
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse_optional(self, parser: Parser, state: ParsingState) -> bool:
         return parser.parse_optional_keyword(self.keyword) is not None
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
@@ -1472,14 +1488,14 @@ class KeywordDirective(FormatDirective):
 
 
 @dataclass(frozen=True)
-class OptionalGroupDirective(FormatDirective):
+class OptionalGroupDirective(OptionalFormatDirective):
     anchor: Directive
     then_whitespace: tuple[WhitespaceDirective, ...]
-    then_first: FormatDirective
+    then_first: OptionalFormatDirective
     then_elements: tuple[FormatDirective, ...]
     else_elements: tuple[FormatDirective, ...]
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse_optional(self, parser: Parser, state: ParsingState) -> bool:
         # If the first element was parsed, parse the then-elements as usual
         if ret := self.then_first.parse_optional(parser, state):
             for element in self.then_elements:

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -47,7 +47,7 @@ from xdsl.irdl import (
 )
 from xdsl.parser import AttrParser, Parser, UnresolvedOperand
 from xdsl.printer import Printer
-from xdsl.utils.exceptions import PyRDLError, VerifyException
+from xdsl.utils.exceptions import ParseError, PyRDLError, VerifyException
 from xdsl.utils.hints import isa
 from xdsl.utils.mlir_lexer import PunctuationSpelling
 
@@ -1254,6 +1254,17 @@ class UniqueBaseAttributeVariable(AttributeVariable):
             return unique_base.new(unique_base.parse_parameter(parser))
         else:
             raise ValueError("Attributes must be Data or ParametrizedAttribute.")
+
+    def parse_optional(self, parser: Parser, state: ParsingState) -> bool:
+        # The parsers of a known attribute base are not optional: they raise
+        # instead of returning None when the attribute is absent. Backtrack so
+        # that an optional group anchored on this variable can be skipped.
+        pos = parser.pos
+        try:
+            return self.parse(parser, state)
+        except ParseError:
+            parser._resume_from(pos)  # pyright: ignore[reportPrivateUsage]
+            return False
 
     def print_attr(self, printer: Printer, attr: Attribute) -> None:
         if isinstance(attr, ParametrizedAttribute):

--- a/xdsl/irdl/declarative_assembly_format_parser.py
+++ b/xdsl/irdl/declarative_assembly_format_parser.py
@@ -60,6 +60,7 @@ from xdsl.irdl.declarative_assembly_format import (
     OperandDirective,
     OperandsDirective,
     OperandVariable,
+    OptionalFormatDirective,
     OptionalGroupDirective,
     OptionalOperandVariable,
     OptionalRegionVariable,
@@ -707,13 +708,17 @@ class FormatParser(BaseParser):
                 "An optional group's anchor must be an anchorable directive."
             )
 
+        then_first = cast(
+            OptionalFormatDirective, then_elements[first_non_whitespace_index]
+        )
+
         return OptionalGroupDirective(
             anchor,
             cast(
                 tuple[WhitespaceDirective, ...],
                 then_elements[:first_non_whitespace_index],
             ),
-            then_elements[first_non_whitespace_index],
+            then_first,
             then_elements[first_non_whitespace_index + 1 :],
             else_elements,
         )


### PR DESCRIPTION
Closes #5562

An optional group whose first element is an attribute variable with a known base (e.g. an optional `IntegerAttr` property) could never be skipped: `UniqueBaseAttributeVariable.parse_attr` uses the base's non-optional parser, which raises `ParseError` instead of returning `None`, so `($index^)? ...` always failed when `$index` was absent. `parse_optional` now saves the position and backtracks on `ParseError`, matching the contract `OptionalGroupDirective` expects.

New parametrized test in `tests/irdl/test_declarative_assembly_format.py` fails with `Expected integer literal` without the fix and passes with it; `tests/irdl` is green (790 passed).
