### PR TITLE
transformations: (concert-x86-scf-to-x86) don't always increment by one

### DIFF
--- a/tests/filecheck/transforms/convert-x86-scf-to-x86.mlir
+++ b/tests/filecheck/transforms/convert-x86-scf-to-x86.mlir
@@ -12,7 +12,7 @@
 //  CHECK-NEXT:      x86.label "scf_body_0_for"
 //  CHECK-NEXT:      "test.op"(%offset, %src, %dst) : (!x86.reg64<r9>, !x86.reg64<rax>, !x86.reg64<rbx>) -> ()
 //  CHECK-NEXT:      %offset_1 = x86.ds.mov %offset : (!x86.reg64<r9>) -> !x86.reg64<r9>
-//  CHECK-NEXT:      %offset_2 = x86.r.inc %offset_1 : (!x86.reg64<r9>) -> !x86.reg64<r9>
+//  CHECK-NEXT:      %offset_2 = x86.rs.add %offset_1, %step : (!x86.reg64<r9>, !x86.reg64<rdx>) -> !x86.reg64<r9>
 //  CHECK-NEXT:      %1 = x86.ss.cmp %offset_2, %forty : (!x86.reg64<r9>, !x86.reg64<r8>) -> !x86.rflags<rflags>
 //  CHECK-NEXT:      x86.c.jl %1 : !x86.rflags<rflags>, ^bb1(%offset_2 : !x86.reg64<r9>), ^bb0(%offset_2 : !x86.reg64<r9>)
 //  CHECK-NEXT:    ^bb0(%offset_3: !x86.reg64<r9>):
@@ -51,13 +51,13 @@ x86_func.func @copy10(%src: !x86.reg64<rax>, %dst: !x86.reg64<rbx>) {
 //  CHECK-NEXT:      x86.label "scf_body_0_for"
 //  CHECK-NEXT:      "test.op"(%src, %dst, %offset_outer, %offset_inner) : (!x86.reg64<rax>, !x86.reg64<rbx>, !x86.reg64<r9>, !x86.reg64<r13>) -> ()
 //  CHECK-NEXT:      %offset_inner_1 = x86.ds.mov %offset_inner : (!x86.reg64<r13>) -> !x86.reg64<r13>
-//  CHECK-NEXT:      %offset_inner_2 = x86.r.inc %offset_inner_1 : (!x86.reg64<r13>) -> !x86.reg64<r13>
+//  CHECK-NEXT:      %offset_inner_2 = x86.rs.add %offset_inner_1, %step_inner : (!x86.reg64<r13>, !x86.reg64<r11>) -> !x86.reg64<r13>
 //  CHECK-NEXT:      %2 = x86.ss.cmp %offset_inner_2, %forty_inner : (!x86.reg64<r13>, !x86.reg64<r12>) -> !x86.rflags<rflags>
 //  CHECK-NEXT:      x86.c.jl %2 : !x86.rflags<rflags>, ^bb3(%offset_inner_2 : !x86.reg64<r13>), ^bb2(%offset_inner_2 : !x86.reg64<r13>)
 //  CHECK-NEXT:    ^bb2(%offset_inner_3: !x86.reg64<r13>):
 //  CHECK-NEXT:      x86.label "scf_body_end_0_for"
 //  CHECK-NEXT:      %offset_outer_1 = x86.ds.mov %offset_outer : (!x86.reg64<r9>) -> !x86.reg64<r9>
-//  CHECK-NEXT:      %offset_outer_2 = x86.r.inc %offset_outer_1 : (!x86.reg64<r9>) -> !x86.reg64<r9>
+//  CHECK-NEXT:      %offset_outer_2 = x86.rs.add %offset_outer_1, %step_outer : (!x86.reg64<r9>, !x86.reg64<rdx>) -> !x86.reg64<r9>
 //  CHECK-NEXT:      %3 = x86.ss.cmp %offset_outer_2, %forty_outer : (!x86.reg64<r9>, !x86.reg64<r8>) -> !x86.rflags<rflags>
 //  CHECK-NEXT:      x86.c.jl %3 : !x86.rflags<rflags>, ^bb1(%offset_outer_2 : !x86.reg64<r9>), ^bb0(%offset_outer_2 : !x86.reg64<r9>)
 //  CHECK-NEXT:    ^bb0(%offset_outer_3: !x86.reg64<r9>):

--- a/xdsl/transforms/convert_x86_scf_to_x86.py
+++ b/xdsl/transforms/convert_x86_scf_to_x86.py
@@ -1,5 +1,3 @@
-from typing import cast
-
 from xdsl.context import Context
 from xdsl.dialects import builtin, x86, x86_scf
 from xdsl.dialects.x86.registers import RFLAGS, GeneralRegisterType
@@ -117,18 +115,21 @@ class LowerX86ScfForPattern(RewritePattern):
         yield_op = last_body_block.last_op
         assert isinstance(yield_op, x86_scf.YieldOp)
 
+        mv_op = x86.ops.DS_MovOp(iv, destination=iv_reg)
+        step_op = x86.ops.RS_AddOp(mv_op.destination, step)
+        new_iv = step_op.register_out
+        cmp_op = x86.ops.SS_CmpOp(new_iv, ub, result=RFLAGS)
+
         rewriter.replace(
             yield_op,
             (
-                mv_op := x86.ops.DS_MovOp(iv, destination=iv_reg),
-                inc_op := x86.ops.R_IncOp(
-                    cast(SSAValue[GeneralRegisterType], mv_op.destination)
-                ),
-                cmp_op := x86.ops.SS_CmpOp(inc_op.register_out, ub, result=RFLAGS),
+                mv_op,
+                step_op,
+                cmp_op,
                 x86.ops.C_JlOp(
                     cmp_op.result,
-                    (inc_op.register_out, *yield_op.operands),
-                    (inc_op.register_out, *yield_op.operands),
+                    (new_iv, *yield_op.operands),
+                    (new_iv, *yield_op.operands),
                     first_body_block,
                     end_block,
                 ),
@@ -136,7 +137,7 @@ class LowerX86ScfForPattern(RewritePattern):
         )
 
         mv_op.destination.name_hint = iv.name_hint
-        inc_op.register_out.name_hint = iv.name_hint
+        step_op.register_out.name_hint = iv.name_hint
         end_block.args[0].name_hint = iv.name_hint
 
         rewriter.inline_region(op.body, BlockInsertPoint.before(end_block))


### PR DESCRIPTION
There's currently a bug in the lowering where `%step` isn't actually used, this PR addresses this.