### PR TITLE
core: (parser) public API for parsing affine maps

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -17,6 +17,7 @@ from xdsl.dialects.builtin import (
     FileLineColLoc,
     FloatAttr,
     FusedLoc,
+    IndexType,
     IntAttr,
     IntegerAttr,
     IntegerType,
@@ -31,6 +32,7 @@ from xdsl.dialects.builtin import (
 from xdsl.dialects.func import Func, FuncOp
 from xdsl.dialects.test import Test
 from xdsl.ir import Attribute, Block, ParametrizedAttribute
+from xdsl.ir.affine import AffineMap
 from xdsl.irdl import (
     IRDLOperation,
     irdl_attr_definition,
@@ -1492,3 +1494,59 @@ def test_parse_keyword_in_non_matching():
     parser = Parser(Context(), "other remaining")
     with pytest.raises(ParseError, match="Expected one of"):
         parser.parse_keyword_in({"fastcc", "ccc"})
+
+
+@pytest.mark.parametrize(
+    "text, expected_map, expected_names",
+    [
+        # Only constants
+        ("[3, 7]", AffineMap.from_callable(lambda: (3, 7)), ()),
+        # Just SSA dims
+        (
+            "[%i0, %i1]",
+            AffineMap.from_callable(lambda s0, s1: (s0, s1), dim_symbol_split=(0, 2)),
+            ("%i0", "%i1"),
+        ),
+        # SSA dims + const sums
+        (
+            "[%i0 + 3, %i1 + 7]",
+            AffineMap.from_callable(
+                lambda s0, s1: (s0 + 3, s1 + 7), dim_symbol_split=(0, 2)
+            ),
+            ("%i0", "%i1"),
+        ),
+        # SSA dims + complex expression
+        (
+            "[%i0 + 3, 7 * %i1 + 7]",
+            AffineMap.from_callable(
+                lambda s0, s1: (s0 + 3, 7 * s1 + 7), dim_symbol_split=(0, 2)
+            ),
+            ("%i0", "%i1"),
+        ),
+        # Same SSA value used twice resolves to the same operand
+        (
+            "[%i0, %i0 + 7]",
+            AffineMap.from_callable(lambda s0: (s0, s0 + 7), dim_symbol_split=(0, 1)),
+            ("%i0",),
+        ),
+    ],
+)
+def test_parse_affine_map_of_ssa_ids(
+    text: str, expected_map: AffineMap, expected_names: tuple[str, ...]
+):
+    ctx = Context()
+    ctx.load_dialect(Builtin)
+    ctx.load_dialect(Test)
+
+    definitions = '%i0, %i1 = "test.op"() : () -> (index, index)\n'
+    parser = Parser(ctx, definitions + text)
+    op = parser.parse_op()
+    affine_map, operands = parser.parse_affine_map_of_ssa_ids()
+
+    assert affine_map == expected_map
+
+    values_by_name = {"%i0": op.results[0], "%i1": op.results[1]}
+
+    for operand, name in zip(operands, expected_names, strict=True):
+        assert operand.type == IndexType()
+        assert operand is values_by_name[name]

--- a/xdsl/parser/core.py
+++ b/xdsl/parser/core.py
@@ -9,7 +9,7 @@ from typing import Literal, overload
 
 from xdsl.context import Context
 from xdsl.dialect_interfaces.op_asm import OpAsmDialectInterface
-from xdsl.dialects.builtin import DictionaryAttr, LocationAttr, ModuleOp
+from xdsl.dialects.builtin import DictionaryAttr, IndexType, LocationAttr, ModuleOp
 from xdsl.ir import (
     Attribute,
     Block,
@@ -17,11 +17,13 @@ from xdsl.ir import (
     Region,
     SSAValue,
 )
+from xdsl.ir.affine import AffineMap
 from xdsl.irdl import IRDLOperation
 from xdsl.utils.exceptions import MultipleSpansParseError
 from xdsl.utils.lexer import Input, Span
 from xdsl.utils.mlir_lexer import MLIRLexer, MLIRTokenKind
 
+from .affine_parser import AffineParser  # noqa: TID251
 from .attribute_parser import AttrParser  # noqa: TID251
 from .generic_parser import ParserState, Position  # noqa: TID251
 
@@ -334,6 +336,21 @@ class Parser(AttrParser):
             )
 
         return resolved
+
+    def parse_affine_map_of_ssa_ids(self) -> tuple[AffineMap, Sequence[SSAValue]]:
+        """
+        Parse an affine map of SSA identifiers, e.g.: `[%i0, %i1 + 7]`.
+        """
+        affine_map, spans = AffineParser(
+            self._parser_state
+        ).parse_affine_map_of_ssa_ids()
+
+        operands = [
+            self.resolve_operand(UnresolvedOperand(span, 0), IndexType())
+            for span in spans
+        ]
+
+        return affine_map, operands
 
     def parse_optional_operand(self) -> SSAValue | None:
         """


### PR DESCRIPTION
PR 2/4 replacing #5365 

- [x] Add spans to affine parser
- [x] Add helper method to parser to allow access to this from dialects (public API)
- [ ] Update the affine.load/store ops for custom print/parsing using this
- [ ] Add the affine.vector_load/vector_store ops with custom syntax

Allows the affine map functionality to be called within custom operation parsers