### PR TITLE
backend: (x86) move value to unallocated in specified insertion point

### DIFF
--- a/tests/backend/x86/test_lowering_utils.py
+++ b/tests/backend/x86/test_lowering_utils.py
@@ -66,6 +66,27 @@ def test_move_value_to_unallocated(
     assert new.name_hint == "src"
 
 
+def test_move_value_to_unallocated_insertion_point():
+    """An explicit insertion point inserts before the pointed-to op, not at the builder cursor."""
+    dest = Reg64Type.unallocated()
+    block = Block(
+        (
+            first := DS_MovOp(create_ssa_value(dest), destination=dest),
+            second := DS_MovOp(create_ssa_value(dest), destination=dest),
+        )
+    )
+    assert list(block.ops) == [first, second]
+
+    src = create_ssa_value(dest)
+    new = arch.UNKNOWN.move_value_to_unallocated(
+        src,
+        Builder(InsertPoint.before(first)),  # builder insert point gets ignored
+        value_type=None,
+        insertion_point=InsertPoint.before(second),  # this insert point gets used
+    )
+    assert list(block.ops) == [first, new.owner, second]
+
+
 @pytest.mark.parametrize(
     "arch",
     [arch.AVX2, arch.AVX512, arch.UNKNOWN],

--- a/xdsl/backend/x86/arch.py
+++ b/xdsl/backend/x86/arch.py
@@ -24,6 +24,7 @@ from xdsl.dialects.x86.registers import (
     X86VectorRegisterType,
 )
 from xdsl.ir import Attribute, SSAValue
+from xdsl.rewriter import InsertPoint
 from xdsl.utils.exceptions import DiagnosticException
 from xdsl.utils.hints import isa
 
@@ -118,6 +119,7 @@ class X86Arch(Arch):
         builder: Builder,
         *,
         value_type: Attribute | None,
+        insertion_point: InsertPoint | None = None,
     ) -> SSAValue:
         """
         Move the value to a new register.
@@ -156,7 +158,7 @@ class X86Arch(Arch):
         else:
             raise ValueError(f"Invalid type for move {value.type}")
 
-        result = builder.insert(mov_op).results[0]
+        result = builder.insert(mov_op, insertion_point).results[0]
         result.name_hint = value.name_hint
         return result
 


### PR DESCRIPTION
Little helper to make it less tedious to juggle insertion points when inserting copies, avoids relying on mutating state in the builder.