### PR TITLE
backend: (x86) make value_type optional when moving to unallocated register

### DIFF
--- a/tests/backend/x86/test_lowering_utils.py
+++ b/tests/backend/x86/test_lowering_utils.py
@@ -26,9 +26,23 @@ from xdsl.utils.test_value import create_ssa_value
             Reg64Type.unallocated(),
         ),
         (
+            arch.UNKNOWN,
+            Reg64Type,
+            None,
+            DS_MovOp,
+            Reg64Type.unallocated(),
+        ),
+        (
             arch.AVX2,
             AVX2RegisterType,
             VectorType(f64, (4,)),
+            DS_VmovapdOp,
+            AVX2RegisterType.unallocated(),
+        ),
+        (
+            arch.AVX2,
+            AVX2RegisterType,
+            None,
             DS_VmovapdOp,
             AVX2RegisterType.unallocated(),
         ),
@@ -37,17 +51,19 @@ from xdsl.utils.test_value import create_ssa_value
 def test_move_value_to_unallocated(
     arch: arch.X86Arch,
     reg_type: type[X86RegisterType],
-    value_type: Attribute,
+    value_type: Attribute | None,
     expected_op: type[DS_Operation[X86RegisterType, X86RegisterType]],
     expected_unallocated_type: object,
 ):
     block = Block()
     b = Builder(InsertPoint.at_start(block))
     src = create_ssa_value(reg_type.unallocated())
-    new = arch.move_value_to_unallocated(src, value_type, b)
+    src.name_hint = "src"
+    new = arch.move_value_to_unallocated(src, b, value_type=value_type)
     assert isinstance(new_op := new.owner, expected_op)
     assert new_op.source is src
     assert new.type == expected_unallocated_type
+    assert new.name_hint == "src"
 
 
 @pytest.mark.parametrize(

--- a/tests/filecheck/backend/x86/convert_arith_to_x86.mlir
+++ b/tests/filecheck/backend/x86/convert_arith_to_x86.mlir
@@ -10,10 +10,10 @@
 // CHECK-NEXT:   %i1 = "test.op"() : () -> i32
 // CHECK-NEXT:   %i0_1 = asm.to_reg %i0 : i32 -> !x86.reg32
 // CHECK-NEXT:   %i1_1 = asm.to_reg %i1 : i32 -> !x86.reg32
-// CHECK-NEXT:   %i2 = x86.ds.mov %i1_1 : (!x86.reg32) -> !x86.reg32
-// CHECK-NEXT:   %i2_1 = x86.rs.add %i2, %i0_1 : (!x86.reg32, !x86.reg32) -> !x86.reg32
-// CHECK-NEXT:   %i2_2 = asm.from_reg %i2_1 : !x86.reg32 -> i32
-// CHECK-NEXT:   "test.op"(%i2_2) : (i32) -> ()
+// CHECK-NEXT:   %i1_2 = x86.ds.mov %i1_1 : (!x86.reg32) -> !x86.reg32
+// CHECK-NEXT:   %i2 = x86.rs.add %i1_2, %i0_1 : (!x86.reg32, !x86.reg32) -> !x86.reg32
+// CHECK-NEXT:   %i2_1 = asm.from_reg %i2 : !x86.reg32 -> i32
+// CHECK-NEXT:   "test.op"(%i2_1) : (i32) -> ()
 // CHECK-NEXT: }
 
 // -----
@@ -36,10 +36,10 @@
 // CHECK-NEXT:   %i1 = "test.op"() : () -> i32
 // CHECK-NEXT:   %i0_1 = asm.to_reg %i0 : i32 -> !x86.reg32
 // CHECK-NEXT:   %i1_1 = asm.to_reg %i1 : i32 -> !x86.reg32
-// CHECK-NEXT:   %i2 = x86.ds.mov %i1_1 : (!x86.reg32) -> !x86.reg32
-// CHECK-NEXT:   %i2_1 = x86.rs.imul %i2, %i0_1 : (!x86.reg32, !x86.reg32) -> !x86.reg32
-// CHECK-NEXT:   %i2_2 = asm.from_reg %i2_1 : !x86.reg32 -> i32
-// CHECK-NEXT:   "test.op"(%i2_2) : (i32) -> ()
+// CHECK-NEXT:   %i1_2 = x86.ds.mov %i1_1 : (!x86.reg32) -> !x86.reg32
+// CHECK-NEXT:   %i2 = x86.rs.imul %i1_2, %i0_1 : (!x86.reg32, !x86.reg32) -> !x86.reg32
+// CHECK-NEXT:   %i2_1 = asm.from_reg %i2 : !x86.reg32 -> i32
+// CHECK-NEXT:   "test.op"(%i2_1) : (i32) -> ()
 // CHECK-NEXT: }
 
 // -----
@@ -92,15 +92,15 @@
 %f0, %f1 = "test.op"(): () -> (f32, f32)
 // CHECK-NEXT:    %f0_1 = asm.to_reg %f0 : f32 -> !x86.reg32
 // CHECK-NEXT:    %f1_1 = asm.to_reg %f1 : f32 -> !x86.reg32
-// CHECK-NEXT:    %addf = x86.ds.mov %f1_1 : (!x86.reg32) -> !x86.reg32
-// CHECK-NEXT:    %addf_1 = x86.rs.fadd %addf, %f0_1 : (!x86.reg32, !x86.reg32) -> !x86.reg32
-// CHECK-NEXT:    %addf_2 = asm.from_reg %addf_1 : !x86.reg32 -> f32
+// CHECK-NEXT:    %f1_2 = x86.ds.mov %f1_1 : (!x86.reg32) -> !x86.reg32
+// CHECK-NEXT:    %addf = x86.rs.fadd %f1_2, %f0_1 : (!x86.reg32, !x86.reg32) -> !x86.reg32
+// CHECK-NEXT:    %addf_1 = asm.from_reg %addf : !x86.reg32 -> f32
 %addf = arith.addf %f0, %f1: f32
 // CHECK-NEXT:    %f0_2 = asm.to_reg %f0 : f32 -> !x86.reg32
-// CHECK-NEXT:    %f1_2 = asm.to_reg %f1 : f32 -> !x86.reg32
-// CHECK-NEXT:    %mulf = x86.ds.mov %f1_2 : (!x86.reg32) -> !x86.reg32
-// CHECK-NEXT:    %mulf_1 = x86.rs.fmul %mulf, %f0_2 : (!x86.reg32, !x86.reg32) -> !x86.reg32
-// CHECK-NEXT:    %mulf_2 = asm.from_reg %mulf_1 : !x86.reg32 -> f32
+// CHECK-NEXT:    %f1_3 = asm.to_reg %f1 : f32 -> !x86.reg32
+// CHECK-NEXT:    %f1_4 = x86.ds.mov %f1_3 : (!x86.reg32) -> !x86.reg32
+// CHECK-NEXT:    %mulf = x86.rs.fmul %f1_4, %f0_2 : (!x86.reg32, !x86.reg32) -> !x86.reg32
+// CHECK-NEXT:    %mulf_1 = asm.from_reg %mulf : !x86.reg32 -> f32
 %mulf = arith.mulf %f0, %f1: f32
 "test.op"(%addf, %mulf) : (f32, f32) -> ()
-// CHECK-NEXT:    "test.op"(%addf_2, %mulf_2) : (f32, f32) -> ()
+// CHECK-NEXT:    "test.op"(%addf_1, %mulf_1) : (f32, f32) -> ()

--- a/xdsl/backend/x86/arch.py
+++ b/xdsl/backend/x86/arch.py
@@ -113,9 +113,18 @@ class X86Arch(Arch):
         ]
 
     def move_value_to_unallocated(
-        self, value: SSAValue, value_type: Attribute, builder: Builder
+        self,
+        value: SSAValue,
+        builder: Builder,
+        *,
+        value_type: Attribute | None,
     ) -> SSAValue:
