### PR TITLE
dialects: (builtin) add SymbolRefAttr.get

### DIFF
--- a/tests/dialects/test_builtin.py
+++ b/tests/dialects/test_builtin.py
@@ -953,6 +953,16 @@ def test_SymbolRefAttr_string_value(ref: SymbolRefAttr, expected: str):
     assert ref.string_value() == expected
 
 
+def test_symbol_ref_attr_get_from_string():
+    assert SymbolRefAttr.get("test") == SymbolRefAttr("test")
+
+
+def test_symbol_ref_attr_get_from_symbol_ref_attr():
+    ref = SymbolRefAttr("test", ["nested"])
+
+    assert SymbolRefAttr.get(ref) is ref
+
+
 def test_array_len_and_iter_attr():
     arr = ArrayAttr([IntAttr(i) for i in range(10)])
 

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -340,6 +340,12 @@ class SymbolRefAttr(ParametrizedAttribute, BuiltinAttribute):
             )
         super().__init__(root, nested)
 
+    @staticmethod
+    def get(value: str | SymbolRefAttr) -> SymbolRefAttr:
+        if isinstance(value, str):
+            return SymbolRefAttr(value)
+        return value
+
     def string_value(self):
         root = self.root_reference.data
         for ref in self.nested_references.data:


### PR DESCRIPTION
Came up in #6315 that we might want a getter that converts a str or SymbolRef to a SymbolRef.

Co-authored by: Codex