### PR TITLE
dialects: (builtin) use AnyOf for ContainerOf

### DIFF
--- a/tests/dialects/test_builtin.py
+++ b/tests/dialects/test_builtin.py
@@ -16,7 +16,6 @@ from xdsl.dialects.builtin import (
     BoolAttr,
     BytesAttr,
     ComplexType,
-    ContainerOf,
     DenseArrayBase,
     DenseIntOrFPElementsAttr,
     FloatAttr,
@@ -43,6 +42,7 @@ from xdsl.dialects.builtin import (
     VectorRankConstraint,
     VectorType,
     bf16,
+    container_of,
     f4E2M1FN,
     f6E2M3FN,
     f6E3M2FN,
@@ -1346,9 +1346,13 @@ def test_array_of_constraint():
         BaseAttr(B)
     )
 
-    container_constraint = ContainerOf(TypeVarConstraint(_A, BaseAttr(A)))
 
-    assert container_constraint.mapping_type_vars({_A: BaseAttr(B)}) == ContainerOf(
+def test_container_of_constraint():
+    """Test mapping type variables in ContainerOf."""
+
+    container_constraint = container_of(TypeVarConstraint(_A, BaseAttr(A)))
+
+    assert container_constraint.mapping_type_vars({_A: BaseAttr(B)}) == container_of(
         BaseAttr(B)
     )
 

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -10,7 +10,6 @@ from xdsl.dialect_interfaces.constant_materialization import (
 from xdsl.dialects.builtin import (
     AnyFloat,
     AnyFloatConstr,
-    ContainerOf,
     DenseIntOrFPElementsAttr,
     DenseResourceAttr,
     FixedBitwidthType,
@@ -25,6 +24,7 @@ from xdsl.dialects.builtin import (
     TensorType,
     UnrankedTensorType,
     VectorType,
+    container_of,
 )
 from xdsl.dialects.utils import BitEnumAttribute, FastMathAttrBase, FastMathFlag
 from xdsl.interfaces import ConditionallySpeculatableInterface, HasFolderInterface
@@ -63,9 +63,9 @@ from xdsl.utils.hints import isa
 from xdsl.utils.str_enum import StrEnum
 from xdsl.utils.type import get_element_type_or_self, have_compatible_shape
 
-boolLike = ContainerOf(IntegerType(1))
-signlessIntegerLike = ContainerOf(AnyOf.get(IntegerType, IndexType))
-floatingPointLike = ContainerOf(AnyFloatConstr)
+boolLike = container_of(IntegerType(1))
+signlessIntegerLike = container_of(AnyOf.get(IntegerType, IndexType))
+floatingPointLike = container_of(AnyFloat)
 
 
 CMPI_COMPARISON_OPERATIONS = [
@@ -1191,11 +1191,11 @@ class BitcastOp(IRDLOperation):
     name = "arith.bitcast"
 
     input = operand_def(
-        ContainerOf(AnyOf.get(IntegerType, IndexType, AnyFloatConstr))
+        container_of(IntegerType | IndexType | AnyFloat)
         | MemRefType.constr(element_type=AnyFloatConstr | SignlessIntegerConstraint)
     )
     result = result_def(
-        ContainerOf(AnyOf.get(IntegerType, IndexType, AnyFloatConstr))
+        container_of(IntegerType | IndexType | AnyFloat)
         | MemRefType.constr(element_type=AnyFloatConstr | SignlessIntegerConstraint)
     )
 

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -18,6 +18,7 @@ from typing import (
     cast,
     overload,
 )
+from warnings import deprecated
 
 from immutabledict import immutabledict
 from typing_extensions import Self, TypeForm, TypeVar, override
@@ -2249,40 +2250,11 @@ def container_of(
     return AnyOf.get(constr, VectorType.constr(constr), TensorType.constr(constr))
 
 
-@dataclass(frozen=True, init=False)
-class ContainerOf(
-    AttrConstraint[
-        AttributeCovT | VectorType[AttributeCovT] | TensorType[AttributeCovT]
-    ],
-    Generic[AttributeCovT],
+@deprecated("Please use `container_of` instead")
+def ContainerOf(
+    constr: IRDLAttrConstraint[AttributeInvT],
 ):
-    """A type constraint that can be nested once in a vector or a tensor."""
-
-    elem_constr: AttrConstraint[AttributeCovT]
-
-    def __init__(
-        self,
-        elem_constr: (
-            AttributeCovT | type[AttributeCovT] | AttrConstraint[AttributeCovT]
-        ),
-    ) -> None:
-        object.__setattr__(self, "elem_constr", irdl_to_attr_constraint(elem_constr))
-
-    def verify(self, attr: Attribute, constraint_context: ConstraintContext) -> None:
-        if isa(attr, VectorType) or isa(attr, TensorType):
-            self.elem_constr.verify(attr.element_type, constraint_context)
-        else:
-            self.elem_constr.verify(attr, constraint_context)
-
-    def get_bases(self) -> set[type[Attribute]] | None:
-        bases = self.elem_constr.get_bases()
-        if bases is not None:
-            return {*bases, TensorType, VectorType}
-
-    def mapping_type_vars(
-        self, type_var_mapping: Mapping[TypeVar, AttrConstraint | IntConstraint]
-    ) -> ContainerOf[AttributeCovT]:
-        return ContainerOf(self.elem_constr.mapping_type_vars(type_var_mapping))
+    container_of(constr)
 
 
 VectorOrTensorOf: TypeAlias = (

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -50,6 +50,7 @@ from xdsl.ir.affine import (
 from xdsl.irdl import (
     AnyAttr,
     AnyInt,
+    AnyOf,
     AttrConstraint,
     BaseAttr,
     ConstraintContext,
@@ -2134,15 +2135,15 @@ class VectorType(
 
     @staticmethod
     def constr(
-        element_type: IRDLAttrConstraint[AttributeCovT] | None = None,
+        element_type: IRDLAttrConstraint[AttributeInvT] | None = None,
         *,
         shape: IRDLAttrConstraint[ArrayAttr[IntAttr]] | None = None,
         scalable_dims: IRDLAttrConstraint[ArrayAttr[BoolAttr]] | None = None,
-    ) -> AttrConstraint[VectorType[AttributeCovT]]:
+    ) -> AttrConstraint[VectorType[AttributeInvT]]:
         shape_constr = AnyAttr() if shape is None else shape
         scalable_dims_constr = AnyAttr() if scalable_dims is None else scalable_dims
         return cast(
-            AttrConstraint[VectorType[AttributeCovT]],
+            AttrConstraint[VectorType[AttributeInvT]],
             ParamAttrConstraint.get(
                 VectorType,
                 element_type,
@@ -2238,6 +2239,14 @@ class UnrankedTensorType(
 
 AnyUnrankedTensorType: TypeAlias = UnrankedTensorType[Attribute]
 AnyUnrankedTensorTypeConstr = BaseAttr[AnyUnrankedTensorType](UnrankedTensorType)
+
+
+def container_of(
+    constr: IRDLAttrConstraint[AttributeInvT],
+) -> AttrConstraint[
+    AttributeInvT | VectorType[AttributeInvT] | TensorType[AttributeInvT]
+]:
+    return AnyOf.get(constr, VectorType.constr(constr), TensorType.constr(constr))
 
 
 @dataclass(frozen=True, init=False)

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -18,10 +18,9 @@ from typing import (
     cast,
     overload,
 )
-from warnings import deprecated
 
 from immutabledict import immutabledict
-from typing_extensions import Self, TypeForm, TypeVar, override
+from typing_extensions import Self, TypeForm, TypeVar, deprecated, override
 
 from xdsl.dialect_interfaces.op_asm import OpAsmDialectInterface
 from xdsl.ir import (

--- a/xdsl/dialects/math.py
+++ b/xdsl/dialects/math.py
@@ -12,14 +12,13 @@ from typing import ClassVar
 
 from xdsl.dialects.arith import FastMathFlagsAttr
 from xdsl.dialects.builtin import (
-    AnyFloatConstr,
-    ContainerOf,
+    AnyFloat,
+    AnySignlessIntegerType,
     IndexType,
-    SignlessIntegerConstraint,
+    container_of,
 )
 from xdsl.ir import Dialect, Operation, SSAValue
 from xdsl.irdl import (
-    AnyOf,
     IRDLOperation,
     VarConstraint,
     irdl_op_definition,
@@ -30,8 +29,8 @@ from xdsl.irdl import (
 )
 from xdsl.traits import Pure, SameOperandsAndResultType
 
-signlessIntegerLike = ContainerOf(AnyOf.get(SignlessIntegerConstraint, IndexType))
-floatingPointLike = ContainerOf(AnyFloatConstr)
+signlessIntegerLike = container_of(AnySignlessIntegerType | IndexType)
+floatingPointLike = container_of(AnyFloat)
 
 
 class SignlessIntegerLikeUnaryMathOperation(IRDLOperation, abc.ABC):

--- a/xdsl/dialects/pdl_interp.py
+++ b/xdsl/dialects/pdl_interp.py
@@ -12,7 +12,6 @@ from xdsl.dialects.builtin import (
     I32,
     ArrayAttr,
     BoolAttr,
-    ContainerOf,
     DenseIntElementsAttr,
     DictionaryAttr,
     Float16Type,
@@ -27,6 +26,7 @@ from xdsl.dialects.builtin import (
     SymbolRefAttr,
     UnitAttr,
     VectorType,
+    container_of,
     i16,
     i32,
 )
@@ -51,7 +51,6 @@ from xdsl.ir import (
 )
 from xdsl.irdl import (
     AnyAttr,
-    AnyOf,
     AttrConstraint,
     AttrSizedOperandSegments,
     ConstraintContext,
@@ -91,9 +90,9 @@ from xdsl.traits import (
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.hints import isa
 
-boolLike = ContainerOf(IntegerType(1))
-signlessIntegerLike = ContainerOf(AnyOf.get(IntegerType, IndexType))
-floatingPointLike = ContainerOf(AnyOf.get(Float16Type, Float32Type, Float64Type))
+boolLike = container_of(IntegerType(1))
+signlessIntegerLike = container_of(IntegerType | IndexType)
+floatingPointLike = container_of(Float16Type | Float32Type | Float64Type)
 
 
 @irdl_op_definition

--- a/xdsl/dialects/polynomial.py
+++ b/xdsl/dialects/polynomial.py
@@ -17,11 +17,10 @@ from typing import ClassVar
 
 from xdsl.dialects.builtin import (
     AnyFloat,
-    AnyFloatConstr,
     ArrayAttr,
-    ContainerOf,
     FloatAttr,
     StringAttr,
+    container_of,
     f64,
 )
 from xdsl.ir import (
@@ -232,7 +231,7 @@ class EvalOp(IRDLOperation):
 
     name = "polynomial.eval"
 
-    T: ClassVar = VarConstraint("T", ContainerOf(AnyFloatConstr))
+    T: ClassVar = VarConstraint("T", container_of(AnyFloat))
 
     value = operand_def(T)
     result = result_def(T)

--- a/xdsl/dialects/varith.py
+++ b/xdsl/dialects/varith.py
@@ -6,7 +6,6 @@ from typing_extensions import Self
 
 from xdsl.dialects.builtin import (
     BFloat16Type,
-    ContainerOf,
     DenseIntElementsAttr,
     Float16Type,
     Float32Type,
@@ -16,11 +15,11 @@ from xdsl.dialects.builtin import (
     IndexType,
     IntegerType,
     VectorType,
+    container_of,
 )
 from xdsl.ir import Attribute, Dialect, Operation, SSAValue
 from xdsl.irdl import (
     AnyAttr,
-    AnyOf,
     IRDLOperation,
     VarConstraint,
     irdl_op_definition,
@@ -35,17 +34,15 @@ from xdsl.printer import Printer
 from xdsl.traits import Pure
 from xdsl.utils.hints import isa
 
-integerOrFloatLike = ContainerOf(
-    AnyOf.get(
-        IntegerType,
-        IndexType,
-        BFloat16Type,
-        Float16Type,
-        Float32Type,
-        Float64Type,
-        Float80Type,
-        Float128Type,
-    )
+integerOrFloatLike = container_of(
+    IntegerType
+    | IndexType
+    | BFloat16Type
+    | Float16Type
+    | Float32Type
+    | Float64Type
+    | Float80Type
+    | Float128Type
 )
 
 


### PR DESCRIPTION
There seems to be no downside to just using AnyOf in place of ContainerOf. I'm not really sure why ContainerOf exists. I'd therefore like to remove it, but it should likely be properly deprecated. 

It feels like the cleanest thing is to add the function in this PR, and then deprecate the class saying to instead use this function? Should I do this all in the same PR?

