### PR TITLE
dialects: (builtin) remove AnySignlessIntegerOrIndexType

### DIFF
--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -50,7 +50,6 @@ from xdsl.ir.affine import (
 from xdsl.irdl import (
     AnyAttr,
     AnyInt,
-    AnyOf,
     AttrConstraint,
     BaseAttr,
     ConstraintContext,
@@ -1042,10 +1041,6 @@ _IntegerAttrType = TypeVar(
 )
 _IntegerAttrTypeInvT = TypeVar("_IntegerAttrTypeInvT", bound=IntegerType | IndexType)
 IntegerAttrTypeConstr = IndexTypeConstr | BaseAttr(IntegerType)
-AnySignlessIntegerOrIndexType: TypeAlias = Annotated[
-    Attribute, AnyOf.get(IndexType, SignlessIntegerConstraint)
-]
-"""Type alias constrained to IndexType or signless IntegerType."""
 
 
 @irdl_attr_definition

--- a/xdsl/dialects/tensor.py
+++ b/xdsl/dialects/tensor.py
@@ -9,7 +9,7 @@ from typing_extensions import Self
 from xdsl.dialects.builtin import (
     DYNAMIC_INDEX,
     I64,
-    AnySignlessIntegerOrIndexType,
+    AnySignlessIntegerType,
     ArrayAttr,
     ArrayOfConstraint,
     DenseArrayBase,
@@ -366,7 +366,7 @@ class ReshapeOp(IRDLOperation):
     name = "tensor.reshape"
 
     source = operand_def(TensorType[Attribute])
-    shape = operand_def(TensorType[AnySignlessIntegerOrIndexType])
+    shape = operand_def(TensorType[AnySignlessIntegerType | IndexType])
     result = result_def(TensorType[Attribute])
     assembly_format = "attr-dict $source `(` $shape `)` `:` `(` type($source) `,` type($shape) `)` `->` type($result)"
 


### PR DESCRIPTION
I'm not sure Annotated even works any more, and in any case this alias is completely unnecessary as `AnySignlessIntegerType | IndexType` is basically the same length