### PR TITLE
backend: verify counts of declarations in HasRegisterConstraints

### DIFF
--- a/tests/backend/test_register_allocation.py
+++ b/tests/backend/test_register_allocation.py
@@ -31,7 +31,7 @@ from xdsl.irdl import (
     var_operand_def,
     var_result_def,
 )
-from xdsl.utils.exceptions import DiagnosticException
+from xdsl.utils.exceptions import DiagnosticException, VerifyException
 from xdsl.utils.test_value import create_ssa_value
 
 
@@ -412,6 +412,91 @@ def test_multiple_outputs():
 
     # Check allocated registers are unique
     assert len(op.result_types) == len(set(op.result_types))
+
+
+def test_verify_register_constraints():
+    u = TestRegisterType.unallocated()
+
+    # Correctly implemented `get_register_constraints` passes verification
+    op([create_ssa_value(u)], u, inouts=[create_ssa_value(u)]).verify()
+
+    # A value may be read as an `in` register and also clobbered as an `inout` register,
+    # as long as it is declared once per operand.
+    shared = create_ssa_value(u)
+    op([shared], u, inouts=[shared]).verify()
+
+    # The same holds for a value clobbered by more than one `inout` register.
+    op([], u, inouts=[shared, shared]).verify()
+
+    unrelated = create_ssa_value(u)
+
+    class MisconstrainedOp(HasRegisterConstraints, IRDLOperation):
+        T: ClassVar = VarConstraint("T", base(TestRegisterType))
+
+        a = operand_def(T)
+        b = result_def(T)
+
+    @irdl_op_definition
+    class UndeclaredOperandOp(MisconstrainedOp):
+        name = "test.undeclared_operand"
+
+        def get_register_constraints(self) -> RegisterConstraints:
+            return RegisterConstraints((), (self.b,), ())
+
+    @irdl_op_definition
+    class RepeatedOperandOp(MisconstrainedOp):
+        name = "test.repeated_operand"
+
+        def get_register_constraints(self) -> RegisterConstraints:
+            return RegisterConstraints((self.a, self.a), (self.b,), ())
+
+    @irdl_op_definition
+    class UndeclaredResultOp(MisconstrainedOp):
+        name = "test.undeclared_result"
+
+        def get_register_constraints(self) -> RegisterConstraints:
+            return RegisterConstraints((self.a,), (), ())
+
+    @irdl_op_definition
+    class RepeatedResultOp(MisconstrainedOp):
+        name = "test.repeated_result"
+
+        def get_register_constraints(self) -> RegisterConstraints:
+            return RegisterConstraints((self.a,), (self.b, self.b), ())
+
+    @irdl_op_definition
+    class ForeignValueOp(MisconstrainedOp):
+        name = "test.foreign_value"
+
+        def get_register_constraints(self) -> RegisterConstraints:
+            return RegisterConstraints((self.a, unrelated), (self.b,), ())
+
+    for op_type, message in (
+        (
+            UndeclaredOperandOp,
+            "Operation test.undeclared_operand operand at index 0 is declared 0 times as `in` or `inout`, expected 1.",
+        ),
+        (
+            RepeatedOperandOp,
+            "Operation test.repeated_operand operand at index 0 is declared 2 times as `in` or `inout`, expected 1.",
+        ),
+        (
+            UndeclaredResultOp,
+            "Operation test.undeclared_result result at index 0 is declared 0 times as `out` or `inout`, expected 1.",
+        ),
+        (
+            RepeatedResultOp,
+            "Operation test.repeated_result result at index 0 is declared 2 times as `out` or `inout`, expected 1.",
+        ),
+        (
+            ForeignValueOp,
+            "Operation test.foreign_value declares values as `in` or `inout` that it "
+            "does not use as operands.",
+        ),
+    ):
+        misconstrained = op_type(operands=[create_ssa_value(u)], result_types=[u])
+        with pytest.raises(VerifyException, match=re.escape(message)):
+            misconstrained.verify()
 
 
 def test_fail_error_message():

