### PR TITLE
core: remove deprecated ArgSpec.args

### DIFF
--- a/tests/test_parse_spec_format.py
+++ b/tests/test_parse_spec_format.py
@@ -113,9 +113,3 @@ def test_invalid_mlir_pipeline():
         match="Expected `mlir-opt` to mark an MLIR pipeline here",
     ):
         list(parse_pipeline("canonicalize[cse]"))
-
-
-def test_deprecated_args():
-    spec = ArgSpec("name", {"hello": ("world",)})
-    with pytest.deprecated_call():
-        assert spec.args == {"hello": ("world",)}  # pyright: ignore[reportDeprecated]

--- a/xdsl/utils/arg_spec.py
+++ b/xdsl/utils/arg_spec.py
@@ -17,7 +17,7 @@ from enum import Enum
 from types import NoneType, UnionType
 from typing import Any, ClassVar, TypeAlias, Union, get_args, get_origin, get_type_hints
 
-from typing_extensions import Self, deprecated
+from typing_extensions import Self
 
 from xdsl.utils.exceptions import ArgSpecParseError
 from xdsl.utils.lexer import Input, Span, Token
@@ -47,11 +47,6 @@ class ArgSpec:
     """
     The parameters of this argument.
     """
-
-    @property
-    @deprecated("Please use ArgSpec.parameters")
-    def args(self) -> dict[str, ParameterListType]:
-        return self.parameters
 
     def normalize_parameter_names(self) -> ArgSpec:
         """


### PR DESCRIPTION
Deprecated 4 months ago.
