### PR TITLE
[WIP] optimize x86_scf loop lowering when bounds and step are static

### DIFF
--- a/tests/filecheck/transforms/convert-x86-scf-to-x86.mlir
+++ b/tests/filecheck/transforms/convert-x86-scf-to-x86.mlir
@@ -31,6 +31,37 @@ x86_func.func @copy10(%src: !x86.reg64<rax>, %dst: !x86.reg64<rbx>) {
 
 // -----
 
+
+// CHECK-LABEL:    @iv_not_used
+//  CHECK-NEXT:      %zero = x86.di.mov 0 : () -> !x86.reg64<rcx>
+//  CHECK-NEXT:      %step = x86.di.mov 4 : () -> !x86.reg64<rdx>
+//  CHECK-NEXT:      %forty = x86.di.mov 40 : () -> !x86.reg64<r8>
+//  CHECK-NEXT:      %zero_1 = x86.ds.mov %zero : (!x86.reg64<rcx>) -> !x86.reg64<r9>
+//  CHECK-NEXT:      %0 = x86.ss.cmp %zero_1, %forty : (!x86.reg64<r9>, !x86.reg64<r8>) -> !x86.rflags<rflags>
+//  CHECK-NEXT:      x86.c.jge %0 : !x86.rflags<rflags>, ^bb0(%zero_1 : !x86.reg64<r9>), ^bb1(%zero_1 : !x86.reg64<r9>)
+//  CHECK-NEXT:    ^bb1(%offset: !x86.reg64<r9>):
+//  CHECK-NEXT:      x86.label "scf_body_0_for"
+//  CHECK-NEXT:      %offset_1 = x86.rs.add %offset, %step : (!x86.reg64<r9>, !x86.reg64<rdx>) -> !x86.reg64<r9>
+//  CHECK-NEXT:      "test.op"(%src, %dst) : (!x86.reg64<rax>, !x86.reg64<rbx>) -> ()
+//  CHECK-NEXT:      %1 = x86.ss.cmp %offset_1, %forty : (!x86.reg64<r9>, !x86.reg64<r8>) -> !x86.rflags<rflags>
+//  CHECK-NEXT:      x86.c.jl %1 : !x86.rflags<rflags>, ^bb1(%offset_1 : !x86.reg64<r9>), ^bb0(%offset_1 : !x86.reg64<r9>)
+//  CHECK-NEXT:    ^bb0(%offset_2: !x86.reg64<r9>):
+//  CHECK-NEXT:      x86.label "scf_body_end_0_for"
+//  CHECK-NEXT:      x86_func.ret
+//  CHECK-NEXT:    }
+x86_func.func @iv_not_used(%src: !x86.reg64<rax>, %dst: !x86.reg64<rbx>) {
+    %zero = x86.di.mov 0 : () -> !x86.reg64<rcx>
+    %step = x86.di.mov 4 : () -> !x86.reg64<rdx>
+    %forty = x86.di.mov 40 : () -> !x86.reg64<r8>
+    x86_scf.for %offset : !x86.reg64<r9> = %zero to %forty step %step {
+        "test.op"(%src, %dst) :  (!x86.reg64<rax>, !x86.reg64<rbx>) -> ()
+        yield
+    }
+    ret
+}
+
+// -----
+
 // CHECK-LABEL:    @lb_i_same_type
 //  CHECK-NEXT:      %zero = x86.di.mov 0 : () -> !x86.reg64<rcx>
 //  CHECK-NEXT:      %step = x86.di.mov 4 : () -> !x86.reg64<rdx>

--- a/tests/filecheck/transforms/convert-x86-scf-to-x86.mlir
+++ b/tests/filecheck/transforms/convert-x86-scf-to-x86.mlir
@@ -31,6 +31,35 @@ x86_func.func @copy10(%src: !x86.reg64<rax>, %dst: !x86.reg64<rbx>) {
 
 // -----
 
+// CHECK-LABEL:    @lb_i_same_type
+//  CHECK-NEXT:      %zero = x86.di.mov 0 : () -> !x86.reg64<rcx>
+//  CHECK-NEXT:      %step = x86.di.mov 4 : () -> !x86.reg64<rdx>
+//  CHECK-NEXT:      %forty = x86.di.mov 40 : () -> !x86.reg64<r8>
+//  CHECK-NEXT:      %0 = x86.ss.cmp %zero, %forty : (!x86.reg64<rcx>, !x86.reg64<r8>) -> !x86.rflags<rflags>
+//  CHECK-NEXT:      x86.c.jge %0 : !x86.rflags<rflags>, ^bb0(%zero : !x86.reg64<rcx>), ^bb1(%zero : !x86.reg64<rcx>)
+//  CHECK-NEXT:    ^bb1(%offset: !x86.reg64<rcx>):
+//  CHECK-NEXT:      x86.label "scf_body_0_for"
+//  CHECK-NEXT:      "test.op"(%offset, %src, %dst) : (!x86.reg64<rcx>, !x86.reg64<rax>, !x86.reg64<rbx>) -> ()
+//  CHECK-NEXT:      %offset_1 = x86.rs.add %offset, %step : (!x86.reg64<rcx>, !x86.reg64<rdx>) -> !x86.reg64<rcx>
+//  CHECK-NEXT:      %1 = x86.ss.cmp %offset_1, %forty : (!x86.reg64<rcx>, !x86.reg64<r8>) -> !x86.rflags<rflags>
+//  CHECK-NEXT:      x86.c.jl %1 : !x86.rflags<rflags>, ^bb1(%offset_1 : !x86.reg64<rcx>), ^bb0(%offset_1 : !x86.reg64<rcx>)
+//  CHECK-NEXT:    ^bb0(%offset_2: !x86.reg64<rcx>):
+//  CHECK-NEXT:      x86.label "scf_body_end_0_for"
+//  CHECK-NEXT:      x86_func.ret
+//  CHECK-NEXT:    }
+x86_func.func @lb_i_same_type(%src: !x86.reg64<rax>, %dst: !x86.reg64<rbx>) {
+    %zero = x86.di.mov 0 : () -> !x86.reg64<rcx>
+    %step = x86.di.mov 4 : () -> !x86.reg64<rdx>
+    %forty = x86.di.mov 40 : () -> !x86.reg64<r8>
+    x86_scf.for %offset : !x86.reg64<rcx> = %zero to %forty step %step {
+        "test.op"(%offset, %src, %dst) :  (!x86.reg64<rcx>, !x86.reg64<rax>, !x86.reg64<rbx>) -> ()
+        yield
+    }
+    ret
+}
+
+// -----
+
 // CHECK-LABEL:    x86_func.func @nested(%src: !x86.reg64<rax>, %dst: !x86.reg64<rbx>) {
 //  CHECK-NEXT:      %zero_outer = x86.di.mov 0 : () -> !x86.reg64<rcx>
 //  CHECK-NEXT:      %step_outer = x86.di.mov 4 : () -> !x86.reg64<rdx>

--- a/tests/filecheck/transforms/convert-x86-scf-to-x86.mlir
+++ b/tests/filecheck/transforms/convert-x86-scf-to-x86.mlir
@@ -91,8 +91,55 @@ x86_func.func @nested(%src: !x86.reg64<rax>, %dst: !x86.reg64<rbx>) {
 //  CHECK-NEXT:      %zero = x86.di.mov 0 : () -> !x86.reg64<rcx>
 //  CHECK-NEXT:      %step = x86.di.mov 2 : () -> !x86.reg64<rdx>
 //  CHECK-NEXT:      %zero_1 = x86.ds.mov %zero : (!x86.reg64<rcx>) -> !x86.reg64<r9>
-//  CHECK-NEXT:      %0 = x86.si.cmp %zero_1, 10 : (!x86.reg64<r9>) -> !x86.rflags<rflags>
-//  CHECK-NEXT:      x86.c.jge %0 : !x86.rflags<rflags>, ^bb0(%zero_1 : !x86.reg64<r9>), ^bb1(%zero_1 : !x86.reg64<r9>)
+//  CHECK-NEXT:      x86.fallthrough ^bb0(%zero_1 : !x86.reg64<r9>)
+//  CHECK-NEXT:    ^bb0(%i: !x86.reg64<r9>):
+//  CHECK-NEXT:      x86.label "scf_body_0_for"
+//  CHECK-NEXT:      %i_1 = x86.ds.mov %i : (!x86.reg64<r9>) -> !x86.reg64<r9>
+//  CHECK-NEXT:      %i_2 = x86.rs.add %i_1, %step : (!x86.reg64<r9>, !x86.reg64<rdx>) -> !x86.reg64<r9>
+//  CHECK-NEXT:      %0 = x86.si.cmp %i_2, 10 : (!x86.reg64<r9>) -> !x86.rflags<rflags>
+//  CHECK-NEXT:      x86.c.jl %0 : !x86.rflags<rflags>, ^bb0(%i_2 : !x86.reg64<r9>), ^bb1(%i_2 : !x86.reg64<r9>)
+//  CHECK-NEXT:    ^bb1(%i_3: !x86.reg64<r9>):
+//  CHECK-NEXT:      x86_func.ret
+//  CHECK-NEXT:    }
+x86_func.func @static_ub_dynamic_step() {
+    %zero = x86.di.mov 0 : () -> !x86.reg64<rcx>
+    %step = x86.di.mov 2 : () -> !x86.reg64<rdx>
+    x86_scf.for %i : !x86.reg64<r9> = %zero to 10 : si32 step %step {
+        x86_scf.yield
+    }
+    ret
+}
+
+// -----
+
+// CHECK-LABEL:    @static_ub_static_step
+//  CHECK-NEXT:      %zero = x86.di.mov 0 : () -> !x86.reg64<rcx>
+//  CHECK-NEXT:      %zero_1 = x86.ds.mov %zero : (!x86.reg64<rcx>) -> !x86.reg64<r9>
+//  CHECK-NEXT:      x86.fallthrough ^bb0(%zero_1 : !x86.reg64<r9>)
+//  CHECK-NEXT:    ^bb0(%i: !x86.reg64<r9>):
+//  CHECK-NEXT:      x86.label "scf_body_0_for"
+//  CHECK-NEXT:      %i_1 = x86.ds.mov %i : (!x86.reg64<r9>) -> !x86.reg64<r9>
+//  CHECK-NEXT:      %i_2 = x86.ri.add %i_1, 1 : (!x86.reg64<r9>) -> !x86.reg64<r9>
+//  CHECK-NEXT:      %0 = x86.si.cmp %i_2, 12 : (!x86.reg64<r9>) -> !x86.rflags<rflags>
+//  CHECK-NEXT:      x86.c.jl %0 : !x86.rflags<rflags>, ^bb0(%i_2 : !x86.reg64<r9>), ^bb1(%i_2 : !x86.reg64<r9>)
+//  CHECK-NEXT:    ^bb1(%i_3: !x86.reg64<r9>):
+//  CHECK-NEXT:      x86_func.ret
+//  CHECK-NEXT:    }
+x86_func.func @static_ub_static_step() {
+    %zero = x86.di.mov 0 : () -> !x86.reg64<rcx>
+    x86_scf.for %i : !x86.reg64<r9> = %zero to 12 : si32 step 1 : si32 {
+        x86_scf.yield
+    }
+    ret
+}
+
+// -----
+
+// CHECK-LABEL:    @dynamic_lb_static_ub_dynamic_step
+//  CHECK-NEXT:      %step = x86.di.mov 2 : () -> !x86.reg64<rdx>
+//  CHECK-NEXT:      %lb_1 = x86.ds.mov %lb : (!x86.reg64<rcx>) -> !x86.reg64<r9>
+//  CHECK-NEXT:      %0 = x86.si.cmp %lb_1, 10 : (!x86.reg64<r9>) -> !x86.rflags<rflags>
+//  CHECK-NEXT:      x86.c.jge %0 : !x86.rflags<rflags>, ^bb0(%lb_1 : !x86.reg64<r9>), ^bb1(%lb_1 : !x86.reg64<r9>)
 //  CHECK-NEXT:    ^bb1(%i: !x86.reg64<r9>):
 //  CHECK-NEXT:      x86.label "scf_body_0_for"
 //  CHECK-NEXT:      %i_1 = x86.ds.mov %i : (!x86.reg64<r9>) -> !x86.reg64<r9>
@@ -103,10 +150,32 @@ x86_func.func @nested(%src: !x86.reg64<rax>, %dst: !x86.reg64<rbx>) {
 //  CHECK-NEXT:      x86.label "scf_body_end_0_for"
 //  CHECK-NEXT:      x86_func.ret
 //  CHECK-NEXT:    }
-x86_func.func @static_ub_dynamic_step() {
-    %zero = x86.di.mov 0 : () -> !x86.reg64<rcx>
+x86_func.func @dynamic_lb_static_ub_dynamic_step(%lb: !x86.reg64<rcx>) {
     %step = x86.di.mov 2 : () -> !x86.reg64<rdx>
-    x86_scf.for %i : !x86.reg64<r9> = %zero to 10 : si32 step %step {
+    x86_scf.for %i : !x86.reg64<r9> = %lb to 10 : si32 step %step {
+        x86_scf.yield
+    }
+    ret
+}
+
+// -----
+
+// CHECK-LABEL:    @dynamic_lb_static_ub_static_step
+//  CHECK-NEXT:      %lb_1 = x86.ds.mov %lb : (!x86.reg64<rcx>) -> !x86.reg64<r9>
+//  CHECK-NEXT:      %0 = x86.si.cmp %lb_1, 12 : (!x86.reg64<r9>) -> !x86.rflags<rflags>
+//  CHECK-NEXT:      x86.c.jge %0 : !x86.rflags<rflags>, ^bb0(%lb_1 : !x86.reg64<r9>), ^bb1(%lb_1 : !x86.reg64<r9>)
+//  CHECK-NEXT:    ^bb1(%i: !x86.reg64<r9>):
+//  CHECK-NEXT:      x86.label "scf_body_0_for"
+//  CHECK-NEXT:      %i_1 = x86.ds.mov %i : (!x86.reg64<r9>) -> !x86.reg64<r9>
+//  CHECK-NEXT:      %i_2 = x86.ri.add %i_1, 1 : (!x86.reg64<r9>) -> !x86.reg64<r9>
+//  CHECK-NEXT:      %1 = x86.si.cmp %i_2, 12 : (!x86.reg64<r9>) -> !x86.rflags<rflags>
+//  CHECK-NEXT:      x86.c.jl %1 : !x86.rflags<rflags>, ^bb1(%i_2 : !x86.reg64<r9>), ^bb0(%i_2 : !x86.reg64<r9>)
+//  CHECK-NEXT:    ^bb0(%i_3: !x86.reg64<r9>):
+//  CHECK-NEXT:      x86.label "scf_body_end_0_for"
+//  CHECK-NEXT:      x86_func.ret
+//  CHECK-NEXT:    }
+x86_func.func @dynamic_lb_static_ub_static_step(%lb: !x86.reg64<rcx>) {
+    x86_scf.for %i : !x86.reg64<r9> = %lb to 12 : si32 step 1 : si32 {
         x86_scf.yield
     }
     ret
@@ -134,31 +203,6 @@ x86_func.func @dynamic_ub_static_step() {
     %zero = x86.di.mov 0 : () -> !x86.reg64<rcx>
     %ub = x86.di.mov 20 : () -> !x86.reg64<r8>
     x86_scf.for %i : !x86.reg64<r9> = %zero to %ub step 3 : si32 {
-        x86_scf.yield
-    }
-    ret
-}
-
-// -----
-
-// CHECK-LABEL:    @static_ub_static_step
-//  CHECK-NEXT:      %zero = x86.di.mov 0 : () -> !x86.reg64<rcx>
-//  CHECK-NEXT:      %zero_1 = x86.ds.mov %zero : (!x86.reg64<rcx>) -> !x86.reg64<r9>
-//  CHECK-NEXT:      %0 = x86.si.cmp %zero_1, 12 : (!x86.reg64<r9>) -> !x86.rflags<rflags>
-//  CHECK-NEXT:      x86.c.jge %0 : !x86.rflags<rflags>, ^bb0(%zero_1 : !x86.reg64<r9>), ^bb1(%zero_1 : !x86.reg64<r9>)
-//  CHECK-NEXT:    ^bb1(%i: !x86.reg64<r9>):
-//  CHECK-NEXT:      x86.label "scf_body_0_for"
-//  CHECK-NEXT:      %i_1 = x86.ds.mov %i : (!x86.reg64<r9>) -> !x86.reg64<r9>
-//  CHECK-NEXT:      %i_2 = x86.ri.add %i_1, 1 : (!x86.reg64<r9>) -> !x86.reg64<r9>
-//  CHECK-NEXT:      %1 = x86.si.cmp %i_2, 12 : (!x86.reg64<r9>) -> !x86.rflags<rflags>
-//  CHECK-NEXT:      x86.c.jl %1 : !x86.rflags<rflags>, ^bb1(%i_2 : !x86.reg64<r9>), ^bb0(%i_2 : !x86.reg64<r9>)
-//  CHECK-NEXT:    ^bb0(%i_3: !x86.reg64<r9>):
-//  CHECK-NEXT:      x86.label "scf_body_end_0_for"
-//  CHECK-NEXT:      x86_func.ret
-//  CHECK-NEXT:    }
-x86_func.func @static_ub_static_step() {
-    %zero = x86.di.mov 0 : () -> !x86.reg64<rcx>
-    x86_scf.for %i : !x86.reg64<r9> = %zero to 12 : si32 step 1 : si32 {
         x86_scf.yield
     }
     ret

--- a/tests/filecheck/transforms/convert-x86-scf-to-x86.mlir
+++ b/tests/filecheck/transforms/convert-x86-scf-to-x86.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -p convert-x86-scf-to-x86 --split-input-file --verify-diagnostics %s | filecheck %s
+// RUN: xdsl-opt -p convert-x86-scf-to-x86 --split-input-file %s | filecheck %s
 
 
 // CHECK-LABEL:    @copy10
@@ -86,51 +86,80 @@ x86_func.func @nested(%src: !x86.reg64<rax>, %dst: !x86.reg64<rbx>) {
 }
 
 // -----
-// Static upper bound is currently unsupported by this lowering.
-x86_func.func @static_ub_for_fails() {
+
+// CHECK-LABEL:    @static_ub_dynamic_step
+//  CHECK-NEXT:      %zero = x86.di.mov 0 : () -> !x86.reg64<rcx>
+//  CHECK-NEXT:      %step = x86.di.mov 2 : () -> !x86.reg64<rdx>
+//  CHECK-NEXT:      %zero_1 = x86.ds.mov %zero : (!x86.reg64<rcx>) -> !x86.reg64<r9>
+//  CHECK-NEXT:      %0 = x86.si.cmp %zero_1, 10 : (!x86.reg64<r9>) -> !x86.rflags<rflags>
+//  CHECK-NEXT:      x86.c.jge %0 : !x86.rflags<rflags>, ^bb0(%zero_1 : !x86.reg64<r9>), ^bb1(%zero_1 : !x86.reg64<r9>)
+//  CHECK-NEXT:    ^bb1(%i: !x86.reg64<r9>):
+//  CHECK-NEXT:      x86.label "scf_body_0_for"
+//  CHECK-NEXT:      %i_1 = x86.ds.mov %i : (!x86.reg64<r9>) -> !x86.reg64<r9>
+//  CHECK-NEXT:      %i_2 = x86.rs.add %i_1, %step : (!x86.reg64<r9>, !x86.reg64<rdx>) -> !x86.reg64<r9>
+//  CHECK-NEXT:      %1 = x86.si.cmp %i_2, 10 : (!x86.reg64<r9>) -> !x86.rflags<rflags>
+//  CHECK-NEXT:      x86.c.jl %1 : !x86.rflags<rflags>, ^bb1(%i_2 : !x86.reg64<r9>), ^bb0(%i_2 : !x86.reg64<r9>)
+//  CHECK-NEXT:    ^bb0(%i_3: !x86.reg64<r9>):
+//  CHECK-NEXT:      x86.label "scf_body_end_0_for"
+//  CHECK-NEXT:      x86_func.ret
+//  CHECK-NEXT:    }
+x86_func.func @static_ub_dynamic_step() {
     %zero = x86.di.mov 0 : () -> !x86.reg64<rcx>
-    %step = x86.di.mov 1 : () -> !x86.reg64<rdx>
+    %step = x86.di.mov 2 : () -> !x86.reg64<rdx>
     x86_scf.for %i : !x86.reg64<r9> = %zero to 10 : si32 step %step {
         x86_scf.yield
     }
     ret
 }
-// CHECK: convert-x86-scf-to-x86 expects x86_scf.for upper bound to be an SSAValue
 
 // -----
-// Static upper bound remains unsupported even with iter_args.
-x86_func.func @static_ub_for_with_iter_args_fails(%init: !x86.reg64<rax>) {
-    %zero = x86.di.mov 0 : () -> !x86.reg64<rcx>
-    %step = x86.di.mov 1 : () -> !x86.reg64<rdx>
-    %res = x86_scf.for %i : !x86.reg64<r9> = %zero to 20 : si32 step %step iter_args(%acc = %init) -> (!x86.reg64<rax>) {
-        x86_scf.yield %acc : !x86.reg64<rax>
-    }
-    "test.op"(%res) : (!x86.reg64<rax>) -> ()
-    ret
-}
-// CHECK: convert-x86-scf-to-x86 expects x86_scf.for upper bound to be an SSAValue
 
-// -----
-// Static step is currently unsupported by this lowering.
-x86_func.func @static_step_for_fails() {
+// CHECK-LABEL:    @dynamic_ub_static_step
+//  CHECK-NEXT:      %zero = x86.di.mov 0 : () -> !x86.reg64<rcx>
+//  CHECK-NEXT:      %ub = x86.di.mov 20 : () -> !x86.reg64<r8>
+//  CHECK-NEXT:      %zero_1 = x86.ds.mov %zero : (!x86.reg64<rcx>) -> !x86.reg64<r9>
+//  CHECK-NEXT:      %0 = x86.ss.cmp %zero_1, %ub : (!x86.reg64<r9>, !x86.reg64<r8>) -> !x86.rflags<rflags>
+//  CHECK-NEXT:      x86.c.jge %0 : !x86.rflags<rflags>, ^bb0(%zero_1 : !x86.reg64<r9>), ^bb1(%zero_1 : !x86.reg64<r9>)
+//  CHECK-NEXT:    ^bb1(%i: !x86.reg64<r9>):
+//  CHECK-NEXT:      x86.label "scf_body_0_for"
+//  CHECK-NEXT:      %i_1 = x86.ds.mov %i : (!x86.reg64<r9>) -> !x86.reg64<r9>
+//  CHECK-NEXT:      %i_2 = x86.ri.add %i_1, 3 : (!x86.reg64<r9>) -> !x86.reg64<r9>
+//  CHECK-NEXT:      %1 = x86.ss.cmp %i_2, %ub : (!x86.reg64<r9>, !x86.reg64<r8>) -> !x86.rflags<rflags>
+//  CHECK-NEXT:      x86.c.jl %1 : !x86.rflags<rflags>, ^bb1(%i_2 : !x86.reg64<r9>), ^bb0(%i_2 : !x86.reg64<r9>)
+//  CHECK-NEXT:    ^bb0(%i_3: !x86.reg64<r9>):
+//  CHECK-NEXT:      x86.label "scf_body_end_0_for"
+//  CHECK-NEXT:      x86_func.ret
+//  CHECK-NEXT:    }
+x86_func.func @dynamic_ub_static_step() {
     %zero = x86.di.mov 0 : () -> !x86.reg64<rcx>
-    %forty = x86.di.mov 40 : () -> !x86.reg64<r8>
-    x86_scf.for %i : !x86.reg64<r9> = %zero to %forty step 1 : si32 {
+    %ub = x86.di.mov 20 : () -> !x86.reg64<r8>
+    x86_scf.for %i : !x86.reg64<r9> = %zero to %ub step 3 : si32 {
         x86_scf.yield
     }
     ret
 }
-// CHECK: convert-x86-scf-to-x86 expects x86_scf.for step to be an SSAValue
 
 // -----
-// Static step remains unsupported even with iter_args.
-x86_func.func @static_step_for_with_iter_args_fails(%init: !x86.reg64<rax>) {
+
+// CHECK-LABEL:    @static_ub_static_step
+//  CHECK-NEXT:      %zero = x86.di.mov 0 : () -> !x86.reg64<rcx>
+//  CHECK-NEXT:      %zero_1 = x86.ds.mov %zero : (!x86.reg64<rcx>) -> !x86.reg64<r9>
+//  CHECK-NEXT:      %0 = x86.si.cmp %zero_1, 12 : (!x86.reg64<r9>) -> !x86.rflags<rflags>
+//  CHECK-NEXT:      x86.c.jge %0 : !x86.rflags<rflags>, ^bb0(%zero_1 : !x86.reg64<r9>), ^bb1(%zero_1 : !x86.reg64<r9>)
+//  CHECK-NEXT:    ^bb1(%i: !x86.reg64<r9>):
+//  CHECK-NEXT:      x86.label "scf_body_0_for"
+//  CHECK-NEXT:      %i_1 = x86.ds.mov %i : (!x86.reg64<r9>) -> !x86.reg64<r9>
+//  CHECK-NEXT:      %i_2 = x86.ri.add %i_1, 1 : (!x86.reg64<r9>) -> !x86.reg64<r9>
+//  CHECK-NEXT:      %1 = x86.si.cmp %i_2, 12 : (!x86.reg64<r9>) -> !x86.rflags<rflags>
+//  CHECK-NEXT:      x86.c.jl %1 : !x86.rflags<rflags>, ^bb1(%i_2 : !x86.reg64<r9>), ^bb0(%i_2 : !x86.reg64<r9>)
+//  CHECK-NEXT:    ^bb0(%i_3: !x86.reg64<r9>):
+//  CHECK-NEXT:      x86.label "scf_body_end_0_for"
+//  CHECK-NEXT:      x86_func.ret
+//  CHECK-NEXT:    }
+x86_func.func @static_ub_static_step() {
     %zero = x86.di.mov 0 : () -> !x86.reg64<rcx>
-    %forty = x86.di.mov 40 : () -> !x86.reg64<r8>
-    %res = x86_scf.for %i : !x86.reg64<r9> = %zero to %forty step 1 : si32 iter_args(%acc = %init) -> (!x86.reg64<rax>) {
-        x86_scf.yield %acc : !x86.reg64<rax>
+    x86_scf.for %i : !x86.reg64<r9> = %zero to 12 : si32 step 1 : si32 {
+        x86_scf.yield
     }
-    "test.op"(%res) : (!x86.reg64<rax>) -> ()
     ret
 }
-// CHECK: convert-x86-scf-to-x86 expects x86_scf.for step to be an SSAValue

--- a/tests/filecheck/transforms/convert-x86-scf-to-x86.mlir
+++ b/tests/filecheck/transforms/convert-x86-scf-to-x86.mlir
@@ -11,11 +11,10 @@
 //  CHECK-NEXT:    ^bb1(%offset: !x86.reg64<r9>):
 //  CHECK-NEXT:      x86.label "scf_body_0_for"
 //  CHECK-NEXT:      "test.op"(%offset, %src, %dst) : (!x86.reg64<r9>, !x86.reg64<rax>, !x86.reg64<rbx>) -> ()
-//  CHECK-NEXT:      %offset_1 = x86.ds.mov %offset : (!x86.reg64<r9>) -> !x86.reg64<r9>
-//  CHECK-NEXT:      %offset_2 = x86.rs.add %offset_1, %step : (!x86.reg64<r9>, !x86.reg64<rdx>) -> !x86.reg64<r9>
-//  CHECK-NEXT:      %1 = x86.ss.cmp %offset_2, %forty : (!x86.reg64<r9>, !x86.reg64<r8>) -> !x86.rflags<rflags>
-//  CHECK-NEXT:      x86.c.jl %1 : !x86.rflags<rflags>, ^bb1(%offset_2 : !x86.reg64<r9>), ^bb0(%offset_2 : !x86.reg64<r9>)
-//  CHECK-NEXT:    ^bb0(%offset_3: !x86.reg64<r9>):
+//  CHECK-NEXT:      %offset_1 = x86.rs.add %offset, %step : (!x86.reg64<r9>, !x86.reg64<rdx>) -> !x86.reg64<r9>
+//  CHECK-NEXT:      %1 = x86.ss.cmp %offset_1, %forty : (!x86.reg64<r9>, !x86.reg64<r8>) -> !x86.rflags<rflags>
+//  CHECK-NEXT:      x86.c.jl %1 : !x86.rflags<rflags>, ^bb1(%offset_1 : !x86.reg64<r9>), ^bb0(%offset_1 : !x86.reg64<r9>)
+//  CHECK-NEXT:    ^bb0(%offset_2: !x86.reg64<r9>):
 //  CHECK-NEXT:      x86.label "scf_body_end_0_for"
 //  CHECK-NEXT:      x86_func.ret
 //  CHECK-NEXT:    }
@@ -50,17 +49,15 @@ x86_func.func @copy10(%src: !x86.reg64<rax>, %dst: !x86.reg64<rbx>) {
 //  CHECK-NEXT:    ^bb3(%offset_inner: !x86.reg64<r13>):
 //  CHECK-NEXT:      x86.label "scf_body_0_for"
 //  CHECK-NEXT:      "test.op"(%src, %dst, %offset_outer, %offset_inner) : (!x86.reg64<rax>, !x86.reg64<rbx>, !x86.reg64<r9>, !x86.reg64<r13>) -> ()
-//  CHECK-NEXT:      %offset_inner_1 = x86.ds.mov %offset_inner : (!x86.reg64<r13>) -> !x86.reg64<r13>
-//  CHECK-NEXT:      %offset_inner_2 = x86.rs.add %offset_inner_1, %step_inner : (!x86.reg64<r13>, !x86.reg64<r11>) -> !x86.reg64<r13>
-//  CHECK-NEXT:      %2 = x86.ss.cmp %offset_inner_2, %forty_inner : (!x86.reg64<r13>, !x86.reg64<r12>) -> !x86.rflags<rflags>
-//  CHECK-NEXT:      x86.c.jl %2 : !x86.rflags<rflags>, ^bb3(%offset_inner_2 : !x86.reg64<r13>), ^bb2(%offset_inner_2 : !x86.reg64<r13>)
-//  CHECK-NEXT:    ^bb2(%offset_inner_3: !x86.reg64<r13>):
+//  CHECK-NEXT:      %offset_inner_1 = x86.rs.add %offset_inner, %step_inner : (!x86.reg64<r13>, !x86.reg64<r11>) -> !x86.reg64<r13>
+//  CHECK-NEXT:      %2 = x86.ss.cmp %offset_inner_1, %forty_inner : (!x86.reg64<r13>, !x86.reg64<r12>) -> !x86.rflags<rflags>
+//  CHECK-NEXT:      x86.c.jl %2 : !x86.rflags<rflags>, ^bb3(%offset_inner_1 : !x86.reg64<r13>), ^bb2(%offset_inner_1 : !x86.reg64<r13>)
+//  CHECK-NEXT:    ^bb2(%offset_inner_2: !x86.reg64<r13>):
 //  CHECK-NEXT:      x86.label "scf_body_end_0_for"
-//  CHECK-NEXT:      %offset_outer_1 = x86.ds.mov %offset_outer : (!x86.reg64<r9>) -> !x86.reg64<r9>
-//  CHECK-NEXT:      %offset_outer_2 = x86.rs.add %offset_outer_1, %step_outer : (!x86.reg64<r9>, !x86.reg64<rdx>) -> !x86.reg64<r9>
-//  CHECK-NEXT:      %3 = x86.ss.cmp %offset_outer_2, %forty_outer : (!x86.reg64<r9>, !x86.reg64<r8>) -> !x86.rflags<rflags>
-//  CHECK-NEXT:      x86.c.jl %3 : !x86.rflags<rflags>, ^bb1(%offset_outer_2 : !x86.reg64<r9>), ^bb0(%offset_outer_2 : !x86.reg64<r9>)
-//  CHECK-NEXT:    ^bb0(%offset_outer_3: !x86.reg64<r9>):
+//  CHECK-NEXT:      %offset_outer_1 = x86.rs.add %offset_outer, %step_outer : (!x86.reg64<r9>, !x86.reg64<rdx>) -> !x86.reg64<r9>
+//  CHECK-NEXT:      %3 = x86.ss.cmp %offset_outer_1, %forty_outer : (!x86.reg64<r9>, !x86.reg64<r8>) -> !x86.rflags<rflags>
+//  CHECK-NEXT:      x86.c.jl %3 : !x86.rflags<rflags>, ^bb1(%offset_outer_1 : !x86.reg64<r9>), ^bb0(%offset_outer_1 : !x86.reg64<r9>)
+//  CHECK-NEXT:    ^bb0(%offset_outer_2: !x86.reg64<r9>):
 //  CHECK-NEXT:      x86.label "scf_body_end_1_for"
 //  CHECK-NEXT:      x86_func.ret
 //  CHECK-NEXT:    }
@@ -94,11 +91,10 @@ x86_func.func @nested(%src: !x86.reg64<rax>, %dst: !x86.reg64<rbx>) {
 //  CHECK-NEXT:      x86.fallthrough ^bb0(%zero_1 : !x86.reg64<r9>)
 //  CHECK-NEXT:    ^bb0(%i: !x86.reg64<r9>):
 //  CHECK-NEXT:      x86.label "scf_body_0_for"
-//  CHECK-NEXT:      %i_1 = x86.ds.mov %i : (!x86.reg64<r9>) -> !x86.reg64<r9>
-//  CHECK-NEXT:      %i_2 = x86.rs.add %i_1, %step : (!x86.reg64<r9>, !x86.reg64<rdx>) -> !x86.reg64<r9>
-//  CHECK-NEXT:      %0 = x86.si.cmp %i_2, 10 : (!x86.reg64<r9>) -> !x86.rflags<rflags>
-//  CHECK-NEXT:      x86.c.jl %0 : !x86.rflags<rflags>, ^bb0(%i_2 : !x86.reg64<r9>), ^bb1(%i_2 : !x86.reg64<r9>)
-//  CHECK-NEXT:    ^bb1(%i_3: !x86.reg64<r9>):
+//  CHECK-NEXT:      %i_1 = x86.rs.add %i, %step : (!x86.reg64<r9>, !x86.reg64<rdx>) -> !x86.reg64<r9>
+//  CHECK-NEXT:      %0 = x86.si.cmp %i_1, 10 : (!x86.reg64<r9>) -> !x86.rflags<rflags>
+//  CHECK-NEXT:      x86.c.jl %0 : !x86.rflags<rflags>, ^bb0(%i_1 : !x86.reg64<r9>), ^bb1(%i_1 : !x86.reg64<r9>)
+//  CHECK-NEXT:    ^bb1(%i_2: !x86.reg64<r9>):
 //  CHECK-NEXT:      x86_func.ret
 //  CHECK-NEXT:    }
 x86_func.func @static_ub_dynamic_step() {
@@ -118,11 +114,10 @@ x86_func.func @static_ub_dynamic_step() {
 //  CHECK-NEXT:      x86.fallthrough ^bb0(%zero_1 : !x86.reg64<r9>)
 //  CHECK-NEXT:    ^bb0(%i: !x86.reg64<r9>):
 //  CHECK-NEXT:      x86.label "scf_body_0_for"
-//  CHECK-NEXT:      %i_1 = x86.ds.mov %i : (!x86.reg64<r9>) -> !x86.reg64<r9>
-//  CHECK-NEXT:      %i_2 = x86.ri.add %i_1, 1 : (!x86.reg64<r9>) -> !x86.reg64<r9>
-//  CHECK-NEXT:      %0 = x86.si.cmp %i_2, 12 : (!x86.reg64<r9>) -> !x86.rflags<rflags>
-//  CHECK-NEXT:      x86.c.jl %0 : !x86.rflags<rflags>, ^bb0(%i_2 : !x86.reg64<r9>), ^bb1(%i_2 : !x86.reg64<r9>)
-//  CHECK-NEXT:    ^bb1(%i_3: !x86.reg64<r9>):
+//  CHECK-NEXT:      %i_1 = x86.ri.add %i, 1 : (!x86.reg64<r9>) -> !x86.reg64<r9>
+//  CHECK-NEXT:      %0 = x86.si.cmp %i_1, 12 : (!x86.reg64<r9>) -> !x86.rflags<rflags>
+//  CHECK-NEXT:      x86.c.jl %0 : !x86.rflags<rflags>, ^bb0(%i_1 : !x86.reg64<r9>), ^bb1(%i_1 : !x86.reg64<r9>)
+//  CHECK-NEXT:    ^bb1(%i_2: !x86.reg64<r9>):
 //  CHECK-NEXT:      x86_func.ret
 //  CHECK-NEXT:    }
 x86_func.func @static_ub_static_step() {
@@ -142,11 +137,10 @@ x86_func.func @static_ub_static_step() {
 //  CHECK-NEXT:      x86.c.jge %0 : !x86.rflags<rflags>, ^bb0(%lb_1 : !x86.reg64<r9>), ^bb1(%lb_1 : !x86.reg64<r9>)
 //  CHECK-NEXT:    ^bb1(%i: !x86.reg64<r9>):
 //  CHECK-NEXT:      x86.label "scf_body_0_for"
-//  CHECK-NEXT:      %i_1 = x86.ds.mov %i : (!x86.reg64<r9>) -> !x86.reg64<r9>
-//  CHECK-NEXT:      %i_2 = x86.rs.add %i_1, %step : (!x86.reg64<r9>, !x86.reg64<rdx>) -> !x86.reg64<r9>
-//  CHECK-NEXT:      %1 = x86.si.cmp %i_2, 10 : (!x86.reg64<r9>) -> !x86.rflags<rflags>
-//  CHECK-NEXT:      x86.c.jl %1 : !x86.rflags<rflags>, ^bb1(%i_2 : !x86.reg64<r9>), ^bb0(%i_2 : !x86.reg64<r9>)
-//  CHECK-NEXT:    ^bb0(%i_3: !x86.reg64<r9>):
+//  CHECK-NEXT:      %i_1 = x86.rs.add %i, %step : (!x86.reg64<r9>, !x86.reg64<rdx>) -> !x86.reg64<r9>
+//  CHECK-NEXT:      %1 = x86.si.cmp %i_1, 10 : (!x86.reg64<r9>) -> !x86.rflags<rflags>
+//  CHECK-NEXT:      x86.c.jl %1 : !x86.rflags<rflags>, ^bb1(%i_1 : !x86.reg64<r9>), ^bb0(%i_1 : !x86.reg64<r9>)
+//  CHECK-NEXT:    ^bb0(%i_2: !x86.reg64<r9>):
 //  CHECK-NEXT:      x86.label "scf_body_end_0_for"
 //  CHECK-NEXT:      x86_func.ret
 //  CHECK-NEXT:    }
@@ -166,11 +160,10 @@ x86_func.func @dynamic_lb_static_ub_dynamic_step(%lb: !x86.reg64<rcx>) {
 //  CHECK-NEXT:      x86.c.jge %0 : !x86.rflags<rflags>, ^bb0(%lb_1 : !x86.reg64<r9>), ^bb1(%lb_1 : !x86.reg64<r9>)
 //  CHECK-NEXT:    ^bb1(%i: !x86.reg64<r9>):
 //  CHECK-NEXT:      x86.label "scf_body_0_for"
-//  CHECK-NEXT:      %i_1 = x86.ds.mov %i : (!x86.reg64<r9>) -> !x86.reg64<r9>
-//  CHECK-NEXT:      %i_2 = x86.ri.add %i_1, 1 : (!x86.reg64<r9>) -> !x86.reg64<r9>
-//  CHECK-NEXT:      %1 = x86.si.cmp %i_2, 12 : (!x86.reg64<r9>) -> !x86.rflags<rflags>
-//  CHECK-NEXT:      x86.c.jl %1 : !x86.rflags<rflags>, ^bb1(%i_2 : !x86.reg64<r9>), ^bb0(%i_2 : !x86.reg64<r9>)
-//  CHECK-NEXT:    ^bb0(%i_3: !x86.reg64<r9>):
+//  CHECK-NEXT:      %i_1 = x86.ri.add %i, 1 : (!x86.reg64<r9>) -> !x86.reg64<r9>
+//  CHECK-NEXT:      %1 = x86.si.cmp %i_1, 12 : (!x86.reg64<r9>) -> !x86.rflags<rflags>
+//  CHECK-NEXT:      x86.c.jl %1 : !x86.rflags<rflags>, ^bb1(%i_1 : !x86.reg64<r9>), ^bb0(%i_1 : !x86.reg64<r9>)
+//  CHECK-NEXT:    ^bb0(%i_2: !x86.reg64<r9>):
 //  CHECK-NEXT:      x86.label "scf_body_end_0_for"
 //  CHECK-NEXT:      x86_func.ret
 //  CHECK-NEXT:    }
@@ -191,11 +184,10 @@ x86_func.func @dynamic_lb_static_ub_static_step(%lb: !x86.reg64<rcx>) {
 //  CHECK-NEXT:      x86.c.jge %0 : !x86.rflags<rflags>, ^bb0(%zero_1 : !x86.reg64<r9>), ^bb1(%zero_1 : !x86.reg64<r9>)
 //  CHECK-NEXT:    ^bb1(%i: !x86.reg64<r9>):
 //  CHECK-NEXT:      x86.label "scf_body_0_for"
-//  CHECK-NEXT:      %i_1 = x86.ds.mov %i : (!x86.reg64<r9>) -> !x86.reg64<r9>
-//  CHECK-NEXT:      %i_2 = x86.ri.add %i_1, 3 : (!x86.reg64<r9>) -> !x86.reg64<r9>
-//  CHECK-NEXT:      %1 = x86.ss.cmp %i_2, %ub : (!x86.reg64<r9>, !x86.reg64<r8>) -> !x86.rflags<rflags>
-//  CHECK-NEXT:      x86.c.jl %1 : !x86.rflags<rflags>, ^bb1(%i_2 : !x86.reg64<r9>), ^bb0(%i_2 : !x86.reg64<r9>)
-//  CHECK-NEXT:    ^bb0(%i_3: !x86.reg64<r9>):
+//  CHECK-NEXT:      %i_1 = x86.ri.add %i, 3 : (!x86.reg64<r9>) -> !x86.reg64<r9>
+//  CHECK-NEXT:      %1 = x86.ss.cmp %i_1, %ub : (!x86.reg64<r9>, !x86.reg64<r8>) -> !x86.rflags<rflags>
+//  CHECK-NEXT:      x86.c.jl %1 : !x86.rflags<rflags>, ^bb1(%i_1 : !x86.reg64<r9>), ^bb0(%i_1 : !x86.reg64<r9>)
+//  CHECK-NEXT:    ^bb0(%i_2: !x86.reg64<r9>):
 //  CHECK-NEXT:      x86.label "scf_body_end_0_for"
 //  CHECK-NEXT:      x86_func.ret
 //  CHECK-NEXT:    }

--- a/tests/filecheck/transforms/convert-x86-scf-to-x86.mlir
+++ b/tests/filecheck/transforms/convert-x86-scf-to-x86.mlir
@@ -12,7 +12,7 @@
 //  CHECK-NEXT:      x86.label "scf_body_0_for"
 //  CHECK-NEXT:      "test.op"(%offset, %src, %dst) : (!x86.reg64<r9>, !x86.reg64<rax>, !x86.reg64<rbx>) -> ()
 //  CHECK-NEXT:      %offset_1 = x86.ds.mov %offset : (!x86.reg64<r9>) -> !x86.reg64<r9>
-//  CHECK-NEXT:      %offset_2 = x86.r.inc %offset_1 : (!x86.reg64<r9>) -> !x86.reg64<r9>
+//  CHECK-NEXT:      %offset_2 = x86.rs.add %offset_1, %step : (!x86.reg64<r9>, !x86.reg64<rdx>) -> !x86.reg64<r9>
 //  CHECK-NEXT:      %1 = x86.ss.cmp %offset_2, %forty : (!x86.reg64<r9>, !x86.reg64<r8>) -> !x86.rflags<rflags>
 //  CHECK-NEXT:      x86.c.jl %1 : !x86.rflags<rflags>, ^bb1(%offset_2 : !x86.reg64<r9>), ^bb0(%offset_2 : !x86.reg64<r9>)
 //  CHECK-NEXT:    ^bb0(%offset_3: !x86.reg64<r9>):
@@ -51,13 +51,13 @@ x86_func.func @copy10(%src: !x86.reg64<rax>, %dst: !x86.reg64<rbx>) {
 //  CHECK-NEXT:      x86.label "scf_body_0_for"
 //  CHECK-NEXT:      "test.op"(%src, %dst, %offset_outer, %offset_inner) : (!x86.reg64<rax>, !x86.reg64<rbx>, !x86.reg64<r9>, !x86.reg64<r13>) -> ()
 //  CHECK-NEXT:      %offset_inner_1 = x86.ds.mov %offset_inner : (!x86.reg64<r13>) -> !x86.reg64<r13>
-//  CHECK-NEXT:      %offset_inner_2 = x86.r.inc %offset_inner_1 : (!x86.reg64<r13>) -> !x86.reg64<r13>
+//  CHECK-NEXT:      %offset_inner_2 = x86.rs.add %offset_inner_1, %step_inner : (!x86.reg64<r13>, !x86.reg64<r11>) -> !x86.reg64<r13>
 //  CHECK-NEXT:      %2 = x86.ss.cmp %offset_inner_2, %forty_inner : (!x86.reg64<r13>, !x86.reg64<r12>) -> !x86.rflags<rflags>
 //  CHECK-NEXT:      x86.c.jl %2 : !x86.rflags<rflags>, ^bb3(%offset_inner_2 : !x86.reg64<r13>), ^bb2(%offset_inner_2 : !x86.reg64<r13>)
 //  CHECK-NEXT:    ^bb2(%offset_inner_3: !x86.reg64<r13>):
 //  CHECK-NEXT:      x86.label "scf_body_end_0_for"
 //  CHECK-NEXT:      %offset_outer_1 = x86.ds.mov %offset_outer : (!x86.reg64<r9>) -> !x86.reg64<r9>
-//  CHECK-NEXT:      %offset_outer_2 = x86.r.inc %offset_outer_1 : (!x86.reg64<r9>) -> !x86.reg64<r9>
+//  CHECK-NEXT:      %offset_outer_2 = x86.rs.add %offset_outer_1, %step_outer : (!x86.reg64<r9>, !x86.reg64<rdx>) -> !x86.reg64<r9>
 //  CHECK-NEXT:      %3 = x86.ss.cmp %offset_outer_2, %forty_outer : (!x86.reg64<r9>, !x86.reg64<r8>) -> !x86.rflags<rflags>
 //  CHECK-NEXT:      x86.c.jl %3 : !x86.rflags<rflags>, ^bb1(%offset_outer_2 : !x86.reg64<r9>), ^bb0(%offset_outer_2 : !x86.reg64<r9>)
 //  CHECK-NEXT:    ^bb0(%offset_outer_3: !x86.reg64<r9>):

--- a/xdsl/transforms/convert_x86_scf_to_x86.py
+++ b/xdsl/transforms/convert_x86_scf_to_x86.py
@@ -95,13 +95,14 @@ class LowerX86ScfForPattern(RewritePattern):
 
         # Get the induction variable and its register
         iv_body = SSAValue.get(first_body_block.args[0], type=GeneralRegisterType)
+        iv_used = iv_body.first_use is not None
         iv_reg = iv_body.type
         ub = op.ub
         step = op.step
 
         # Insert label at the start of the first body block.
         rewriter.insert(
-            x86.ops.LabelOp(f"scf_body_{suffix}"),
+            body_label_op := x86.ops.LabelOp(f"scf_body_{suffix}"),
             InsertPoint.at_start(first_body_block),
         )
 
@@ -118,17 +119,19 @@ class LowerX86ScfForPattern(RewritePattern):
                     iv_body,
                     step,
                 )
+        step_op.register_out.name_hint = iv_body.name_hint
         new_iv = step_op.register_out
+
         match ub:
             case SSAValue():
                 cmp_op = x86.ops.SS_CmpOp(new_iv, ub, result=RFLAGS)
             case builtin.IntegerAttr():
                 cmp_op = x86.ops.SI_CmpOp(new_iv, ub)
 
+        # Insert comparison and jump to beginning of loop
         rewriter.replace(
             yield_op,
             (
-                step_op,
                 cmp_op,
                 x86.ops.C_JlOp(
                     cmp_op.result,
@@ -140,7 +143,14 @@ class LowerX86ScfForPattern(RewritePattern):
             ),
         )
 
-        step_op.register_out.name_hint = iv_body.name_hint
+        # Insert iv increment
+        # If iv was not used prior to lowering, then put it at the start of the loop as
+        # an optimisation to avoid cycles waiting for the increment.
+        rewriter.insert(
+            step_op,
+            InsertPoint.before(cmp_op) if iv_used else InsertPoint.after(body_label_op),
+        )
+
         end_block.args[0].name_hint = iv_body.name_hint
 
         rewriter.inline_region(op.body, BlockInsertPoint.before(end_block))

--- a/xdsl/transforms/convert_x86_scf_to_x86.py
+++ b/xdsl/transforms/convert_x86_scf_to_x86.py
@@ -110,13 +110,12 @@ class LowerX86ScfForPattern(RewritePattern):
         yield_op = last_body_block.last_op
         assert isinstance(yield_op, x86_scf.YieldOp)
 
-        mv_op = x86.ops.DS_MovOp(iv, destination=iv_reg)
         match step:
             case SSAValue():
-                step_op = x86.ops.RS_AddOp(mv_op.destination, step)
+                step_op = x86.ops.RS_AddOp(iv, step)
             case builtin.IntegerAttr():
                 step_op = x86.ops.RI_AddOp(
-                    mv_op.destination,
+                    iv,
                     step,
                 )
         new_iv = step_op.register_out
@@ -129,7 +128,6 @@ class LowerX86ScfForPattern(RewritePattern):
         rewriter.replace(
             yield_op,
             (
-                mv_op,
                 step_op,
                 cmp_op,
                 x86.ops.C_JlOp(
@@ -142,7 +140,6 @@ class LowerX86ScfForPattern(RewritePattern):
             ),
         )
 
-        mv_op.destination.name_hint = iv.name_hint
         step_op.register_out.name_hint = iv.name_hint
         end_block.args[0].name_hint = iv.name_hint
 

--- a/xdsl/transforms/convert_x86_scf_to_x86.py
+++ b/xdsl/transforms/convert_x86_scf_to_x86.py
@@ -10,8 +10,6 @@ from xdsl.pattern_rewriter import (
     op_type_rewrite_pattern,
 )
 from xdsl.rewriter import BlockInsertPoint, InsertPoint
-from xdsl.utils.exceptions import PassFailedException
-from xdsl.utils.hints import isa
 
 
 class LowerX86ScfForPattern(RewritePattern):
@@ -96,19 +94,10 @@ class LowerX86ScfForPattern(RewritePattern):
         last_body_block = op.body.blocks[-1]
 
         # Get the induction variable and its register
-        iv = first_body_block.args[0]
-        assert isa(iv, SSAValue[GeneralRegisterType])
+        iv = SSAValue.get(first_body_block.args[0], type=GeneralRegisterType)
         iv_reg = iv.type
         ub = op.ub
-        if not isinstance(ub, SSAValue):
-            raise PassFailedException(
-                "convert-x86-scf-to-x86 expects x86_scf.for upper bound to be an SSAValue"
-            )
         step = op.step
-        if not isinstance(step, SSAValue):
-            raise PassFailedException(
-                "convert-x86-scf-to-x86 expects x86_scf.for step to be an SSAValue"
-            )
 
         # Append the induction variable stepping logic to the last body block, add
         # comparison with upper bound, and conditionally branch back into the body.
@@ -116,9 +105,20 @@ class LowerX86ScfForPattern(RewritePattern):
         assert isinstance(yield_op, x86_scf.YieldOp)
 
         mv_op = x86.ops.DS_MovOp(iv, destination=iv_reg)
-        step_op = x86.ops.RS_AddOp(mv_op.destination, step)
+        match step:
+            case SSAValue():
+                step_op = x86.ops.RS_AddOp(mv_op.destination, step)
+            case builtin.IntegerAttr():
+                step_op = x86.ops.RI_AddOp(
+                    mv_op.destination,
+                    step,
+                )
         new_iv = step_op.register_out
-        cmp_op = x86.ops.SS_CmpOp(new_iv, ub, result=RFLAGS)
+        match ub:
+            case SSAValue():
+                cmp_op = x86.ops.SS_CmpOp(new_iv, ub, result=RFLAGS)
+            case builtin.IntegerAttr():
+                cmp_op = x86.ops.SI_CmpOp(new_iv, ub)
 
         rewriter.replace(
             yield_op,
@@ -147,7 +147,14 @@ class LowerX86ScfForPattern(RewritePattern):
         rewriter.insert(
             (
                 mv_op := x86.ops.DS_MovOp(op.lb, destination=iv_reg),
-                cmp_op := x86.ops.SS_CmpOp(mv_op.destination, ub, result=RFLAGS),
+                cmp_op := (
+                    x86.ops.SS_CmpOp(mv_op.destination, ub, result=RFLAGS)
+                    if isinstance(ub, SSAValue)
+                    else x86.ops.SI_CmpOp(
+                        mv_op.destination,
+                        ub,
+                    )
+                ),
                 x86.ops.C_JgeOp(
                     cmp_op.result,
                     (mv_op.destination, *op.iter_args),

--- a/xdsl/transforms/convert_x86_scf_to_x86.py
+++ b/xdsl/transforms/convert_x86_scf_to_x86.py
@@ -1,5 +1,3 @@
-from typing import cast
-
 from xdsl.context import Context
 from xdsl.dialects import builtin, x86, x86_scf
 from xdsl.dialects.x86.registers import RFLAGS, GeneralRegisterType
@@ -117,18 +115,21 @@ class LowerX86ScfForPattern(RewritePattern):
         yield_op = last_body_block.last_op
         assert isinstance(yield_op, x86_scf.YieldOp)
 
+        mv_op = x86.ops.DS_MovOp(iv, destination=iv_reg)
+        step_op = x86.ops.RS_AddOp(mv_op.destination, step)
+        new_iv = step_op.register_out
+        cmp_op = x86.ops.SS_CmpOp(new_iv, ub, result=RFLAGS)
+
         rewriter.replace(
             yield_op,
             (
-                mv_op := x86.ops.DS_MovOp(iv, destination=iv_reg),
-                inc_op := x86.ops.R_IncOp(
-                    cast(SSAValue[GeneralRegisterType], mv_op.destination)
-                ),
-                cmp_op := x86.ops.SS_CmpOp(inc_op.register_out, ub, result=RFLAGS),
+                mv_op,
+                step_op,
+                cmp_op,
                 x86.ops.C_JlOp(
                     cmp_op.result,
-                    (inc_op.register_out, *yield_op.operands),
-                    (inc_op.register_out, *yield_op.operands),
+                    (new_iv, *yield_op.operands),
+                    (new_iv, *yield_op.operands),
                     first_body_block,
                     end_block,
                 ),
@@ -136,7 +137,7 @@ class LowerX86ScfForPattern(RewritePattern):
         )
 
         mv_op.destination.name_hint = iv.name_hint
-        inc_op.register_out.name_hint = iv.name_hint
+        step_op.register_out.name_hint = iv.name_hint
         end_block.args[0].name_hint = iv.name_hint
 
         rewriter.inline_region(op.body, BlockInsertPoint.before(end_block))

--- a/xdsl/transforms/convert_x86_scf_to_x86.py
+++ b/xdsl/transforms/convert_x86_scf_to_x86.py
@@ -1,7 +1,7 @@
 from xdsl.context import Context
 from xdsl.dialects import builtin, x86, x86_scf
 from xdsl.dialects.x86.registers import RFLAGS, GeneralRegisterType
-from xdsl.ir import SSAValue
+from xdsl.ir import Operation, SSAValue
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
     PatternRewriter,
@@ -99,6 +99,12 @@ class LowerX86ScfForPattern(RewritePattern):
         ub = op.ub
         step = op.step
 
+        # Insert label at the start of the first body block.
+        rewriter.insert(
+            x86.ops.LabelOp(f"scf_body_{suffix}"),
+            InsertPoint.at_start(first_body_block),
+        )
+
         # Append the induction variable stepping logic to the last body block, add
         # comparison with upper bound, and conditionally branch back into the body.
         yield_op = last_body_block.last_op
@@ -142,44 +148,63 @@ class LowerX86ScfForPattern(RewritePattern):
 
         rewriter.inline_region(op.body, BlockInsertPoint.before(end_block))
 
-        # Move lb to new register to initialize the iv.
-        # Skip for loop if condition is not satisfied at start.
-        rewriter.insert(
-            (
-                mv_op := x86.ops.DS_MovOp(op.lb, destination=iv_reg),
-                cmp_op := (
-                    x86.ops.SS_CmpOp(mv_op.destination, ub, result=RFLAGS)
-                    if isinstance(ub, SSAValue)
-                    else x86.ops.SI_CmpOp(
-                        mv_op.destination,
-                        ub,
-                    )
+        if (
+            isinstance(lb_owner := op.lb.owner, Operation)
+            and isinstance(lb_owner, x86.DI_MovOp)
+            and isinstance(ub, builtin.IntegerAttr)
+            and lb_owner.immediate.value.data < ub.value.data
+        ):
+            # Loop executes at least once, fallthrough directly into it without runtime checks
+            rewriter.insert(
+                (
+                    mv_op := x86.ops.DS_MovOp(op.lb, destination=iv_reg),
+                    x86.ops.FallthroughOp(
+                        (mv_op.destination, *op.iter_args),
+                        first_body_block,
+                    ),
                 ),
-                x86.ops.C_JgeOp(
-                    cmp_op.result,
-                    (mv_op.destination, *op.iter_args),
-                    (mv_op.destination, *op.iter_args),
-                    end_block,
-                    first_body_block,
+                InsertPoint.at_end(init_block),
+            )
+
+            # Replace operation by arguments to the newly added end block.
+            rewriter.replace(
+                op,
+                (),
+                end_block.args[1:],
+            )
+        else:
+            # Move lb to new register to initialize the iv.
+            # Skip for loop if condition is not satisfied at start.
+            rewriter.insert(
+                (
+                    mv_op := x86.ops.DS_MovOp(op.lb, destination=iv_reg),
+                    cmp_op := (
+                        x86.ops.SS_CmpOp(mv_op.destination, ub, result=RFLAGS)
+                        if isinstance(ub, SSAValue)
+                        else x86.ops.SI_CmpOp(
+                            mv_op.destination,
+                            ub,
+                        )
+                    ),
+                    x86.ops.C_JgeOp(
+                        cmp_op.result,
+                        (mv_op.destination, *op.iter_args),
+                        (mv_op.destination, *op.iter_args),
+                        end_block,
+                        first_body_block,
+                    ),
                 ),
-            ),
-            InsertPoint.at_end(init_block),
-        )
+                InsertPoint.at_end(init_block),
+            )
+
+            # Replace operation by arguments to the newly added end block.
+            rewriter.replace(
+                op,
+                x86.ops.LabelOp(f"scf_body_end_{suffix}"),
+                end_block.args[1:],
+            )
 
         mv_op.destination.name_hint = op.lb.name_hint
-
-        # Insert label at the start of the first body block.
-        rewriter.insert(
-            x86.ops.LabelOp(f"scf_body_{suffix}"),
-            InsertPoint.at_start(first_body_block),
-        )
-
-        # Replace operation by arguments to the newly end block.
-        rewriter.replace(
-            op,
-            x86.ops.LabelOp(f"scf_body_end_{suffix}"),
-            end_block.args[1:],
-        )
 
 
 class ConvertX86ScfToX86Pass(ModulePass):

--- a/xdsl/transforms/convert_x86_scf_to_x86.py
+++ b/xdsl/transforms/convert_x86_scf_to_x86.py
@@ -94,8 +94,8 @@ class LowerX86ScfForPattern(RewritePattern):
         last_body_block = op.body.blocks[-1]
 
         # Get the induction variable and its register
-        iv = SSAValue.get(first_body_block.args[0], type=GeneralRegisterType)
-        iv_reg = iv.type
+        iv_body = SSAValue.get(first_body_block.args[0], type=GeneralRegisterType)
+        iv_reg = iv_body.type
         ub = op.ub
         step = op.step
 
@@ -112,10 +112,10 @@ class LowerX86ScfForPattern(RewritePattern):
 
         match step:
             case SSAValue():
-                step_op = x86.ops.RS_AddOp(iv, step)
+                step_op = x86.ops.RS_AddOp(iv_body, step)
             case builtin.IntegerAttr():
                 step_op = x86.ops.RI_AddOp(
-                    iv,
+                    iv_body,
                     step,
                 )
         new_iv = step_op.register_out
@@ -140,8 +140,8 @@ class LowerX86ScfForPattern(RewritePattern):
             ),
         )
 
-        step_op.register_out.name_hint = iv.name_hint
-        end_block.args[0].name_hint = iv.name_hint
+        step_op.register_out.name_hint = iv_body.name_hint
+        end_block.args[0].name_hint = iv_body.name_hint
 
         rewriter.inline_region(op.body, BlockInsertPoint.before(end_block))
 
@@ -163,6 +163,8 @@ class LowerX86ScfForPattern(RewritePattern):
                 InsertPoint.at_end(init_block),
             )
 
+            mv_op.destination.name_hint = op.lb.name_hint
+
             # Replace operation by arguments to the newly added end block.
             rewriter.replace(
                 op,
@@ -172,21 +174,27 @@ class LowerX86ScfForPattern(RewritePattern):
         else:
             # Move lb to new register to initialize the iv.
             # Skip for loop if condition is not satisfied at start.
+            if op.lb.type == iv_reg:
+                # Just use lb for iv, no need to move to self
+                iv_condition = op.lb
+            else:
+                iv_condition = rewriter.insert(
+                    x86.ops.DS_MovOp(op.lb, destination=iv_reg),
+                    InsertPoint.at_end(init_block),
+                ).destination
+                iv_condition.name_hint = op.lb.name_hint
+
             rewriter.insert(
                 (
-                    mv_op := x86.ops.DS_MovOp(op.lb, destination=iv_reg),
                     cmp_op := (
-                        x86.ops.SS_CmpOp(mv_op.destination, ub, result=RFLAGS)
+                        x86.ops.SS_CmpOp(iv_condition, ub, result=RFLAGS)
                         if isinstance(ub, SSAValue)
-                        else x86.ops.SI_CmpOp(
-                            mv_op.destination,
-                            ub,
-                        )
+                        else x86.ops.SI_CmpOp(iv_condition, ub)
                     ),
                     x86.ops.C_JgeOp(
                         cmp_op.result,
-                        (mv_op.destination, *op.iter_args),
-                        (mv_op.destination, *op.iter_args),
+                        (iv_condition, *op.iter_args),
+                        (iv_condition, *op.iter_args),
                         end_block,
                         first_body_block,
                     ),
@@ -200,8 +208,6 @@ class LowerX86ScfForPattern(RewritePattern):
                 x86.ops.LabelOp(f"scf_body_end_{suffix}"),
                 end_block.args[1:],
             )
-
-        mv_op.destination.name_hint = op.lb.name_hint
 
 
 class ConvertX86ScfToX86Pass(ModulePass):

--- a/xdsl/transforms/convert_x86_scf_to_x86.py
+++ b/xdsl/transforms/convert_x86_scf_to_x86.py
@@ -155,6 +155,17 @@ class LowerX86ScfForPattern(RewritePattern):
 
         rewriter.inline_region(op.body, BlockInsertPoint.before(end_block))
 
+        # Move lb to new register to initialize the iv.
+        if op.lb.type == iv_reg:
+            # Just use lb for iv, no need to move to self
+            iv_condition = op.lb
+        else:
+            iv_condition = rewriter.insert(
+                x86.ops.DS_MovOp(op.lb, destination=iv_reg),
+                InsertPoint.at_end(init_block),
+            ).destination
+            iv_condition.name_hint = op.lb.name_hint
+
         if (
             isinstance(lb_owner := op.lb.owner, Operation)
             and isinstance(lb_owner, x86.DI_MovOp)
@@ -164,16 +175,13 @@ class LowerX86ScfForPattern(RewritePattern):
             # Loop executes at least once, fallthrough directly into it without runtime checks
             rewriter.insert(
                 (
-                    mv_op := x86.ops.DS_MovOp(op.lb, destination=iv_reg),
                     x86.ops.FallthroughOp(
-                        (mv_op.destination, *op.iter_args),
+                        (iv_condition, *op.iter_args),
                         first_body_block,
                     ),
                 ),
                 InsertPoint.at_end(init_block),
             )
-
-            mv_op.destination.name_hint = op.lb.name_hint
 
             # Replace operation by arguments to the newly added end block.
             rewriter.replace(
@@ -182,18 +190,7 @@ class LowerX86ScfForPattern(RewritePattern):
                 end_block.args[1:],
             )
         else:
-            # Move lb to new register to initialize the iv.
             # Skip for loop if condition is not satisfied at start.
-            if op.lb.type == iv_reg:
-                # Just use lb for iv, no need to move to self
-                iv_condition = op.lb
-            else:
-                iv_condition = rewriter.insert(
-                    x86.ops.DS_MovOp(op.lb, destination=iv_reg),
-                    InsertPoint.at_end(init_block),
-                ).destination
-                iv_condition.name_hint = op.lb.name_hint
-
             rewriter.insert(
                 (
                     cmp_op := (


### PR DESCRIPTION
This is the tracking PR for all the changes needed to optimise loops like libxsmm does. I'm currently not 100% happy with them, but the bottom of the stack is ready to merge IMO. Here are some remaining steps:

1. add regalloc legalization pass
2. one of the commits in the stack inserts a move if lb is used more than once, but this should be done by the legalization pass in step 1
3. add a new result to the loop operation that returns the final state of lb at the end of the loop. If the bounds are known, then the original state of lb can be recovered, and then that value can be used again without saving that value somewhere, increasing the register pressure.