--- a/xdsl/backend/register_allocatable.py
+++ b/xdsl/backend/register_allocatable.py
@@ -1,5 +1,6 @@
 import abc
-from collections.abc import Iterator, Sequence
+from collections import Counter
+from collections.abc import Iterator, Mapping, Sequence
 from collections.abc import Set as AbstractSet
 from typing import NamedTuple
 
@@ -7,7 +8,7 @@ from typing_extensions import deprecated
 
 from xdsl.backend.register_allocator import BlockAllocator
 from xdsl.backend.register_type import RegisterAllocatedMemoryEffect, RegisterType
-from xdsl.ir import Operation, Region, SSAValue
+from xdsl.ir import Operation, OpResult, Region, SSAValue, SSAValueCovT
 from xdsl.irdl import traits_def
 from xdsl.traits import OpTrait
 from xdsl.utils.exceptions import VerifyException
@@ -77,16 +78,45 @@ class RegisterConstraints(NamedTuple):
     """
 
     ins: Sequence[SSAValue]
-    outs: Sequence[SSAValue]
-    inouts: Sequence[Sequence[SSAValue]]
+    outs: Sequence[OpResult]
+    inouts: Sequence[tuple[SSAValue, OpResult]]
+
+
+def _verify_declared_once(
+    op_name: str,
+    kind: str,
+    values: Sequence[SSAValueCovT],
+    declared: Mapping[SSAValueCovT, int],
+    roles: str,
+) -> None:
+    """
+    Verify that each of `values` is declared as many times as it occurs.
+    Counting occurrences rather than testing membership lets a value taking several
+    roles be declared once per role, as when an operation reads a value and also
+    clobbers it.
+    """
+    occurrences = Counter(values)
+    if declared == occurrences:
+        return
+    for index, value in enumerate(values):
+        if declared[value] != occurrences[value]:
+            raise VerifyException(
+                f"Operation {op_name} {kind} at index {index} is declared "
+                f"{declared[value]} times as {roles}, expected {occurrences[value]}."
+            )
+    raise VerifyException(
+        f"Operation {op_name} declares values as {roles} that it does not use as "
+        f"{kind}s."
+    )
 
 
 class HasRegisterConstraintsTrait(OpTrait):
     """
     Trait that verifies that the operation implements HasRegisterConstraints, and that
-    its inout operands are used only once.
-    Using an inout operand more than once breaks SSA, as the register will hold an
-    unexpected value after being mutated by this operation.
+    its constraints account for each operand and result as many times as it occurs.
+    An operand is declared by `ins` or `inouts`, a result by `outs` or `inouts`. A value
+    occupying several operands is declared once per operand, so an operation may read a
+    value as an `in` register and also clobber it as an `inout` register.
     """
 
     def verify(self, op: Operation) -> None:
@@ -94,6 +124,21 @@ class HasRegisterConstraintsTrait(OpTrait):
             raise VerifyException(
                 f"Operation {op.name} is not a subclass of {HasRegisterConstraints.__name__}."
             )
+        ins, outs, inouts = op.get_register_constraints()
+
+        declared_operands = Counter(ins)
+        declared_results = Counter(outs)
+        # A value cannot be both an operand and a result of the same operation, so
+        # membership tells which side of the constraint each inout value belongs to.
+        for operand, result in inouts:
+            declared_operands[operand] += 1
+            declared_results[result] += 1
+        _verify_declared_once(
+            op.name, "operand", op.operands, declared_operands, "`in` or `inout`"
+        )
+        _verify_declared_once(
+            op.name, "result", op.results, declared_results, "`out` or `inout`"
+        )
 
 
 class HasRegisterConstraints(RegisterAllocatableOperation, abc.ABC):


### PR DESCRIPTION
Adds more robust verification of register constraints. This would be even more robust if we had uses instead of operands, as we currently don't know which operand corresponds to which use, but we don't have an ergonomic way to get the uses in xDSL.