### PR TITLE
core: add typevar defaults to mapping

### DIFF
--- a/tests/utils/test_hints.py
+++ b/tests/utils/test_hints.py
@@ -4,11 +4,12 @@ from typing import Generic
 import pytest
 from typing_extensions import TypeVar
 
-from xdsl.utils.hints import get_type_var_mapping
+from xdsl.utils.hints import get_type_var_mapping, get_type_var_mapping_with_defaults
 
 T0 = TypeVar("T0")
 T1 = TypeVar("T1")
 T2 = TypeVar("T2")
+T3 = TypeVar("T3", default=int)
 
 
 class A(Generic[T1, T2]): ...
@@ -70,3 +71,37 @@ def test_get_type_var_mapping():
         ),
     ):
         assert get_type_var_mapping(F) == ()
+
+
+class G(Generic[T3]): ...
+
+
+class H(G): ...
+
+
+class J(G[str]): ...
+
+
+def test_get_type_var_mapping_with_defaults():
+    assert get_type_var_mapping_with_defaults(A) == {}
+    assert get_type_var_mapping_with_defaults(B) == {T2: int}
+    assert get_type_var_mapping_with_defaults(C) == {T1: str, T2: int}
+    assert get_type_var_mapping_with_defaults(D) == {T1: T0, T2: T0}
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "Invalid definition D2, generic classes must subclass `Generic`."
+        ),
+    ):
+        assert get_type_var_mapping_with_defaults(D2) == {T1: T0, T2: T0}
+    assert get_type_var_mapping_with_defaults(E) == {}
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "Error extracting assignments of TypeVars of F, inconsistent assignments to ~T2 in superclasses: str, int."
+        ),
+    ):
+        assert get_type_var_mapping_with_defaults(F) == ()
+
+    assert get_type_var_mapping_with_defaults(H) == {T3: int}
+    assert get_type_var_mapping_with_defaults(J) == {T3: str}

--- a/xdsl/irdl/operations.py
+++ b/xdsl/irdl/operations.py
@@ -39,7 +39,11 @@ from xdsl.utils.exceptions import (
     PyRDLOpDefinitionError,
     VerifyException,
 )
-from xdsl.utils.hints import PropertyType, get_type_var_mapping, isa
+from xdsl.utils.hints import (
+    PropertyType,
+    get_type_var_mapping_with_defaults,
+    isa,
+)
 
 from .attributes import (  # noqa: TID251
     IRDLAttrConstraint,
@@ -919,7 +923,7 @@ class OpDef:
         if issubclass(pyrdl_def, Generic):
             type_var_mapping = {
                 k: irdl_to_attr_constraint(v)
-                for k, v in get_type_var_mapping(pyrdl_def)[1].items()
+                for k, v in get_type_var_mapping_with_defaults(pyrdl_def).items()
             }
 
         def wrong_field_exception(field_name: str) -> PyRDLOpDefinitionError:

--- a/xdsl/utils/hints.py
+++ b/xdsl/utils/hints.py
@@ -206,6 +206,22 @@ def get_type_var_mapping(
     return args, mapping
 
 
+def get_type_var_mapping_with_defaults(cls: type[Any]) -> dict[TypeVar, Any]:
+    """
+    Given a Generic class, returns the mapping from the generic class type variables
+    to the specialized arguments for all type variables used in ancestor classes.
+    Maps unspecialized type variables to their defaults, if they exist.
+    """
+
+    args, mapping = get_type_var_mapping(cls)
+
+    for a in args:
+        if a.has_default():
+            mapping[a] = a.__default__
+
+    return mapping
+
+
 def type_repr(obj: Any) -> str:
     """Return the repr() of an object, special-casing types."""
     if isinstance(obj, types.GenericAlias):


### PR DESCRIPTION
After creating the type_var_mapping, we need to add any unassigned type vars which have defaults. This should only be done at the top level, so we create another helper function wrapping `get_type_var_mapping` to implement this.

Fixes the issue in #6321 