-        if isa(value_type, VectorType[FixedBitwidthType]):
+        """
+        Move the value to a new register.
+        If the value type is known, use a specialised move operation, otherwise use a
+        default move operation for the input register.
+        """
+        if value_type is not None and isa(value_type, VectorType[FixedBitwidthType]):
             if not isinstance(reg_type := value.type, X86VectorRegisterType):
                 raise ValueError(f"Invalid type for move {value_type}")
             # Choose the x86 vector instruction according to the
@@ -137,12 +146,19 @@ class X86Arch(Arch):
                     raise DiagnosticException(
                         "Float precision must be half, single or double."
                     )
-        else:
-            if not isinstance(reg_type := value.type, GeneralRegisterType):
-                raise ValueError(f"Invalid type for move {value_type}")
+        elif isinstance(reg_type := value.type, X86VectorRegisterType):
+            # In the future, we want to be more careful about register types.
+            mov_op = x86.ops.DS_VmovapdOp(
+                value, destination=type(reg_type).unallocated()
+            )
+        elif isinstance(reg_type, GeneralRegisterType):
             mov_op = x86.DS_MovOp(value, destination=type(reg_type).unallocated())
+        else:
+            raise ValueError(f"Invalid type for move {value.type}")
 
-        return builder.insert(mov_op).results[0]
+        result = builder.insert(mov_op).results[0]
+        result.name_hint = value.name_hint
+        return result
 
 
 UNKNOWN = X86Arch()

--- a/xdsl/backend/x86/lowering/convert_arith_to_x86.py
+++ b/xdsl/backend/x86/lowering/convert_arith_to_x86.py
@@ -64,7 +64,7 @@ class ArithBinaryToX86(RewritePattern):
 
         lhs_x86, rhs_x86 = self.arch.cast_to_regs(op.operands, rewriter)
         moved_rhs = self.arch.move_value_to_unallocated(
-            rhs_x86, op.operands[1].type, rewriter
+            rhs_x86, rewriter, value_type=op.operands[1].type
         )
         add_op = new_type(source=lhs_x86, register_in=moved_rhs)
         result_cast_op = asm.FromRegOp.get(add_op.register_out, lhs.type)

--- a/xdsl/transforms/convert_scf_to_x86_scf.py
+++ b/xdsl/transforms/convert_scf_to_x86_scf.py
@@ -49,7 +49,7 @@ class ScfForLowering(RewritePattern):
         cast_block_args_to_regs(new_region.block, self.arch, rewriter)
 
         values = tuple(
-            self.arch.move_value_to_unallocated(value, value_type, rewriter)
+            self.arch.move_value_to_unallocated(value, rewriter, value_type=value_type)
             for value, value_type in zip(args, op.iter_args.types)
         )
 


### PR DESCRIPTION
Also small drive-by fix in which name the new value takes on. Previously we didn't specify what the name_hint should be, but now it's copied from the register being moved.