### PR TITLE
core: (assembly format) fix optional typed attribute parsing

### DIFF
--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -611,6 +611,37 @@ def test_optional_qualified_property(program: str, generic_program: str):
     "program, generic_program",
     [
         (
+            "test.optional_typed_property of",
+            '"test.optional_typed_property"() : () -> ()',
+        ),
+        (
+            "test.optional_typed_property 3 of",
+            '"test.optional_typed_property"() <{prop = 3 : i32}> : () -> ()',
+        ),
+    ],
+)
+def test_optional_typed_property(program: str, generic_program: str):
+    """Test the parsing of an optional property with a unique typed base."""
+
+    @irdl_op_definition
+    class OptionalTypedPropertyOp(IRDLOperation):
+        name = "test.optional_typed_property"
+        prop = opt_prop_def(IntegerAttr.constr(type=i32))
+
+        assembly_format = "($prop^)? `of` attr-dict"
+
+    ctx = Context()
+    ctx.load_op(OptionalTypedPropertyOp)
+    ctx.load_dialect(Test)
+
+    check_roundtrip(program, ctx)
+    check_equivalence(program, generic_program, ctx)
+
+
+@pytest.mark.parametrize(
+    "program, generic_program",
+    [
+        (
             "test.optional_property()",
             '"test.optional_property"() : () -> ()',
         ),

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -47,7 +47,7 @@ from xdsl.irdl import (
 )
 from xdsl.parser import AttrParser, Parser, UnresolvedOperand
 from xdsl.printer import Printer
-from xdsl.utils.exceptions import PyRDLError, VerifyException
+from xdsl.utils.exceptions import ParseError, PyRDLError, VerifyException
 from xdsl.utils.hints import isa
 from xdsl.utils.mlir_lexer import PunctuationSpelling
 
@@ -1271,6 +1271,15 @@ class TypedAttributeVariable(UniqueBaseAttributeVariable):
     def parse_attr(self, parser: Parser) -> Attribute | None:
         unique_base = self.unique_base
         assert issubclass(unique_base, TypedAttribute)
+        if self.is_optional:
+            # `parse_with_type` has no optional counterpart, so backtrack to the
+            # start of the attribute if nothing parseable is there.
+            pos = parser.pos
+            try:
+                return unique_base.parse_with_type(parser, self.unique_type)
+            except ParseError:
+                parser._resume_from(pos)  # pyright: ignore[reportPrivateUsage]
+                return None
         return unique_base.parse_with_type(parser, self.unique_type)
 
     def print_attr(self, printer: Printer, attr: Attribute) -> None:


### PR DESCRIPTION
Closes #5562.

An optional attribute variable whose constraint pins a unique typed base is parsed through `TypedAttribute.parse_with_type`, which has no optional counterpart and raises rather than returning `None`. So in an optional group like `` ($index^)? `of` ``, the *absent* case failed with `Expected integer literal` instead of skipping the group — this is what broke `pdl_interp.get_operands`' assembly format.

`TypedAttributeVariable.parse_attr` now backtracks to the attribute's start position and returns `None` when the parse fails in the optional case, matching the optional contract the sibling `AttributeVariable` implementations already honour.

Regression test added in `tests/irdl/test_declarative_assembly_format.py` alongside the existing optional-property tests, covering both the present and absent forms; it fails on `main` and passes with the fix.
