### PR TITLE
testing: add test.allocatable and use in unit tests

### DIFF
--- a/tests/backend/test_register_allocation.py
+++ b/tests/backend/test_register_allocation.py
@@ -67,8 +67,6 @@ class TestAliasRegisterB(RegisterType):
         return "test.alias_pool"
 
 
-
-
 def op(
     ins: Sequence[SSAValue],
     *out_result_types: Attribute,

--- a/tests/backend/test_register_allocation.py
+++ b/tests/backend/test_register_allocation.py
@@ -15,11 +15,9 @@ from xdsl.backend.register_allocator import ValueAllocator
 from xdsl.backend.register_stack import OutOfRegisters, RegisterStack
 from xdsl.backend.register_type import RegisterAllocatedMemoryEffect, RegisterType
 from xdsl.builder import Builder
-from xdsl.dialects.test import TestOp, TestRegisterType
+from xdsl.dialects.test import TestAllocatableOp, TestOp, TestRegisterType
 from xdsl.ir import Attribute, Block, SSAValue
 from xdsl.irdl import (
-    AttrSizedOperandSegments,
-    AttrSizedResultSegments,
     IRDLOperation,
     VarConstraint,
     base,
@@ -69,37 +67,6 @@ class TestAliasRegisterB(RegisterType):
         return "test.alias_pool"
 
 
-@irdl_op_definition
-class TestAllocatableOp(IRDLOperation, HasRegisterConstraints):
-    name = "test.allocatable"
-
-    in_operands = var_operand_def()
-    inout_operands = var_operand_def()
-    out_results = var_result_def()
-    inout_results = var_result_def()
-
-    traits = traits_def(RegisterAllocatedMemoryEffect())
-
-    irdl_options = (AttrSizedOperandSegments(), AttrSizedResultSegments())
-
-    def __init__(
-        self,
-        in_operands: Sequence[SSAValue],
-        inout_operands: Sequence[SSAValue],
-        out_result_types: Sequence[Attribute],
-        inout_result_types: Sequence[Attribute],
-    ):
-        super().__init__(
-            operands=(in_operands, inout_operands),
-            result_types=(out_result_types, inout_result_types),
-        )
-
-    def get_register_constraints(self) -> RegisterConstraints:
-        return RegisterConstraints(
-            self.in_operands,
-            self.out_results,
-            tuple(zip(self.inout_operands, self.inout_results)),
-        )
 
 
 def op(

--- a/tests/backend/test_register_allocation.py
+++ b/tests/backend/test_register_allocation.py
@@ -15,7 +15,7 @@ from xdsl.backend.register_allocator import ValueAllocator
 from xdsl.backend.register_stack import OutOfRegisters, RegisterStack
 from xdsl.backend.register_type import RegisterAllocatedMemoryEffect, RegisterType
 from xdsl.builder import Builder
-from xdsl.dialects.test import TestAllocatableOp, TestOp, TestRegisterType
+from xdsl.dialects.test import TestHasRegisterConstraintsOp, TestOp, TestRegisterType
 from xdsl.ir import Attribute, Block, SSAValue
 from xdsl.irdl import (
     IRDLOperation,
@@ -72,7 +72,7 @@ def op(
     *out_result_types: Attribute,
     inouts: Sequence[SSAValue] = (),
 ):
-    return TestAllocatableOp(
+    return TestHasRegisterConstraintsOp(
         ins, inouts, out_result_types, tuple(val.type for val in inouts)
     )
 

--- a/tests/backend/test_register_allocation.py
+++ b/tests/backend/test_register_allocation.py
@@ -15,7 +15,7 @@ from xdsl.backend.register_allocator import ValueAllocator
 from xdsl.backend.register_stack import OutOfRegisters, RegisterStack
 from xdsl.backend.register_type import RegisterAllocatedMemoryEffect, RegisterType
 from xdsl.builder import Builder
-from xdsl.dialects.test import TestHasRegisterConstraintsOp, TestOp, TestRegisterType
+from xdsl.dialects.test import TestAllocatableOp, TestOp, TestRegisterType
 from xdsl.ir import Attribute, Block, SSAValue
 from xdsl.irdl import (
     IRDLOperation,
@@ -72,7 +72,7 @@ def op(
     *out_result_types: Attribute,
     inouts: Sequence[SSAValue] = (),
 ):
-    return TestHasRegisterConstraintsOp(
+    return TestAllocatableOp(
         ins, inouts, out_result_types, tuple(val.type for val in inouts)
     )
 

--- a/tests/backend/test_register_type.py
+++ b/tests/backend/test_register_type.py
@@ -1,43 +1,11 @@
-from collections.abc import Sequence
-
-from xdsl import ir, irdl
-from xdsl.backend.register_type import (
-    RegisterAllocatedMemoryEffect,
-    RegisterResource,
-)
-from xdsl.dialects.test import TestRegisterType
+from xdsl.backend.register_type import RegisterResource
+from xdsl.dialects.test import TestAllocatableOp, TestRegisterType
 from xdsl.traits import (
     EffectInstance,
     MemoryEffectKind,
     get_effects,
     is_side_effect_free,
 )
-
-
-@irdl.irdl_op_definition
-class TestAllocatableOp(irdl.IRDLOperation):
-    name = "test.allocatable"
-
-    in_operands = irdl.var_operand_def()
-    inout_operands = irdl.var_operand_def()
-    out_results = irdl.var_result_def()
-    inout_results = irdl.var_result_def()
-
-    traits = irdl.traits_def(RegisterAllocatedMemoryEffect())
-
-    irdl_options = (irdl.AttrSizedOperandSegments(), irdl.AttrSizedResultSegments())
-
-    def __init__(
-        self,
-        in_operands: Sequence[ir.SSAValue],
-        inout_operands: Sequence[ir.SSAValue],
-        out_result_types: Sequence[ir.Attribute],
-        inout_result_types: Sequence[ir.Attribute],
-    ):
-        super().__init__(
-            operands=(in_operands, inout_operands),
-            result_types=(out_result_types, inout_result_types),
-        )
 
 
 def test_register_resource_name():

--- a/tests/backend/test_register_type.py
+++ b/tests/backend/test_register_type.py
@@ -1,5 +1,5 @@
 from xdsl.backend.register_type import RegisterResource
-from xdsl.dialects.test import TestHasRegisterConstraintsOp, TestRegisterType
+from xdsl.dialects.test import TestAllocatableOp, TestRegisterType
 from xdsl.traits import (
     EffectInstance,
     MemoryEffectKind,
@@ -17,7 +17,7 @@ def test_register_resource_name():
 
 def test_no_effects_for_unallocated_registers():
     """Test that unallocated registers produce no memory effects."""
-    op = TestHasRegisterConstraintsOp([], [], [TestRegisterType.unallocated()], [])
+    op = TestAllocatableOp([], [], [TestRegisterType.unallocated()], [])
     effects = get_effects(op)
     assert effects == set()
     assert is_side_effect_free(op)
@@ -26,7 +26,7 @@ def test_no_effects_for_unallocated_registers():
 def test_write_effect_for_allocated_result():
     """Test that allocated register results produce WRITE effects."""
     allocated_reg = TestRegisterType.from_name("x0")
-    op = TestHasRegisterConstraintsOp([], [], [allocated_reg], [])
+    op = TestAllocatableOp([], [], [allocated_reg], [])
     effects = get_effects(op)
 
     assert effects == {
@@ -38,10 +38,10 @@ def test_read_effect_for_allocated_operand():
     """Test that allocated register operands produce READ effects."""
     # Create an op that produces an allocated register to use as operand
     allocated_reg = TestRegisterType.from_name("x1")
-    producer = TestHasRegisterConstraintsOp([], [], [allocated_reg], [])
+    producer = TestAllocatableOp([], [], [allocated_reg], [])
 
     # Use the result as an operand
-    op = TestHasRegisterConstraintsOp([producer.results[0]], [], [], [])
+    op = TestAllocatableOp([producer.results[0]], [], [], [])
     effects = get_effects(op)
 
     assert effects == {
@@ -55,10 +55,10 @@ def test_mixed_read_write_effects():
     reg_x1 = TestRegisterType.from_name("x1")
 
     # Producer for operand
-    producer = TestHasRegisterConstraintsOp([], [], [reg_x0], [])
+    producer = TestAllocatableOp([], [], [reg_x0], [])
 
     # Op that reads x0 and writes x1
-    op = TestHasRegisterConstraintsOp([producer.results[0]], [], [reg_x1], [])
+    op = TestAllocatableOp([producer.results[0]], [], [reg_x1], [])
     effects = get_effects(op)
 
     assert effects == {

--- a/tests/backend/test_register_type.py
+++ b/tests/backend/test_register_type.py
@@ -1,5 +1,5 @@
 from xdsl.backend.register_type import RegisterResource
-from xdsl.dialects.test import TestAllocatableOp, TestRegisterType
+from xdsl.dialects.test import TestHasRegisterConstraintsOp, TestRegisterType
 from xdsl.traits import (
     EffectInstance,
     MemoryEffectKind,
@@ -17,7 +17,7 @@ def test_register_resource_name():
 
 def test_no_effects_for_unallocated_registers():
     """Test that unallocated registers produce no memory effects."""
-    op = TestAllocatableOp([], [], [TestRegisterType.unallocated()], [])
+    op = TestHasRegisterConstraintsOp([], [], [TestRegisterType.unallocated()], [])
     effects = get_effects(op)
     assert effects == set()
     assert is_side_effect_free(op)
@@ -26,7 +26,7 @@ def test_no_effects_for_unallocated_registers():
 def test_write_effect_for_allocated_result():
     """Test that allocated register results produce WRITE effects."""
     allocated_reg = TestRegisterType.from_name("x0")
-    op = TestAllocatableOp([], [], [allocated_reg], [])
+    op = TestHasRegisterConstraintsOp([], [], [allocated_reg], [])
     effects = get_effects(op)
 
     assert effects == {
@@ -38,10 +38,10 @@ def test_read_effect_for_allocated_operand():
     """Test that allocated register operands produce READ effects."""
     # Create an op that produces an allocated register to use as operand
     allocated_reg = TestRegisterType.from_name("x1")
-    producer = TestAllocatableOp([], [], [allocated_reg], [])
+    producer = TestHasRegisterConstraintsOp([], [], [allocated_reg], [])
 
     # Use the result as an operand
-    op = TestAllocatableOp([producer.results[0]], [], [], [])
+    op = TestHasRegisterConstraintsOp([producer.results[0]], [], [], [])
     effects = get_effects(op)
 
     assert effects == {
@@ -55,10 +55,10 @@ def test_mixed_read_write_effects():
     reg_x1 = TestRegisterType.from_name("x1")
 
     # Producer for operand
-    producer = TestAllocatableOp([], [], [reg_x0], [])
+    producer = TestHasRegisterConstraintsOp([], [], [reg_x0], [])
 
     # Op that reads x0 and writes x1
-    op = TestAllocatableOp([producer.results[0]], [], [reg_x1], [])
+    op = TestHasRegisterConstraintsOp([producer.results[0]], [], [reg_x1], [])
     effects = get_effects(op)
 
     assert effects == {

--- a/xdsl/dialects/test.py
+++ b/xdsl/dialects/test.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 
-from xdsl.backend.register_type import RegisterType
+from xdsl.backend.register_allocatable import (
+    HasRegisterConstraints,
+    RegisterConstraints,
+)
+from xdsl.backend.register_type import RegisterAllocatedMemoryEffect, RegisterType
 from xdsl.dialect_interfaces.op_asm import OpAsmDialectInterface
 from xdsl.dialects.builtin import IntegerAttr, IntegerType, SymbolNameConstraint
 from xdsl.interfaces import HasFolderInterface
@@ -17,6 +21,8 @@ from xdsl.ir import (
     TypeAttribute,
 )
 from xdsl.irdl import (
+    AttrSizedOperandSegments,
+    AttrSizedResultSegments,
     IRDLOperation,
     irdl_attr_definition,
     irdl_op_definition,
@@ -327,6 +333,37 @@ class TestSymbolOp(IRDLOperation):
             regions=(regions,),
         )
 
+@irdl_op_definition
+class TestAllocatableOp(IRDLOperation, HasRegisterConstraints):
+    name = "test.allocatable"
+
+    in_operands = var_operand_def()
+    inout_operands = var_operand_def()
+    out_results = var_result_def()
+    inout_results = var_result_def()
+
+    traits = traits_def(RegisterAllocatedMemoryEffect())
+
+    irdl_options = (AttrSizedOperandSegments(), AttrSizedResultSegments())
+
+    def __init__(
+        self,
+        in_operands: Sequence[SSAValue],
+        inout_operands: Sequence[SSAValue],
+        out_result_types: Sequence[Attribute],
+        inout_result_types: Sequence[Attribute],
+    ):
+        super().__init__(
+            operands=(in_operands, inout_operands),
+            result_types=(out_result_types, inout_result_types),
+        )
+
+    def get_register_constraints(self) -> RegisterConstraints:
+        return RegisterConstraints(
+            self.in_operands,
+            self.out_results,
+            tuple(zip(self.inout_operands, self.inout_results)),
+        )
 
 @irdl_attr_definition
 class TestRegisterType(RegisterType):
@@ -350,6 +387,7 @@ Test = Dialect(
         TestTermOp,
         TestWriteOp,
         TestSymbolOp,
+        TestAllocatableOp,
     ],
     [
         TestType,

--- a/xdsl/dialects/test.py
+++ b/xdsl/dialects/test.py
@@ -333,6 +333,7 @@ class TestSymbolOp(IRDLOperation):
             regions=(regions,),
         )
 
+
 @irdl_op_definition
 class TestAllocatableOp(IRDLOperation, HasRegisterConstraints):
     name = "test.allocatable"
@@ -364,6 +365,7 @@ class TestAllocatableOp(IRDLOperation, HasRegisterConstraints):
             self.out_results,
             tuple(zip(self.inout_operands, self.inout_results)),
         )
+
 
 @irdl_attr_definition
 class TestRegisterType(RegisterType):

--- a/xdsl/dialects/test.py
+++ b/xdsl/dialects/test.py
@@ -335,8 +335,8 @@ class TestSymbolOp(IRDLOperation):
 
 
 @irdl_op_definition
-class TestHasRegisterConstraintsOp(IRDLOperation, HasRegisterConstraints):
-    name = "test.has_register_constraints"
+class TestAllocatableOp(IRDLOperation, HasRegisterConstraints):
+    name = "test.allocatable"
 
     in_operands = var_operand_def()
     inout_operands = var_operand_def()
@@ -389,7 +389,7 @@ Test = Dialect(
         TestTermOp,
         TestWriteOp,
         TestSymbolOp,
-        TestHasRegisterConstraintsOp,
+        TestAllocatableOp,
     ],
     [
         TestType,

--- a/xdsl/dialects/test.py
+++ b/xdsl/dialects/test.py
@@ -335,8 +335,8 @@ class TestSymbolOp(IRDLOperation):
 
 
 @irdl_op_definition
-class TestAllocatableOp(IRDLOperation, HasRegisterConstraints):
-    name = "test.allocatable"
+class TestHasRegisterConstraintsOp(IRDLOperation, HasRegisterConstraints):
+    name = "test.has_register_constraints"
 
     in_operands = var_operand_def()
     inout_operands = var_operand_def()
@@ -389,7 +389,7 @@ Test = Dialect(
         TestTermOp,
         TestWriteOp,
         TestSymbolOp,
-        TestAllocatableOp,
+        TestHasRegisterConstraintsOp,
     ],
     [
         TestType,


### PR DESCRIPTION
It's useful to have a generic op for this, especially for the liveness and legalization introduced in #6322 and #6317 .