### PR TITLE
Add annotations to all operation fields

### DIFF
--- a/scripts/script.el
+++ b/scripts/script.el
@@ -1,0 +1,12 @@
+(defun my-callback (docstring a b)
+  (save-match-data
+    (save-excursion
+      (forward-whitespace 1)
+      (forward-whitespace -1)
+      (insert ":")
+      (insert (car (last (split-string (car (split-string docstring "\n")) ":")))))
+    (if (next-error) (get-type-hint))))
+
+(defun get-type-hint ()
+  (interactive)
+  (eglot-hover-eldoc-function #'my-callback))

--- a/tests/backend/riscv/test_register_allocation.py
+++ b/tests/backend/riscv/test_register_allocation.py
@@ -11,8 +11,14 @@ from xdsl.backend.riscv.register_allocation import (
 from xdsl.backend.riscv.register_stack import RiscvRegisterStack
 from xdsl.dialects import riscv
 from xdsl.dialects.test import TestOp
-from xdsl.ir import SSAValue
-from xdsl.irdl import IRDLOperation, irdl_op_definition, operand_def, result_def
+from xdsl.ir import OpResult, SSAValue
+from xdsl.irdl import (
+    IRDLOperation,
+    Operand,
+    irdl_op_definition,
+    operand_def,
+    result_def,
+)
 from xdsl.utils.exceptions import DiagnosticException
 
 
@@ -78,10 +84,10 @@ def test_allocate_with_inout_constraints():
     ):
         name = "riscv.my_instruction"
 
-        rs0 = operand_def()
-        rs1 = operand_def()
-        rd0 = result_def()
-        rd1 = result_def()
+        rs0: Operand = operand_def()
+        rs1: Operand = operand_def()
+        rd0: OpResult = result_def()
+        rd1: OpResult = result_def()
 
         @classmethod
         def get(cls, rs0: SSAValue, rs1: SSAValue, rd0: str, rd1: str) -> Self:

--- a/tests/backend/test_register_allocation.py
+++ b/tests/backend/test_register_allocation.py
@@ -19,7 +19,11 @@ from xdsl.dialects.test import TestAllocatableOp, TestOp, TestRegisterType
 from xdsl.ir import Attribute, Block, SSAValue
 from xdsl.irdl import (
     IRDLOperation,
+    Operand,
+    OpResult,
     VarConstraint,
+    VarOperand,
+    VarOpResult,
     base,
     irdl_attr_definition,
     irdl_op_definition,
@@ -144,8 +148,8 @@ def test_deprecated_iter_used_registers():
     class TestDepracatedAllocatableOp(IRDLOperation, HasRegisterConstraints):
         name = "test.allocatable"
 
-        o = var_operand_def()
-        r = var_result_def()
+        o: VarOperand = var_operand_def()
+        r: VarOpResult = var_result_def()
 
         traits = traits_def(RegisterAllocatedMemoryEffect())
 
@@ -398,8 +402,8 @@ def test_verify_register_constraints():
     class MisconstrainedOp(HasRegisterConstraints, IRDLOperation):
         T: ClassVar = VarConstraint("T", base(TestRegisterType))
 
-        a = operand_def(T)
-        b = result_def(T)
+        a: Operand = operand_def(T)
+        b: OpResult[TestRegisterType] = result_def(T)
 
     @irdl_op_definition
     class UndeclaredOperandOp(MisconstrainedOp):
@@ -471,8 +475,8 @@ def test_fail_error_message():
 
         T: ClassVar = VarConstraint("T", base(TestRegisterType))
 
-        a = operand_def(T)
-        b = result_def(T)
+        a: Operand = operand_def(T)
+        b: OpResult[TestRegisterType] = result_def(T)
 
         def get_register_constraints(self) -> RegisterConstraints:
             return RegisterConstraints((), (), ((self.a, self.b),))

--- a/tests/dialects/test_bufferization.py
+++ b/tests/dialects/test_bufferization.py
@@ -25,6 +25,7 @@ from xdsl.irdl import (
     ConstraintContext,
     EqAttrConstraint,
     IRDLOperation,
+    Operand,
     VarConstraint,
     irdl_op_definition,
     operand_def,
@@ -54,15 +55,15 @@ class TensorFromMemRefOp(IRDLOperation):
     name = "test.tensor_from_memref"
     T: ClassVar = VarConstraint("T", MemRefType.constr() | AnyUnrankedMemRefTypeConstr)
 
-    in_tensor = operand_def(
+    in_tensor: Operand = operand_def(
         TensorFromMemRefConstraint(
             MemRefType.constr(element_type=EqAttrConstraint(IndexType()))
         )
     )
 
-    in_var_memref = operand_def(T)
+    in_var_memref: Operand = operand_def(T)
 
-    in_var_tensor = operand_def(TensorFromMemRefConstraint(T))
+    in_var_tensor: Operand = operand_def(TensorFromMemRefConstraint(T))
 
 
 def test_tensor_from_memref_constraint():

--- a/tests/dialects/test_func.py
+++ b/tests/dialects/test_func.py
@@ -189,7 +189,7 @@ def test_call_not_function():
     class SymbolOp(IRDLOperation):
         name = "test.symbol"
 
-        sym_name = attr_def(SymbolNameConstraint())
+        sym_name: StringAttr = attr_def(SymbolNameConstraint())
 
         traits = traits_def(SymbolOpInterface())
 

--- a/tests/dialects/test_hw.py
+++ b/tests/dialects/test_hw.py
@@ -78,8 +78,8 @@ def test_inner_sym_target():
 @irdl_op_definition
 class ModuleOp(IRDLOperation):
     name = "module"
-    region = region_def()
-    sym_name = attr_def(SymbolNameConstraint())
+    region: Region = region_def()
+    sym_name: StringAttr = attr_def(SymbolNameConstraint())
     traits = traits_def(InnerSymbolTableTrait(), SymbolOpInterface())
 
 
@@ -93,7 +93,7 @@ class OutputOp(IRDLOperation):
 class CircuitOp(IRDLOperation):
     name = "circuit"
     region: Region | None = opt_region_def()
-    sym_name = attr_def(SymbolNameConstraint())
+    sym_name: StringAttr = attr_def(SymbolNameConstraint())
     traits = traits_def(
         InnerRefNamespaceTrait(),
         SymbolTable(),
@@ -108,7 +108,7 @@ class CircuitOp(IRDLOperation):
 @irdl_op_definition
 class WireOp(IRDLOperation):
     name = "wire"
-    sym_name = attr_def(SymbolNameConstraint())
+    sym_name: StringAttr = attr_def(SymbolNameConstraint())
     traits = traits_def(InnerRefUserOpInterfaceTrait())
 
 
@@ -150,8 +150,8 @@ def test_inner_symbol_table_interface():
     @irdl_op_definition
     class MissingTraitModuleOp(IRDLOperation):
         name = "module"
-        region = region_def()
-        sym_name = attr_def(SymbolNameConstraint())
+        region: Region = region_def()
+        sym_name: StringAttr = attr_def(SymbolNameConstraint())
         traits = traits_def(InnerSymbolTableTrait())
 
     mod_missing_trait = MissingTraitModuleOp(
@@ -170,7 +170,7 @@ def test_inner_symbol_table_interface():
     @irdl_op_definition
     class MissingAttrModuleOp(IRDLOperation):
         name = "module"
-        region = region_def()
+        region: Region = region_def()
         traits = traits_def(InnerSymbolTableTrait(), SymbolOpInterface())
 
     mod_missing_trait_parent = ModuleOp(regions=[[OutputOp()]])
@@ -191,7 +191,7 @@ def test_inner_ref_namespace_interface():
     class MissingTraitCircuitOp(IRDLOperation):
         name = "circuit"
         region: Region | None = opt_region_def()
-        sym_name = attr_def(SymbolNameConstraint())
+        sym_name: StringAttr = attr_def(SymbolNameConstraint())
         traits = traits_def(
             InnerRefNamespaceTrait(), SingleBlockImplicitTerminator(OutputOp)
         )

--- a/tests/dialects/test_mpi_lowering.py
+++ b/tests/dialects/test_mpi_lowering.py
@@ -4,6 +4,7 @@ from xdsl.ir import Attribute, Operation, OpResult
 from xdsl.irdl import (
     IRDLOperation,
     Operand,
+    VarOpResult,
     irdl_op_definition,
     var_result_def,
 )
@@ -38,7 +39,7 @@ def check_emitted_function_signature(
 @irdl_op_definition
 class CreateTestValsOp(IRDLOperation):
     name = "testing.test"
-    result = var_result_def()
+    result: VarOpResult = var_result_def()
 
     @staticmethod
     def get(*types: Attribute):

--- a/tests/dialects/test_omp.py
+++ b/tests/dialects/test_omp.py
@@ -9,7 +9,7 @@ from xdsl.utils.exceptions import VerifyException
 @irdl_op_definition
 class DummyLoopWrapper(IRDLOperation):
     name = "dummy.loop_wrapper"
-    body = region_def()
+    body: Region = region_def()
 
     traits = traits_def(omp.LoopWrapper())
 
@@ -54,8 +54,8 @@ def test_loop_wrapper_many_regions():
         name = "dummy.loop_wrapper"
 
         traits = traits_def(omp.LoopWrapper())
-        b1 = region_def()
-        b2 = region_def()
+        b1: Region = region_def()
+        b2: Region = region_def()
 
     with pytest.raises(
         VerifyException, match="is not a LoopWrapper: has 2 region, expected 1"

--- a/tests/interpreters/test_eqsat_pdl_interp_interpreter.py
+++ b/tests/interpreters/test_eqsat_pdl_interp_interpreter.py
@@ -17,6 +17,8 @@ from xdsl.ir import Attribute, Block, Operation, Region, SSAValue
 from xdsl.irdl import (
     AttrSizedResultSegments,
     IRDLOperation,
+    OpResult,
+    VarOpResult,
     irdl_op_definition,
     result_def,
     var_result_def,
@@ -106,9 +108,9 @@ def test_run_get_results():
     @irdl_op_definition
     class MultiResultGroupsOp(IRDLOperation):
         name = "test.multi_result_group"
-        res1 = var_result_def()
-        res2 = result_def()
-        res3 = var_result_def()
+        res1: VarOpResult = var_result_def()
+        res2: OpResult = result_def()
+        res3: VarOpResult = var_result_def()
 
         irdl_options = (AttrSizedResultSegments(),)
 
@@ -1444,9 +1446,9 @@ def test_run_replace_rangetype_mixed():
     @irdl_op_definition
     class MultiResultGroupsOp(IRDLOperation):
         name = "test.multi_result_group"
-        res1 = var_result_def()
-        res2 = result_def()
-        res3 = var_result_def()
+        res1: VarOpResult = var_result_def()
+        res2: OpResult = result_def()
+        res3: VarOpResult = var_result_def()
 
         irdl_options = (AttrSizedResultSegments(),)
 

--- a/tests/interpreters/test_pdl_interp_interpreter.py
+++ b/tests/interpreters/test_pdl_interp_interpreter.py
@@ -29,6 +29,8 @@ from xdsl.ir import Attribute, Block, Operation, Region
 from xdsl.irdl import (
     AttrSizedResultSegments,
     IRDLOperation,
+    OpResult,
+    VarOpResult,
     irdl_op_definition,
     result_def,
     var_result_def,
@@ -874,9 +876,9 @@ def test_run_get_results():
     @irdl_op_definition
     class MultiResultGroupsOp(IRDLOperation):
         name = "test.multi_result_group"
-        res1 = var_result_def()
-        res2 = result_def()
-        res3 = var_result_def()
+        res1: VarOpResult = var_result_def()
+        res2: OpResult = result_def()
+        res3: VarOpResult = var_result_def()
 
         irdl_options = (AttrSizedResultSegments(),)
 

--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -34,7 +34,9 @@ from xdsl.dialects.utils import DynamicIndexList
 from xdsl.ir import (
     Attribute,
     Operation,
+    OpResult,
     ParametrizedAttribute,
+    Region,
     TypeAttribute,
 )
 from xdsl.irdl import (
@@ -49,15 +51,23 @@ from xdsl.irdl import (
     EqAttrConstraint,
     IntVarConstraint,
     IRDLOperation,
+    Operand,
+    OptOperand,
+    OptOpResult,
+    OptRegion,
+    OptSuccessor,
     ParamAttrConstraint,
     ParsePropInAttrDict,
     RangeOf,
     RangeVarConstraint,
     SameVariadicOperandSize,
     SameVariadicResultSize,
+    Successor,
     VarConstraint,
     VarOperand,
     VarOpResult,
+    VarRegion,
+    VarSuccessor,
     attr_def,
     eq,
     irdl_attr_definition,
@@ -302,7 +312,7 @@ def test_attr_dict_prop_fallback(program: str, generic_program: str):
     @irdl_op_definition
     class PropOp(IRDLOperation):
         name = "test.prop"
-        prop = opt_prop_def()
+        prop: Attribute | None = opt_prop_def()
         irdl_options = (ParsePropInAttrDict(),)
         assembly_format = "attr-dict"
 
@@ -330,8 +340,8 @@ def test_partial_attr_dict_prop_fallback(program: str, generic_program: str):
     @irdl_op_definition
     class PropOp(IRDLOperation):
         name = "test.prop"
-        prop1 = prop_def()
-        prop2 = opt_prop_def()
+        prop1: Attribute = prop_def()
+        prop2: Attribute | None = opt_prop_def()
         irdl_options = (ParsePropInAttrDict(),)
         assembly_format = "$prop1 attr-dict"
 
@@ -351,7 +361,7 @@ def test_partial_attr_dict_prop_fallback(program: str, generic_program: str):
 class OpWithAttrOp(IRDLOperation):
     name = "test.one_attr"
 
-    attr = attr_def()
+    attr: Attribute = attr_def()
     assembly_format = "$attr attr-dict"
 
 
@@ -400,7 +410,7 @@ def test_attr_name(program: str, generic_program: str):
     class RenamedAttrOp(IRDLOperation):
         name = "test.one_attr"
 
-        python = attr_def(Attribute, attr_name="irdl")
+        python: Attribute = attr_def(Attribute, attr_name="irdl")
         assembly_format = "$irdl attr-dict"
 
     ctx = Context()
@@ -437,7 +447,7 @@ def test_unqualified_attr(program: str, generic_program: str):
     class UnqualifiedAttrOp(IRDLOperation):
         name = "test.one_attr"
 
-        attr = attr_def(ParamOne)
+        attr: ParamOne = attr_def(ParamOne)
         assembly_format = "$attr attr-dict"
 
     ctx = Context()
@@ -452,8 +462,8 @@ def test_missing_property_error():
     class MissingPropOp(IRDLOperation):
         name = "test.missing_prop"
 
-        prop1 = prop_def()
-        prop2 = prop_def()
+        prop1: Attribute = prop_def()
+        prop2: Attribute = prop_def()
         assembly_format = "$prop1 attr-dict"
 
     with pytest.raises(
@@ -474,7 +484,7 @@ def test_attribute_duplicated():
             IRDLOperation
         ):
             name = "test.duplicated_attribute_op"
-            attr = attr_def()
+            attr: Attribute = attr_def()
 
             assembly_format = "$attr $attr attr-dict"
 
@@ -490,7 +500,7 @@ def test_property_duplicated():
             IRDLOperation
         ):
             name = "test.duplicated_property_op"
-            attr = prop_def()
+            attr: Attribute = prop_def()
 
             assembly_format = "$attr $attr attr-dict"
 
@@ -510,7 +520,7 @@ def test_standard_prop_directive(program: str, generic_program: str):
     class PropOp(IRDLOperation):
         name = "test.one_prop"
 
-        prop = prop_def()
+        prop: Attribute = prop_def()
         assembly_format = "$prop attr-dict"
 
     ctx = Context()
@@ -535,7 +545,7 @@ def test_prop_name(program: str, generic_program: str):
     class RenamedPropOp(IRDLOperation):
         name = "test.one_prop"
 
-        python = prop_def(Attribute, prop_name="irdl")
+        python: Attribute = prop_def(Attribute, prop_name="irdl")
         assembly_format = "$irdl attr-dict"
 
     ctx = Context()
@@ -564,7 +574,7 @@ def test_optional_property(program: str, generic_program: str):
     @irdl_op_definition
     class OptionalPropertyOp(IRDLOperation):
         name = "test.optional_property"
-        prop = opt_prop_def()
+        prop: Attribute | None = opt_prop_def()
 
         assembly_format = "(`prop` $prop^)? attr-dict"
 
@@ -595,7 +605,7 @@ def test_optional_qualified_property(program: str, generic_program: str):
     @irdl_op_definition
     class OptionalPropertyOp(IRDLOperation):
         name = "test.optional_property"
-        prop = opt_prop_def()
+        prop: Attribute | None = opt_prop_def()
 
         assembly_format = "($prop^)? attr-dict"
 
@@ -626,7 +636,7 @@ def test_optional_property_with_whitespace(program: str, generic_program: str):
     @irdl_op_definition
     class OptionalPropertyOp(IRDLOperation):
         name = "test.optional_property"
-        prop = opt_prop_def()
+        prop: Attribute | None = opt_prop_def()
 
         assembly_format = "`(` (` ` `prop` $prop^ ` `)? `)` attr-dict"
 
@@ -657,7 +667,7 @@ def test_optional_unit_attr_property(program: str, generic_program: str):
     @irdl_op_definition
     class OptionalUnitAttrPropertyOp(IRDLOperation):
         name = "test.optional_unit_attr_prop"
-        unit_attr = opt_prop_def(UnitAttr)
+        unit_attr: UnitAttr | None = opt_prop_def(UnitAttr)
 
         assembly_format = "(`unit_attr` $unit_attr^)? attr-dict"
 
@@ -688,7 +698,7 @@ def test_optional_unit_attr_attribute(program: str, generic_program: str):
     @irdl_op_definition
     class OptionalUnitAttrOp(IRDLOperation):
         name = "test.optional_unit_attr"
-        unit_attr = opt_prop_def(UnitAttr)
+        unit_attr: UnitAttr | None = opt_prop_def(UnitAttr)
 
         assembly_format = "(`unit_attr` $unit_attr^)? attr-dict"
 
@@ -719,7 +729,7 @@ def test_optional_attribute(program: str, generic_program: str):
     @irdl_op_definition
     class OptionalAttributeOp(IRDLOperation):
         name = "test.optional_attribute"
-        attr = opt_attr_def()
+        attr: Attribute | None = opt_attr_def()
 
         assembly_format = "(`attr` $attr^)? attr-dict"
 
@@ -746,8 +756,8 @@ def test_typed_attribute_variable(program: str, generic_program: str):
     @irdl_op_definition
     class TypedAttributeOp(IRDLOperation):
         name = "test.typed_attr"
-        attr = attr_def(IntegerAttr[I32])
-        float_attr = attr_def(FloatAttr[Float64Type])
+        attr: IntegerAttr[I32] = attr_def(IntegerAttr[I32])
+        float_attr: FloatAttr[Float64Type] = attr_def(FloatAttr[Float64Type])
 
         assembly_format = "$attr $float_attr attr-dict"
 
@@ -777,8 +787,8 @@ def test_symbol_name_variable(program: str, generic_program: str):
     class SymbolNameOp(IRDLOperation):
         name = "test.symbol"
 
-        sym_name = prop_def(SymbolNameConstraint())
-        attr_sym_name = attr_def(SymbolNameConstraint())
+        sym_name: StringAttr = prop_def(SymbolNameConstraint())
+        attr_sym_name: StringAttr = attr_def(SymbolNameConstraint())
 
         assembly_format = "$sym_name $attr_sym_name attr-dict"
 
@@ -808,9 +818,9 @@ def test_optional_symbol_name_variable(program: str, generic_program: str):
     class SymbolNameOp(IRDLOperation):
         name = "test.symbol"
 
-        sym_name = opt_prop_def(SymbolNameConstraint())
+        sym_name: StringAttr | None = opt_prop_def(SymbolNameConstraint())
 
-        other_sym_name = opt_prop_def(SymbolNameConstraint())
+        other_sym_name: StringAttr | None = opt_prop_def(SymbolNameConstraint())
 
         assembly_format = "$other_sym_name (`symbol` $sym_name^)? attr-dict"
 
@@ -842,13 +852,13 @@ def test_dense_array_special_cases(program: str, generic_program: str, format: s
     class DenseArrayOp(IRDLOperation):
         name = "test.symbol"
 
-        i32s = attr_def(DenseArrayBase[I32])
-        i64s = opt_prop_def(DenseArrayBase[I64])
-        f32s = prop_def(
+        i32s: DenseArrayBase[I32] = attr_def(DenseArrayBase[I32])
+        i64s: DenseArrayBase[I64] | None = opt_prop_def(DenseArrayBase[I64])
+        f32s: DenseArrayBase[Float32Type] = prop_def(
             DenseArrayBase[Float32Type],
             default_value=DenseArrayBase.from_list(f32, (9.0,)),
         )
-        f64s = prop_def(
+        f64s: DenseArrayBase[Float64Type] = prop_def(
             VarConstraint("F64S", irdl_to_attr_constraint(DenseArrayBase[Float64Type]))
         )
 
@@ -954,7 +964,7 @@ def test_missing_operand():
         @irdl_op_definition
         class NoOperandTypeOp(IRDLOperation):  # pyright: ignore[reportUnusedClass]
             name = "test.no_operand_type_op"
-            operand = operand_def()
+            operand: Operand = operand_def()
 
             assembly_format = "attr-dict"
 
@@ -968,7 +978,7 @@ def test_operands_missing_type():
         @irdl_op_definition
         class NoOperandTypeOp(IRDLOperation):  # pyright: ignore[reportUnusedClass]
             name = "test.no_operand_type_op"
-            operand = operand_def()
+            operand: Operand = operand_def()
 
             assembly_format = "$operand attr-dict"
 
@@ -984,7 +994,7 @@ def test_operands_duplicated():
             IRDLOperation
         ):
             name = "test.duplicated_operand_op"
-            operand = operand_def()
+            operand: Operand = operand_def()
 
             assembly_format = "$operand $operand type($operand) attr-dict"
 
@@ -1000,7 +1010,7 @@ def test_operands_duplicated_type():
             IRDLOperation
         ):
             name = "test.duplicated_operand_type_op"
-            operand = operand_def()
+            operand: Operand = operand_def()
 
             assembly_format = "$operand type($operand) type($operand) attr-dict"
 
@@ -1035,8 +1045,8 @@ def test_operands(format: str, program: str, generic_program: str):
     @irdl_op_definition
     class TwoOperandsOp(IRDLOperation):
         name = "test.two_operands"
-        lhs = operand_def()
-        rhs = operand_def()
+        lhs: Operand = operand_def()
+        rhs: Operand = operand_def()
 
         assembly_format = format
 
@@ -1083,7 +1093,7 @@ def test_variadic_operand(format: str, program: str, generic_program: str):
     @irdl_op_definition
     class VariadicOperandOp(IRDLOperation):
         name = "test.variadic_operand"
-        args = var_operand_def()
+        args: VarOperand = var_operand_def()
 
         assembly_format = format
 
@@ -1116,7 +1126,7 @@ def test_optional_operand(format: str, program: str, generic_program: str):
     @irdl_op_definition
     class OptionalOperandOp(IRDLOperation):
         name = "test.optional_operand"
-        args = opt_operand_def()
+        args: OptOperand = opt_operand_def()
 
         assembly_format = format
 
@@ -1167,8 +1177,8 @@ def test_multiple_variadic_operands(
     @irdl_op_definition
     class VariadicOperandsOp(IRDLOperation):
         name = "test.variadic_operands"
-        args1 = var_operand_def()
-        args2 = var_operand_def()
+        args1: VarOperand = var_operand_def()
+        args2: VarOperand = var_operand_def()
 
         irdl_options = (AttrSizedOperandSegments(as_property=as_property),)
 
@@ -1204,8 +1214,8 @@ def test_multiple_optional_operands(program: str, generic_program: str):
     @irdl_op_definition
     class OptionalOperandsOp(IRDLOperation):
         name = "test.optional_operands"
-        arg1 = opt_operand_def()
-        arg2 = opt_operand_def()
+        arg1: OptOperand = opt_operand_def()
+        arg2: OptOperand = opt_operand_def()
 
         irdl_options = (AttrSizedOperandSegments(),)
 
@@ -1237,8 +1247,8 @@ def test_operands_graph_region(format: str, program: str):
     @irdl_op_definition
     class TwoOperandsOp(IRDLOperation):
         name = "test.two_operands"
-        lhs = operand_def()
-        rhs = operand_def()
+        lhs: Operand = operand_def()
+        rhs: Operand = operand_def()
 
         assembly_format = format
 
@@ -1264,8 +1274,8 @@ def test_operands_directive_with_variadic(program: str):
     class OperandsDirectiveOp(IRDLOperation):
         name = "test.operands_directive"
 
-        op1 = operand_def()
-        op2 = var_operand_def()
+        op1: Operand = operand_def()
+        op2: VarOperand = var_operand_def()
 
         assembly_format = "operands `:` type(operands) attr-dict"
 
@@ -1290,8 +1300,8 @@ def test_operands_directive_with_optional(program: str):
     class OperandsDirectiveOp(IRDLOperation):
         name = "test.operands_directive"
 
-        op1 = opt_operand_def()
-        op2 = operand_def()
+        op1: OptOperand = opt_operand_def()
+        op2: Operand = operand_def()
 
         assembly_format = "operands `:` type(operands) attr-dict"
 
@@ -1309,8 +1319,8 @@ def test_operands_directive_with_no_variadic():
     class OperandsDirectiveOp(IRDLOperation):
         name = "test.operands_directive"
 
-        op1 = operand_def()
-        op2 = operand_def()
+        op1: Operand = operand_def()
+        op2: Operand = operand_def()
 
         assembly_format = "operands `:` type(operands) attr-dict"
 
@@ -1333,8 +1343,8 @@ def test_operands_directive_fails_with_two_var():
         class TwoVarOp(IRDLOperation):  # pyright: ignore[reportUnusedClass]
             name = "test.two_var_op"
 
-            op1 = var_operand_def()
-            op2 = var_operand_def()
+            op1: VarOperand = var_operand_def()
+            op2: VarOperand = var_operand_def()
 
             irdl_options = (AttrSizedOperandSegments(),)
 
@@ -1359,8 +1369,8 @@ def test_operands_directive_works_with_two_var_and_option(program: str):
     class TwoVarOp(IRDLOperation):
         name = "test.two_var_op"
 
-        res1 = var_operand_def()
-        res2 = var_operand_def()
+        res1: VarOperand = var_operand_def()
+        res2: VarOperand = var_operand_def()
 
         irdl_options = (SameVariadicOperandSize(),)
 
@@ -1390,8 +1400,8 @@ def test_operands_directive_works_with_two_opt_and_option(program: str):
     class TwoVarOp(IRDLOperation):
         name = "test.two_var_op"
 
-        res1 = var_operand_def()
-        res2 = var_operand_def()
+        res1: VarOperand = var_operand_def()
+        res2: VarOperand = var_operand_def()
 
         irdl_options = (SameVariadicOperandSize(),)
 
@@ -1431,8 +1441,8 @@ def test_operands_directive_fails_with_other_directive():
         class TwoOperandsOp(IRDLOperation):  # pyright: ignore[reportUnusedClass]
             name = "test.two_operands_op"
 
-            op1 = operand_def()
-            op2 = operand_def()
+            op1: Operand = operand_def()
+            op2: Operand = operand_def()
 
             assembly_format = "$op1 `,` operands attr-dict `:` type(operands)"
 
@@ -1449,8 +1459,8 @@ def test_operands_directive_fails_with_other_type_directive():
         class TwoOperandsOp(IRDLOperation):  # pyright: ignore[reportUnusedClass]
             name = "test.two_operands_op"
 
-            op1 = operand_def()
-            op2 = operand_def()
+            op1: Operand = operand_def()
+            op2: Operand = operand_def()
 
             assembly_format = "operands attr-dict `:` type($op1) `,` type(operands)"
 
@@ -1475,8 +1485,8 @@ def test_operands_directive_bounds(program: str, error: str):
     class TwoOperandsOp(IRDLOperation):
         name = "test.two_operands"
 
-        op1 = operand_def()
-        op2 = operand_def()
+        op1: Operand = operand_def()
+        op2: Operand = operand_def()
 
         assembly_format = "operands attr-dict `:` type(operands)"
 
@@ -1514,9 +1524,9 @@ def test_operands_directive_bounds_with_opt(program: str, error: str):
     class ThreeOperandsOp(IRDLOperation):
         name = "test.three_operands"
 
-        op1 = operand_def()
-        op2 = opt_operand_def()
-        op3 = operand_def()
+        op1: Operand = operand_def()
+        op2: OptOperand = opt_operand_def()
+        op3: Operand = operand_def()
 
         assembly_format = "operands attr-dict `:` type(operands)"
 
@@ -1546,9 +1556,9 @@ def test_operands_directive_bound_with_var(program: str, error: str):
     class ThreeOperandsOp(IRDLOperation):
         name = "test.three_operands"
 
-        op1 = operand_def()
-        op2 = var_operand_def()
-        op3 = operand_def()
+        op1: Operand = operand_def()
+        op2: VarOperand = var_operand_def()
+        op3: Operand = operand_def()
 
         assembly_format = "operands attr-dict `:` type(operands)"
 
@@ -1578,7 +1588,7 @@ def test_operands_directive_with_non_variadic_type_directive():
     class OneOperandOp(IRDLOperation):
         name = "test.one_operand"
 
-        op1 = operand_def()
+        op1: Operand = operand_def()
 
         @classmethod
         def parse(cls, parser: Parser) -> OneOperandOp:
@@ -1613,8 +1623,8 @@ def test_operands_directive_with_variadic_type_directive():
     class TwoOperandOp(IRDLOperation):
         name = "test.two_operand"
 
-        op1 = operand_def()
-        op2 = var_operand_def()
+        op1: Operand = operand_def()
+        op2: VarOperand = var_operand_def()
 
         @classmethod
         def parse(cls, parser: Parser) -> TwoOperandOp:
@@ -1643,7 +1653,7 @@ def test_missing_result_type():
         @irdl_op_definition
         class NoResultTypeOp(IRDLOperation):  # pyright: ignore[reportUnusedClass]
             name = "test.no_result_type_op"
-            result = result_def()
+            result: OpResult = result_def()
 
             assembly_format = "attr-dict"
 
@@ -1659,7 +1669,7 @@ def test_results_duplicated_type():
             IRDLOperation
         ):
             name = "test.duplicated_result_type_op"
-            result = result_def()
+            result: OpResult = result_def()
 
             assembly_format = "type($result) type($result) attr-dict"
 
@@ -1690,8 +1700,8 @@ def test_results(format: str, program: str, generic_program: str):
     @irdl_op_definition
     class TwoResultOp(IRDLOperation):
         name = "test.two_results"
-        lhs = result_def()
-        rhs = result_def()
+        lhs: OpResult = result_def()
+        rhs: OpResult = result_def()
 
         assembly_format = format
 
@@ -1734,7 +1744,7 @@ def test_variadic_result(format: str, program: str, generic_program: str):
     @irdl_op_definition
     class VariadicResultOp(IRDLOperation):
         name = "test.variadic_result"
-        res = var_result_def()
+        res: VarOpResult = var_result_def()
 
         assembly_format = format
 
@@ -1758,7 +1768,7 @@ def test_variadic_result_failure():
         class VariadicResultsOp(IRDLOperation):  # pyright: ignore[reportUnusedClass]
             name = "test.var_results_op"
 
-            res = var_result_def(IndexType())
+            res: VarOpResult[IndexType] = var_result_def(IndexType())
 
             irdl_options = (AttrSizedResultSegments(),)
 
@@ -1786,7 +1796,7 @@ def test_optional_result(format: str, program: str, generic_program: str):
     @irdl_op_definition
     class OptionalResultOp(IRDLOperation):
         name = "test.optional_result"
-        res = opt_result_def()
+        res: OptOpResult = opt_result_def()
 
         assembly_format = format
 
@@ -1813,8 +1823,8 @@ def test_results_directive_with_variadic(program: str):
     class ResultsDirectiveOp(IRDLOperation):
         name = "test.results_directive"
 
-        res1 = result_def()
-        res2 = var_result_def()
+        res1: OpResult = result_def()
+        res2: VarOpResult = var_result_def()
 
         assembly_format = "attr-dict `:` type(results)"
 
@@ -1839,8 +1849,8 @@ def test_results_directive_with_optional(program: str):
     class ResultsDirectiveOp(IRDLOperation):
         name = "test.results_directive"
 
-        res1 = opt_result_def()
-        res2 = result_def()
+        res1: OptOpResult = opt_result_def()
+        res2: OpResult = result_def()
 
         assembly_format = "attr-dict `:` type(results)"
 
@@ -1858,8 +1868,8 @@ def test_results_directive_with_no_variadic():
     class ResultsDirectiveOp(IRDLOperation):
         name = "test.results_directive"
 
-        res1 = result_def()
-        res2 = result_def()
+        res1: OpResult = result_def()
+        res2: OpResult = result_def()
 
         assembly_format = "attr-dict `:` type(results)"
 
@@ -1882,8 +1892,8 @@ def test_results_directive_fails_with_two_var():
         class TwoVarOp(IRDLOperation):  # pyright: ignore[reportUnusedClass]
             name = "test.two_var_op"
 
-            res1 = var_result_def()
-            res2 = var_result_def()
+            res1: VarOpResult = var_result_def()
+            res2: VarOpResult = var_result_def()
 
             irdl_options = (AttrSizedResultSegments(),)
 
@@ -1908,8 +1918,8 @@ def test_results_directive_works_with_two_var_and_option(program: str):
     class TwoVarOp(IRDLOperation):
         name = "test.two_var_op"
 
-        res1 = var_result_def()
-        res2 = var_result_def()
+        res1: VarOpResult = var_result_def()
+        res2: VarOpResult = var_result_def()
 
         irdl_options = (SameVariadicResultSize(),)
 
@@ -1939,8 +1949,8 @@ def test_results_directive_works_with_two_opt_and_option(program: str):
     class TwoVarOp(IRDLOperation):
         name = "test.two_var_op"
 
-        res1 = var_result_def()
-        res2 = var_result_def()
+        res1: VarOpResult = var_result_def()
+        res2: VarOpResult = var_result_def()
 
         irdl_options = (SameVariadicResultSize(),)
 
@@ -1980,8 +1990,8 @@ def test_results_directive_fails_with_other_type_directive():
         class TwoResultsOp(IRDLOperation):  # pyright: ignore[reportUnusedClass]
             name = "test.two_results_op"
 
-            res1 = result_def()
-            res2 = result_def()
+            res1: OpResult = result_def()
+            res2: OpResult = result_def()
 
             assembly_format = "attr-dict `:` type($res1) `,` type(results)"
 
@@ -2001,8 +2011,8 @@ def test_results_directive_bounds(program: str, error: str):
     class TwoResultsOp(IRDLOperation):
         name = "test.two_results"
 
-        res1 = result_def()
-        res2 = result_def()
+        res1: OpResult = result_def()
+        res2: OpResult = result_def()
 
         assembly_format = "attr-dict `:` type(results)"
 
@@ -2032,9 +2042,9 @@ def test_results_directive_bounds_with_opt(program: str, error: str):
     class ThreeResultsOp(IRDLOperation):
         name = "test.three_results"
 
-        res1 = result_def()
-        res2 = opt_result_def()
-        res3 = result_def()
+        res1: OpResult = result_def()
+        res2: OptOpResult = opt_result_def()
+        res3: OpResult = result_def()
 
         assembly_format = "attr-dict `:` type(results)"
 
@@ -2051,9 +2061,9 @@ def test_results_directive_bound_with_var():
     class ThreeResultsOp(IRDLOperation):
         name = "test.three_results"
 
-        res1 = result_def()
-        res2 = var_result_def()
-        res3 = result_def()
+        res1: OpResult = result_def()
+        res2: VarOpResult = var_result_def()
+        res3: OpResult = result_def()
 
         assembly_format = "attr-dict `:` type(results)"
 
@@ -2082,7 +2092,7 @@ def test_results_directive_with_non_variadic_type_directive():
     class OneResultOp(IRDLOperation):
         name = "test.one_result"
 
-        res = result_def()
+        res: OpResult = result_def()
 
         @classmethod
         def parse(cls, parser: Parser) -> OneResultOp:
@@ -2116,8 +2126,8 @@ def test_results_directive_with_variadic_type_directive():
     class TwoResultsOp(IRDLOperation):
         name = "test.two_results"
 
-        res1 = result_def()
-        res2 = var_result_def()
+        res1: OpResult = result_def()
+        res2: VarOpResult = var_result_def()
 
         @classmethod
         def parse(cls, parser: Parser) -> TwoResultsOp:
@@ -2154,8 +2164,8 @@ def test_functional_type(program: str):
     class FunctionalTypeOp(IRDLOperation):
         name = "test.functional_type"
 
-        ops = var_operand_def()
-        res = var_result_def()
+        ops: VarOperand = var_operand_def()
+        res: VarOpResult = var_result_def()
 
         assembly_format = "$ops attr-dict `:` functional-type($ops, $res)"
 
@@ -2183,10 +2193,10 @@ def test_functional_type_with_operands_and_results(program: str):
     class FunctionalTypeOp(IRDLOperation):
         name = "test.functional_type"
 
-        op1 = operand_def()
-        ops2 = var_operand_def()
-        res1 = var_result_def()
-        res2 = result_def()
+        op1: Operand = operand_def()
+        ops2: VarOperand = var_operand_def()
+        res1: VarOpResult = var_result_def()
+        res2: OpResult = result_def()
 
         assembly_format = "operands attr-dict `:` functional-type(operands, results)"
 
@@ -2208,7 +2218,7 @@ def test_missing_region():
         @irdl_op_definition
         class NoRegionOp(IRDLOperation):  # pyright: ignore[reportUnusedClass]
             name = "test.no_region_op"
-            region = region_def()
+            region: Region = region_def()
 
             assembly_format = "attr-dict-with-keyword"
 
@@ -2222,7 +2232,7 @@ def test_region_duplicated():
             IRDLOperation
         ):
             name = "test.duplicated_region_op"
-            r = region_def()
+            r: Region = region_def()
 
             assembly_format = "$r $r attr-dict"
 
@@ -2237,7 +2247,7 @@ def test_attr_dict_directly_before_region_variable():
         @irdl_op_definition
         class RegionAttrDictWrongOp(IRDLOperation):  # pyright: ignore[reportUnusedClass]
             name = "test.region_op_missing_keyword"
-            region = region_def()
+            region: Region = region_def()
 
             assembly_format = "attr-dict $region"
 
@@ -2273,7 +2283,7 @@ def test_regions_with_attr_dict(format: str, program: str, generic_program: str)
     @irdl_op_definition
     class RegionsOp(IRDLOperation):
         name = "test.region_attr_dict"
-        region = region_def()
+        region: Region = region_def()
 
         assembly_format = format
 
@@ -2311,8 +2321,8 @@ def test_regions(format: str, program: str, generic_program: str):
     @irdl_op_definition
     class TwoRegionsOp(IRDLOperation):
         name = "test.two_regions"
-        fst = region_def()
-        snd = region_def()
+        fst: Region = region_def()
+        snd: Region = region_def()
 
         assembly_format = format
 
@@ -2355,7 +2365,7 @@ def test_variadic_region(format: str, program: str, generic_program: str):
     @irdl_op_definition
     class VariadicRegionOp(IRDLOperation):
         name = "test.variadic_region"
-        region = var_region_def()
+        region: VarRegion = var_region_def()
 
         assembly_format = format
 
@@ -2388,7 +2398,7 @@ def test_optional_region(format: str, program: str, generic_program: str):
     @irdl_op_definition
     class OptionalRegionOp(IRDLOperation):
         name = "test.optional_region"
-        region = opt_region_def()
+        region: OptRegion = opt_region_def()
 
         assembly_format = format
 
@@ -2411,8 +2421,8 @@ def test_multiple_optional_regions():
         class OptionalRegionsOp(IRDLOperation):  # pyright: ignore[reportUnusedClass]
             name = "test.optional_regions"
             irdl_options = (AttrSizedRegionSegments(),)
-            region1 = opt_region_def()
-            region2 = opt_region_def()
+            region1: OptRegion = opt_region_def()
+            region2: OptRegion = opt_region_def()
 
             assembly_format = "attr-dict-with-keyword $region1 $region2"
 
@@ -2438,7 +2448,7 @@ def test_optional_groups_regions(format: str, program: str, generic_program: str
     @irdl_op_definition
     class OptionalRegionOp(IRDLOperation):
         name = "test.optional_region_group"
-        opt_region = opt_region_def()
+        opt_region: OptRegion = opt_region_def()
 
         assembly_format = format
 
@@ -2473,7 +2483,7 @@ def test_optional_groups_empty_regions(program: str, generic_program: str):
     @irdl_op_definition
     class EmptyRegionOp(IRDLOperation):
         name = "test.empty_region_group"
-        maybe_empty = region_def()
+        maybe_empty: Region = region_def()
 
         assembly_format = "(`keyword` $maybe_empty^)? attr-dict"
 
@@ -2495,7 +2505,7 @@ def test_attr_dict_directly_after_optional_group_with_first_region_variable():
         @irdl_op_definition
         class RegionAttrDictWrongOp(IRDLOperation):  # pyright: ignore[reportUnusedClass]
             name = "test.region_op_ambiguous_optional_group"
-            region = region_def()
+            region: Region = region_def()
 
             assembly_format = "($region^)? attr-dict"
 
@@ -2512,7 +2522,7 @@ def test_missing_successor():
         @irdl_op_definition
         class NoSuccessorOp(IRDLOperation):  # pyright: ignore[reportUnusedClass]
             name = "test.no_successor_op"
-            successor = successor_def()
+            successor: Successor = successor_def()
 
             assembly_format = "attr-dict-with-keyword"
 
@@ -2528,7 +2538,7 @@ def test_successor_duplicated():
             IRDLOperation
         ):
             name = "test.duplicated_successor_op"
-            succ = successor_def()
+            succ: Successor = successor_def()
 
             assembly_format = "$succ $succ attr-dict"
 
@@ -2557,8 +2567,8 @@ def test_successors():
     @irdl_op_definition
     class TwoSuccessorsOp(IRDLOperation):
         name = "test.two_successors"
-        fst = successor_def()
-        snd = successor_def()
+        fst: Successor = successor_def()
+        snd: Successor = successor_def()
 
         assembly_format = "$fst $snd attr-dict"
 
@@ -2628,7 +2638,7 @@ def test_variadic_successor(program: str, generic_program: str):
     @irdl_op_definition
     class VarSuccessorOp(IRDLOperation):
         name = "test.var_successor"
-        succ = var_successor_def()
+        succ: VarSuccessor = var_successor_def()
 
         assembly_format = "$succ attr-dict"
 
@@ -2680,7 +2690,7 @@ def test_optional_successor(program: str, generic_program: str):
     @irdl_op_definition
     class OptSuccessorOp(IRDLOperation):
         name = "test.opt_successor"
-        succ = opt_successor_def()
+        succ: OptSuccessor = opt_successor_def()
 
         assembly_format = "$succ attr-dict"
 
@@ -2715,9 +2725,9 @@ def test_basic_inference(format: str):
         T: ClassVar = VarConstraint("T", AnyAttr())
 
         name = "test.two_operands_one_result_with_var"
-        res = result_def(T)
-        lhs = operand_def(T)
-        rhs = operand_def(T)
+        res: OpResult = result_def(T)
+        lhs: Operand = operand_def(T)
+        rhs: Operand = operand_def(T)
 
         assembly_format = format
 
@@ -2743,8 +2753,8 @@ def test_eq_attr_inference():
     @irdl_op_definition
     class OneOperandEqTypeOp(IRDLOperation):
         name = "test.one_operand_eq_type"
-        index = operand_def(UnitType())
-        res = result_def(UnitType())
+        index: Operand = operand_def(UnitType())
+        res: OpResult[UnitType] = result_def(UnitType())
 
         assembly_format = "attr-dict $index"
 
@@ -2771,7 +2781,7 @@ def test_all_of_attr_inference():
     @irdl_op_definition
     class OneOperandEqTypeAllOfNestedOp(IRDLOperation):
         name = "test.one_operand_eq_type_all_of_nested"
-        index = operand_def(AllOf((AnyAttr(), EqAttrConstraint(UnitType()))))
+        index: Operand = operand_def(AllOf((AnyAttr(), EqAttrConstraint(UnitType()))))
 
         assembly_format = "attr-dict $index"
 
@@ -2816,9 +2826,9 @@ def test_nested_inference():
         T: ClassVar = VarConstraint("T", AnyAttr())
 
         name = "test.two_operands_one_result_with_var"
-        res = result_def(T)
-        lhs = operand_def(ParamOne.constr(p=T))
-        rhs = operand_def(T)
+        res: OpResult = result_def(T)
+        lhs: Operand = operand_def(ParamOne.constr(p=T))
+        rhs: Operand = operand_def(T)
 
         assembly_format = "$lhs $rhs attr-dict `:` type($lhs)"
 
@@ -2855,8 +2865,8 @@ def test_nested_inference_variable():
         U: ClassVar = VarConstraint("U", ParamOne.constr(p=T))
 
         name = "test.result_type_is_operand_param"
-        res = result_def(T)
-        arg = operand_def(U)
+        res: OpResult = result_def(T)
+        arg: Operand = operand_def(U)
 
         assembly_format = "$arg attr-dict `:` type($arg)"
 
@@ -2897,8 +2907,8 @@ def test_non_verifying_inference():
         T: ClassVar = VarConstraint("T", AnyAttr())
 
         name = "test.one_operand_one_result_nested"
-        res = result_def(T)
-        lhs = operand_def(ParamOne.constr(p=T))
+        res: OpResult = result_def(T)
+        lhs: Operand = operand_def(ParamOne.constr(p=T))
 
         assembly_format = "$lhs attr-dict `:` type($lhs)"
 
@@ -2925,8 +2935,8 @@ def test_variadic_length_inference():
     class RangeVarOp(IRDLOperation):
         name = "test.range_var"
         T: ClassVar = RangeVarConstraint("T", RangeOf(AnyAttr()))
-        ins = var_operand_def(T)
-        outs = var_result_def(T)
+        ins: VarOperand = var_operand_def(T)
+        outs: VarOpResult = var_result_def(T)
 
         assembly_format = "$ins attr-dict `:` type($ins)"
 
@@ -2952,8 +2962,10 @@ def test_int_var_inference():
     class IntVarOp(IRDLOperation):
         name = "test.int_var"
         T: ClassVar = IntVarConstraint("T", AnyInt())
-        ins = var_operand_def(RangeOf(eq(IndexType())).of_length(T))
-        outs = var_result_def(RangeOf(eq(IntegerType(64))).of_length(T))
+        ins: VarOperand = var_operand_def(RangeOf(eq(IndexType())).of_length(T))
+        outs: VarOpResult[IntegerType] = var_result_def(
+            RangeOf(eq(IntegerType(64))).of_length(T)
+        )
 
         assembly_format = "$ins attr-dict"
 
@@ -3096,7 +3108,7 @@ def test_optional_group_optional_operand_anchor(
     class OptionalGroupOp(IRDLOperation):
         name = "test.optional_group"
 
-        args = opt_operand_def()
+        args: OptOperand = opt_operand_def()
 
         assembly_format = "(`(` $args^ `:` type($args) `)`)? attr-dict"
 
@@ -3129,8 +3141,8 @@ def test_optional_else_group(
     class OptionalElseGroupOp(IRDLOperation):
         name = "test.optional_else_group"
 
-        v = opt_operand_def(i32)
-        a = opt_prop_def(IntegerAttr[I32])
+        v: OptOperand = opt_operand_def(i32)
+        a: IntegerAttr[I32] | None = opt_prop_def(IntegerAttr[I32])
 
         assembly_format = """($v^):($a)? attr-dict"""
 
@@ -3153,7 +3165,7 @@ def test_impossible_optional_else_group():
         class OptionalImpossibleElseGroup(IRDLOperation):  # pyright: ignore[reportUnusedClass]
             name = "test.impossible_optional_else_group"
 
-            val = opt_prop_def(IntegerAttr[I32])
+            val: IntegerAttr[I32] | None = opt_prop_def(IntegerAttr[I32])
 
             assembly_format = """($val^):($val)? attr-dict"""
 
@@ -3183,8 +3195,8 @@ def test_optional_optional_group_optional_operand_anchor(
     class OptionalOptionalGroupOp(IRDLOperation):
         name = "test.optional_optional_group"
 
-        prop = opt_prop_def(StringAttr)
-        arg = opt_operand_def(I32)
+        prop: StringAttr | None = opt_prop_def(StringAttr)
+        arg: OptOperand = opt_operand_def(I32)
 
         assembly_format = "(`with` $prop^ ($arg^)?)? attr-dict"
 
@@ -3223,7 +3235,7 @@ def test_optional_group_variadic_operand_anchor(
     class OptionalGroupOp(IRDLOperation):
         name = "test.optional_group"
 
-        args = var_operand_def()
+        args: VarOperand = var_operand_def()
 
         assembly_format = "($args^ `:` type($args))? attr-dict"
 
@@ -3256,7 +3268,7 @@ def test_optional_group_optional_result_anchor(
     class OptionalGroupOp(IRDLOperation):
         name = "test.optional_group"
 
-        res = opt_result_def()
+        res: OptOpResult = opt_result_def()
 
         assembly_format = "(`(` type($res)^ `)`)? attr-dict"
 
@@ -3293,7 +3305,7 @@ def test_optional_group_variadic_result_anchor(
     class OptionalGroupOp(IRDLOperation):
         name = "test.optional_group"
 
-        res = var_result_def()
+        res: VarOpResult = var_result_def()
 
         assembly_format = "(`(` type($res)^ `)`)? attr-dict"
 
@@ -3338,10 +3350,10 @@ def test_optional_group_checkers(format: str, error: str):
         class WrongOptionalGroupOp(IRDLOperation):  # pyright: ignore[reportUnusedClass]
             name = "test.wrong_optional_group"
 
-            args = var_operand_def()
-            rets = var_result_def()
-            mandatory_arg = operand_def()
-            optional_unit_arg = opt_prop_def(UnitAttr())
+            args: VarOperand = var_operand_def()
+            rets: VarOpResult = var_result_def()
+            mandatory_arg: Operand = operand_def()
+            optional_unit_arg: UnitAttr | None = opt_prop_def(UnitAttr())
 
             assembly_format = format
 
@@ -3370,8 +3382,8 @@ def test_variadic_and_single_mixed(program: str, generic_program: str):
     @irdl_op_definition
     class MixedOp(IRDLOperation):
         name = "test.mixed"
-        var = var_operand_def(TestType("index"))
-        sin = operand_def(TestType("index"))
+        var: VarOperand = var_operand_def(TestType("index"))
+        sin: Operand = operand_def(TestType("index"))
 
         assembly_format = "$sin `(` $var `)` attr-dict"
 
@@ -3387,11 +3399,11 @@ def test_variadic_and_single_mixed(program: str, generic_program: str):
 class DefaultOp(IRDLOperation):
     name = "test.default"
 
-    prop = prop_def(BoolAttr, default_value=BoolAttr.from_bool(False))
-    opt_prop = opt_prop_def(BoolAttr, default_value=BoolAttr.from_bool(True))
+    prop: BoolAttr = prop_def(BoolAttr, default_value=BoolAttr.from_bool(False))
+    opt_prop: BoolAttr = opt_prop_def(BoolAttr, default_value=BoolAttr.from_bool(True))
 
-    attr = attr_def(BoolAttr, default_value=BoolAttr.from_bool(False))
-    opt_attr = opt_attr_def(BoolAttr, default_value=BoolAttr.from_bool(True))
+    attr: BoolAttr = attr_def(BoolAttr, default_value=BoolAttr.from_bool(False))
+    opt_attr: BoolAttr = opt_attr_def(BoolAttr, default_value=BoolAttr.from_bool(True))
 
     assembly_format = "(`prop` $prop^)? (`opt_prop` $opt_prop^)? (`attr` $attr^)? (`opt_attr` $opt_attr^)? attr-dict"
 
@@ -3470,10 +3482,10 @@ def test_default_properties(program: str, output: str, generic: str):
 class RenamedPropOp(IRDLOperation):
     name = "test.renamed"
 
-    prop1 = prop_def(
+    prop1: BoolAttr = prop_def(
         BoolAttr, default_value=BoolAttr.from_bool(False), prop_name="test_prop1"
     )
-    prop2 = opt_prop_def(BoolAttr, prop_name="test_prop2")
+    prop2: BoolAttr | None = opt_prop_def(BoolAttr, prop_name="test_prop2")
 
     assembly_format = "(`prop1` $test_prop1^)? (`prop2` $test_prop2^)? attr-dict"
 
@@ -3536,9 +3548,9 @@ def test_default_property_in_attr_dict(program: str, generic: str):
     class DefaultAttrDictOp(IRDLOperation):
         name = "test.default_attr_dict"
 
-        prop = prop_def(BoolAttr, default_value=BoolAttr.from_bool(False))
+        prop: BoolAttr = prop_def(BoolAttr, default_value=BoolAttr.from_bool(False))
 
-        attr = attr_def(BoolAttr, default_value=BoolAttr.from_bool(False))
+        attr: BoolAttr = attr_def(BoolAttr, default_value=BoolAttr.from_bool(False))
 
         irdl_options = (ParsePropInAttrDict(),)
 
@@ -3569,7 +3581,7 @@ def test_default_attr_in_attr_dict(program: str, generic: str):
     class DefaultAttrDictOp(IRDLOperation):
         name = "test.default_attr_dict"
 
-        attr = attr_def(BoolAttr, default_value=BoolAttr.from_bool(False))
+        attr: BoolAttr = attr_def(BoolAttr, default_value=BoolAttr.from_bool(False))
 
         assembly_format = "attr-dict"
 
@@ -3590,8 +3602,8 @@ class AllOfExtractorOp(IRDLOperation):
     name = "test.all_of_extractor"
 
     T: ClassVar = VarConstraint("T", AnyAttr())
-    lhs = operand_def(T & MemRefType.constr(T))
-    rhs = operand_def(T)
+    lhs: Operand = operand_def(T & MemRefType.constr(T))
+    rhs: Operand = operand_def(T)
 
     assembly_format = "$lhs `,` $rhs attr-dict `:` type($lhs)"
 
@@ -3627,8 +3639,8 @@ class ParamExtractorOp(IRDLOperation):
     name = "test.param_extractor"
 
     T: ClassVar = VarConstraint("T", AnyAttr())
-    lhs = operand_def(ParamAttrConstraint(DoubleParamAttr, (T, T)))
-    rhs = operand_def(T)
+    lhs: Operand = operand_def(ParamAttrConstraint(DoubleParamAttr, (T, T)))
+    rhs: Operand = operand_def(T)
 
     assembly_format = "$lhs `,` $rhs attr-dict `:` type($lhs)"
 
@@ -3655,8 +3667,8 @@ class MultipleOperandExtractorOp(IRDLOperation):
     name = "test.multiple_operand_extractor"
 
     T: ClassVar = VarConstraint("T", AnyAttr())
-    lhs = operand_def(T)
-    rhs = operand_def(T)
+    lhs: Operand = operand_def(T)
+    rhs: Operand = operand_def(T)
 
     assembly_format = "$lhs `,` $rhs attr-dict `:` type($lhs) `,` type($rhs)"
 
@@ -3688,9 +3700,11 @@ class IntAttrExtractOp(IRDLOperation):
 
     _I: ClassVar = IntVarConstraint("I", AnyInt())
 
-    prop = prop_def(IntegerAttr.constr(value=_I, type=eq(IndexType())))
+    prop: IntegerAttr = prop_def(IntegerAttr.constr(value=_I, type=eq(IndexType())))
 
-    outs = var_result_def(RangeOf(eq(IndexType())).of_length(_I))
+    outs: VarOpResult[IndexType] = var_result_def(
+        RangeOf(eq(IndexType())).of_length(_I)
+    )
 
     assembly_format = "$prop attr-dict"
 
@@ -3733,11 +3747,13 @@ class IntAttrVerifyOp(IRDLOperation):
 
     _I: ClassVar = IntVarConstraint("I", AnyInt())
 
-    prop = prop_def(IntegerAttr.constr(value=_I, type=eq(IndexType())))
+    prop: IntegerAttr = prop_def(IntegerAttr.constr(value=_I, type=eq(IndexType())))
 
-    prop2 = opt_prop_def(IntegerAttr.constr(value=_I, type=eq(IndexType())))
+    prop2: IntegerAttr | None = opt_prop_def(
+        IntegerAttr.constr(value=_I, type=eq(IndexType()))
+    )
 
-    ins = var_operand_def(RangeOf(eq(IndexType())).of_length(_I))
+    ins: VarOperand = var_operand_def(RangeOf(eq(IndexType())).of_length(_I))
 
     assembly_format = "$prop (`and` $prop2^)? `,` $ins attr-dict"
 
@@ -3800,7 +3816,7 @@ class MyAttr(ParametrizedAttribute):
 class NonQualifiedAttrOp(IRDLOperation):
     name = "test.non_qualified_attr"
 
-    attr = prop_def(MyAttr)
+    attr: MyAttr = prop_def(MyAttr)
 
     assembly_format = "$attr attr-dict"
 
@@ -3820,7 +3836,7 @@ def test_non_qualified_attr():
 class QualifiedAttrOp(IRDLOperation):
     name = "test.qualified_attr"
 
-    attr = prop_def(MyAttr)
+    attr: MyAttr = prop_def(MyAttr)
 
     assembly_format = "qualified($attr) attr-dict"
 
@@ -3904,7 +3920,7 @@ class Bars(CustomDirective):
 class CustomDirectiveWithParamOp(IRDLOperation):
     name = "test.custom_param"
 
-    ops = var_operand_def()
+    ops: VarOperand = var_operand_def()
 
     assembly_format = "custom<Bars>($ops) (`:` type($ops)^)? attr-dict"
 
@@ -3988,12 +4004,12 @@ class EmptyDirectiveWithParams(CustomDirective):
 class RefDirectivesOp(IRDLOperation):
     name = "test.ref_directives"
 
-    op = operand_def()
-    res = result_def()
-    attr = attr_def()
-    prop = prop_def()
-    region = region_def()
-    successor = successor_def()
+    op: Operand = operand_def()
+    res: OpResult = result_def()
+    attr: Attribute = attr_def()
+    prop: Attribute = prop_def()
+    region: Region = region_def()
+    successor: Successor = successor_def()
 
     assembly_format = (
         "$op type($op) type($res) $attr $prop $region $successor "
@@ -4049,8 +4065,8 @@ def test_optional_anchor_dynamic_index_list(program: str, generic_program: str):
     class DynIndexListOp(IRDLOperation):
         name = "test.dyn_index_list"
 
-        dynamic_indices = var_operand_def(I64)
-        static_indices = prop_def(DenseArrayBase[I64])
+        dynamic_indices: VarOperand = var_operand_def(I64)
+        static_indices: DenseArrayBase[I64] = prop_def(DenseArrayBase[I64])
 
         assembly_format = "(`keyword` custom<DynamicIndexList>($dynamic_indices, $static_indices)^)? attr-dict"
 

--- a/tests/irdl/test_operation_builder.py
+++ b/tests/irdl/test_operation_builder.py
@@ -14,7 +14,18 @@ from xdsl.irdl import (
     AttrSizedResultSegments,
     AttrSizedSuccessorSegments,
     IRDLOperation,
+    Operand,
+    OpResult,
+    OptOperand,
+    OptOpResult,
+    OptRegion,
+    OptSuccessor,
     SameVariadicOperandSize,
+    Successor,
+    VarOperand,
+    VarOpResult,
+    VarRegion,
+    VarSuccessor,
     attr_def,
     irdl_op_definition,
     operand_def,
@@ -46,7 +57,7 @@ from xdsl.utils.exceptions import VerifyException
 class ResultOp(IRDLOperation):
     name = "test.result_op"
 
-    res = result_def(StringAttr)
+    res: OpResult[StringAttr] = result_def(StringAttr)
 
 
 def test_result_builder():
@@ -64,7 +75,7 @@ def test_result_builder_exception():
 class OptResultOp(IRDLOperation):
     name = "test.opt_result_op"
 
-    res = opt_result_def(StringAttr)
+    res: OptOpResult[StringAttr] = opt_result_def(StringAttr)
 
 
 def test_opt_result_builder():
@@ -94,7 +105,7 @@ def test_opt_result_builder_two_args():
 class VarResultOp(IRDLOperation):
     name = "test.var_result_op"
 
-    res = var_result_def(StringAttr)
+    res: VarOpResult[StringAttr] = var_result_def(StringAttr)
 
 
 def test_var_result_builder():
@@ -110,8 +121,8 @@ def test_var_result_builder():
 class TwoVarResultOp(IRDLOperation):
     name = "test.two_var_result_op"
 
-    res1 = var_result_def(StringAttr)
-    res2 = var_result_def(StringAttr)
+    res1: VarOpResult[StringAttr] = var_result_def(StringAttr)
+    res2: VarOpResult[StringAttr] = var_result_def(StringAttr)
     irdl_options = (AttrSizedResultSegments(),)
 
 
@@ -158,9 +169,9 @@ def test_two_var_result_builder2():
 class MixedResultOp(IRDLOperation):
     name = "test.mixed"
 
-    res1 = var_result_def(StringAttr)
-    res2 = result_def(StringAttr)
-    res3 = var_result_def(StringAttr)
+    res1: VarOpResult[StringAttr] = var_result_def(StringAttr)
+    res2: OpResult[StringAttr] = result_def(StringAttr)
+    res3: VarOpResult[StringAttr] = var_result_def(StringAttr)
     irdl_options = (AttrSizedResultSegments(),)
 
 
@@ -195,7 +206,7 @@ def test_var_mixed_builder():
 class OperandOp(IRDLOperation):
     name = "test.operand_op"
 
-    res = operand_def(StringAttr)
+    res: Operand = operand_def(StringAttr)
 
 
 def test_operand_builder_operation():
@@ -221,7 +232,7 @@ def test_operand_builder_exception():
 class OptOperandOp(IRDLOperation):
     name = "test.opt_operand_op"
 
-    res = opt_operand_def(StringAttr)
+    res: OptOperand = opt_operand_def(StringAttr)
 
 
 def test_opt_operand_builder():
@@ -250,7 +261,7 @@ def test_opt_operand_builder_two_args():
 class VarOperandOp(IRDLOperation):
     name = "test.var_operand_op"
 
-    res = var_operand_def(StringAttr)
+    res: VarOperand = var_operand_def(StringAttr)
 
 
 def test_var_operand_builder():
@@ -264,8 +275,8 @@ def test_var_operand_builder():
 class TwoVarOperandOp(IRDLOperation):
     name = "test.two_var_operand_op"
 
-    res1 = var_operand_def(StringAttr)
-    res2 = var_operand_def(StringAttr)
+    res1: VarOperand = var_operand_def(StringAttr)
+    res2: VarOperand = var_operand_def(StringAttr)
     irdl_options = (AttrSizedOperandSegments(),)
 
 
@@ -274,8 +285,8 @@ class TwoVarOperandOp(IRDLOperation):
 class TwoVarOperandPropOp(IRDLOperation):
     name = "test.two_var_operand_op"
 
-    res1 = var_operand_def(StringAttr)
-    res2 = var_operand_def(StringAttr)
+    res1: VarOperand = var_operand_def(StringAttr)
+    res2: VarOperand = var_operand_def(StringAttr)
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
 
@@ -323,9 +334,9 @@ def test_two_var_operand_prop_builder2():
 class SameSizeVarOperandOp(IRDLOperation):
     name = "test.same_size_var_operand_op"
 
-    var1 = var_operand_def()
-    op1 = operand_def()
-    var2 = var_operand_def()
+    var1: VarOperand = var_operand_def()
+    op1: Operand = operand_def()
+    var2: VarOperand = var_operand_def()
     irdl_options = (SameVariadicOperandSize(),)
 
 
@@ -363,7 +374,7 @@ def test_same_size_operand_builder2():
 @irdl_op_definition
 class AttrOp(IRDLOperation):
     name = "test.attr_op"
-    attr = attr_def(StringAttr)
+    attr: StringAttr = attr_def(StringAttr)
 
 
 def test_attr_op():
@@ -383,7 +394,7 @@ def test_attr_new_attr_op():
 class OptionalAttrOp(IRDLOperation):
     name = "test.opt_attr_op"
 
-    opt_attr = opt_attr_def(StringAttr)
+    opt_attr: StringAttr | None = opt_attr_def(StringAttr)
 
 
 def test_optional_attr_op_empty():
@@ -400,7 +411,7 @@ def test_optional_attr_op_empty():
 @irdl_op_definition
 class PropertyOp(IRDLOperation):
     name = "test.prop_op"
-    attr = prop_def(StringAttr)
+    attr: StringAttr = prop_def(StringAttr)
 
 
 def test_prop_op():
@@ -413,7 +424,7 @@ def test_prop_op():
 class OptionalPropertyOp(IRDLOperation):
     name = "test.opt_prop_op"
 
-    opt_attr = opt_prop_def(StringAttr)
+    opt_attr: StringAttr | None = opt_prop_def(StringAttr)
 
 
 def test_optional_prop_op_empty():
@@ -431,7 +442,7 @@ def test_optional_prop_op_empty():
 class RegionOp(IRDLOperation):
     name = "test.region_op"
 
-    region = region_def()
+    region: Region = region_def()
 
 
 def test_region_op_region():
@@ -471,7 +482,7 @@ def test_singleop_region():
 class SBRegionOp(IRDLOperation):
     name = "test.sbregion_op"
 
-    region = region_def("single_block")
+    region: Region = region_def("single_block")
 
 
 def test_sbregion_one_block():
@@ -484,7 +495,7 @@ def test_sbregion_one_block():
 class OptRegionOp(IRDLOperation):
     name = "test.opt_region_op"
 
-    reg = opt_region_def()
+    reg: OptRegion = opt_region_def()
 
 
 def test_opt_region_builder():
@@ -511,7 +522,7 @@ def test_opt_region_builder_two_args():
 class OptSBRegionOp(IRDLOperation):
     name = "test.sbregion_op"
 
-    region = opt_region_def("single_block")
+    region: OptRegion = opt_region_def("single_block")
 
 
 def test_opt_sbregion_one_block():
@@ -528,7 +539,7 @@ def test_opt_sbregion_one_block():
 class VarRegionOp(IRDLOperation):
     name = "test.var_operand_op"
 
-    regs = var_region_def()
+    regs: VarRegion = var_region_def()
 
 
 def test_var_region_builder():
@@ -542,7 +553,7 @@ def test_var_region_builder():
 class VarSBRegionOp(IRDLOperation):
     name = "test.sbregion_op"
 
-    regs = var_region_def("single_block")
+    regs: VarRegion = var_region_def("single_block")
 
 
 def test_var_sbregion_one_block():
@@ -560,8 +571,8 @@ def test_var_sbregion_one_block():
 class TwoVarRegionOp(IRDLOperation):
     name = "test.two_var_region_op"
 
-    res1 = var_region_def()
-    res2 = var_region_def()
+    res1: VarRegion = var_region_def()
+    res2: VarRegion = var_region_def()
     irdl_options = (AttrSizedRegionSegments(),)
 
 
@@ -600,7 +611,7 @@ def test_two_var_operand_builder3():
 class SuccessorOp(IRDLOperation):
     name = "test.successor_op"
 
-    successor = successor_def()
+    successor: Successor = successor_def()
 
     traits = traits_def(IsTerminator())
 
@@ -622,7 +633,7 @@ def test_successor_op_successor():
 class OptSuccessorOp(IRDLOperation):
     name = "test.opt_successora_op"
 
-    successor = opt_successor_def()
+    successor: OptSuccessor = opt_successor_def()
 
     traits = traits_def(IsTerminator())
 
@@ -650,7 +661,7 @@ def test_opt_successor_builder():
 class VarSuccessorOp(IRDLOperation):
     name = "test.var_succesor_op"
 
-    successor = var_successor_def()
+    successor: VarSuccessor = var_successor_def()
 
     traits = traits_def(IsTerminator())
 
@@ -673,8 +684,8 @@ def test_var_successor_builder():
 class TwoVarSuccessorOp(IRDLOperation):
     name = "test.two_var_successor_op"
 
-    res1 = var_successor_def()
-    res2 = var_successor_def()
+    res1: VarSuccessor = var_successor_def()
+    res2: VarSuccessor = var_successor_def()
     irdl_options = (AttrSizedSuccessorSegments(),)
 
     traits = traits_def(IsTerminator())

--- a/tests/irdl/test_operation_definition.py
+++ b/tests/irdl/test_operation_definition.py
@@ -8,6 +8,7 @@ from typing_extensions import TypeVar
 
 from xdsl.context import Context
 from xdsl.dialects.builtin import (
+    I32,
     BoolAttr,
     DenseArrayBase,
     IndexType,
@@ -33,13 +34,21 @@ from xdsl.irdl import (
     IntVarConstraint,
     IRDLOperation,
     OpDef,
+    Operand,
     OperandDef,
+    OptOperand,
+    OptOpResult,
+    OptRegion,
     PropertyDef,
     RangeOf,
     RangeVarConstraint,
     RegionDef,
     ResultDef,
     VarConstraint,
+    VarOperand,
+    VarOpResult,
+    VarRegion,
+    VarSuccessor,
     attr_def,
     base,
     irdl_op_definition,
@@ -78,11 +87,11 @@ class OpDefTestOp(IRDLOperation):
 
     irdl_options = (AttrSizedOperandSegments(),)
 
-    operand = operand_def()
-    result = result_def()
-    prop = prop_def()
-    attr = attr_def()
-    region = region_def()
+    operand: Operand = operand_def()
+    result: OpResult = result_def()
+    prop: Attribute = prop_def()
+    attr: Attribute = attr_def()
+    region: Region = region_def()
 
     # Check that we can define methods in operation definitions
     def test(self):
@@ -187,7 +196,7 @@ def test_list_irdl_options():
 @irdl_op_definition
 class AttrOp(IRDLOperation):
     name = "test.two_var_result_op"
-    attr = attr_def(StringAttr)
+    attr: StringAttr = attr_def(StringAttr)
 
 
 def test_attr_verify():
@@ -204,9 +213,9 @@ class GenericConstraintVarOp(IRDLOperation):
 
     T: ClassVar = VarConstraint("T", base(IntegerType) | base(IndexType))
 
-    operand = operand_def(T)
-    result = result_def(T)
-    attribute = attr_def(T)
+    operand: Operand = operand_def(T)
+    result: OpResult[IntegerType | IndexType] = result_def(T)
+    attribute: IntegerType | IndexType = attr_def(T)
 
 
 def test_generic_constraint_var():
@@ -284,10 +293,12 @@ def test_generic_constraint_var_fail_not_satisfy_constraint():
 class ConstraintRangeVarOp(IRDLOperation):
     name = "test.constraint_range_var"
 
-    operand = var_operand_def(
+    operand: VarOperand = var_operand_def(
         RangeVarConstraint("T", RangeOf(AnyOf.get(i32, IndexType)))
     )
-    result = var_result_def(RangeVarConstraint("T", RangeOf(AnyOf.get(i32, IndexType))))
+    result: VarOpResult[I32 | IndexType] = var_result_def(
+        RangeVarConstraint("T", RangeOf(AnyOf.get(i32, IndexType)))
+    )
 
 
 def test_range_var():
@@ -370,8 +381,8 @@ class SameLengthOp(IRDLOperation):
     name = "test.same_length"
 
     LENGTH: ClassVar = IntVarConstraint("length", AnyInt())
-    operand = var_operand_def(RangeOf(AnyAttr()).of_length(LENGTH))
-    result = var_result_def(RangeOf(AnyAttr()).of_length(LENGTH))
+    operand: VarOperand = var_operand_def(RangeOf(AnyAttr()).of_length(LENGTH))
+    result: VarOpResult = var_result_def(RangeOf(AnyAttr()).of_length(LENGTH))
 
 
 def test_same_length_op():
@@ -410,7 +421,7 @@ def test_same_length_op():
 class WithoutPropOp(IRDLOperation):
     name = "test.op_without_prop"
 
-    prop1 = prop_def()
+    prop1: Attribute = prop_def()
 
 
 # Check that an operation cannot accept properties that are not defined
@@ -433,9 +444,9 @@ class RegionOp(IRDLOperation):
 
     irdl_options = (AttrSizedRegionSegments(),)
 
-    region = region_def()
-    opt_region = opt_region_def()
-    var_region = var_region_def()
+    region: Region = region_def()
+    opt_region: OptRegion = opt_region_def()
+    var_region: VarRegion = var_region_def()
 
 
 def test_region_accessors():
@@ -465,9 +476,9 @@ class OperandOp(IRDLOperation):
 
     irdl_options = (AttrSizedOperandSegments(),)
 
-    operand = operand_def()
-    opt_operand = opt_operand_def()
-    var_operand = var_operand_def()
+    operand: Operand = operand_def()
+    opt_operand: OptOperand = opt_operand_def()
+    var_operand: VarOperand = var_operand_def()
 
 
 def test_operand_accessors():
@@ -495,9 +506,9 @@ class OpResultOp(IRDLOperation):
 
     irdl_options = (AttrSizedResultSegments(),)
 
-    result = result_def()
-    opt_result = opt_result_def()
-    var_result = var_result_def()
+    result: OpResult = result_def()
+    opt_result: OptOpResult = opt_result_def()
+    var_result: VarOpResult = var_result_def()
 
 
 def test_opresult_accessors():
@@ -518,8 +529,8 @@ def test_opresult_accessors():
 class AttributeOp(IRDLOperation):
     name = "test.attribute_op"
 
-    attr = attr_def(StringAttr)
-    opt_attr = opt_attr_def(StringAttr)
+    attr: StringAttr = attr_def(StringAttr)
+    opt_attr: StringAttr | None = opt_attr_def(StringAttr)
 
 
 def test_attribute_accessors():
@@ -566,8 +577,8 @@ def test_attribute_missing():
 class PropertyOp(IRDLOperation):
     name = "test.attribute_op"
 
-    attr = prop_def(StringAttr)
-    opt_attr = opt_prop_def(StringAttr)
+    attr: StringAttr = prop_def(StringAttr)
+    opt_attr: StringAttr | None = opt_prop_def(StringAttr)
 
 
 def test_property_accessors():
@@ -638,7 +649,7 @@ def test_op_accessor_assignment():
     ):
         op1.ops = new_operands
 
-    new_results: SSAValues[OpResult[Attribute]] = SSAValues((val1, val2))
+    new_results: SSAValues[OpResult] = SSAValues((val1, val2))
     with pytest.raises(
         NotImplementedError,
         match="Cannot write to named operands, regions, results, or successors.",
@@ -664,17 +675,17 @@ def test_op_segmented_accessor_assignment():
     @irdl_op_definition
     class TestSegmentedOp(IRDLOperation):
         name = "test.segmentedop"
-        operands1 = var_operand_def()
-        operands2 = var_operand_def()
+        operands1: VarOperand = var_operand_def()
+        operands2: VarOperand = var_operand_def()
 
-        results1 = var_result_def()
-        results2 = var_result_def()
+        results1: VarOpResult = var_result_def()
+        results2: VarOpResult = var_result_def()
 
-        regions1 = var_region_def()
-        regions2 = var_region_def()
+        regions1: VarRegion = var_region_def()
+        regions2: VarRegion = var_region_def()
 
-        successors1 = var_successor_def()
-        successors2 = var_successor_def()
+        successors1: VarSuccessor = var_successor_def()
+        successors2: VarSuccessor = var_successor_def()
 
         irdl_options = (
             AttrSizedOperandSegments(as_property=True),
@@ -699,7 +710,7 @@ def test_op_segmented_accessor_assignment():
     ):
         op1.operands1 = new_operands
 
-    new_results: SSAValues[OpResult[Attribute]] = SSAValues((val1, val2))
+    new_results: SSAValues[OpResult] = SSAValues((val1, val2))
     with pytest.raises(
         NotImplementedError,
         match="Cannot write to named operands, regions, results, or successors.",
@@ -736,8 +747,10 @@ class RenamedAttributeOp(IRDLOperation):
 
     name = "test.renamed_attribute_op"
 
-    accessor = attr_def(StringAttr, attr_name="attr_name")
-    opt_accessor = opt_attr_def(StringAttr, attr_name="opt_attr_name")
+    accessor: StringAttr = attr_def(StringAttr, attr_name="attr_name")
+    opt_accessor: StringAttr | None = opt_attr_def(
+        StringAttr, attr_name="opt_attr_name"
+    )
 
 
 def test_renamed_attributes_verify():
@@ -791,8 +804,10 @@ class RenamedPropertyOp(IRDLOperation):
 
     name = "test.renamed_property_op"
 
-    accessor = prop_def(StringAttr, prop_name="prop_name")
-    opt_accessor = opt_prop_def(StringAttr, prop_name="opt_prop_name")
+    accessor: StringAttr = prop_def(StringAttr, prop_name="prop_name")
+    opt_accessor: StringAttr | None = opt_prop_def(
+        StringAttr, prop_name="opt_prop_name"
+    )
 
 
 def test_renamed_properties_verify():
@@ -854,8 +869,8 @@ class GenericOp(IRDLOperation, Generic[_Attr, _Operand, _Result]):
     name = "test.string_or_int_generic"
 
     attr: _Attr = attr_def(_Attr)
-    operand = operand_def(_Operand)
-    result = result_def(_Result)
+    operand: Operand = operand_def(_Operand)
+    result: OpResult[_Result] = result_def(_Result)
 
 
 @irdl_op_definition
@@ -912,7 +927,7 @@ def test_generic_op(cls: type[StringFooOp | StringFoo2Op]):
 
 
 class OtherParentOp(IRDLOperation):
-    other_attr = attr_def()
+    other_attr: Attribute = attr_def()
 
 
 @irdl_op_definition
@@ -952,7 +967,7 @@ def test_multiple_inheritance_op():
 @irdl_op_definition
 class EntryArgsOp(IRDLOperation):
     name = "test.entry_args"
-    body = opt_region_def(entry_args=RangeOf(EqAttrConstraint(i32)))
+    body: OptRegion = opt_region_def(entry_args=RangeOf(EqAttrConstraint(i32)))
 
     traits = traits_def(NoTerminator())
 
@@ -990,9 +1005,9 @@ Operation does not verify: Region 'body' at position 0 entry arguments do not ve
 @irdl_op_definition
 class MultipleEntryArgsOp(IRDLOperation):
     name = "test.entry_args"
-    body1 = opt_region_def(entry_args=RangeOf(AnyAttr()).of_length(1))
-    bodies1 = var_region_def(entry_args=RangeOf(AnyAttr()).of_length(2))
-    bodies2 = var_region_def(entry_args=RangeOf(AnyAttr()).of_length(3))
+    body1: OptRegion = opt_region_def(entry_args=RangeOf(AnyAttr()).of_length(1))
+    bodies1: VarRegion = var_region_def(entry_args=RangeOf(AnyAttr()).of_length(2))
+    bodies2: VarRegion = var_region_def(entry_args=RangeOf(AnyAttr()).of_length(3))
 
     traits = traits_def(NoTerminator())
 
@@ -1029,8 +1044,8 @@ def test_multiple_entry_args_op():
 class OptionlessMultipleVarOp(IRDLOperation):
     name = "test.multiple_var_op"
 
-    optional = opt_operand_def()
-    variadic = var_operand_def()
+    optional: OptOperand = opt_operand_def()
+    variadic: VarOperand = var_operand_def()
 
 
 def test_no_multiple_var_option():
@@ -1047,11 +1062,11 @@ def test_no_multiple_var_option():
 class DefaultOp(IRDLOperation):
     name = "test.default"
 
-    prop = prop_def(BoolAttr, default_value=BoolAttr.from_bool(False))
-    opt_prop = opt_prop_def(BoolAttr, default_value=BoolAttr.from_bool(True))
+    prop: BoolAttr = prop_def(BoolAttr, default_value=BoolAttr.from_bool(False))
+    opt_prop: BoolAttr = opt_prop_def(BoolAttr, default_value=BoolAttr.from_bool(True))
 
-    attr = attr_def(BoolAttr, default_value=BoolAttr.from_bool(False))
-    opt_attr = opt_attr_def(BoolAttr, default_value=BoolAttr.from_bool(True))
+    attr: BoolAttr = attr_def(BoolAttr, default_value=BoolAttr.from_bool(False))
+    opt_attr: BoolAttr = opt_attr_def(BoolAttr, default_value=BoolAttr.from_bool(True))
 
     assembly_format = "(`prop` $prop^)? (`opt_prop` $opt_prop^)? (`attr` $attr^)? (`opt_attr` $opt_attr^)? attr-dict"
 

--- a/tests/test_builtin_traits.py
+++ b/tests/test_builtin_traits.py
@@ -11,6 +11,8 @@ from xdsl.ir import Block, Region
 from xdsl.irdl import (
     AttrSizedRegionSegments,
     IRDLOperation,
+    OptRegion,
+    OptSuccessor,
     irdl_op_definition,
     lazy_traits_def,
     opt_region_def,
@@ -33,7 +35,7 @@ from xdsl.utils.exceptions import VerifyException
 class ParentOp(IRDLOperation):
     name = "test.parent"
 
-    region = region_def()
+    region: Region = region_def()
 
     traits = traits_def(NoTerminator())
 
@@ -42,7 +44,7 @@ class ParentOp(IRDLOperation):
 class Parent2Op(IRDLOperation):
     name = "test.parent2"
 
-    region = region_def()
+    region: Region = region_def()
 
     traits = traits_def(NoTerminator())
 
@@ -127,7 +129,7 @@ class HasNoTerminatorOp(IRDLOperation):
 
     name = "test.has_no_terminator"
 
-    region = region_def()
+    region: Region = region_def()
 
     traits = traits_def(NoTerminator())
 
@@ -166,7 +168,7 @@ class IsTerminatorOp(IRDLOperation):
 
     name = "test.is_terminator"
 
-    successor = opt_successor_def()
+    successor: OptSuccessor = opt_successor_def()
 
     traits = traits_def(IsTerminator())
 
@@ -282,8 +284,8 @@ class HasSingleBlockImplicitTerminatorOp(IRDLOperation):
 
     irdl_options = (AttrSizedRegionSegments(),)
 
-    region = region_def()
-    opt_region = opt_region_def()
+    region: Region = region_def()
+    opt_region: OptRegion = opt_region_def()
 
     traits = traits_def(
         SingleBlockImplicitTerminator(IsSingleBlockImplicitTerminatorOp)
@@ -306,8 +308,8 @@ class HasSingleBlockImplicitTerminatorWrongCreationOp(IRDLOperation):
 
     irdl_options = (AttrSizedRegionSegments(),)
 
-    region = region_def()
-    opt_region = opt_region_def()
+    region: Region = region_def()
+    opt_region: OptRegion = opt_region_def()
 
     traits = traits_def(
         SingleBlockImplicitTerminator(IsSingleBlockImplicitTerminatorOp)
@@ -329,8 +331,8 @@ class HasSingleBlockImplicitTerminatorWrongCreation2Op(IRDLOperation):
 
     irdl_options = (AttrSizedRegionSegments(),)
 
-    region = region_def()
-    opt_region = opt_region_def()
+    region: Region = region_def()
+    opt_region: OptRegion = opt_region_def()
 
     traits = traits_def(
         NoTerminator(),
@@ -439,7 +441,7 @@ class IsolatedFromAboveOp(IRDLOperation):
 
     name = "test.isolated_from_above"
 
-    region = region_def()
+    region: Region = region_def()
 
     traits = traits_def(IsolatedFromAbove(), NoTerminator())
 

--- a/tests/test_folder.py
+++ b/tests/test_folder.py
@@ -163,7 +163,7 @@ def test_fold_dynamic_trait():
     @irdl_op_definition
     class TestFoldOp(IRDLOperation):
         name = "arith.fold"
-        res = result_def()
+        res: OpResult = result_def()
 
     class TestFold(HasFolder):
         @classmethod

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -18,6 +18,7 @@ from xdsl.dialects.builtin import (
 from xdsl.dialects.cf import Cf
 from xdsl.dialects.func import Func
 from xdsl.ir import (
+    Attribute,
     Block,
     ErasedSSAValue,
     Operation,
@@ -26,6 +27,8 @@ from xdsl.ir import (
 )
 from xdsl.irdl import (
     IRDLOperation,
+    Operand,
+    VarRegion,
     irdl_op_definition,
     operand_def,
     prop_def,
@@ -41,7 +44,7 @@ from xdsl.utils.test_value import create_ssa_value
 class TestWithPropOp(IRDLOperation):
     name = "test.op_with_prop"
 
-    prop = prop_def()
+    prop: Attribute = prop_def()
 
 
 def test_ops_accessor():
@@ -941,7 +944,7 @@ ModuleOp(
 @irdl_op_definition
 class MultipleRegionsOp(IRDLOperation):
     name = "test.custom_op_with_multiple_regions"
-    region = var_region_def()
+    region: VarRegion = var_region_def()
 
 
 def test_region_index_fetch():
@@ -1031,7 +1034,7 @@ def test_region_hashable():
 @irdl_op_definition
 class CustomVerifyOp(IRDLOperation):
     name = "test.custom_verify_op"
-    val = operand_def(i64)
+    val: Operand = operand_def(i64)
 
     @staticmethod
     def get(val: SSAValue):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -31,7 +31,7 @@ from xdsl.dialects.builtin import (
 )
 from xdsl.dialects.func import Func, FuncOp
 from xdsl.dialects.test import Test
-from xdsl.ir import Attribute, Block, ParametrizedAttribute
+from xdsl.ir import Attribute, Block, ParametrizedAttribute, Region
 from xdsl.ir.affine import AffineMap
 from xdsl.irdl import (
     IRDLOperation,
@@ -417,8 +417,8 @@ def test_parse_region_with_args_fail(text: str):
 @irdl_op_definition
 class MultiRegionOp(IRDLOperation):
     name = "test.multi_region"
-    r1 = region_def()
-    r2 = region_def()
+    r1: Region = region_def()
+    r2: Region = region_def()
 
 
 def test_parse_multi_region_mlir():
@@ -974,8 +974,8 @@ def test_parse_number_error(text: str, allow_boolean: bool):
 class PropertyOp(IRDLOperation):
     name = "test.prop_op"
 
-    first = prop_def(StringAttr)
-    second = prop_def(IntegerAttr[IntegerType])
+    first: StringAttr = prop_def(StringAttr)
+    second: IntegerAttr[IntegerType] = prop_def(IntegerAttr[IntegerType])
 
 
 def test_properties_retrocompatibility():

--- a/tests/test_parser_error.py
+++ b/tests/test_parser_error.py
@@ -3,6 +3,8 @@ import pytest
 from xdsl.context import Context
 from xdsl.irdl import (
     IRDLOperation,
+    VarOperand,
+    VarOpResult,
     irdl_op_definition,
     var_operand_def,
     var_result_def,
@@ -14,8 +16,8 @@ from xdsl.utils.exceptions import ParseError
 @irdl_op_definition
 class UnknownOp(IRDLOperation):
     name = "test.unknown"
-    ops = var_operand_def()
-    res = var_result_def()
+    ops: VarOperand = var_operand_def()
+    res: VarOpResult = var_result_def()
 
 
 def check_error(prog: str, line: int, column: int, message: str):

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -44,6 +44,10 @@ from xdsl.ir import (
 )
 from xdsl.irdl import (
     IRDLOperation,
+    Operand,
+    OpResult,
+    VarOperand,
+    VarOpResult,
     irdl_attr_definition,
     irdl_op_definition,
     operand_def,
@@ -110,7 +114,7 @@ def test_print_custom_format_op_location():
 class UnitAttrOp(IRDLOperation):
     name = "unit_attr_op"
 
-    parallelize = opt_attr_def(UnitAttr)
+    parallelize: UnitAttr | None = opt_attr_def(UnitAttr)
 
 
 def test_unit_attr():
@@ -614,9 +618,9 @@ def test_print_region_empty_block_with_args():
 @irdl_op_definition
 class PlusCustomFormatOp(IRDLOperation):
     name = "test.add"
-    lhs = operand_def(IntegerType)
-    rhs = operand_def(IntegerType)
-    res = result_def(IntegerType)
+    lhs: Operand = operand_def(IntegerType)
+    rhs: Operand = operand_def(IntegerType)
+    res: OpResult[IntegerType] = result_def(IntegerType)
 
     @classmethod
     def parse(cls, parser: Parser) -> PlusCustomFormatOp:
@@ -727,8 +731,8 @@ def test_custom_format_II():
 class NoCustomFormatOp(IRDLOperation):
     name = "test.no_custom_format"
 
-    ops = var_operand_def()
-    res = var_result_def()
+    ops: VarOperand = var_operand_def()
+    res: VarOpResult = var_result_def()
 
 
 def test_missing_custom_format():

--- a/tests/test_ssa_value.py
+++ b/tests/test_ssa_value.py
@@ -3,7 +3,7 @@ import re
 import pytest
 
 from xdsl.dialects.builtin import StringAttr, i32, i64
-from xdsl.ir import Block, BlockArgument, Operation, SSAValue
+from xdsl.ir import Block, BlockArgument, Operation, OpResult, SSAValue
 from xdsl.irdl import IRDLOperation, irdl_op_definition, result_def
 from xdsl.rewriter import Rewriter
 from xdsl.utils.test_value import create_ssa_value
@@ -13,8 +13,8 @@ from xdsl.utils.test_value import create_ssa_value
 class TwoResultOp(IRDLOperation):
     name = "test.tworesults"
 
-    res1 = result_def(StringAttr)
-    res2 = result_def(StringAttr)
+    res1: OpResult[StringAttr] = result_def(StringAttr)
+    res2: OpResult[StringAttr] = result_def(StringAttr)
 
 
 def test_var_mixed_builder():

--- a/tests/test_traits.py
+++ b/tests/test_traits.py
@@ -16,6 +16,7 @@ from xdsl.dialects.builtin import (
     DYNAMIC_INDEX,
     AnyTensorTypeConstr,
     AnyUnrankedMemRefTypeConstr,
+    AnyUnrankedTensorType,
     AnyUnrankedTensorTypeConstr,
     IntegerAttr,
     IntegerType,
@@ -25,6 +26,7 @@ from xdsl.dialects.builtin import (
     SymbolNameConstraint,
     SymbolRefAttr,
     TensorType,
+    UnrankedMemRefType,
     UnrankedTensorType,
     i1,
     i32,
@@ -35,7 +37,13 @@ from xdsl.ir import Attribute, Operation, OpTrait, SSAValue
 from xdsl.irdl import (
     Block,
     IRDLOperation,
+    Operand,
+    OpResult,
+    OptRegion,
     Region,
+    VarOperand,
+    VarOpResult,
+    VarSuccessor,
     attr_def,
     irdl_op_definition,
     lazy_traits_def,
@@ -132,8 +140,8 @@ class TestOp(IRDLOperation):
     name = "test.test"
     traits = traits_def(LargerOperandTrait(), BitwidthSumLessThanTrait(64))
 
-    ops = operand_def(IntegerType)
-    res = result_def(IntegerType)
+    ops: Operand = operand_def(IntegerType)
+    res: OpResult[IntegerType] = result_def(IntegerType)
 
 
 def test_has_trait_object():
@@ -272,7 +280,7 @@ class HasInterfaceOp(IRDLOperation):
     name = "test.op_with_interface"
     traits = traits_def(GetNumResultsTraitForOpWithOneResult())
 
-    res = result_def(IntegerType)
+    res: OpResult[IntegerType] = result_def(IntegerType)
 
 
 def test_interface():
@@ -322,7 +330,7 @@ def test_symbol_op_interface():
     class SymNameWrongTypeOp(IRDLOperation):
         name = "wrong_sym_name_type"
 
-        sym_name = attr_def(IntegerAttr)
+        sym_name: IntegerAttr = attr_def(IntegerAttr)
         traits = traits_def(SymbolOpInterface())
 
     op1 = SymNameWrongTypeOp(attributes={"sym_name": IntegerAttr(1, 32)})
@@ -337,7 +345,7 @@ def test_symbol_op_interface():
     class SymNameOp(IRDLOperation):
         name = "sym_name"
 
-        sym_name = attr_def(SymbolNameConstraint())
+        sym_name: StringAttr = attr_def(SymbolNameConstraint())
         traits = traits_def(SymbolOpInterface())
 
     op2 = SymNameOp(attributes={"sym_name": StringAttr("symbol_name")})
@@ -353,7 +361,7 @@ def test_optional_symbol_op_interface():
     class OptionalSymNameOp(IRDLOperation):
         name = "no_sym_name"
 
-        sym_name = opt_attr_def(StringAttr)
+        sym_name: StringAttr | None = opt_attr_def(StringAttr)
 
         traits = traits_def(OptionalSymbolOpInterface())
 
@@ -376,7 +384,7 @@ def test_optional_symbol_op_interface():
 class SymbolOp(IRDLOperation):
     name = "test.symbol"
 
-    sym_name = attr_def(SymbolNameConstraint())
+    sym_name: StringAttr = attr_def(SymbolNameConstraint())
 
     traits = traits_def(SymbolOpInterface())
 
@@ -388,7 +396,7 @@ class SymbolOp(IRDLOperation):
 class PropSymbolOp(IRDLOperation):
     name = "test.symbol"
 
-    sym_name = prop_def(SymbolNameConstraint())
+    sym_name: StringAttr = prop_def(SymbolNameConstraint())
 
     traits = traits_def(SymbolOpInterface())
 
@@ -403,10 +411,10 @@ def test_symbol_table(SymbolOp: type[PropSymbolOp | SymbolOp]):
     class SymbolTableOp(IRDLOperation):
         name = "test.symbol_table"
 
-        sym_name = opt_attr_def(StringAttr)
+        sym_name: StringAttr | None = opt_attr_def(StringAttr)
 
-        one = region_def()
-        two = opt_region_def()
+        one: Region = region_def()
+        two: OptRegion = opt_region_def()
 
         traits = traits_def(SymbolTable(), OptionalSymbolOpInterface())
 
@@ -506,7 +514,7 @@ def test_insert_or_update():
     class SymbolTableOp(IRDLOperation):
         name = "test.symbol_table"
 
-        reg = region_def()
+        reg: Region = region_def()
 
         traits = traits_def(SymbolTable())
 
@@ -559,7 +567,7 @@ def test_speculability(
     @irdl_op_definition
     class SupeculatabilityTestOp(IRDLOperation):
         name = "test.speculatability"
-        region = region_def()
+        region: Region = region_def()
 
         traits = traits_def(*trait)
 
@@ -582,7 +590,7 @@ def test_conditionally_speculatable_interface(speculatability: bool):
         IRDLOperation, ConditionallySpeculatableInterface
     ):
         name = "test.interface_speculatability"
-        region = region_def()
+        region: Region = region_def()
 
         def is_speculatable(self) -> bool:
             return speculatability
@@ -611,8 +619,8 @@ def test_same_operands_and_result_type_trait_for_scalar_types(
     class SameOperandsAndResultTypeOp(IRDLOperation):
         name = "test.same_operand_and_result_type"
 
-        ops = var_operand_def(test.TestType("foo"))
-        res = var_result_def(test.TestType("foo"))
+        ops: VarOperand = var_operand_def(test.TestType("foo"))
+        res: VarOpResult[test.TestType] = var_result_def(test.TestType("foo"))
 
         traits = traits_def(SameOperandsAndResultType())
 
@@ -628,14 +636,16 @@ def test_same_operands_and_result_type_trait_for_scalar_types(
 class SameOperandsAndResultTypeOp(IRDLOperation):
     name = "test.same_operand_and_result_type"
 
-    ops = var_operand_def(
+    ops: VarOperand = var_operand_def(
         MemRefType.constr()
         | AnyUnrankedMemRefTypeConstr
         | AnyUnrankedTensorTypeConstr
         | AnyTensorTypeConstr
     )
 
-    res = var_result_def(
+    res: VarOpResult[
+        MemRefType | UnrankedMemRefType | AnyUnrankedTensorType | TensorType
+    ] = var_result_def(
         MemRefType.constr()
         | AnyUnrankedMemRefTypeConstr
         | AnyUnrankedTensorTypeConstr
@@ -1058,8 +1068,8 @@ def test_return_like():
         name = "test.return_like"
 
         traits = traits_def(ReturnLike())
-        my_results = var_result_def()
-        my_successors = var_successor_def()
+        my_results: VarOpResult = var_result_def()
+        my_successors: VarSuccessor = var_successor_def()
 
     terminator = TestReturnLikeOp(result_types=((),), successors=((),))
 

--- a/xdsl/dialects/acc.py
+++ b/xdsl/dialects/acc.py
@@ -48,7 +48,12 @@ from xdsl.ir import (
 from xdsl.irdl import (
     AttrSizedOperandSegments,
     IRDLOperation,
+    Operand,
+    OpResult,
+    OptOperand,
     ParsePropInAttrDict,
+    VarOperand,
+    VarOpResult,
     irdl_attr_definition,
     irdl_op_definition,
     lazy_traits_def,
@@ -2453,47 +2458,55 @@ class ParallelOp(IRDLOperation):
 
     name = "acc.parallel"
 
-    async_operands = var_operand_def(IntegerType | IndexType)
-    wait_operands = var_operand_def(IntegerType | IndexType)
-    num_gangs = var_operand_def(IntegerType | IndexType)
-    num_workers = var_operand_def(IntegerType | IndexType)
-    vector_length = var_operand_def(IntegerType | IndexType)
-    if_cond = opt_operand_def(I1)
-    self_cond = opt_operand_def(I1)
-    reduction_operands = var_operand_def()
-    private_operands = var_operand_def()
-    firstprivate_operands = var_operand_def()
-    data_clause_operands = var_operand_def()
+    async_operands: VarOperand = var_operand_def(IntegerType | IndexType)
+    wait_operands: VarOperand = var_operand_def(IntegerType | IndexType)
+    num_gangs: VarOperand = var_operand_def(IntegerType | IndexType)
+    num_workers: VarOperand = var_operand_def(IntegerType | IndexType)
+    vector_length: VarOperand = var_operand_def(IntegerType | IndexType)
+    if_cond: OptOperand = opt_operand_def(I1)
+    self_cond: OptOperand = opt_operand_def(I1)
+    reduction_operands: VarOperand = var_operand_def()
+    private_operands: VarOperand = var_operand_def()
+    firstprivate_operands: VarOperand = var_operand_def()
+    data_clause_operands: VarOperand = var_operand_def()
 
-    async_operands_device_type = opt_prop_def(
+    async_operands_device_type: ArrayAttr[DeviceTypeAttr] | None = opt_prop_def(
         ArrayAttr[DeviceTypeAttr], prop_name="asyncOperandsDeviceType"
     )
-    async_only = opt_prop_def(ArrayAttr[DeviceTypeAttr], prop_name="asyncOnly")
-    wait_operands_device_type = opt_prop_def(
+    async_only: ArrayAttr[DeviceTypeAttr] | None = opt_prop_def(
+        ArrayAttr[DeviceTypeAttr], prop_name="asyncOnly"
+    )
+    wait_operands_device_type: ArrayAttr[DeviceTypeAttr] | None = opt_prop_def(
         ArrayAttr[DeviceTypeAttr], prop_name="waitOperandsDeviceType"
     )
-    wait_operands_segments = opt_prop_def(
+    wait_operands_segments: DenseArrayBase[IntegerType] | None = opt_prop_def(
         DenseArrayBase.constr(IntegerType(32)), prop_name="waitOperandsSegments"
     )
-    has_wait_devnum = opt_prop_def(ArrayAttr[BoolAttr], prop_name="hasWaitDevnum")
-    wait_only = opt_prop_def(ArrayAttr[DeviceTypeAttr], prop_name="waitOnly")
-    num_gangs_segments = opt_prop_def(
+    has_wait_devnum: ArrayAttr[BoolAttr] | None = opt_prop_def(
+        ArrayAttr[BoolAttr], prop_name="hasWaitDevnum"
+    )
+    wait_only: ArrayAttr[DeviceTypeAttr] | None = opt_prop_def(
+        ArrayAttr[DeviceTypeAttr], prop_name="waitOnly"
+    )
+    num_gangs_segments: DenseArrayBase[IntegerType] | None = opt_prop_def(
         DenseArrayBase.constr(IntegerType(32)), prop_name="numGangsSegments"
     )
-    num_gangs_device_type = opt_prop_def(
+    num_gangs_device_type: ArrayAttr[DeviceTypeAttr] | None = opt_prop_def(
         ArrayAttr[DeviceTypeAttr], prop_name="numGangsDeviceType"
     )
-    num_workers_device_type = opt_prop_def(
+    num_workers_device_type: ArrayAttr[DeviceTypeAttr] | None = opt_prop_def(
         ArrayAttr[DeviceTypeAttr], prop_name="numWorkersDeviceType"
     )
-    vector_length_device_type = opt_prop_def(
+    vector_length_device_type: ArrayAttr[DeviceTypeAttr] | None = opt_prop_def(
         ArrayAttr[DeviceTypeAttr], prop_name="vectorLengthDeviceType"
     )
-    self_attr = opt_prop_def(UnitAttr, prop_name="selfAttr")
-    default_attr = opt_prop_def(ClauseDefaultValueAttr, prop_name="defaultAttr")
-    combined = opt_prop_def(UnitAttr)
+    self_attr: UnitAttr | None = opt_prop_def(UnitAttr, prop_name="selfAttr")
+    default_attr: ClauseDefaultValueAttr | None = opt_prop_def(
+        ClauseDefaultValueAttr, prop_name="defaultAttr"
+    )
+    combined: UnitAttr | None = opt_prop_def(UnitAttr)
 
-    region = region_def("single_block")
+    region: Region = region_def("single_block")
 
     irdl_options = (
         AttrSizedOperandSegments(as_property=True),
@@ -2626,32 +2639,40 @@ class SerialOp(IRDLOperation):
 
     name = "acc.serial"
 
-    async_operands = var_operand_def(IntegerType | IndexType)
-    wait_operands = var_operand_def(IntegerType | IndexType)
-    if_cond = opt_operand_def(I1)
-    self_cond = opt_operand_def(I1)
-    reduction_operands = var_operand_def()
-    private_operands = var_operand_def()
-    firstprivate_operands = var_operand_def()
-    data_clause_operands = var_operand_def()
+    async_operands: VarOperand = var_operand_def(IntegerType | IndexType)
+    wait_operands: VarOperand = var_operand_def(IntegerType | IndexType)
+    if_cond: OptOperand = opt_operand_def(I1)
+    self_cond: OptOperand = opt_operand_def(I1)
+    reduction_operands: VarOperand = var_operand_def()
+    private_operands: VarOperand = var_operand_def()
+    firstprivate_operands: VarOperand = var_operand_def()
+    data_clause_operands: VarOperand = var_operand_def()
 
-    async_operands_device_type = opt_prop_def(
+    async_operands_device_type: ArrayAttr[DeviceTypeAttr] | None = opt_prop_def(
         ArrayAttr[DeviceTypeAttr], prop_name="asyncOperandsDeviceType"
     )
-    async_only = opt_prop_def(ArrayAttr[DeviceTypeAttr], prop_name="asyncOnly")
-    wait_operands_device_type = opt_prop_def(
+    async_only: ArrayAttr[DeviceTypeAttr] | None = opt_prop_def(
+        ArrayAttr[DeviceTypeAttr], prop_name="asyncOnly"
+    )
+    wait_operands_device_type: ArrayAttr[DeviceTypeAttr] | None = opt_prop_def(
         ArrayAttr[DeviceTypeAttr], prop_name="waitOperandsDeviceType"
     )
-    wait_operands_segments = opt_prop_def(
+    wait_operands_segments: DenseArrayBase[IntegerType] | None = opt_prop_def(
         DenseArrayBase.constr(IntegerType(32)), prop_name="waitOperandsSegments"
     )
-    has_wait_devnum = opt_prop_def(ArrayAttr[BoolAttr], prop_name="hasWaitDevnum")
-    wait_only = opt_prop_def(ArrayAttr[DeviceTypeAttr], prop_name="waitOnly")
-    self_attr = opt_prop_def(UnitAttr, prop_name="selfAttr")
-    default_attr = opt_prop_def(ClauseDefaultValueAttr, prop_name="defaultAttr")
-    combined = opt_prop_def(UnitAttr)
+    has_wait_devnum: ArrayAttr[BoolAttr] | None = opt_prop_def(
+        ArrayAttr[BoolAttr], prop_name="hasWaitDevnum"
+    )
+    wait_only: ArrayAttr[DeviceTypeAttr] | None = opt_prop_def(
+        ArrayAttr[DeviceTypeAttr], prop_name="waitOnly"
+    )
+    self_attr: UnitAttr | None = opt_prop_def(UnitAttr, prop_name="selfAttr")
+    default_attr: ClauseDefaultValueAttr | None = opt_prop_def(
+        ClauseDefaultValueAttr, prop_name="defaultAttr"
+    )
+    combined: UnitAttr | None = opt_prop_def(UnitAttr)
 
-    region = region_def("single_block")
+    region: Region = region_def("single_block")
 
     irdl_options = (
         AttrSizedOperandSegments(as_property=True),
@@ -2762,47 +2783,55 @@ class KernelsOp(IRDLOperation):
 
     name = "acc.kernels"
 
-    async_operands = var_operand_def(IntegerType | IndexType)
-    wait_operands = var_operand_def(IntegerType | IndexType)
-    num_gangs = var_operand_def(IntegerType | IndexType)
-    num_workers = var_operand_def(IntegerType | IndexType)
-    vector_length = var_operand_def(IntegerType | IndexType)
-    if_cond = opt_operand_def(I1)
-    self_cond = opt_operand_def(I1)
-    reduction_operands = var_operand_def()
-    private_operands = var_operand_def()
-    firstprivate_operands = var_operand_def()
-    data_clause_operands = var_operand_def()
+    async_operands: VarOperand = var_operand_def(IntegerType | IndexType)
+    wait_operands: VarOperand = var_operand_def(IntegerType | IndexType)
+    num_gangs: VarOperand = var_operand_def(IntegerType | IndexType)
+    num_workers: VarOperand = var_operand_def(IntegerType | IndexType)
+    vector_length: VarOperand = var_operand_def(IntegerType | IndexType)
+    if_cond: OptOperand = opt_operand_def(I1)
+    self_cond: OptOperand = opt_operand_def(I1)
+    reduction_operands: VarOperand = var_operand_def()
+    private_operands: VarOperand = var_operand_def()
+    firstprivate_operands: VarOperand = var_operand_def()
+    data_clause_operands: VarOperand = var_operand_def()
 
-    async_operands_device_type = opt_prop_def(
+    async_operands_device_type: ArrayAttr[DeviceTypeAttr] | None = opt_prop_def(
         ArrayAttr[DeviceTypeAttr], prop_name="asyncOperandsDeviceType"
     )
-    async_only = opt_prop_def(ArrayAttr[DeviceTypeAttr], prop_name="asyncOnly")
-    wait_operands_device_type = opt_prop_def(
+    async_only: ArrayAttr[DeviceTypeAttr] | None = opt_prop_def(
+        ArrayAttr[DeviceTypeAttr], prop_name="asyncOnly"
+    )
+    wait_operands_device_type: ArrayAttr[DeviceTypeAttr] | None = opt_prop_def(
         ArrayAttr[DeviceTypeAttr], prop_name="waitOperandsDeviceType"
     )
-    wait_operands_segments = opt_prop_def(
+    wait_operands_segments: DenseArrayBase[IntegerType] | None = opt_prop_def(
         DenseArrayBase.constr(IntegerType(32)), prop_name="waitOperandsSegments"
     )
-    has_wait_devnum = opt_prop_def(ArrayAttr[BoolAttr], prop_name="hasWaitDevnum")
-    wait_only = opt_prop_def(ArrayAttr[DeviceTypeAttr], prop_name="waitOnly")
-    num_gangs_segments = opt_prop_def(
+    has_wait_devnum: ArrayAttr[BoolAttr] | None = opt_prop_def(
+        ArrayAttr[BoolAttr], prop_name="hasWaitDevnum"
+    )
+    wait_only: ArrayAttr[DeviceTypeAttr] | None = opt_prop_def(
+        ArrayAttr[DeviceTypeAttr], prop_name="waitOnly"
+    )
+    num_gangs_segments: DenseArrayBase[IntegerType] | None = opt_prop_def(
         DenseArrayBase.constr(IntegerType(32)), prop_name="numGangsSegments"
     )
-    num_gangs_device_type = opt_prop_def(
+    num_gangs_device_type: ArrayAttr[DeviceTypeAttr] | None = opt_prop_def(
         ArrayAttr[DeviceTypeAttr], prop_name="numGangsDeviceType"
     )
-    num_workers_device_type = opt_prop_def(
+    num_workers_device_type: ArrayAttr[DeviceTypeAttr] | None = opt_prop_def(
         ArrayAttr[DeviceTypeAttr], prop_name="numWorkersDeviceType"
     )
-    vector_length_device_type = opt_prop_def(
+    vector_length_device_type: ArrayAttr[DeviceTypeAttr] | None = opt_prop_def(
         ArrayAttr[DeviceTypeAttr], prop_name="vectorLengthDeviceType"
     )
-    self_attr = opt_prop_def(UnitAttr, prop_name="selfAttr")
-    default_attr = opt_prop_def(ClauseDefaultValueAttr, prop_name="defaultAttr")
-    combined = opt_prop_def(UnitAttr)
+    self_attr: UnitAttr | None = opt_prop_def(UnitAttr, prop_name="selfAttr")
+    default_attr: ClauseDefaultValueAttr | None = opt_prop_def(
+        ClauseDefaultValueAttr, prop_name="defaultAttr"
+    )
+    combined: UnitAttr | None = opt_prop_def(UnitAttr)
 
-    region = region_def()
+    region: Region = region_def()
 
     irdl_options = (
         AttrSizedOperandSegments(as_property=True),
@@ -2940,24 +2969,30 @@ class KernelEnvironmentOp(IRDLOperation):
 
     name = "acc.kernel_environment"
 
-    data_clause_operands = var_operand_def()
-    async_operands = var_operand_def(IntegerType | IndexType)
-    wait_operands = var_operand_def(IntegerType | IndexType)
+    data_clause_operands: VarOperand = var_operand_def()
+    async_operands: VarOperand = var_operand_def(IntegerType | IndexType)
+    wait_operands: VarOperand = var_operand_def(IntegerType | IndexType)
 
-    async_operands_device_type = opt_prop_def(
+    async_operands_device_type: ArrayAttr[DeviceTypeAttr] | None = opt_prop_def(
         ArrayAttr[DeviceTypeAttr], prop_name="asyncOperandsDeviceType"
     )
-    async_only = opt_prop_def(ArrayAttr[DeviceTypeAttr], prop_name="asyncOnly")
-    wait_operands_segments = opt_prop_def(
+    async_only: ArrayAttr[DeviceTypeAttr] | None = opt_prop_def(
+        ArrayAttr[DeviceTypeAttr], prop_name="asyncOnly"
+    )
+    wait_operands_segments: DenseArrayBase[IntegerType] | None = opt_prop_def(
         DenseArrayBase.constr(IntegerType(32)), prop_name="waitOperandsSegments"
     )
-    wait_operands_device_type = opt_prop_def(
+    wait_operands_device_type: ArrayAttr[DeviceTypeAttr] | None = opt_prop_def(
         ArrayAttr[DeviceTypeAttr], prop_name="waitOperandsDeviceType"
     )
-    has_wait_devnum = opt_prop_def(ArrayAttr[BoolAttr], prop_name="hasWaitDevnum")
-    wait_only = opt_prop_def(ArrayAttr[DeviceTypeAttr], prop_name="waitOnly")
+    has_wait_devnum: ArrayAttr[BoolAttr] | None = opt_prop_def(
+        ArrayAttr[BoolAttr], prop_name="hasWaitDevnum"
+    )
+    wait_only: ArrayAttr[DeviceTypeAttr] | None = opt_prop_def(
+        ArrayAttr[DeviceTypeAttr], prop_name="waitOnly"
+    )
 
-    region = region_def("single_block")
+    region: Region = region_def("single_block")
 
     irdl_options = (
         AttrSizedOperandSegments(as_property=True),
@@ -3035,58 +3070,64 @@ class LoopOp(IRDLOperation):
 
     name = "acc.loop"
 
-    lowerbound = var_operand_def(IntegerType | IndexType)
-    upperbound = var_operand_def(IntegerType | IndexType)
-    step = var_operand_def(IntegerType | IndexType)
-    gang_operands = var_operand_def(IntegerType | IndexType)
-    worker_num_operands = var_operand_def(IntegerType | IndexType)
-    vector_operands = var_operand_def(IntegerType | IndexType)
-    tile_operands = var_operand_def(IntegerType | IndexType)
-    cache_operands = var_operand_def()
-    private_operands = var_operand_def()
-    firstprivate_operands = var_operand_def()
-    reduction_operands = var_operand_def()
+    lowerbound: VarOperand = var_operand_def(IntegerType | IndexType)
+    upperbound: VarOperand = var_operand_def(IntegerType | IndexType)
+    step: VarOperand = var_operand_def(IntegerType | IndexType)
+    gang_operands: VarOperand = var_operand_def(IntegerType | IndexType)
+    worker_num_operands: VarOperand = var_operand_def(IntegerType | IndexType)
+    vector_operands: VarOperand = var_operand_def(IntegerType | IndexType)
+    tile_operands: VarOperand = var_operand_def(IntegerType | IndexType)
+    cache_operands: VarOperand = var_operand_def()
+    private_operands: VarOperand = var_operand_def()
+    firstprivate_operands: VarOperand = var_operand_def()
+    reduction_operands: VarOperand = var_operand_def()
 
-    inclusive_upperbound = opt_prop_def(
+    inclusive_upperbound: DenseArrayBase[IntegerType] | None = opt_prop_def(
         DenseArrayBase.constr(IntegerType(1)), prop_name="inclusiveUpperbound"
     )
-    collapse = opt_prop_def(ArrayAttr[IntegerAttr])
-    collapse_device_type = opt_prop_def(
+    collapse: ArrayAttr[IntegerAttr] | None = opt_prop_def(ArrayAttr[IntegerAttr])
+    collapse_device_type: ArrayAttr[DeviceTypeAttr] | None = opt_prop_def(
         ArrayAttr[DeviceTypeAttr], prop_name="collapseDeviceType"
     )
-    gang_operands_arg_type = opt_prop_def(
+    gang_operands_arg_type: ArrayAttr[GangArgTypeAttr] | None = opt_prop_def(
         ArrayAttr[GangArgTypeAttr], prop_name="gangOperandsArgType"
     )
-    gang_operands_segments = opt_prop_def(
+    gang_operands_segments: DenseArrayBase[IntegerType] | None = opt_prop_def(
         DenseArrayBase.constr(IntegerType(32)), prop_name="gangOperandsSegments"
     )
-    gang_operands_device_type = opt_prop_def(
+    gang_operands_device_type: ArrayAttr[DeviceTypeAttr] | None = opt_prop_def(
         ArrayAttr[DeviceTypeAttr], prop_name="gangOperandsDeviceType"
     )
-    worker_num_operands_device_type = opt_prop_def(
+    worker_num_operands_device_type: ArrayAttr[DeviceTypeAttr] | None = opt_prop_def(
         ArrayAttr[DeviceTypeAttr], prop_name="workerNumOperandsDeviceType"
     )
-    vector_operands_device_type = opt_prop_def(
+    vector_operands_device_type: ArrayAttr[DeviceTypeAttr] | None = opt_prop_def(
         ArrayAttr[DeviceTypeAttr], prop_name="vectorOperandsDeviceType"
     )
-    seq = opt_prop_def(ArrayAttr[DeviceTypeAttr])
-    independent = opt_prop_def(ArrayAttr[DeviceTypeAttr])
-    auto_ = opt_prop_def(ArrayAttr[DeviceTypeAttr], prop_name="auto_")
-    gang = opt_prop_def(ArrayAttr[DeviceTypeAttr])
-    worker = opt_prop_def(ArrayAttr[DeviceTypeAttr])
-    vector = opt_prop_def(ArrayAttr[DeviceTypeAttr])
-    tile_operands_segments = opt_prop_def(
+    seq: ArrayAttr[DeviceTypeAttr] | None = opt_prop_def(ArrayAttr[DeviceTypeAttr])
+    independent: ArrayAttr[DeviceTypeAttr] | None = opt_prop_def(
+        ArrayAttr[DeviceTypeAttr]
+    )
+    auto_: ArrayAttr[DeviceTypeAttr] | None = opt_prop_def(
+        ArrayAttr[DeviceTypeAttr], prop_name="auto_"
+    )
+    gang: ArrayAttr[DeviceTypeAttr] | None = opt_prop_def(ArrayAttr[DeviceTypeAttr])
+    worker: ArrayAttr[DeviceTypeAttr] | None = opt_prop_def(ArrayAttr[DeviceTypeAttr])
+    vector: ArrayAttr[DeviceTypeAttr] | None = opt_prop_def(ArrayAttr[DeviceTypeAttr])
+    tile_operands_segments: DenseArrayBase[IntegerType] | None = opt_prop_def(
         DenseArrayBase.constr(IntegerType(32)), prop_name="tileOperandsSegments"
     )
-    tile_operands_device_type = opt_prop_def(
+    tile_operands_device_type: ArrayAttr[DeviceTypeAttr] | None = opt_prop_def(
         ArrayAttr[DeviceTypeAttr], prop_name="tileOperandsDeviceType"
     )
-    combined = opt_prop_def(CombinedConstructsTypeAttr)
-    unstructured = opt_prop_def(UnitAttr)
+    combined: CombinedConstructsTypeAttr | None = opt_prop_def(
+        CombinedConstructsTypeAttr
+    )
+    unstructured: UnitAttr | None = opt_prop_def(UnitAttr)
 
-    results_ = var_result_def()
+    results_: VarOpResult = var_result_def()
 
-    region = region_def()
+    region: Region = region_def()
 
     irdl_options = (
         AttrSizedOperandSegments(as_property=True),
@@ -3450,26 +3491,34 @@ class DataOp(IRDLOperation):
 
     name = "acc.data"
 
-    if_cond = opt_operand_def(I1)
-    async_operands = var_operand_def(IntegerType | IndexType)
-    wait_operands = var_operand_def(IntegerType | IndexType)
-    data_clause_operands = var_operand_def()
+    if_cond: OptOperand = opt_operand_def(I1)
+    async_operands: VarOperand = var_operand_def(IntegerType | IndexType)
+    wait_operands: VarOperand = var_operand_def(IntegerType | IndexType)
+    data_clause_operands: VarOperand = var_operand_def()
 
-    async_operands_device_type = opt_prop_def(
+    async_operands_device_type: ArrayAttr[DeviceTypeAttr] | None = opt_prop_def(
         ArrayAttr[DeviceTypeAttr], prop_name="asyncOperandsDeviceType"
     )
-    async_only = opt_prop_def(ArrayAttr[DeviceTypeAttr], prop_name="asyncOnly")
-    wait_operands_segments = opt_prop_def(
+    async_only: ArrayAttr[DeviceTypeAttr] | None = opt_prop_def(
+        ArrayAttr[DeviceTypeAttr], prop_name="asyncOnly"
+    )
+    wait_operands_segments: DenseArrayBase[IntegerType] | None = opt_prop_def(
         DenseArrayBase.constr(IntegerType(32)), prop_name="waitOperandsSegments"
     )
-    wait_operands_device_type = opt_prop_def(
+    wait_operands_device_type: ArrayAttr[DeviceTypeAttr] | None = opt_prop_def(
         ArrayAttr[DeviceTypeAttr], prop_name="waitOperandsDeviceType"
     )
-    has_wait_devnum = opt_prop_def(ArrayAttr[BoolAttr], prop_name="hasWaitDevnum")
-    wait_only = opt_prop_def(ArrayAttr[DeviceTypeAttr], prop_name="waitOnly")
-    default_attr = opt_prop_def(ClauseDefaultValueAttr, prop_name="defaultAttr")
+    has_wait_devnum: ArrayAttr[BoolAttr] | None = opt_prop_def(
+        ArrayAttr[BoolAttr], prop_name="hasWaitDevnum"
+    )
+    wait_only: ArrayAttr[DeviceTypeAttr] | None = opt_prop_def(
+        ArrayAttr[DeviceTypeAttr], prop_name="waitOnly"
+    )
+    default_attr: ClauseDefaultValueAttr | None = opt_prop_def(
+        ClauseDefaultValueAttr, prop_name="defaultAttr"
+    )
 
-    region = region_def()
+    region: Region = region_def()
 
     irdl_options = (
         AttrSizedOperandSegments(as_property=True),
@@ -3587,12 +3636,12 @@ class HostDataOp(IRDLOperation):
 
     name = "acc.host_data"
 
-    if_cond = opt_operand_def(I1)
-    data_clause_operands = var_operand_def()
+    if_cond: OptOperand = opt_operand_def(I1)
+    data_clause_operands: VarOperand = var_operand_def()
 
-    if_present = opt_prop_def(UnitAttr, prop_name="ifPresent")
+    if_present: UnitAttr | None = opt_prop_def(UnitAttr, prop_name="ifPresent")
 
-    region = region_def()
+    region: Region = region_def()
 
     irdl_options = (
         AttrSizedOperandSegments(as_property=True),
@@ -3674,35 +3723,37 @@ class _DataEntryOperation(IRDLOperation, ABC):
     here.
     """
 
-    var = operand_def()
-    var_ptr_ptr = opt_operand_def()
-    bounds = var_operand_def(DataBoundsType)
-    async_operands = var_operand_def(IntegerType | IndexType)
+    var: Operand = operand_def()
+    var_ptr_ptr: OptOperand = opt_operand_def()
+    bounds: VarOperand = var_operand_def(DataBoundsType)
+    async_operands: VarOperand = var_operand_def(IntegerType | IndexType)
 
-    var_type = prop_def(TypeAttribute, prop_name="varType")
-    async_operands_device_type = opt_prop_def(
+    var_type: TypeAttribute = prop_def(TypeAttribute, prop_name="varType")
+    async_operands_device_type: ArrayAttr[DeviceTypeAttr] | None = opt_prop_def(
         ArrayAttr[DeviceTypeAttr], prop_name="asyncOperandsDeviceType"
     )
-    async_only = opt_prop_def(ArrayAttr[DeviceTypeAttr], prop_name="asyncOnly")
-    structured = opt_prop_def(
+    async_only: ArrayAttr[DeviceTypeAttr] | None = opt_prop_def(
+        ArrayAttr[DeviceTypeAttr], prop_name="asyncOnly"
+    )
+    structured: BoolAttr = opt_prop_def(
         BoolAttr,
         default_value=IntegerAttr.from_bool(True),
         prop_name="structured",
     )
-    implicit = opt_prop_def(
+    implicit: BoolAttr = opt_prop_def(
         BoolAttr,
         default_value=IntegerAttr.from_bool(False),
         prop_name="implicit",
     )
-    modifiers = opt_prop_def(
+    modifiers: DataClauseModifierAttr = opt_prop_def(
         DataClauseModifierAttr,
         default_value=DataClauseModifierAttr(frozenset[DataClauseModifier]()),
         prop_name="modifiers",
     )
-    var_name = opt_prop_def(StringAttr, prop_name="name")
-    recipe = opt_prop_def(SymbolRefAttr, prop_name="recipe")
+    var_name: StringAttr | None = opt_prop_def(StringAttr, prop_name="name")
+    recipe: SymbolRefAttr | None = opt_prop_def(SymbolRefAttr, prop_name="recipe")
 
-    acc_var = result_def()
+    acc_var: OpResult = result_def()
 
     irdl_options = (
         AttrSizedOperandSegments(as_property=True),
@@ -3795,7 +3846,7 @@ class CopyinOp(_DataEntryOperation):
     """Implementation of upstream acc.copyin."""
 
     name = "acc.copyin"
-    data_clause = opt_prop_def(
+    data_clause: DataClauseAttr = opt_prop_def(
         DataClauseAttr,
         default_value=DataClauseAttr(DataClause.ACC_COPYIN),
         prop_name="dataClause",
@@ -3807,7 +3858,7 @@ class CreateOp(_DataEntryOperation):
     """Implementation of upstream acc.create."""
 
     name = "acc.create"
-    data_clause = opt_prop_def(
+    data_clause: DataClauseAttr = opt_prop_def(
         DataClauseAttr,
         default_value=DataClauseAttr(DataClause.ACC_CREATE),
         prop_name="dataClause",
@@ -3819,7 +3870,7 @@ class PresentOp(_DataEntryOperation):
     """Implementation of upstream acc.present."""
 
     name = "acc.present"
-    data_clause = opt_prop_def(
+    data_clause: DataClauseAttr = opt_prop_def(
         DataClauseAttr,
         default_value=DataClauseAttr(DataClause.ACC_PRESENT),
         prop_name="dataClause",
@@ -3831,7 +3882,7 @@ class NoCreateOp(_DataEntryOperation):
     """Implementation of upstream acc.nocreate."""
 
     name = "acc.nocreate"
-    data_clause = opt_prop_def(
+    data_clause: DataClauseAttr = opt_prop_def(
         DataClauseAttr,
         default_value=DataClauseAttr(DataClause.ACC_NO_CREATE),
         prop_name="dataClause",
@@ -3843,7 +3894,7 @@ class AttachOp(_DataEntryOperation):
     """Implementation of upstream acc.attach."""
 
     name = "acc.attach"
-    data_clause = opt_prop_def(
+    data_clause: DataClauseAttr = opt_prop_def(
         DataClauseAttr,
         default_value=DataClauseAttr(DataClause.ACC_ATTACH),
         prop_name="dataClause",
@@ -3855,7 +3906,7 @@ class DevicePtrOp(_DataEntryOperation):
     """Implementation of upstream acc.deviceptr."""
 
     name = "acc.deviceptr"
-    data_clause = opt_prop_def(
+    data_clause: DataClauseAttr = opt_prop_def(
         DataClauseAttr,
         default_value=DataClauseAttr(DataClause.ACC_DEVICEPTR),
         prop_name="dataClause",
@@ -3867,7 +3918,7 @@ class UseDeviceOp(_DataEntryOperation):
     """Implementation of upstream acc.use_device."""
 
     name = "acc.use_device"
-    data_clause = opt_prop_def(
+    data_clause: DataClauseAttr = opt_prop_def(
         DataClauseAttr,
         default_value=DataClauseAttr(DataClause.ACC_USE_DEVICE),
         prop_name="dataClause",
@@ -3879,7 +3930,7 @@ class CacheOp(_DataEntryOperation):
     """Implementation of upstream acc.cache. Carries `NoMemoryEffect` per upstream."""
 
     name = "acc.cache"
-    data_clause = opt_prop_def(
+    data_clause: DataClauseAttr = opt_prop_def(
         DataClauseAttr,
         default_value=DataClauseAttr(DataClause.ACC_CACHE),
         prop_name="dataClause",
@@ -3893,7 +3944,7 @@ class DeclareDeviceResidentOp(_DataEntryOperation):
     """Implementation of upstream acc.declare_device_resident."""
 
     name = "acc.declare_device_resident"
-    data_clause = opt_prop_def(
+    data_clause: DataClauseAttr = opt_prop_def(
         DataClauseAttr,
         default_value=DataClauseAttr(DataClause.ACC_DECLARE_DEVICE_RESIDENT),
         prop_name="dataClause",
@@ -3905,7 +3956,7 @@ class DeclareLinkOp(_DataEntryOperation):
     """Implementation of upstream acc.declare_link."""
 
     name = "acc.declare_link"
-    data_clause = opt_prop_def(
+    data_clause: DataClauseAttr = opt_prop_def(
         DataClauseAttr,
         default_value=DataClauseAttr(DataClause.ACC_DECLARE_LINK),
         prop_name="dataClause",
@@ -3922,7 +3973,7 @@ class GetDevicePtrOp(_DataEntryOperation):
     """
 
     name = "acc.getdeviceptr"
-    data_clause = opt_prop_def(
+    data_clause: DataClauseAttr = opt_prop_def(
         DataClauseAttr,
         default_value=DataClauseAttr(DataClause.ACC_GETDEVICEPTR),
         prop_name="dataClause",
@@ -3934,7 +3985,7 @@ class UpdateDeviceOp(_DataEntryOperation):
     """Implementation of upstream acc.update_device."""
 
     name = "acc.update_device"
-    data_clause = opt_prop_def(
+    data_clause: DataClauseAttr = opt_prop_def(
         DataClauseAttr,
         default_value=DataClauseAttr(DataClause.ACC_UPDATE_DEVICE),
         prop_name="dataClause",
@@ -3962,7 +4013,7 @@ class PrivateOp(_DataEntryOperation):
     """Implementation of upstream acc.private."""
 
     name = "acc.private"
-    data_clause = opt_prop_def(
+    data_clause: DataClauseAttr = opt_prop_def(
         DataClauseAttr,
         default_value=DataClauseAttr(DataClause.ACC_PRIVATE),
         prop_name="dataClause",
@@ -3974,7 +4025,7 @@ class FirstprivateOp(_DataEntryOperation):
     """Implementation of upstream acc.firstprivate."""
 
     name = "acc.firstprivate"
-    data_clause = opt_prop_def(
+    data_clause: DataClauseAttr = opt_prop_def(
         DataClauseAttr,
         default_value=DataClauseAttr(DataClause.ACC_FIRSTPRIVATE),
         prop_name="dataClause",
@@ -3992,7 +4043,7 @@ class FirstprivateMapOp(_DataEntryOperation):
     """
 
     name = "acc.firstprivate_map"
-    data_clause = opt_prop_def(
+    data_clause: DataClauseAttr = opt_prop_def(
         DataClauseAttr,
         default_value=DataClauseAttr(DataClause.ACC_FIRSTPRIVATE),
         prop_name="dataClause",
@@ -4010,7 +4061,7 @@ class ReductionOp(_DataEntryOperation):
     """
 
     name = "acc.reduction"
-    data_clause = opt_prop_def(
+    data_clause: DataClauseAttr = opt_prop_def(
         DataClauseAttr,
         default_value=DataClauseAttr(DataClause.ACC_REDUCTION),
         prop_name="dataClause",
@@ -4042,32 +4093,34 @@ class _DataExitOperationWithVarPtr(IRDLOperation, ABC):
     format, and the keyword-only `__init__` live here.
     """
 
-    acc_var = operand_def()
-    var = operand_def()
-    bounds = var_operand_def(DataBoundsType)
-    async_operands = var_operand_def(IntegerType | IndexType)
+    acc_var: Operand = operand_def()
+    var: Operand = operand_def()
+    bounds: VarOperand = var_operand_def(DataBoundsType)
+    async_operands: VarOperand = var_operand_def(IntegerType | IndexType)
 
-    var_type = prop_def(TypeAttribute, prop_name="varType")
-    async_operands_device_type = opt_prop_def(
+    var_type: TypeAttribute = prop_def(TypeAttribute, prop_name="varType")
+    async_operands_device_type: ArrayAttr[DeviceTypeAttr] | None = opt_prop_def(
         ArrayAttr[DeviceTypeAttr], prop_name="asyncOperandsDeviceType"
     )
-    async_only = opt_prop_def(ArrayAttr[DeviceTypeAttr], prop_name="asyncOnly")
-    structured = opt_prop_def(
+    async_only: ArrayAttr[DeviceTypeAttr] | None = opt_prop_def(
+        ArrayAttr[DeviceTypeAttr], prop_name="asyncOnly"
+    )
+    structured: BoolAttr = opt_prop_def(
         BoolAttr,
         default_value=IntegerAttr.from_bool(True),
         prop_name="structured",
     )
-    implicit = opt_prop_def(
+    implicit: BoolAttr = opt_prop_def(
         BoolAttr,
         default_value=IntegerAttr.from_bool(False),
         prop_name="implicit",
     )
-    modifiers = opt_prop_def(
+    modifiers: DataClauseModifierAttr = opt_prop_def(
         DataClauseModifierAttr,
         default_value=DataClauseModifierAttr(frozenset[DataClauseModifier]()),
         prop_name="modifiers",
     )
-    var_name = opt_prop_def(StringAttr, prop_name="name")
+    var_name: StringAttr | None = opt_prop_def(StringAttr, prop_name="name")
 
     irdl_options = (
         AttrSizedOperandSegments(as_property=True),
@@ -4147,7 +4200,7 @@ class CopyoutOp(_DataExitOperationWithVarPtr):
     """Implementation of upstream acc.copyout."""
 
     name = "acc.copyout"
-    data_clause = opt_prop_def(
+    data_clause: DataClauseAttr = opt_prop_def(
         DataClauseAttr,
         default_value=DataClauseAttr(DataClause.ACC_COPYOUT),
         prop_name="dataClause",
@@ -4159,7 +4212,7 @@ class UpdateHostOp(_DataExitOperationWithVarPtr):
     """Implementation of upstream acc.update_host."""
 
     name = "acc.update_host"
-    data_clause = opt_prop_def(
+    data_clause: DataClauseAttr = opt_prop_def(
         DataClauseAttr,
         default_value=DataClauseAttr(DataClause.ACC_UPDATE_HOST),
         prop_name="dataClause",
@@ -4177,30 +4230,32 @@ class _DataExitOperationNoVarPtr(IRDLOperation, ABC):
     need to know the host-side mapping.
     """
 
-    acc_var = operand_def()
-    bounds = var_operand_def(DataBoundsType)
-    async_operands = var_operand_def(IntegerType | IndexType)
+    acc_var: Operand = operand_def()
+    bounds: VarOperand = var_operand_def(DataBoundsType)
+    async_operands: VarOperand = var_operand_def(IntegerType | IndexType)
 
-    async_operands_device_type = opt_prop_def(
+    async_operands_device_type: ArrayAttr[DeviceTypeAttr] | None = opt_prop_def(
         ArrayAttr[DeviceTypeAttr], prop_name="asyncOperandsDeviceType"
     )
-    async_only = opt_prop_def(ArrayAttr[DeviceTypeAttr], prop_name="asyncOnly")
-    structured = opt_prop_def(
+    async_only: ArrayAttr[DeviceTypeAttr] | None = opt_prop_def(
+        ArrayAttr[DeviceTypeAttr], prop_name="asyncOnly"
+    )
+    structured: BoolAttr = opt_prop_def(
         BoolAttr,
         default_value=IntegerAttr.from_bool(True),
         prop_name="structured",
     )
-    implicit = opt_prop_def(
+    implicit: BoolAttr = opt_prop_def(
         BoolAttr,
         default_value=IntegerAttr.from_bool(False),
         prop_name="implicit",
     )
-    modifiers = opt_prop_def(
+    modifiers: DataClauseModifierAttr = opt_prop_def(
         DataClauseModifierAttr,
         default_value=DataClauseModifierAttr(frozenset[DataClauseModifier]()),
         prop_name="modifiers",
     )
-    var_name = opt_prop_def(StringAttr, prop_name="name")
+    var_name: StringAttr | None = opt_prop_def(StringAttr, prop_name="name")
 
     irdl_options = (
         AttrSizedOperandSegments(as_property=True),
@@ -4271,7 +4326,7 @@ class DeleteOp(_DataExitOperationNoVarPtr):
     """Implementation of upstream acc.delete."""
 
     name = "acc.delete"
-    data_clause = opt_prop_def(
+    data_clause: DataClauseAttr = opt_prop_def(
         DataClauseAttr,
         default_value=DataClauseAttr(DataClause.ACC_DELETE),
         prop_name="dataClause",
@@ -4283,7 +4338,7 @@ class DetachOp(_DataExitOperationNoVarPtr):
     """Implementation of upstream acc.detach."""
 
     name = "acc.detach"
-    data_clause = opt_prop_def(
+    data_clause: DataClauseAttr = opt_prop_def(
         DataClauseAttr,
         default_value=DataClauseAttr(DataClause.ACC_DETACH),
         prop_name="dataClause",
@@ -4315,14 +4370,14 @@ class EnterDataOp(IRDLOperation):
 
     name = "acc.enter_data"
 
-    if_cond = opt_operand_def(I1)
-    async_operand = opt_operand_def(IntegerType | IndexType)
-    wait_devnum = opt_operand_def(IntegerType | IndexType)
-    wait_operands = var_operand_def(IntegerType | IndexType)
-    data_clause_operands = var_operand_def()
+    if_cond: OptOperand = opt_operand_def(I1)
+    async_operand: OptOperand = opt_operand_def(IntegerType | IndexType)
+    wait_devnum: OptOperand = opt_operand_def(IntegerType | IndexType)
+    wait_operands: VarOperand = var_operand_def(IntegerType | IndexType)
+    data_clause_operands: VarOperand = var_operand_def()
 
-    async_attr = opt_prop_def(UnitAttr, prop_name="async")
-    wait_attr = opt_prop_def(UnitAttr, prop_name="wait")
+    async_attr: UnitAttr | None = opt_prop_def(UnitAttr, prop_name="async")
+    wait_attr: UnitAttr | None = opt_prop_def(UnitAttr, prop_name="wait")
 
     irdl_options = (
         AttrSizedOperandSegments(as_property=True),
@@ -4408,15 +4463,15 @@ class ExitDataOp(IRDLOperation):
 
     name = "acc.exit_data"
 
-    if_cond = opt_operand_def(I1)
-    async_operand = opt_operand_def(IntegerType | IndexType)
-    wait_devnum = opt_operand_def(IntegerType | IndexType)
-    wait_operands = var_operand_def(IntegerType | IndexType)
-    data_clause_operands = var_operand_def()
+    if_cond: OptOperand = opt_operand_def(I1)
+    async_operand: OptOperand = opt_operand_def(IntegerType | IndexType)
+    wait_devnum: OptOperand = opt_operand_def(IntegerType | IndexType)
+    wait_operands: VarOperand = var_operand_def(IntegerType | IndexType)
+    data_clause_operands: VarOperand = var_operand_def()
 
-    async_attr = opt_prop_def(UnitAttr, prop_name="async")
-    wait_attr = opt_prop_def(UnitAttr, prop_name="wait")
-    finalize = opt_prop_def(UnitAttr, prop_name="finalize")
+    async_attr: UnitAttr | None = opt_prop_def(UnitAttr, prop_name="async")
+    wait_attr: UnitAttr | None = opt_prop_def(UnitAttr, prop_name="wait")
+    finalize: UnitAttr | None = opt_prop_def(UnitAttr, prop_name="finalize")
 
     irdl_options = (
         AttrSizedOperandSegments(as_property=True),
@@ -4518,24 +4573,30 @@ class UpdateOp(IRDLOperation):
 
     name = "acc.update"
 
-    if_cond = opt_operand_def(I1)
-    async_operands = var_operand_def(IntegerType | IndexType)
-    wait_operands = var_operand_def(IntegerType | IndexType)
-    data_clause_operands = var_operand_def()
+    if_cond: OptOperand = opt_operand_def(I1)
+    async_operands: VarOperand = var_operand_def(IntegerType | IndexType)
+    wait_operands: VarOperand = var_operand_def(IntegerType | IndexType)
+    data_clause_operands: VarOperand = var_operand_def()
 
-    async_operands_device_type = opt_prop_def(
+    async_operands_device_type: ArrayAttr[DeviceTypeAttr] | None = opt_prop_def(
         ArrayAttr[DeviceTypeAttr], prop_name="asyncOperandsDeviceType"
     )
-    async_only = opt_prop_def(ArrayAttr[DeviceTypeAttr], prop_name="asyncOnly")
-    wait_operands_device_type = opt_prop_def(
+    async_only: ArrayAttr[DeviceTypeAttr] | None = opt_prop_def(
+        ArrayAttr[DeviceTypeAttr], prop_name="asyncOnly"
+    )
+    wait_operands_device_type: ArrayAttr[DeviceTypeAttr] | None = opt_prop_def(
         ArrayAttr[DeviceTypeAttr], prop_name="waitOperandsDeviceType"
     )
-    wait_operands_segments = opt_prop_def(
+    wait_operands_segments: DenseArrayBase[IntegerType] | None = opt_prop_def(
         DenseArrayBase.constr(IntegerType(32)), prop_name="waitOperandsSegments"
     )
-    has_wait_devnum = opt_prop_def(ArrayAttr[BoolAttr], prop_name="hasWaitDevnum")
-    wait_only = opt_prop_def(ArrayAttr[DeviceTypeAttr], prop_name="waitOnly")
-    if_present = opt_prop_def(UnitAttr, prop_name="ifPresent")
+    has_wait_devnum: ArrayAttr[BoolAttr] | None = opt_prop_def(
+        ArrayAttr[BoolAttr], prop_name="hasWaitDevnum"
+    )
+    wait_only: ArrayAttr[DeviceTypeAttr] | None = opt_prop_def(
+        ArrayAttr[DeviceTypeAttr], prop_name="waitOnly"
+    )
+    if_present: UnitAttr | None = opt_prop_def(UnitAttr, prop_name="ifPresent")
 
     irdl_options = (
         AttrSizedOperandSegments(as_property=True),
@@ -4633,11 +4694,11 @@ class AtomicReadOp(IRDLOperation):
 
     name = "acc.atomic.read"
 
-    x = operand_def()
-    v = operand_def()
-    if_cond = opt_operand_def(I1)
+    x: Operand = operand_def()
+    v: Operand = operand_def()
+    if_cond: OptOperand = opt_operand_def(I1)
 
-    element_type = prop_def(TypeAttribute)
+    element_type: TypeAttribute = prop_def(TypeAttribute)
 
     irdl_options = (ParsePropInAttrDict(),)
 
@@ -4681,9 +4742,9 @@ class AtomicWriteOp(IRDLOperation):
 
     name = "acc.atomic.write"
 
-    x = operand_def()
-    expr = operand_def()
-    if_cond = opt_operand_def(I1)
+    x: Operand = operand_def()
+    expr: Operand = operand_def()
+    if_cond: OptOperand = opt_operand_def(I1)
 
     custom_directives = (AtomicIfClause,)
 
@@ -4726,10 +4787,10 @@ class AtomicUpdateOp(IRDLOperation):
 
     name = "acc.atomic.update"
 
-    x = operand_def()
-    if_cond = opt_operand_def(I1)
+    x: Operand = operand_def()
+    if_cond: OptOperand = opt_operand_def(I1)
 
-    region = region_def("single_block")
+    region: Region = region_def("single_block")
 
     custom_directives = (AtomicIfClause,)
 
@@ -4795,9 +4856,9 @@ class AtomicCaptureOp(IRDLOperation):
 
     name = "acc.atomic.capture"
 
-    if_cond = opt_operand_def(I1)
+    if_cond: OptOperand = opt_operand_def(I1)
 
-    region = region_def("single_block")
+    region: Region = region_def("single_block")
 
     traits = lazy_traits_def(
         lambda: (
@@ -4939,9 +5000,9 @@ class DeclareEnterOp(IRDLOperation):
 
     name = "acc.declare_enter"
 
-    data_clause_operands = var_operand_def()
+    data_clause_operands: VarOperand = var_operand_def()
 
-    token = result_def(DeclareTokenType)
+    token: OpResult[DeclareTokenType] = result_def(DeclareTokenType)
 
     assembly_format = (
         "(`dataOperands` `(` $data_clause_operands^ `:`"
@@ -4974,8 +5035,8 @@ class DeclareExitOp(IRDLOperation):
 
     name = "acc.declare_exit"
 
-    token = opt_operand_def(DeclareTokenType)
-    data_clause_operands = var_operand_def()
+    token: OptOperand = opt_operand_def(DeclareTokenType)
+    data_clause_operands: VarOperand = var_operand_def()
 
     irdl_options = (
         AttrSizedOperandSegments(as_property=True),
@@ -5022,9 +5083,9 @@ class DeclareOp(IRDLOperation):
 
     name = "acc.declare"
 
-    data_clause_operands = var_operand_def()
+    data_clause_operands: VarOperand = var_operand_def()
 
-    region = region_def()
+    region: Region = region_def()
 
     assembly_format = (
         "(`dataOperands` `(` $data_clause_operands^ `:`"
@@ -5062,15 +5123,15 @@ class DataBoundsOp(IRDLOperation):
 
     name = "acc.bounds"
 
-    lowerbound = opt_operand_def(IntegerType | IndexType)
-    upperbound = opt_operand_def(IntegerType | IndexType)
-    extent = opt_operand_def(IntegerType | IndexType)
-    stride = opt_operand_def(IntegerType | IndexType)
-    start_idx = opt_operand_def(IntegerType | IndexType)
+    lowerbound: OptOperand = opt_operand_def(IntegerType | IndexType)
+    upperbound: OptOperand = opt_operand_def(IntegerType | IndexType)
+    extent: OptOperand = opt_operand_def(IntegerType | IndexType)
+    stride: OptOperand = opt_operand_def(IntegerType | IndexType)
+    start_idx: OptOperand = opt_operand_def(IntegerType | IndexType)
 
-    stride_in_bytes = opt_prop_def(BoolAttr, prop_name="strideInBytes")
+    stride_in_bytes: BoolAttr | None = opt_prop_def(BoolAttr, prop_name="strideInBytes")
 
-    result = result_def(DataBoundsType)
+    result: OpResult[DataBoundsType] = result_def(DataBoundsType)
 
     irdl_options = (
         AttrSizedOperandSegments(as_property=True),
@@ -5127,8 +5188,8 @@ class _DataBoundsAccessorOp(IRDLOperation, ABC):
     `!acc.data_bounds_ty` operand and yields an `index`.
     """
 
-    bounds = operand_def(DataBoundsType)
-    result = result_def(IndexType)
+    bounds: Operand = operand_def(DataBoundsType)
+    result: OpResult[IndexType] = result_def(IndexType)
 
     assembly_format = "$bounds attr-dict `:` `(` type($bounds) `)` `->` type($result)"
 
@@ -5217,8 +5278,8 @@ class _RecipeOperation(IRDLOperation, ABC):
     per-op `verify_`.
     """
 
-    sym_name = prop_def(SymbolNameConstraint())
-    var_type = prop_def(TypeAttribute, prop_name="type")
+    sym_name: StringAttr = prop_def(SymbolNameConstraint())
+    var_type: TypeAttribute = prop_def(TypeAttribute, prop_name="type")
 
 
 @irdl_op_definition
@@ -5230,8 +5291,8 @@ class PrivateRecipeOp(_RecipeOperation):
 
     name = "acc.private.recipe"
 
-    init_region = region_def()
-    destroy_region = region_def()
+    init_region: Region = region_def()
+    destroy_region: Region = region_def()
 
     traits = lazy_traits_def(lambda: (IsolatedFromAbove(), SymbolOpInterface()))
 
@@ -5285,9 +5346,9 @@ class FirstprivateRecipeOp(_RecipeOperation):
 
     name = "acc.firstprivate.recipe"
 
-    init_region = region_def()
-    copy_region = region_def()
-    destroy_region = region_def()
+    init_region: Region = region_def()
+    copy_region: Region = region_def()
+    destroy_region: Region = region_def()
 
     traits = lazy_traits_def(lambda: (IsolatedFromAbove(), SymbolOpInterface()))
 
@@ -5354,11 +5415,13 @@ class ReductionRecipeOp(_RecipeOperation):
 
     name = "acc.reduction.recipe"
 
-    reduction_operator = prop_def(ReductionOpKindAttr, prop_name="reductionOperator")
+    reduction_operator: ReductionOpKindAttr = prop_def(
+        ReductionOpKindAttr, prop_name="reductionOperator"
+    )
 
-    init_region = region_def()
-    combiner_region = region_def()
-    destroy_region = region_def()
+    init_region: Region = region_def()
+    combiner_region: Region = region_def()
+    destroy_region: Region = region_def()
 
     traits = lazy_traits_def(lambda: (IsolatedFromAbove(), SymbolOpInterface()))
 
@@ -5480,10 +5543,12 @@ class _RuntimeDeviceTypesOperation(IRDLOperation, ABC):
     `__init__`, and `verify_` — they only override `name`.
     """
 
-    device_num = opt_operand_def(IntegerType | IndexType)
-    if_cond = opt_operand_def(I1)
+    device_num: OptOperand = opt_operand_def(IntegerType | IndexType)
+    if_cond: OptOperand = opt_operand_def(I1)
 
-    device_types = opt_prop_def(ArrayAttr[DeviceTypeAttr], prop_name="device_types")
+    device_types: ArrayAttr[DeviceTypeAttr] | None = opt_prop_def(
+        ArrayAttr[DeviceTypeAttr], prop_name="device_types"
+    )
 
     irdl_options = (
         AttrSizedOperandSegments(as_property=True),
@@ -5542,11 +5607,13 @@ class SetOp(IRDLOperation):
 
     name = "acc.set"
 
-    default_async = opt_operand_def(IntegerType | IndexType)
-    device_num = opt_operand_def(IntegerType | IndexType)
-    if_cond = opt_operand_def(I1)
+    default_async: OptOperand = opt_operand_def(IntegerType | IndexType)
+    device_num: OptOperand = opt_operand_def(IntegerType | IndexType)
+    if_cond: OptOperand = opt_operand_def(I1)
 
-    device_type = opt_prop_def(DeviceTypeAttr, prop_name="device_type")
+    device_type: DeviceTypeAttr | None = opt_prop_def(
+        DeviceTypeAttr, prop_name="device_type"
+    )
 
     irdl_options = (
         AttrSizedOperandSegments(as_property=True),
@@ -5595,12 +5662,12 @@ class WaitOp(IRDLOperation):
 
     name = "acc.wait"
 
-    wait_operands = var_operand_def(IntegerType | IndexType)
-    async_operand = opt_operand_def(IntegerType | IndexType)
-    wait_devnum = opt_operand_def(IntegerType | IndexType)
-    if_cond = opt_operand_def(I1)
+    wait_operands: VarOperand = var_operand_def(IntegerType | IndexType)
+    async_operand: OptOperand = opt_operand_def(IntegerType | IndexType)
+    wait_devnum: OptOperand = opt_operand_def(IntegerType | IndexType)
+    if_cond: OptOperand = opt_operand_def(I1)
 
-    async_attr = opt_prop_def(UnitAttr, prop_name="async")
+    async_attr: UnitAttr | None = opt_prop_def(UnitAttr, prop_name="async")
 
     irdl_options = (
         AttrSizedOperandSegments(as_property=True),
@@ -5661,24 +5728,30 @@ class RoutineOp(IRDLOperation):
 
     name = "acc.routine"
 
-    sym_name = prop_def(SymbolNameConstraint())
-    func_name = prop_def(SymbolRefAttr)
-    bind_id_name = opt_prop_def(ArrayAttr[SymbolRefAttr], prop_name="bindIdName")
-    bind_str_name = opt_prop_def(ArrayAttr[StringAttr], prop_name="bindStrName")
-    bind_id_name_device_type = opt_prop_def(
+    sym_name: StringAttr = prop_def(SymbolNameConstraint())
+    func_name: SymbolRefAttr = prop_def(SymbolRefAttr)
+    bind_id_name: ArrayAttr[SymbolRefAttr] | None = opt_prop_def(
+        ArrayAttr[SymbolRefAttr], prop_name="bindIdName"
+    )
+    bind_str_name: ArrayAttr[StringAttr] | None = opt_prop_def(
+        ArrayAttr[StringAttr], prop_name="bindStrName"
+    )
+    bind_id_name_device_type: ArrayAttr[DeviceTypeAttr] | None = opt_prop_def(
         ArrayAttr[DeviceTypeAttr], prop_name="bindIdNameDeviceType"
     )
-    bind_str_name_device_type = opt_prop_def(
+    bind_str_name_device_type: ArrayAttr[DeviceTypeAttr] | None = opt_prop_def(
         ArrayAttr[DeviceTypeAttr], prop_name="bindStrNameDeviceType"
     )
-    worker = opt_prop_def(ArrayAttr[DeviceTypeAttr])
-    vector = opt_prop_def(ArrayAttr[DeviceTypeAttr])
-    seq = opt_prop_def(ArrayAttr[DeviceTypeAttr])
-    nohost = opt_prop_def(UnitAttr)
-    implicit = opt_prop_def(UnitAttr)
-    gang = opt_prop_def(ArrayAttr[DeviceTypeAttr])
-    gang_dim = opt_prop_def(ArrayAttr[IntegerAttr], prop_name="gangDim")
-    gang_dim_device_type = opt_prop_def(
+    worker: ArrayAttr[DeviceTypeAttr] | None = opt_prop_def(ArrayAttr[DeviceTypeAttr])
+    vector: ArrayAttr[DeviceTypeAttr] | None = opt_prop_def(ArrayAttr[DeviceTypeAttr])
+    seq: ArrayAttr[DeviceTypeAttr] | None = opt_prop_def(ArrayAttr[DeviceTypeAttr])
+    nohost: UnitAttr | None = opt_prop_def(UnitAttr)
+    implicit: UnitAttr | None = opt_prop_def(UnitAttr)
+    gang: ArrayAttr[DeviceTypeAttr] | None = opt_prop_def(ArrayAttr[DeviceTypeAttr])
+    gang_dim: ArrayAttr[IntegerAttr] | None = opt_prop_def(
+        ArrayAttr[IntegerAttr], prop_name="gangDim"
+    )
+    gang_dim_device_type: ArrayAttr[DeviceTypeAttr] | None = opt_prop_def(
         ArrayAttr[DeviceTypeAttr], prop_name="gangDimDeviceType"
     )
 
@@ -5793,8 +5866,8 @@ class _GlobalCtorDtorOperation(IRDLOperation, ABC):
     `sym_name` and an unrestricted region. Concrete leaves override only `name`.
     """
 
-    sym_name = prop_def(SymbolNameConstraint())
-    region = region_def()
+    sym_name: StringAttr = prop_def(SymbolNameConstraint())
+    region: Region = region_def()
 
     assembly_format = "$sym_name $region attr-dict-with-keyword"
 

--- a/xdsl/dialects/accfg.py
+++ b/xdsl/dialects/accfg.py
@@ -25,6 +25,10 @@ from xdsl.ir import (
 from xdsl.irdl import (
     AttrSizedOperandSegments,
     IRDLOperation,
+    Operand,
+    OpResult,
+    OptOperand,
+    VarOperand,
     VerifyException,
     irdl_attr_definition,
     irdl_op_definition,
@@ -114,21 +118,21 @@ class LaunchOp(IRDLOperation):
 
     name = "accfg.launch"
 
-    values = var_operand_def(Attribute)  # TODO: make more precise?
+    values: VarOperand = var_operand_def(Attribute)  # TODO: make more precise?
     """
     The actual values used to set up registers linked to launch
     """
 
-    state = operand_def(StateType)
+    state: Operand = operand_def(StateType)
 
-    param_names = prop_def(ArrayAttr[StringAttr])
+    param_names: ArrayAttr[StringAttr] = prop_def(ArrayAttr[StringAttr])
     """
     Maps the SSA values in `values` to accelerator launch parameters
     """
 
-    accelerator = prop_def(StringAttr)
+    accelerator: StringAttr = prop_def(StringAttr)
 
-    token = result_def()
+    token: OpResult = result_def()
 
     def __init__(
         self,
@@ -187,7 +191,7 @@ class AwaitOp(IRDLOperation):
 
     name = "accfg.await"
 
-    token = operand_def(TokenType)
+    token: Operand = operand_def(TokenType)
 
     def __init__(self, token: SSAValue | Operation):
         super().__init__(operands=[token])
@@ -205,27 +209,27 @@ class SetupOp(IRDLOperation):
 
     name = "accfg.setup"
 
-    values = var_operand_def(Attribute)  # TODO: make more precise?
+    values: VarOperand = var_operand_def(Attribute)  # TODO: make more precise?
     """
     The actual values used to set up the CSRs
     """
 
-    in_state = opt_operand_def(StateType)
+    in_state: OptOperand = opt_operand_def(StateType)
     """
     The state produced by a previous accfg.setup
     """
 
-    out_state = result_def(StateType)
+    out_state: OpResult[StateType] = result_def(StateType)
     """
     The CSR state after the setup op modified it.
     """
 
-    param_names = prop_def(ArrayAttr[StringAttr])
+    param_names: ArrayAttr[StringAttr] = prop_def(ArrayAttr[StringAttr])
     """
     Maps the SSA values in `values` to accelerator parameter names
     """
 
-    accelerator = prop_def(StringAttr)
+    accelerator: StringAttr = prop_def(StringAttr)
     """
     Name of the accelerator this setup is for
     """
@@ -370,13 +374,13 @@ class AcceleratorOp(IRDLOperation):
 
     traits = traits_def(AcceleratorSymbolOpTrait())
 
-    name_prop = prop_def(SymbolRefAttr, prop_name="name")
+    name_prop: SymbolRefAttr = prop_def(SymbolRefAttr, prop_name="name")
 
-    fields = prop_def(DictionaryAttr)
+    fields: DictionaryAttr = prop_def(DictionaryAttr)
 
-    launch_fields = prop_def(DictionaryAttr)
+    launch_fields: DictionaryAttr = prop_def(DictionaryAttr)
 
-    barrier = prop_def(
+    barrier: IntegerAttr[IntegerType] = prop_def(
         IntegerAttr[IntegerType]
     )  # TODO: this will be reworked in a later version
 
@@ -436,7 +440,7 @@ class AcceleratorOp(IRDLOperation):
 class ResetOp(IRDLOperation):
     name = "accfg.reset"
 
-    in_state = operand_def(StateType)
+    in_state: Operand = operand_def(StateType)
 
     assembly_format = "$in_state attr-dict `:` type($in_state)"
 

--- a/xdsl/dialects/affine.py
+++ b/xdsl/dialects/affine.py
@@ -38,7 +38,11 @@ from xdsl.irdl import (
     AnyAttr,
     AttrSizedOperandSegments,
     IRDLOperation,
+    Operand,
+    OpResult,
     VarConstraint,
+    VarOperand,
+    VarOpResult,
     irdl_op_definition,
     operand_def,
     prop_def,
@@ -64,9 +68,9 @@ from xdsl.utils.hints import isa
 class ApplyOp(IRDLOperation):
     name = "affine.apply"
 
-    mapOperands = var_operand_def(IndexType)
-    map = prop_def(AffineMapAttr)
-    result = result_def(IndexType)
+    mapOperands: VarOperand = var_operand_def(IndexType)
+    map: AffineMapAttr = prop_def(AffineMapAttr)
+    result: OpResult[IndexType] = result_def(IndexType)
 
     traits = traits_def(Pure())
 
@@ -131,16 +135,16 @@ class ApplyOp(IRDLOperation):
 class ForOp(IRDLOperation):
     name = "affine.for"
 
-    lowerBoundOperands = var_operand_def(IndexType)
-    upperBoundOperands = var_operand_def(IndexType)
-    inits = var_operand_def()
-    res = var_result_def()
+    lowerBoundOperands: VarOperand = var_operand_def(IndexType)
+    upperBoundOperands: VarOperand = var_operand_def(IndexType)
+    inits: VarOperand = var_operand_def()
+    res: VarOpResult = var_result_def()
 
-    lowerBoundMap = prop_def(AffineMapAttr)
-    upperBoundMap = prop_def(AffineMapAttr)
-    step = prop_def(IntegerAttr)
+    lowerBoundMap: AffineMapAttr = prop_def(AffineMapAttr)
+    upperBoundMap: AffineMapAttr = prop_def(AffineMapAttr)
+    step: IntegerAttr = prop_def(IntegerAttr)
 
-    body = region_def()
+    body: Region = region_def()
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
@@ -218,13 +222,13 @@ class IfOp(IRDLOperation):
 
     name = "affine.if"
 
-    args = var_operand_def(IndexType)
-    res = var_result_def()
+    args: VarOperand = var_operand_def(IndexType)
+    res: VarOpResult = var_result_def()
 
-    condition = prop_def(AffineSetAttr)
+    condition: AffineSetAttr = prop_def(AffineSetAttr)
 
-    then_region = region_def("single_block")
-    else_region = region_def()
+    then_region: Region = region_def("single_block")
+    else_region: Region = region_def()
 
     traits = traits_def(RecursiveMemoryEffect(), RecursivelySpeculatable())
 
@@ -237,18 +241,20 @@ class ParallelOp(IRDLOperation):
 
     name = "affine.parallel"
 
-    map_operands = var_operand_def(IndexType)
+    map_operands: VarOperand = var_operand_def(IndexType)
 
-    reductions = prop_def(ArrayAttr[StringAttr])
-    lowerBoundsMap = prop_def(AffineMapAttr)
-    lowerBoundsGroups = prop_def(DenseIntElementsAttr)
-    upperBoundsMap = prop_def(AffineMapAttr)
-    upperBoundsGroups = prop_def(DenseIntElementsAttr)
-    steps = prop_def(ArrayAttr[IntegerAttr[IntegerType]])
+    reductions: ArrayAttr[StringAttr] = prop_def(ArrayAttr[StringAttr])
+    lowerBoundsMap: AffineMapAttr = prop_def(AffineMapAttr)
+    lowerBoundsGroups: DenseIntElementsAttr = prop_def(DenseIntElementsAttr)
+    upperBoundsMap: AffineMapAttr = prop_def(AffineMapAttr)
+    upperBoundsGroups: DenseIntElementsAttr = prop_def(DenseIntElementsAttr)
+    steps: ArrayAttr[IntegerAttr[IntegerType]] = prop_def(
+        ArrayAttr[IntegerAttr[IntegerType]]
+    )
 
-    res = var_result_def()
+    res: VarOpResult = var_result_def()
 
-    body = region_def("single_block")
+    body: Region = region_def("single_block")
 
     def verify_(self) -> None:
         if (
@@ -369,10 +375,10 @@ class StoreOp(IRDLOperation):
 
     T: ClassVar = VarConstraint("T", AnyAttr())
 
-    value = operand_def(T)
-    memref = operand_def(MemRefType.constr(T))
-    indices = var_operand_def(IndexType)
-    map = prop_def(AffineMapAttr)
+    value: Operand = operand_def(T)
+    memref: Operand = operand_def(MemRefType.constr(T))
+    indices: VarOperand = var_operand_def(IndexType)
+    map: AffineMapAttr = prop_def(AffineMapAttr)
 
     def __init__(
         self,
@@ -422,12 +428,12 @@ class LoadOp(IRDLOperation):
 
     T: ClassVar = VarConstraint("T", AnyAttr())
 
-    memref = operand_def(MemRefType.constr(T))
-    indices = var_operand_def(IndexType)
+    memref: Operand = operand_def(MemRefType.constr(T))
+    indices: VarOperand = var_operand_def(IndexType)
 
-    result = result_def(T)
+    result: OpResult = result_def(T)
 
-    map = prop_def(AffineMapAttr)
+    map: AffineMapAttr = prop_def(AffineMapAttr)
 
     def __init__(
         self,
@@ -479,10 +485,10 @@ class LoadOp(IRDLOperation):
 @irdl_op_definition
 class MinOp(IRDLOperation):
     name = "affine.min"
-    arguments = var_operand_def(IndexType())
-    result = result_def(IndexType())
+    arguments: VarOperand = var_operand_def(IndexType())
+    result: OpResult[IndexType] = result_def(IndexType())
 
-    map = prop_def(AffineMapAttr)
+    map: AffineMapAttr = prop_def(AffineMapAttr)
 
     def verify_(self) -> None:
         if len(self.operands) != self.map.data.num_dims + self.map.data.num_symbols:
@@ -497,7 +503,7 @@ class MinOp(IRDLOperation):
 @irdl_op_definition
 class YieldOp(IRDLOperation):
     name = "affine.yield"
-    arguments = var_operand_def()
+    arguments: VarOperand = var_operand_def()
 
     traits = traits_def(IsTerminator(), Pure())
 

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -38,6 +38,8 @@ from xdsl.irdl import (
     AnyAttr,
     AnyOf,
     IRDLOperation,
+    Operand,
+    OpResult,
     ParamAttrConstraint,
     VarConstraint,
     base,
@@ -136,12 +138,14 @@ class IntegerOverflowAttr(BitEnumAttribute[IntegerOverflowFlag]):
 class ConstantOp(IRDLOperation, HasFolderInterface):
     name = "arith.constant"
     _T: ClassVar = VarConstraint("T", AnyAttr())
-    result = result_def(_T)
-    value = prop_def(
-        IntegerAttr.constr((SignlessIntegerConstraint | IndexTypeConstr) & _T)
-        | ParamAttrConstraint(FloatAttr, (AnyAttr(), _T))
-        | ParamAttrConstraint(DenseIntOrFPElementsAttr, (_T, AnyAttr()))
-        | ParamAttrConstraint(DenseResourceAttr, (AnyAttr(), _T))
+    result: OpResult = result_def(_T)
+    value: IntegerAttr | FloatAttr | DenseIntOrFPElementsAttr | DenseResourceAttr = (
+        prop_def(
+            IntegerAttr.constr((SignlessIntegerConstraint | IndexTypeConstr) & _T)
+            | ParamAttrConstraint(FloatAttr, (AnyAttr(), _T))
+            | ParamAttrConstraint(DenseIntOrFPElementsAttr, (_T, AnyAttr()))
+            | ParamAttrConstraint(DenseResourceAttr, (AnyAttr(), _T))
+        )
     )
 
     traits = traits_def(Pure(), ConstantLike())
@@ -185,9 +189,14 @@ class SignlessIntegerBinaryOperation(IRDLOperation, HasFolderInterface, abc.ABC)
 
     T: ClassVar = VarConstraint("T", signlessIntegerLike)
 
-    lhs = operand_def(T)
-    rhs = operand_def(T)
-    result = result_def(T)
+    lhs: Operand = operand_def(T)
+    rhs: Operand = operand_def(T)
+    result: OpResult[
+        IntegerType
+        | IndexType
+        | VectorType[IntegerType | IndexType]
+        | TensorType[IntegerType | IndexType]
+    ] = result_def(T)
 
     assembly_format = "$lhs `,` $rhs attr-dict `:` type($result)"
 
@@ -277,7 +286,7 @@ class SignlessIntegerBinaryOperationWithOverflow(
     can overflow.
     """
 
-    overflow_flags = prop_def(
+    overflow_flags: IntegerOverflowAttr = prop_def(
         IntegerOverflowAttr,
         default_value=IntegerOverflowAttr("none"),
         prop_name="overflowFlags",
@@ -332,11 +341,15 @@ class FloatingPointLikeBinaryOperation(IRDLOperation, abc.ABC):
 
     T: ClassVar = VarConstraint("T", floatingPointLike)
 
-    lhs = operand_def(T)
-    rhs = operand_def(T)
-    result = result_def(T)
+    lhs: Operand = operand_def(T)
+    rhs: Operand = operand_def(T)
+    result: OpResult[AnyFloat | VectorType[AnyFloat] | TensorType[AnyFloat]] = (
+        result_def(T)
+    )
 
-    fastmath = prop_def(FastMathFlagsAttr, default_value=FastMathFlagsAttr("none"))
+    fastmath: FastMathFlagsAttr = prop_def(
+        FastMathFlagsAttr, default_value=FastMathFlagsAttr("none")
+    )
 
     def __init__(
         self,
@@ -390,11 +403,18 @@ class AddUIExtendedOp(IRDLOperation):
 
     T: ClassVar = VarConstraint("T", signlessIntegerLike)
 
-    lhs = operand_def(T)
-    rhs = operand_def(T)
+    lhs: Operand = operand_def(T)
+    rhs: Operand = operand_def(T)
 
-    sum = result_def(T)
-    overflow = result_def(boolLike)
+    sum: OpResult[
+        IntegerType
+        | IndexType
+        | VectorType[IntegerType | IndexType]
+        | TensorType[IntegerType | IndexType]
+    ] = result_def(T)
+    overflow: OpResult[
+        IntegerType | VectorType[IntegerType] | TensorType[IntegerType]
+    ] = result_def(boolLike)
 
     assembly_format = "$lhs `,` $rhs attr-dict `:` type($sum) `,` type($overflow)"
 
@@ -469,10 +489,20 @@ class MulExtendedBase(IRDLOperation):
 
     T: ClassVar = VarConstraint("T", signlessIntegerLike)
 
-    lhs = operand_def(T)
-    rhs = operand_def(T)
-    low = result_def(T)
-    high = result_def(T)
+    lhs: Operand = operand_def(T)
+    rhs: Operand = operand_def(T)
+    low: OpResult[
+        IntegerType
+        | IndexType
+        | VectorType[IntegerType | IndexType]
+        | TensorType[IntegerType | IndexType]
+    ] = result_def(T)
+    high: OpResult[
+        IntegerType
+        | IndexType
+        | VectorType[IntegerType | IndexType]
+        | TensorType[IntegerType | IndexType]
+    ] = result_def(T)
 
     traits = traits_def(Pure())
 
@@ -539,7 +569,7 @@ class DivUIOp(SignlessIntegerBinaryOperation, ConditionallySpeculatableInterface
 
     def is_speculatable(self) -> bool:
         rhs = ConstantLike.get_constant_value(self.rhs)
-        return isa(rhs, IntegerAttr[IntegerType | IndexType]) and rhs.value.data != 0
+        return isa(rhs, IntegerAttr | IntegerAttr) and rhs.value.data != 0
 
     @staticmethod
     def is_right_unit(attr: IntegerAttr) -> bool:
@@ -563,7 +593,7 @@ class DivSIOp(SignlessIntegerBinaryOperation, ConditionallySpeculatableInterface
     def is_speculatable(self) -> bool:
         rhs = ConstantLike.get_constant_value(self.rhs)
         return (
-            isa(rhs, IntegerAttr[IntegerType | IndexType])
+            isa(rhs, IntegerAttr | IntegerAttr)
             and rhs.value.data != 0
             and rhs.value.data != -1
         )
@@ -848,10 +878,10 @@ class CmpiOp(ComparisonOperation):
     """
 
     name = "arith.cmpi"
-    predicate = prop_def(IntegerAttr)
-    lhs = operand_def(signlessIntegerLike)
-    rhs = operand_def(signlessIntegerLike)
-    result = result_def(IntegerType(1))
+    predicate: IntegerAttr = prop_def(IntegerAttr)
+    lhs: Operand = operand_def(signlessIntegerLike)
+    rhs: Operand = operand_def(signlessIntegerLike)
+    result: OpResult[IntegerType] = result_def(IntegerType(1))
 
     traits = traits_def(CmpiHasCanonicalizationPatterns(), Pure())
 
@@ -940,11 +970,13 @@ class CmpfOp(ComparisonOperation):
     """
 
     name = "arith.cmpf"
-    predicate = prop_def(IntegerAttr)
-    lhs = operand_def(floatingPointLike)
-    rhs = operand_def(floatingPointLike)
-    fastmath = prop_def(FastMathFlagsAttr, default_value=FastMathFlagsAttr("none"))
-    result = result_def(IntegerType(1))
+    predicate: IntegerAttr = prop_def(IntegerAttr)
+    lhs: Operand = operand_def(floatingPointLike)
+    rhs: Operand = operand_def(floatingPointLike)
+    fastmath: FastMathFlagsAttr = prop_def(
+        FastMathFlagsAttr, default_value=FastMathFlagsAttr("none")
+    )
+    result: OpResult[IntegerType] = result_def(IntegerType(1))
 
     traits = traits_def(Pure())
 
@@ -1053,10 +1085,10 @@ class SelectOp(IRDLOperation):
     name = "arith.select"
 
     _T: ClassVar = VarConstraint("_T", AnyAttr())
-    cond = operand_def(IntegerType(1))
-    lhs = operand_def(_T)
-    rhs = operand_def(_T)
-    result = result_def(_T)
+    cond: Operand = operand_def(IntegerType(1))
+    lhs: Operand = operand_def(_T)
+    rhs: Operand = operand_def(_T)
+    result: OpResult = result_def(_T)
 
     traits = traits_def(Pure(), SelectHasCanonicalizationPatterns())
 
@@ -1118,9 +1150,13 @@ class NegfOp(IRDLOperation):
 
     _T: ClassVar = VarConstraint("_T", floatingPointLike)
 
-    fastmath = prop_def(FastMathFlagsAttr, default_value=FastMathFlagsAttr("none"))
-    operand = operand_def(_T)
-    result = result_def(_T)
+    fastmath: FastMathFlagsAttr = prop_def(
+        FastMathFlagsAttr, default_value=FastMathFlagsAttr("none")
+    )
+    operand: Operand = operand_def(_T)
+    result: OpResult[AnyFloat | VectorType[AnyFloat] | TensorType[AnyFloat]] = (
+        result_def(_T)
+    )
 
     traits = traits_def(Pure())
 
@@ -1190,11 +1226,18 @@ class MinnumfOp(FloatingPointLikeBinaryOperation):
 class BitcastOp(IRDLOperation):
     name = "arith.bitcast"
 
-    input = operand_def(
+    input: Operand = operand_def(
         container_of(IntegerType | IndexType | AnyFloat)
         | MemRefType.constr(element_type=AnyFloatConstr | SignlessIntegerConstraint)
     )
-    result = result_def(
+    result: OpResult[
+        IntegerType
+        | IndexType
+        | AnyFloat
+        | VectorType[AnyFloat | IntegerType | IndexType]
+        | TensorType[AnyFloat | IntegerType | IndexType]
+        | MemRefType
+    ] = result_def(
         container_of(IntegerType | IndexType | AnyFloat)
         | MemRefType.constr(element_type=AnyFloatConstr | SignlessIntegerConstraint)
     )
@@ -1237,9 +1280,11 @@ class BitcastOp(IRDLOperation):
 class IndexCastOp(IRDLOperation):
     name = "arith.index_cast"
 
-    input = operand_def(base(IntegerType) | base(IndexType))
+    input: Operand = operand_def(base(IntegerType) | base(IndexType))
 
-    result = result_def(base(IntegerType) | base(IndexType))
+    result: OpResult[IntegerType | IndexType] = result_def(
+        base(IntegerType) | base(IndexType)
+    )
 
     traits = traits_def(Pure())
 
@@ -1259,8 +1304,8 @@ class IndexCastOp(IRDLOperation):
 
 
 class FloatingPointToIntegerBaseOp(IRDLOperation, abc.ABC):
-    input = operand_def(AnyFloatConstr)
-    result = result_def(IntegerType)
+    input: Operand = operand_def(AnyFloatConstr)
+    result: OpResult[IntegerType] = result_def(IntegerType)
 
     assembly_format = "$input attr-dict `:` type($input) `to` type($result)"
 
@@ -1281,8 +1326,8 @@ class FPToUIOp(FloatingPointToIntegerBaseOp):
 
 
 class IntegerToFloatingPointBaseOp(IRDLOperation, abc.ABC):
-    input = operand_def(IntegerType)
-    result = result_def(AnyFloatConstr)
+    input: Operand = operand_def(IntegerType)
+    result: OpResult[AnyFloat] = result_def(AnyFloatConstr)
 
     assembly_format = "$input attr-dict `:` type($input) `to` type($result)"
 
@@ -1306,8 +1351,10 @@ class UIToFPOp(IntegerToFloatingPointBaseOp):
 class ExtFOp(IRDLOperation):
     name = "arith.extf"
 
-    input = operand_def(floatingPointLike)
-    result = result_def(floatingPointLike)
+    input: Operand = operand_def(floatingPointLike)
+    result: OpResult[AnyFloat | VectorType[AnyFloat] | TensorType[AnyFloat]] = (
+        result_def(floatingPointLike)
+    )
 
     def __init__(self, op: SSAValue | Operation, target_type: Attribute):
         super().__init__(operands=[op], result_types=[target_type])
@@ -1321,8 +1368,10 @@ class ExtFOp(IRDLOperation):
 class TruncFOp(IRDLOperation):
     name = "arith.truncf"
 
-    input = operand_def(floatingPointLike)
-    result = result_def(floatingPointLike)
+    input: Operand = operand_def(floatingPointLike)
+    result: OpResult[AnyFloat | VectorType[AnyFloat] | TensorType[AnyFloat]] = (
+        result_def(floatingPointLike)
+    )
 
     def __init__(self, op: SSAValue | Operation, target_type: Attribute):
         super().__init__(operands=[op], result_types=[target_type])
@@ -1336,8 +1385,8 @@ class TruncFOp(IRDLOperation):
 class TruncIOp(IRDLOperation):
     name = "arith.trunci"
 
-    input = operand_def(IntegerType)
-    result = result_def(IntegerType)
+    input: Operand = operand_def(IntegerType)
+    result: OpResult[IntegerType] = result_def(IntegerType)
 
     def __init__(self, op: SSAValue | Operation, target_type: IntegerType):
         super().__init__(operands=[op], result_types=[target_type])
@@ -1358,8 +1407,8 @@ class TruncIOp(IRDLOperation):
 class ExtSIOp(IRDLOperation):
     name = "arith.extsi"
 
-    input = operand_def(IntegerType)
-    result = result_def(IntegerType)
+    input: Operand = operand_def(IntegerType)
+    result: OpResult[IntegerType] = result_def(IntegerType)
 
     def __init__(self, op: SSAValue | Operation, target_type: IntegerType):
         super().__init__(operands=[op], result_types=[target_type])
@@ -1378,8 +1427,8 @@ class ExtSIOp(IRDLOperation):
 class ExtUIOp(IRDLOperation):
     name = "arith.extui"
 
-    input = operand_def(IntegerType)
-    result = result_def(IntegerType)
+    input: Operand = operand_def(IntegerType)
+    result: OpResult[IntegerType] = result_def(IntegerType)
 
     def __init__(self, op: SSAValue | Operation, target_type: IntegerType):
         super().__init__(operands=[op], result_types=[target_type])

--- a/xdsl/dialects/arm/ops.py
+++ b/xdsl/dialects/arm/ops.py
@@ -5,6 +5,8 @@ from xdsl.dialects.builtin import StringAttr
 from xdsl.ir import Operation, SSAValue
 from xdsl.irdl import (
     IRDLOperation,
+    Operand,
+    OpResult,
     irdl_op_definition,
     operand_def,
     opt_attr_def,
@@ -28,7 +30,7 @@ class ARMInstruction(ARMAsmOperation, ABC):
     The name of the operation will be used as the x86 assembly instruction name.
     """
 
-    comment = opt_attr_def(StringAttr)
+    comment: StringAttr | None = opt_attr_def(StringAttr)
     """
     An optional comment that will be printed along with the instruction.
     """
@@ -65,8 +67,8 @@ class DSMovOp(ARMInstruction):
 
     name = "arm.ds.mov"
 
-    d = result_def(IntRegisterType)
-    s = operand_def(IntRegisterType)
+    d: OpResult[IntRegisterType] = result_def(IntRegisterType)
+    s: Operand = operand_def(IntRegisterType)
     assembly_format = "$s attr-dict `:` `(` type($s) `)` `->` type($d)"
 
     def __init__(
@@ -99,7 +101,7 @@ class GetRegisterOp(ARMAsmOperation):
 
     name = "arm.get_register"
 
-    result = result_def(IntRegisterType)
+    result: OpResult[IntRegisterType] = result_def(IntRegisterType)
     assembly_format = "attr-dict `:` type($result)"
 
     def __init__(self, register_type: IntRegisterType):
@@ -119,9 +121,9 @@ class DSSMulOp(ARMInstruction):
 
     name = "arm.dss.mul"
 
-    d = result_def(IntRegisterType)
-    s1 = operand_def(IntRegisterType)
-    s2 = operand_def(IntRegisterType)
+    d: OpResult[IntRegisterType] = result_def(IntRegisterType)
+    s1: Operand = operand_def(IntRegisterType)
+    s2: Operand = operand_def(IntRegisterType)
     assembly_format = (
         "$s1 `,` $s2 attr-dict `:` `(` type($s1) `,` type($s2) `)` `->` type($d)"
     )
@@ -159,8 +161,8 @@ class LabelOp(ARMAsmOperation):
     """
 
     name = "arm.label"
-    label = prop_def(StringAttr)
-    comment = opt_attr_def(StringAttr)
+    label: StringAttr = prop_def(StringAttr)
+    comment: StringAttr | None = opt_attr_def(StringAttr)
 
     assembly_format = "$label attr-dict"
 
@@ -196,8 +198,8 @@ class CmpRegOp(ARMInstruction):
     """
 
     name = "arm.cmp"
-    s1 = operand_def(IntRegisterType)
-    s2 = operand_def(IntRegisterType)
+    s1: Operand = operand_def(IntRegisterType)
+    s2: Operand = operand_def(IntRegisterType)
 
     assembly_format = "$s1 `,` $s2 attr-dict `:` `(` type($s1) `,` type($s2) `)`"
 

--- a/xdsl/dialects/arm_func.py
+++ b/xdsl/dialects/arm_func.py
@@ -49,10 +49,10 @@ class FuncOp(arm.ops.ARMAsmOperation):
     """ARM function definition operation"""
 
     name = "arm_func.func"
-    sym_name = attr_def(SymbolNameConstraint())
-    body = region_def()
-    function_type = attr_def(FunctionType)
-    sym_visibility = opt_attr_def(StringAttr)
+    sym_name: StringAttr = attr_def(SymbolNameConstraint())
+    body: Region = region_def()
+    function_type: FunctionType = attr_def(FunctionType)
+    sym_visibility: StringAttr | None = opt_attr_def(StringAttr)
 
     traits = traits_def(
         SymbolOpInterface(),

--- a/xdsl/dialects/arm_neon.py
+++ b/xdsl/dialects/arm_neon.py
@@ -7,6 +7,7 @@ from xdsl.backend.assembly_printer import reg
 from xdsl.dialects.arm.ops import ARMAsmOperation, ARMInstruction
 from xdsl.dialects.arm.registers import ARMRegisterType, IntRegisterType
 from xdsl.dialects.builtin import (
+    I8,
     IntegerAttr,
     StringAttr,
     VectorType,
@@ -25,7 +26,11 @@ from xdsl.ir import (
     StrEnum,
 )
 from xdsl.irdl import (
+    Operand,
+    OpResult,
     VarConstraint,
+    VarOperand,
+    VarOpResult,
     base,
     irdl_attr_definition,
     irdl_op_definition,
@@ -176,7 +181,7 @@ class GetRegisterOp(ARMAsmOperation):
 
     name = "arm_neon.get_register"
 
-    result = result_def(NEONRegisterType)
+    result: OpResult[NEONRegisterType] = result_def(NEONRegisterType)
     assembly_format = "attr-dict `:` type($result)"
 
     def __init__(self, register_type: NEONRegisterType):
@@ -206,11 +211,11 @@ class DSSFMulOp(ARMInstruction):
     """
 
     name = "arm_neon.dss.fmul"
-    d = result_def(NEONRegisterType)
-    s1 = operand_def(NEONRegisterType)
-    s2 = operand_def(NEONRegisterType)
-    scalar_idx = opt_prop_def(IntegerAttr[i8])
-    arrangement = prop_def(NeonArrangementAttr)
+    d: OpResult[NEONRegisterType] = result_def(NEONRegisterType)
+    s1: Operand = operand_def(NEONRegisterType)
+    s2: Operand = operand_def(NEONRegisterType)
+    scalar_idx: IntegerAttr[I8] | None = opt_prop_def(IntegerAttr[i8])
+    arrangement: NeonArrangementAttr = prop_def(NeonArrangementAttr)
 
     assembly_format = (
         "$s1 `,` $s2 (`[` $scalar_idx^ `]`)? $arrangement attr-dict "
@@ -277,12 +282,12 @@ class DSSFmlaVecScalarOp(ARMInstruction):
     )
 
     name = "arm_neon.dss.fmla"
-    res = result_def(SAME_NEON_REGISTER_TYPE)
-    d = operand_def(SAME_NEON_REGISTER_TYPE)
-    s1 = operand_def(NEONRegisterType)
-    s2 = operand_def(NEONRegisterType)
-    scalar_idx = prop_def(IntegerAttr[i8])
-    arrangement = prop_def(NeonArrangementAttr)
+    res: OpResult[NEONRegisterType] = result_def(SAME_NEON_REGISTER_TYPE)
+    d: Operand = operand_def(SAME_NEON_REGISTER_TYPE)
+    s1: Operand = operand_def(NEONRegisterType)
+    s2: Operand = operand_def(NEONRegisterType)
+    scalar_idx: IntegerAttr[I8] = prop_def(IntegerAttr[i8])
+    arrangement: NeonArrangementAttr = prop_def(NeonArrangementAttr)
 
     assembly_format = (
         "$d `,` $s1 `,` $s2 `[` $scalar_idx `]` $arrangement attr-dict `:` \
@@ -336,9 +341,9 @@ class DSDupOp(ARMInstruction):
     """
 
     name = "arm_neon.ds.dup"
-    s = operand_def(IntRegisterType)
-    d = result_def(NEONRegisterType)
-    arrangement = prop_def(NeonArrangementAttr)
+    s: Operand = operand_def(IntRegisterType)
+    d: OpResult[NEONRegisterType] = result_def(NEONRegisterType)
+    arrangement: NeonArrangementAttr = prop_def(NeonArrangementAttr)
 
     assembly_format = "$s $arrangement attr-dict `:` type($s) `->` `(` type($d) `)`"
 
@@ -381,10 +386,10 @@ class DSVecMovOp(ARMInstruction):
     """
 
     name = "arm_neon.dsvec.mov"
-    s = operand_def(NEONRegisterType)
-    d = result_def(IntRegisterType)
-    scalar_idx = prop_def(IntegerAttr[i8])
-    arrangement = prop_def(NeonArrangementAttr)
+    s: Operand = operand_def(NEONRegisterType)
+    d: OpResult[IntRegisterType] = result_def(IntRegisterType)
+    scalar_idx: IntegerAttr[I8] = prop_def(IntegerAttr[i8])
+    arrangement: NeonArrangementAttr = prop_def(NeonArrangementAttr)
     assembly_format = (
         "$s `[` $scalar_idx `]` $arrangement attr-dict `:` type($s) `->` type($d)"
     )
@@ -431,9 +436,9 @@ class DVarSLd1Op(ARMInstruction):
     """
 
     name = "arm_neon.dvars.ld1"
-    s = operand_def(IntRegisterType)
-    dest_regs = var_result_def(NEONRegisterType)
-    arrangement = prop_def(NeonArrangementAttr)
+    s: Operand = operand_def(IntRegisterType)
+    dest_regs: VarOpResult[NEONRegisterType] = var_result_def(NEONRegisterType)
+    arrangement: NeonArrangementAttr = prop_def(NeonArrangementAttr)
 
     assembly_format = " ` ` `[` $s `]` $arrangement attr-dict `:` type($s) `->` `(` type($dest_regs) `)`"
 
@@ -485,9 +490,9 @@ class DVarSSt1Op(ARMInstruction):
     """
 
     name = "arm_neon.dvars.st1"
-    d = operand_def(IntRegisterType)
-    src_regs = var_operand_def(NEONRegisterType)
-    arrangement = prop_def(NeonArrangementAttr)
+    d: Operand = operand_def(IntRegisterType)
+    src_regs: VarOperand = var_operand_def(NEONRegisterType)
+    arrangement: NeonArrangementAttr = prop_def(NeonArrangementAttr)
 
     assembly_format = "$src_regs ` ` `[` $d `]` $arrangement attr-dict `:` `(` type($src_regs) `)` `->` type($d)"
 

--- a/xdsl/dialects/bigint.py
+++ b/xdsl/dialects/bigint.py
@@ -3,7 +3,7 @@
 import abc
 from collections.abc import Sequence
 
-from xdsl.dialects.builtin import IntAttr, IntegerType, f64, i1
+from xdsl.dialects.builtin import I1, Float64Type, IntAttr, IntegerType, f64, i1
 from xdsl.ir import (
     Attribute,
     Dialect,
@@ -14,6 +14,8 @@ from xdsl.ir import (
 )
 from xdsl.irdl import (
     IRDLOperation,
+    Operand,
+    OpResult,
     irdl_attr_definition,
     irdl_op_definition,
     operand_def,
@@ -45,9 +47,9 @@ bigint = BigIntegerType()
 class BinaryOperation(IRDLOperation, abc.ABC):
     """Binary operation where all operands and results are `bigint`s."""
 
-    lhs = operand_def(bigint)
-    rhs = operand_def(bigint)
-    result = result_def(bigint)
+    lhs: Operand = operand_def(bigint)
+    rhs: Operand = operand_def(bigint)
+    result: OpResult[BigIntegerType] = result_def(bigint)
 
     assembly_format = "$lhs `,` $rhs attr-dict `:` type($result)"
 
@@ -62,8 +64,8 @@ class BinaryOperation(IRDLOperation, abc.ABC):
 @irdl_op_definition
 class ConstantOp(IRDLOperation):
     name = "bigint.constant"
-    result = result_def(bigint)
-    value = prop_def(IntAttr)
+    result: OpResult[BigIntegerType] = result_def(bigint)
+    value: IntAttr[int] = prop_def(IntAttr)
 
     traits = traits_def(ConstantLike(), HasFolder(), Pure())
 
@@ -102,8 +104,8 @@ class ConstantOp(IRDLOperation):
 @irdl_op_definition
 class TruncateToIntOp(IRDLOperation):
     name = "bigint.truncate_to_int"
-    result = result_def(IntegerType)
-    value = operand_def(bigint)
+    result: OpResult[IntegerType] = result_def(IntegerType)
+    value: Operand = operand_def(bigint)
 
     traits = traits_def(Pure())
 
@@ -266,9 +268,9 @@ class DivOp(IRDLOperation):
 
     name = "bigint.div"
 
-    lhs = operand_def(bigint)
-    rhs = operand_def(bigint)
-    result = result_def(f64)
+    lhs: Operand = operand_def(bigint)
+    rhs: Operand = operand_def(bigint)
+    result: OpResult[Float64Type] = result_def(f64)
 
     assembly_format = "$lhs `,` $rhs attr-dict `:` type($result)"
 
@@ -287,9 +289,9 @@ class DivOp(IRDLOperation):
 class ComparisonOperation(IRDLOperation, abc.ABC):
     """Binary operation comparing two `bigint`s and returning a boolean."""
 
-    lhs = operand_def(bigint)
-    rhs = operand_def(bigint)
-    result = result_def(i1)
+    lhs: Operand = operand_def(bigint)
+    rhs: Operand = operand_def(bigint)
+    result: OpResult[I1] = result_def(i1)
 
     assembly_format = "$lhs `,` $rhs attr-dict `:` type($result)"
 

--- a/xdsl/dialects/bufferization.py
+++ b/xdsl/dialects/bufferization.py
@@ -10,6 +10,7 @@ from typing_extensions import TypeVar
 from xdsl.dialects.builtin import (
     AnyTensorTypeConstr,
     AnyUnrankedMemRefTypeConstr,
+    AnyUnrankedTensorType,
     AnyUnrankedTensorTypeConstr,
     IndexType,
     MemRefType,
@@ -25,7 +26,12 @@ from xdsl.irdl import (
     ConstraintContext,
     IntConstraint,
     IRDLOperation,
+    Operand,
+    OpResult,
+    OptOperand,
+    OptOpResult,
     VarConstraint,
+    VarOperand,
     irdl_op_definition,
     operand_def,
     opt_operand_def,
@@ -39,9 +45,7 @@ from xdsl.utils.hints import isa
 
 
 @dataclass(frozen=True)
-class TensorFromMemRefConstraint(
-    AttrConstraint[TensorType[Attribute] | UnrankedTensorType[Attribute]]
-):
+class TensorFromMemRefConstraint(AttrConstraint[TensorType | UnrankedTensorType]):
     """
     Converts an input memref constraint to the corresponding tensor constraint, i.e. the constraints
     on element type and shape are the same as the input constraint, but the attribute is verified to be
@@ -71,9 +75,7 @@ class TensorFromMemRefConstraint(
     def can_infer(self, var_constraint_names: AbstractSet[str]) -> bool:
         return self.memref_constraint.can_infer(var_constraint_names)
 
-    def infer(
-        self, context: ConstraintContext
-    ) -> TensorType[Attribute] | UnrankedTensorType[Attribute]:
+    def infer(self, context: ConstraintContext) -> TensorType | UnrankedTensorType:
         memref_type = self.memref_constraint.infer(context)
         return self.memref_to_tensor(memref_type)
 
@@ -137,11 +139,11 @@ class AllocTensorOp(IRDLOperation):
 
     T: ClassVar = VarConstraint("T", AnyTensorTypeConstr | AnyUnrankedTensorTypeConstr)
 
-    dynamic_sizes = var_operand_def(IndexType())
-    copy = opt_operand_def(T)
-    size_hint = opt_operand_def(IndexType())
+    dynamic_sizes: VarOperand = var_operand_def(IndexType())
+    copy: OptOperand = opt_operand_def(T)
+    size_hint: OptOperand = opt_operand_def(IndexType())
 
-    tensor = result_def(T)
+    tensor: OpResult[TensorType | AnyUnrankedTensorType] = result_def(T)
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
@@ -166,8 +168,8 @@ class CloneOp(IRDLOperation):
 
     T: ClassVar = VarConstraint("T", MemRefType.constr() | AnyUnrankedMemRefTypeConstr)
 
-    input = operand_def(T)
-    output = result_def(T)
+    input: Operand = operand_def(T)
+    output: OpResult[MemRefType | UnrankedMemRefType] = result_def(T)
 
     assembly_format = "$input attr-dict `:` type($input) `to` type($output)"
 
@@ -182,11 +184,13 @@ class ToTensorOp(IRDLOperation):
 
     T: ClassVar = VarConstraint("T", MemRefType.constr() | AnyUnrankedMemRefTypeConstr)
 
-    memref = operand_def(T)
-    tensor = result_def(TensorFromMemRefConstraint(T))
+    memref: Operand = operand_def(T)
+    tensor: OpResult[TensorType | UnrankedTensorType] = result_def(
+        TensorFromMemRefConstraint(T)
+    )
 
-    writable = opt_prop_def(UnitAttr)
-    restrict = opt_prop_def(UnitAttr)
+    writable: UnitAttr | None = opt_prop_def(UnitAttr)
+    restrict: UnitAttr | None = opt_prop_def(UnitAttr)
 
     assembly_format = "$memref (`restrict` $restrict^)? (`writable` $writable^)? attr-dict `:` type($memref) `to` type($tensor)"
 
@@ -214,10 +218,10 @@ class ToBufferOp(IRDLOperation):
     name = "bufferization.to_buffer"
 
     T: ClassVar = VarConstraint("T", MemRefType.constr() | AnyUnrankedMemRefTypeConstr)
-    tensor = operand_def(TensorFromMemRefConstraint(T))
-    memref = result_def(T)
+    tensor: Operand = operand_def(TensorFromMemRefConstraint(T))
+    memref: OpResult[MemRefType | UnrankedMemRefType] = result_def(T)
 
-    read_only = opt_prop_def(UnitAttr)
+    read_only: UnitAttr | None = opt_prop_def(UnitAttr)
 
     assembly_format = "$tensor (`read_only` $read_only^)?  `:` attr-dict type($tensor) `to` type($memref)"
 
@@ -227,12 +231,14 @@ class MaterializeInDestinationOp(IRDLOperation):
     name = "bufferization.materialize_in_destination"
 
     T: ClassVar = VarConstraint("T", MemRefType.constr() | AnyUnrankedMemRefTypeConstr)
-    source = operand_def(TensorFromMemRefConstraint(T))
-    dest = operand_def(T | TensorFromMemRefConstraint(T))
-    result = opt_result_def(TensorFromMemRefConstraint(T))
+    source: Operand = operand_def(TensorFromMemRefConstraint(T))
+    dest: Operand = operand_def(T | TensorFromMemRefConstraint(T))
+    result: OptOpResult[TensorType | UnrankedTensorType] = opt_result_def(
+        TensorFromMemRefConstraint(T)
+    )
 
-    restrict = opt_prop_def(UnitAttr)
-    writable = opt_prop_def(UnitAttr)
+    restrict: UnitAttr | None = opt_prop_def(UnitAttr)
+    writable: UnitAttr | None = opt_prop_def(UnitAttr)
 
     assembly_format = "$source `in` (`restrict` $restrict^)? (`writable` $writable^)? $dest attr-dict `:` functional-type(operands, results)"  # noqa: E501
 

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -68,6 +68,8 @@ from xdsl.irdl import (
     RangeConstraint,
     RangeOf,
     TypeVarConstraint,
+    VarOperand,
+    VarOpResult,
     get_int_constraint,
     irdl_attr_definition,
     irdl_op_definition,
@@ -2213,8 +2215,8 @@ class TensorType(
         )
 
 
-AnyTensorType: TypeAlias = TensorType[Attribute]
-AnyTensorTypeConstr = BaseAttr[TensorType[Attribute]](TensorType)
+AnyTensorType: TypeAlias = TensorType
+AnyTensorTypeConstr = BaseAttr[TensorType](TensorType)
 
 
 @irdl_attr_definition
@@ -2237,7 +2239,7 @@ class UnrankedTensorType(
             printer.print_attribute(self.element_type)
 
 
-AnyUnrankedTensorType: TypeAlias = UnrankedTensorType[Attribute]
+AnyUnrankedTensorType: TypeAlias = UnrankedTensorType
 AnyUnrankedTensorTypeConstr = BaseAttr[AnyUnrankedTensorType](UnrankedTensorType)
 
 
@@ -2719,8 +2721,8 @@ class AffineSetAttr(_BuiltinData[AffineSet]):
 class UnrealizedConversionCastOp(IRDLOperation):
     name = "builtin.unrealized_conversion_cast"
 
-    inputs = var_operand_def()
-    outputs = var_result_def()
+    inputs: VarOperand = var_operand_def()
+    outputs: VarOpResult = var_result_def()
 
     traits = traits_def(NoMemoryEffect())
 
@@ -2936,9 +2938,9 @@ class UnregisteredAttr(ParametrizedAttribute, BuiltinAttribute, ABC):
 class ModuleOp(IRDLOperation):
     name = "builtin.module"
 
-    sym_name = opt_prop_def(StringAttr)
+    sym_name: StringAttr | None = opt_prop_def(StringAttr)
 
-    body = region_def("single_block")
+    body: Region = region_def("single_block")
 
     traits = traits_def(
         IsolatedFromAbove(),

--- a/xdsl/dialects/cf.py
+++ b/xdsl/dialects/cf.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 
 from xdsl.dialects.builtin import (
+    I32,
     DenseArrayBase,
     DenseIntElementsAttr,
     IndexType,
@@ -17,8 +18,10 @@ from xdsl.ir import Attribute, Block, Dialect, Operation, SSAValue
 from xdsl.irdl import (
     AttrSizedOperandSegments,
     IRDLOperation,
+    Operand,
     Successor,
     VarOperand,
+    VarSuccessor,
     irdl_op_definition,
     operand_def,
     opt_prop_def,
@@ -62,8 +65,8 @@ class AssertOp(IRDLOperation):
 
     name = "cf.assert"
 
-    arg = operand_def(IntegerType(1))
-    msg = prop_def(StringAttr)
+    arg: Operand = operand_def(IntegerType(1))
+    msg: StringAttr = prop_def(StringAttr)
 
     traits = traits_def(AssertHasCanonicalizationPatterns())
 
@@ -95,8 +98,8 @@ class BranchOp(IRDLOperation):
 
     name = "cf.br"
 
-    arguments = var_operand_def()
-    successor = successor_def()
+    arguments: VarOperand = var_operand_def()
+    successor: Successor = successor_def()
 
     traits = traits_def(IsTerminator(), BranchOpHasCanonicalizationPatterns())
 
@@ -130,14 +133,14 @@ class ConditionalBranchOp(IRDLOperation):
 
     name = "cf.cond_br"
 
-    cond = operand_def(IntegerType(1))
-    then_arguments = var_operand_def()
-    else_arguments = var_operand_def()
+    cond: Operand = operand_def(IntegerType(1))
+    then_arguments: VarOperand = var_operand_def()
+    else_arguments: VarOperand = var_operand_def()
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
-    then_block = successor_def()
-    else_block = successor_def()
+    then_block: Successor = successor_def()
+    else_block: Successor = successor_def()
 
     traits = traits_def(
         IsTerminator(), ConditionalBranchOpHasCanonicalizationPatterns()
@@ -326,20 +329,20 @@ class SwitchOp(IRDLOperation):
 
     name = "cf.switch"
 
-    case_values = opt_prop_def(DenseIntElementsAttr)
+    case_values: DenseIntElementsAttr | None = opt_prop_def(DenseIntElementsAttr)
 
-    flag = operand_def(IndexTypeConstr | SignlessIntegerConstraint)
+    flag: Operand = operand_def(IndexTypeConstr | SignlessIntegerConstraint)
 
-    default_operands = var_operand_def()
+    default_operands: VarOperand = var_operand_def()
 
-    case_operands = var_operand_def()
+    case_operands: VarOperand = var_operand_def()
 
     # Copied from AttrSizedSegments
-    case_operand_segments = prop_def(DenseArrayBase.constr(i32))
+    case_operand_segments: DenseArrayBase[I32] = prop_def(DenseArrayBase.constr(i32))
 
-    default_block = successor_def()
+    default_block: Successor = successor_def()
 
-    case_blocks = var_successor_def()
+    case_blocks: VarSuccessor = var_successor_def()
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 

--- a/xdsl/dialects/comb.py
+++ b/xdsl/dialects/comb.py
@@ -25,7 +25,10 @@ from xdsl.dialects.builtin import (
 from xdsl.ir import Attribute, Dialect, Operation, SSAValue, TypeAttribute
 from xdsl.irdl import (
     IRDLOperation,
+    Operand,
+    OpResult,
     VarConstraint,
+    VarOperand,
     base,
     irdl_op_definition,
     operand_def,
@@ -60,7 +63,7 @@ class TwoStateOperation(IRDLOperation, ABC):
     languages. The two_state variable describes if we are using 2-state (binary) logic or not."
     """
 
-    two_state = opt_prop_def(UnitAttr, prop_name="twoState")
+    two_state: UnitAttr | None = opt_prop_def(UnitAttr, prop_name="twoState")
 
     def __init__(
         self: TwoStateOperation,
@@ -101,9 +104,9 @@ class BinCombOperation(TwoStateOperation, ABC):
 
     T: ClassVar = VarConstraint("T", base(IntegerType))
 
-    lhs = operand_def(T)
-    rhs = operand_def(T)
-    result = result_def(T)
+    lhs: Operand = operand_def(T)
+    rhs: Operand = operand_def(T)
+    result: OpResult[IntegerType] = result_def(T)
 
     def __init__(
         self,
@@ -153,8 +156,8 @@ class VariadicCombOperation(TwoStateOperation, ABC):
 
     T: ClassVar = VarConstraint("T", base(IntegerType))
 
-    inputs = var_operand_def(T)
-    result = result_def(T)
+    inputs: VarOperand = var_operand_def(T)
+    result: OpResult[IntegerType] = result_def(T)
 
     def __init__(
         self,
@@ -321,10 +324,10 @@ class ICmpOp(TwoStateOperation, ABC):
 
     T: ClassVar = VarConstraint("T", base(IntegerType))
 
-    predicate = prop_def(IntegerAttr[I64])
-    lhs = operand_def(T)
-    rhs = operand_def(T)
-    result = result_def(IntegerType(1))
+    predicate: IntegerAttr[I64] = prop_def(IntegerAttr[I64])
+    lhs: Operand = operand_def(T)
+    rhs: Operand = operand_def(T)
+    result: OpResult[IntegerType] = result_def(IntegerType(1))
 
     @staticmethod
     def _get_comparison_predicate(
@@ -405,8 +408,8 @@ class ParityOp(TwoStateOperation):
 
     name = "comb.parity"
 
-    input = operand_def(IntegerType)
-    result = result_def(IntegerType(1))
+    input: Operand = operand_def(IntegerType)
+    result: OpResult[IntegerType] = result_def(IntegerType(1))
 
     def __init__(
         self,
@@ -455,9 +458,9 @@ class ExtractOp(IRDLOperation):
 
     name = "comb.extract"
 
-    input = operand_def(IntegerType)
-    low_bit = prop_def(IntegerAttr[I32], prop_name="lowBit")
-    result = result_def(IntegerType)
+    input: Operand = operand_def(IntegerType)
+    low_bit: IntegerAttr[I32] = prop_def(IntegerAttr[I32], prop_name="lowBit")
+    result: OpResult[IntegerType] = result_def(IntegerType)
 
     def __init__(
         self,
@@ -539,8 +542,8 @@ class ConcatOp(IRDLOperation):
 
     name = "comb.concat"
 
-    inputs = var_operand_def(IntegerType)
-    result = result_def(IntegerType)
+    inputs: VarOperand = var_operand_def(IntegerType)
+    result: OpResult[IntegerType] = result_def(IntegerType)
 
     def __init__(
         self,
@@ -610,8 +613,8 @@ class ReplicateOp(IRDLOperation):
 
     name = "comb.replicate"
 
-    input = operand_def(IntegerType)
-    result = result_def(IntegerType)
+    input: Operand = operand_def(IntegerType)
+    result: OpResult[IntegerType] = result_def(IntegerType)
 
     def __init__(
         self,
@@ -652,10 +655,10 @@ class MuxOp(TwoStateOperation):
 
     T: ClassVar = VarConstraint("T", base(TypeAttribute))
 
-    cond = operand_def(IntegerType(1))
-    true_value = operand_def(T)
-    false_value = operand_def(T)
-    result = result_def(T)
+    cond: Operand = operand_def(IntegerType(1))
+    true_value: Operand = operand_def(T)
+    false_value: Operand = operand_def(T)
+    result: OpResult[TypeAttribute] = result_def(T)
 
     def __init__(
         self,

--- a/xdsl/dialects/complex.py
+++ b/xdsl/dialects/complex.py
@@ -37,6 +37,8 @@ from xdsl.irdl import (
     BaseAttr,
     EqIntConstraint,
     IRDLOperation,
+    Operand,
+    OpResult,
     ParamAttrConstraint,
     RangeOf,
     VarConstraint,
@@ -120,9 +122,11 @@ class ComplexUnaryComplexResultOperation(IRDLOperation, abc.ABC):
     """Base class for unary operations on complex numbers."""
 
     T: ClassVar = VarConstraint("T", ComplexTypeConstr)
-    complex = operand_def(T)
-    result = result_def(T)
-    fastmath = prop_def(FastMathFlagsAttr, default_value=FastMathFlagsAttr("none"))
+    complex: Operand = operand_def(T)
+    result: OpResult[ComplexType[AnyFloat | IntegerType]] = result_def(T)
+    fastmath: FastMathFlagsAttr = prop_def(
+        FastMathFlagsAttr, default_value=FastMathFlagsAttr("none")
+    )
 
     traits = traits_def(Pure())
 
@@ -148,9 +152,11 @@ class ComplexUnaryRealResultOperation(IRDLOperation, abc.ABC):
 
     T: ClassVar = VarConstraint("T", AnyFloatConstr)
 
-    complex = operand_def(ComplexType.constr(T))
-    result = result_def(T)
-    fastmath = prop_def(FastMathFlagsAttr, default_value=FastMathFlagsAttr("none"))
+    complex: Operand = operand_def(ComplexType.constr(T))
+    result: OpResult[AnyFloat] = result_def(T)
+    fastmath: FastMathFlagsAttr = prop_def(
+        FastMathFlagsAttr, default_value=FastMathFlagsAttr("none")
+    )
 
     traits = traits_def(Pure())
 
@@ -184,10 +190,12 @@ class ComplexBinaryOp(IRDLOperation, HasFolderInterface, abc.ABC):
     """Base class for binary operations on complex numbers."""
 
     T: ClassVar = VarConstraint("T", ComplexTypeConstr)
-    lhs = operand_def(T)
-    rhs = operand_def(T)
-    result = result_def(T)
-    fastmath = prop_def(FastMathFlagsAttr, default_value=FastMathFlagsAttr("none"))
+    lhs: Operand = operand_def(T)
+    rhs: Operand = operand_def(T)
+    result: OpResult[ComplexType[AnyFloat | IntegerType]] = result_def(T)
+    fastmath: FastMathFlagsAttr = prop_def(
+        FastMathFlagsAttr, default_value=FastMathFlagsAttr("none")
+    )
 
     traits = traits_def(Pure())
 
@@ -243,9 +251,9 @@ class ComplexCompareOp(IRDLOperation, abc.ABC):
     """Base class for comparison operations on complex numbers."""
 
     T: ClassVar = VarConstraint("T", ComplexTypeConstr)
-    lhs = operand_def(T)
-    rhs = operand_def(T)
-    result = result_def(IntegerType(1))
+    lhs: Operand = operand_def(T)
+    rhs: Operand = operand_def(T)
+    result: OpResult[IntegerType] = result_def(IntegerType(1))
 
     traits = traits_def(Pure())
 
@@ -295,11 +303,13 @@ class BitcastOp(IRDLOperation):
     """
 
     name = "complex.bitcast"
-    operand = operand_def(
+    operand: Operand = operand_def(
         ComplexType.constr(AnyFloatConstr) | AnyFloatConstr | BaseAttr(IntegerType)
     )
-    result = result_def(
-        ComplexType.constr(AnyFloatConstr) | AnyFloatConstr | BaseAttr(IntegerType)
+    result: OpResult[ComplexType[AnyFloat | IntegerType] | AnyFloat | IntegerType] = (
+        result_def(
+            ComplexType.constr(AnyFloatConstr) | AnyFloatConstr | BaseAttr(IntegerType)
+        )
     )
 
     traits = traits_def(Pure())
@@ -342,7 +352,7 @@ class ConjOp(ComplexUnaryComplexResultOperation):
 class ConstantOp(IRDLOperation, HasFolderInterface):
     name = "complex.constant"
     T: ClassVar = VarConstraint("T", AnyFloatConstr | base(IntegerType))
-    value = prop_def(
+    value: ArrayAttr[IntegerAttr | FloatAttr[AnyFloat]] = prop_def(
         ArrayOfConstraint(
             RangeOf(
                 AnyOf.get(
@@ -355,7 +365,9 @@ class ConstantOp(IRDLOperation, HasFolderInterface):
 
     # In contrast to other operations, `complex.constant` can
     # have any complex result type, not just floating point:
-    complex = result_def(ComplexType.constr(T))
+    complex: OpResult[ComplexType[AnyFloat | IntegerType]] = result_def(
+        ComplexType.constr(T)
+    )
 
     traits = traits_def(Pure(), ConstantLike())
 
@@ -391,9 +403,11 @@ class CosOp(ComplexUnaryComplexResultOperation):
 class CreateOp(IRDLOperation):
     name = "complex.create"
     T: ClassVar = VarConstraint("T", AnyFloatConstr)
-    real = operand_def(T)
-    imaginary = operand_def(T)
-    complex = result_def(ComplexType.constr(T))
+    real: Operand = operand_def(T)
+    imaginary: Operand = operand_def(T)
+    complex: OpResult[ComplexType[AnyFloat | IntegerType]] = result_def(
+        ComplexType.constr(T)
+    )
 
     traits = traits_def(Pure())
 

--- a/xdsl/dialects/csl.py
+++ b/xdsl/dialects/csl.py
@@ -54,8 +54,13 @@ from xdsl.ir import (
 from xdsl.irdl import (
     BaseAttr,
     IRDLOperation,
+    Operand,
+    OpResult,
+    OptOperand,
+    OptOpResult,
     ParametrizedAttribute,
     VarConstraint,
+    VarOperand,
     attr_def,
     base,
     eq,
@@ -135,11 +140,15 @@ class _FuncBase(IRDLOperation, ABC):
     Base class for the shared functionalty of FuncOp and TaskOp
     """
 
-    body = region_def()
-    sym_name = prop_def(SymbolNameConstraint())
-    function_type = prop_def(FunctionType)
-    arg_attrs = opt_prop_def(ArrayAttr[DictionaryAttr])
-    res_attrs = opt_prop_def(ArrayAttr[DictionaryAttr])
+    body: Region = region_def()
+    sym_name: StringAttr = prop_def(SymbolNameConstraint())
+    function_type: FunctionType = prop_def(FunctionType)
+    arg_attrs: ArrayAttr[DictionaryAttr] | None = opt_prop_def(
+        ArrayAttr[DictionaryAttr]
+    )
+    res_attrs: ArrayAttr[DictionaryAttr] | None = opt_prop_def(
+        ArrayAttr[DictionaryAttr]
+    )
 
     def _props_region(
         self,
@@ -338,8 +347,8 @@ class PtrCastOp(IRDLOperation):
 
     name = "csl.ptrcast"
 
-    ptr = operand_def(PtrType)
-    result = result_def(PtrType)
+    ptr: Operand = operand_def(PtrType)
+    result: OpResult[PtrType] = result_def(PtrType)
 
     traits = traits_def(NoMemoryEffect())
 
@@ -430,8 +439,8 @@ class VariableOp(IRDLOperation):
 
     name = "csl.variable"
 
-    default = opt_prop_def(ParamAttr)
-    res = result_def(VarType)
+    default: ParamAttr | None = opt_prop_def(ParamAttr)
+    res: OpResult[VarType] = result_def(VarType)
 
     assembly_format = "`(` $default `)` `:` type($res) attr-dict"
 
@@ -470,8 +479,8 @@ class LoadVarOp(IRDLOperation):
     """
 
     name = "csl.load_var"
-    var = operand_def(VarType)
-    res = result_def()
+    var: Operand = operand_def(VarType)
+    res: OpResult = result_def()
 
     traits = traits_def(MemoryReadEffect())
 
@@ -504,8 +513,8 @@ class StoreVarOp(IRDLOperation):
     """
 
     name = "csl.store_var"
-    var = operand_def(VarType)
-    new_value = operand_def()
+    var: Operand = operand_def(VarType)
+    new_value: Operand = operand_def()
 
     traits = traits_def(MemoryWriteEffect())
 
@@ -529,9 +538,9 @@ class StoreVarOp(IRDLOperation):
 class DirectionOp(IRDLOperation):
     name = "csl.get_dir"
 
-    dir = prop_def(DirectionAttr)
+    dir: DirectionAttr = prop_def(DirectionAttr)
 
-    res = result_def(DirectionType)
+    res: OpResult[DirectionType] = result_def(DirectionType)
 
     traits = traits_def(NoMemoryEffect())
 
@@ -548,9 +557,9 @@ class CslModuleOp(IRDLOperation):
     """
 
     name = "csl.module"
-    body = region_def("single_block")
-    kind = prop_def(ModuleKindAttr)
-    sym_name = attr_def(SymbolNameConstraint())
+    body: Region = region_def("single_block")
+    kind: ModuleKindAttr = prop_def(ModuleKindAttr)
+    sym_name: StringAttr = attr_def(SymbolNameConstraint())
 
     traits = traits_def(
         HasParent(ModuleOp),
@@ -570,11 +579,11 @@ class ImportModuleConstOp(IRDLOperation):
 
     traits = traits_def(HasParent(CslModuleOp))
 
-    module = prop_def(StringAttr)
+    module: StringAttr = prop_def(StringAttr)
 
-    params = opt_operand_def(StructLikeConstr)
+    params: OptOperand = opt_operand_def(StructLikeConstr)
 
-    result = result_def(ImportedModuleType)
+    result: OpResult[ImportedModuleType] = result_def(ImportedModuleType)
 
     def __init__(
         self, name: str | StringAttr, params: SSAValue | Operation | None = None
@@ -594,10 +603,10 @@ class ConstStructOp(IRDLOperation):
 
     traits = traits_def(NoMemoryEffect())
 
-    items = opt_prop_def(DictionaryAttr)
-    ssa_fields = opt_prop_def(ArrayAttr[StringAttr])
-    ssa_values = var_operand_def()
-    res = result_def(ComptimeStructType)
+    items: DictionaryAttr | None = opt_prop_def(DictionaryAttr)
+    ssa_fields: ArrayAttr[StringAttr] | None = opt_prop_def(ArrayAttr[StringAttr])
+    ssa_values: VarOperand = var_operand_def()
+    res: OpResult[ComptimeStructType] = result_def(ComptimeStructType)
 
     def __init__(self, *args: tuple[str, Operation | SSAValue]):
         operands: list[Operation | SSAValue] = []
@@ -640,11 +649,11 @@ class ZerosOp(IRDLOperation):
 
     T: ClassVar = VarConstraint("T", ZerosOpAttrConstr)
 
-    size = opt_operand_def(T)
+    size: OptOperand = opt_operand_def(T)
 
-    result = result_def(MemRefType.constr(T))
+    result: OpResult[MemRefType] = result_def(MemRefType.constr(T))
 
-    is_const = opt_prop_def(builtin.UnitAttr)
+    is_const: builtin.UnitAttr | None = opt_prop_def(builtin.UnitAttr)
 
     def __init__(
         self,
@@ -675,13 +684,13 @@ class ConstantsOp(IRDLOperation):
         "T", BaseAttr(IntegerType) | BaseAttr(Float32Type) | BaseAttr(Float16Type)
     )
 
-    size = operand_def(IntegerType)
+    size: Operand = operand_def(IntegerType)
 
-    value = operand_def(T)
+    value: Operand = operand_def(T)
 
-    result = result_def(MemRefType.constr(T))
+    result: OpResult[MemRefType] = result_def(MemRefType.constr(T))
 
-    is_const = opt_prop_def(builtin.UnitAttr)
+    is_const: builtin.UnitAttr | None = opt_prop_def(builtin.UnitAttr)
 
     def __init__(self, size: SSAValue | Operation, value: SSAValue | Operation):
         super().__init__(
@@ -696,8 +705,8 @@ class GetColorOp(IRDLOperation):
 
     traits = traits_def(NoMemoryEffect())
 
-    id = operand_def(IntegerType)
-    res = result_def(ColorType)
+    id: Operand = operand_def(IntegerType)
+    res: OpResult[ColorType] = result_def(ColorType)
 
     def __init__(self, op: Operation):
         super().__init__(operands=[op], result_types=[ColorType()])
@@ -713,11 +722,11 @@ class MemberAccessOp(IRDLOperation):
 
     traits = traits_def(NoMemoryEffect())
 
-    struct = operand_def(StructLikeConstr)
+    struct: Operand = operand_def(StructLikeConstr)
 
-    field = prop_def(StringAttr)
+    field: StringAttr = prop_def(StringAttr)
 
-    result = result_def(Attribute)
+    result: OpResult = result_def(Attribute)
 
 
 @irdl_op_definition
@@ -728,13 +737,13 @@ class MemberCallOp(IRDLOperation):
 
     name = "csl.member_call"
 
-    struct = operand_def(StructLikeConstr)
+    struct: Operand = operand_def(StructLikeConstr)
 
-    field = prop_def(StringAttr)
+    field: StringAttr = prop_def(StringAttr)
 
-    args = var_operand_def(Attribute)
+    args: VarOperand = var_operand_def(Attribute)
 
-    result = opt_result_def(Attribute)
+    result: OptOpResult = opt_result_def(Attribute)
 
     def __init__(
         self,
@@ -830,8 +839,8 @@ class TaskOp(_FuncBase):
 
     name = "csl.task"
 
-    kind = prop_def(TaskKindAttr)
-    id = opt_prop_def(ColorIdAttr)
+    kind: TaskKindAttr = prop_def(TaskKindAttr)
+    id: ColorIdAttr | None = opt_prop_def(ColorIdAttr)
 
     traits = traits_def(InModuleKind(ModuleKind.PROGRAM))
 
@@ -960,8 +969,8 @@ class ActivateOp(IRDLOperation):
 
     name = "csl.activate"
 
-    id = prop_def(ColorIdAttr)
-    kind = prop_def(TaskKindAttr)
+    id: ColorIdAttr = prop_def(ColorIdAttr)
+    kind: TaskKindAttr = prop_def(TaskKindAttr)
 
     assembly_format = "attr-dict $kind `,` $id"
 
@@ -982,7 +991,7 @@ class ReturnOp(IRDLOperation):
 
     name = "csl.return"
 
-    ret_val = opt_operand_def(Attribute)
+    ret_val: OptOperand = opt_operand_def(Attribute)
 
     assembly_format = "attr-dict ($ret_val^ `:` type($ret_val))?"
 
@@ -1005,7 +1014,7 @@ class ReturnOp(IRDLOperation):
 class LayoutOp(IRDLOperation):
     name = "csl.layout"
 
-    body = region_def()
+    body: Region = region_def()
 
     traits = traits_def(NoTerminator(), InModuleKind(ModuleKind.LAYOUT))
 
@@ -1033,9 +1042,9 @@ class CallOp(IRDLOperation):
 
     name = "csl.call"
 
-    callee = prop_def(SymbolRefAttr)
-    args = var_operand_def(Attribute)
-    result = opt_result_def(Attribute)
+    callee: SymbolRefAttr = prop_def(SymbolRefAttr)
+    args: VarOperand = var_operand_def(Attribute)
+    result: OptOpResult = opt_result_def(Attribute)
 
     def __init__(
         self,
@@ -1058,8 +1067,8 @@ class SetRectangleOp(IRDLOperation):
 
     traits = traits_def(HasParent(LayoutOp))
 
-    x_dim = operand_def(IntegerType)
-    y_dim = operand_def(IntegerType)
+    x_dim: Operand = operand_def(IntegerType)
+    y_dim: Operand = operand_def(IntegerType)
 
 
 @irdl_op_definition
@@ -1068,11 +1077,11 @@ class SetTileCodeOp(IRDLOperation):
 
     traits = traits_def(HasAncestor(LayoutOp))
 
-    file = prop_def(StringAttr)
+    file: StringAttr = prop_def(StringAttr)
 
-    x_coord = operand_def(IntegerType)
-    y_coord = operand_def(IntegerType)
-    params = opt_operand_def(ComptimeStructType)
+    x_coord: Operand = operand_def(IntegerType)
+    y_coord: Operand = operand_def(IntegerType)
+    params: OptOperand = opt_operand_def(ComptimeStructType)
 
     def __init__(
         self,
@@ -1138,8 +1147,8 @@ class _GetDsdOp(IRDLOperation, ABC):
     Abstract base class for CSL @get_dsd()
     """
 
-    sizes = var_operand_def(IntegerType)
-    result = result_def(DsdType)
+    sizes: VarOperand = var_operand_def(IntegerType)
+    result: OpResult[DsdType] = result_def(DsdType)
 
 
 @irdl_op_definition
@@ -1153,8 +1162,8 @@ class GetMemDsdOp(_GetDsdOp):
     """
 
     name = "csl.get_mem_dsd"
-    base_addr = operand_def(base(MemRefType) | base(TensorType[Attribute]))
-    tensor_access = opt_prop_def(AffineMapAttr)
+    base_addr: Operand = operand_def(base(MemRefType) | base(TensorType))
+    tensor_access: AffineMapAttr | None = opt_prop_def(AffineMapAttr)
 
     traits = traits_def(
         Pure(),
@@ -1197,10 +1206,10 @@ class GetFabDsdOp(_GetDsdOp):
     """
 
     name = "csl.get_fab_dsd"
-    fabric_color = prop_def(ColorIdAttr)
-    queue_id = prop_def(QueueIdAttr)
-    control = opt_prop_def(BoolAttr)
-    wavelet_index_offset = opt_prop_def(BoolAttr)
+    fabric_color: ColorIdAttr = prop_def(ColorIdAttr)
+    queue_id: QueueIdAttr = prop_def(QueueIdAttr)
+    control: BoolAttr | None = opt_prop_def(BoolAttr)
+    wavelet_index_offset: BoolAttr | None = opt_prop_def(BoolAttr)
 
     def verify_(self) -> None:
         if self.result.type.data not in [DsdKind.fabin_dsd, DsdKind.fabout_dsd]:
@@ -1227,11 +1236,11 @@ class SetDsdBaseAddrOp(IRDLOperation):
 
     name = "csl.set_dsd_base_addr"
 
-    op = operand_def(DsdType)
-    base_addr = operand_def(
-        base(MemRefType) | base(TensorType[Attribute]) | base(PtrType)
+    op: Operand = operand_def(DsdType)
+    base_addr: Operand = operand_def(
+        base(MemRefType) | base(TensorType) | base(PtrType)
     )
-    result = result_def(DsdType)
+    result: OpResult[DsdType] = result_def(DsdType)
 
     traits = traits_def(Pure())
 
@@ -1267,10 +1276,10 @@ class IncrementDsdOffsetOp(IRDLOperation):
 
     name = "csl.increment_dsd_offset"
 
-    op = operand_def(DsdType)
-    offset = operand_def(eq(i16) | eq(i16_value))
-    elem_type = prop_def(DsdElementTypeConstr)
-    result = result_def(DsdType)
+    op: Operand = operand_def(DsdType)
+    offset: Operand = operand_def(eq(i16) | eq(i16_value))
+    elem_type: Float16Type | Float32Type | IntegerType = prop_def(DsdElementTypeConstr)
+    result: OpResult[DsdType] = result_def(DsdType)
 
     traits = traits_def(Pure(), IncrementDsdOffsetOpHasCanonicalizationPatternsTrait())
 
@@ -1294,9 +1303,9 @@ class SetDsdLengthOp(IRDLOperation):
     """
 
     name = "csl.set_dsd_length"
-    op = operand_def(DsdType)
-    length = operand_def(eq(i16) | eq(u16_value))
-    result = result_def(DsdType)
+    op: Operand = operand_def(DsdType)
+    length: Operand = operand_def(eq(i16) | eq(u16_value))
+    result: OpResult[DsdType] = result_def(DsdType)
 
     traits = traits_def(Pure(), SetDsdLengthOpHasCanonicalizationPatternsTrait())
 
@@ -1321,9 +1330,9 @@ class SetDsdStrideOp(IRDLOperation):
     """
 
     name = "csl.set_dsd_stride"
-    op = operand_def(DsdType)
-    stride = operand_def(eq(i8) | eq(i8_value))
-    result = result_def(DsdType)
+    op: Operand = operand_def(DsdType)
+    stride: Operand = operand_def(eq(i8) | eq(i8_value))
+    result: OpResult[DsdType] = result_def(DsdType)
 
     traits = traits_def(Pure(), SetDsdStrideOpHasCanonicalizationPatternsTrait())
 
@@ -1339,7 +1348,7 @@ FunctionSignatures = list[tuple[Attribute | type[Attribute], ...]]
 
 
 class BuiltinDsdOp(IRDLOperation, ABC):
-    ops = var_operand_def()
+    ops: VarOperand = var_operand_def()
 
     SIGNATURES: ClassVar[FunctionSignatures]
 
@@ -1783,11 +1792,13 @@ class SymbolExportOp(IRDLOperation):
 
     traits = traits_def(InModuleKind(ModuleKind.PROGRAM))
 
-    value = opt_operand_def(PtrType)
+    value: OptOperand = opt_operand_def(PtrType)
 
-    var_name = prop_def(base(StringAttr) | base(SymbolRefAttr))
+    var_name: StringAttr | SymbolRefAttr = prop_def(
+        base(StringAttr) | base(SymbolRefAttr)
+    )
 
-    type = prop_def(base(PtrType) | base(FunctionType))
+    type: PtrType | FunctionType = prop_def(base(PtrType) | base(FunctionType))
 
     def __init__(self, sym_name: str | StringAttr, type_or_op: SSAValue | FunctionType):
         var_name: StringAttr | SymbolRefAttr = (
@@ -1848,9 +1859,9 @@ class AddressOfFnOp(IRDLOperation):
     """
 
     name = "csl.addressof_fn"
-    fn_name = prop_def(SymbolRefAttr)
+    fn_name: SymbolRefAttr = prop_def(SymbolRefAttr)
 
-    res = result_def(PtrType)
+    res: OpResult[PtrType] = result_def(PtrType)
 
     def __init__(self, fn: FuncOp):
         fn_name = SymbolRefAttr(fn.sym_name)
@@ -1887,8 +1898,8 @@ class AddressOfOp(IRDLOperation):
 
     name = "csl.addressof"
 
-    value = operand_def()
-    res = result_def(PtrType)
+    value: Operand = operand_def()
+    res: OpResult[PtrType] = result_def(PtrType)
 
     traits = traits_def(NoMemoryEffect())
 
@@ -1955,7 +1966,7 @@ class RpcOp(IRDLOperation):
 
     traits = traits_def(InModuleKind(ModuleKind.PROGRAM))
 
-    id = operand_def(ColorType)
+    id: Operand = operand_def(ColorType)
 
 
 ParamOpAttr: TypeAlias = (
@@ -1997,10 +2008,18 @@ class ParamOp(IRDLOperation):
 
     traits = traits_def(HasParent(CslModuleOp))  # has to be at top level
 
-    param_name = prop_def(StringAttr)
-    init_value = opt_operand_def(T)
+    param_name: StringAttr = prop_def(StringAttr)
+    init_value: OptOperand = opt_operand_def(T)
 
-    res = result_def(T)
+    res: OpResult[
+        Float16Type
+        | Float32Type
+        | IntegerType
+        | ColorType
+        | FunctionType
+        | ImportedModuleType
+        | ComptimeStructType
+    ] = result_def(T)
 
     def __init__(
         self,
@@ -2025,9 +2044,9 @@ class SignednessCastOp(IRDLOperation):
 
     name = "csl.mlir.signedness_cast"
 
-    inp = operand_def(IntegerType)
+    inp: Operand = operand_def(IntegerType)
 
-    result = result_def(IntegerType)
+    result: OpResult[IntegerType] = result_def(IntegerType)
 
     assembly_format = "$inp attr-dict `:` type($inp) `to` type($result)"
 
@@ -2082,11 +2101,11 @@ class ConcatStructOp(IRDLOperation):
 
     name = "csl.concat_structs"
 
-    this_struct = operand_def(ComptimeStructType)
+    this_struct: Operand = operand_def(ComptimeStructType)
 
-    another_struct = operand_def(ComptimeStructType)
+    another_struct: Operand = operand_def(ComptimeStructType)
 
-    result = result_def(ComptimeStructType)
+    result: OpResult[ComptimeStructType] = result_def(ComptimeStructType)
 
     def __init__(self, struct_a: Operation | SSAValue, struct_b: Operation | SSAValue):
         super().__init__(

--- a/xdsl/dialects/csl_stencil.py
+++ b/xdsl/dialects/csl_stencil.py
@@ -23,12 +23,16 @@ from xdsl.ir import (
     Dialect,
     Operation,
     ParametrizedAttribute,
+    Region,
     SSAValue,
 )
 from xdsl.irdl import (
     AttrSizedOperandSegments,
     IRDLOperation,
     Operand,
+    OpResult,
+    VarOperand,
+    VarOpResult,
     irdl_attr_definition,
     irdl_op_definition,
     lazy_traits_def,
@@ -123,17 +127,21 @@ class PrefetchOp(IRDLOperation):
 
     name = "csl_stencil.prefetch"
 
-    input_stencil = operand_def(
+    input_stencil: Operand = operand_def(
         stencil.StencilTypeConstr | MemRefType.constr() | AnyTensorTypeConstr
     )
 
-    swaps = prop_def(builtin.ArrayAttr[ExchangeDeclarationAttr])
+    swaps: builtin.ArrayAttr[ExchangeDeclarationAttr] = prop_def(
+        builtin.ArrayAttr[ExchangeDeclarationAttr]
+    )
 
-    topo = prop_def(dmp.RankTopoAttr)
+    topo: dmp.RankTopoAttr = prop_def(dmp.RankTopoAttr)
 
-    num_chunks = prop_def(IntegerAttr)
+    num_chunks: IntegerAttr = prop_def(IntegerAttr)
 
-    result = result_def(MemRefType.constr() | AnyTensorTypeConstr)
+    result: OpResult[MemRefType | TensorType] = result_def(
+        MemRefType.constr() | AnyTensorTypeConstr
+    )
 
     def __init__(
         self,
@@ -141,7 +149,7 @@ class PrefetchOp(IRDLOperation):
         topo: dmp.RankTopoAttr,
         num_chunks: IntegerAttr,
         swaps: Sequence[ExchangeDeclarationAttr],
-        result_type: memref.MemRefType | TensorType[Attribute] | None = None,
+        result_type: memref.MemRefType | TensorType | None = None,
     ):
         super().__init__(
             operands=[input_stencil],
@@ -216,28 +224,32 @@ class ApplyOp(IRDLOperation):
 
     name = "csl_stencil.apply"
 
-    field = operand_def(stencil.StencilTypeConstr | MemRefType.constr())
+    field: Operand = operand_def(stencil.StencilTypeConstr | MemRefType.constr())
 
-    accumulator = operand_def(TensorType | MemRefType)
+    accumulator: Operand = operand_def(TensorType | MemRefType)
 
-    args_rchunk = var_operand_def(Attribute)
-    args_dexchng = var_operand_def(Attribute)
-    dest = var_operand_def(stencil.FieldTypeConstr | MemRefType.constr())
+    args_rchunk: VarOperand = var_operand_def(Attribute)
+    args_dexchng: VarOperand = var_operand_def(Attribute)
+    dest: VarOperand = var_operand_def(stencil.FieldTypeConstr | MemRefType.constr())
 
-    receive_chunk = region_def()
-    done_exchange = region_def()
+    receive_chunk: Region = region_def()
+    done_exchange: Region = region_def()
 
-    swaps = prop_def(builtin.ArrayAttr[ExchangeDeclarationAttr])
+    swaps: builtin.ArrayAttr[ExchangeDeclarationAttr] = prop_def(
+        builtin.ArrayAttr[ExchangeDeclarationAttr]
+    )
 
-    topo = prop_def(dmp.RankTopoAttr)
+    topo: dmp.RankTopoAttr = prop_def(dmp.RankTopoAttr)
 
-    num_chunks = prop_def(IntegerAttr)
+    num_chunks: IntegerAttr = prop_def(IntegerAttr)
 
-    bounds = opt_prop_def(stencil.StencilBoundsAttr)
+    bounds: stencil.StencilBoundsAttr | None = opt_prop_def(stencil.StencilBoundsAttr)
 
-    coeffs = opt_prop_def(builtin.ArrayAttr[CoeffAttr])
+    coeffs: builtin.ArrayAttr[CoeffAttr] | None = opt_prop_def(
+        builtin.ArrayAttr[CoeffAttr]
+    )
 
-    res = var_result_def(stencil.StencilTypeConstr)
+    res: VarOpResult[stencil.StencilType] = var_result_def(stencil.StencilTypeConstr)
 
     traits = traits_def(
         IsolatedFromAbove(),
@@ -447,12 +459,12 @@ class AccessOp(IRDLOperation):
     """
 
     name = "csl_stencil.access"
-    op = operand_def(
+    op: Operand = operand_def(
         MemRefType.constr() | stencil.StencilTypeConstr | AnyTensorTypeConstr
     )
-    offset = prop_def(stencil.IndexAttr)
-    offset_mapping = opt_prop_def(stencil.IndexAttr)
-    result = result_def(TensorType | MemRefType)
+    offset: stencil.IndexAttr = prop_def(stencil.IndexAttr)
+    offset_mapping: stencil.IndexAttr | None = opt_prop_def(stencil.IndexAttr)
+    result: OpResult[TensorType | MemRefType] = result_def(TensorType | MemRefType)
 
     traits = traits_def(HasAncestor(stencil.ApplyOp, ApplyOp), Pure())
 
@@ -460,7 +472,7 @@ class AccessOp(IRDLOperation):
         self,
         op: Operand,
         offset: stencil.IndexAttr,
-        result_type: TensorType[Attribute] | MemRefType,
+        result_type: TensorType | MemRefType,
         offset_mapping: stencil.IndexAttr | None = None,
     ):
         super().__init__(

--- a/xdsl/dialects/csl_wrapper.py
+++ b/xdsl/dialects/csl_wrapper.py
@@ -24,6 +24,8 @@ from xdsl.ir import (
 )
 from xdsl.irdl import (
     IRDLOperation,
+    OpResult,
+    VarOperand,
     irdl_attr_definition,
     irdl_op_definition,
     lazy_traits_def,
@@ -103,10 +105,10 @@ class ImportOp(IRDLOperation):
 
     name = "csl_wrapper.import"
 
-    ops = var_operand_def()
-    module = prop_def(StringAttr)
-    fields = prop_def(ArrayAttr[StringAttr])
-    result = result_def(csl.ImportedModuleType)
+    ops: VarOperand = var_operand_def()
+    module: StringAttr = prop_def(StringAttr)
+    fields: ArrayAttr[StringAttr] = prop_def(ArrayAttr[StringAttr])
+    result: OpResult[csl.ImportedModuleType] = result_def(csl.ImportedModuleType)
 
     def __init__(
         self, module: str, field_name_mapping: dict[str, Operation | SSAValue]
@@ -158,14 +160,14 @@ class ModuleOp(IRDLOperation):
 
     name = "csl_wrapper.module"
 
-    width = prop_def(IntegerAttr[IntegerType])
-    height = prop_def(IntegerAttr[IntegerType])
-    program_name = opt_prop_def(StringAttr)
-    target = prop_def(StringAttr)
-    params = prop_def(ArrayAttr[ParamAttribute])
+    width: IntegerAttr[IntegerType] = prop_def(IntegerAttr[IntegerType])
+    height: IntegerAttr[IntegerType] = prop_def(IntegerAttr[IntegerType])
+    program_name: StringAttr | None = opt_prop_def(StringAttr)
+    target: StringAttr = prop_def(StringAttr)
+    params: ArrayAttr[ParamAttribute] = prop_def(ArrayAttr[ParamAttribute])
 
-    layout_module = region_def("single_block")
-    program_module = region_def("single_block")
+    layout_module: Region = region_def("single_block")
+    program_module: Region = region_def("single_block")
 
     def __init__(
         self,
@@ -374,8 +376,8 @@ class YieldOp(IRDLOperation):
 
     name = "csl_wrapper.yield"
 
-    values = var_operand_def(Attribute)
-    fields = prop_def(ArrayAttr[StringAttr])
+    values: VarOperand = var_operand_def(Attribute)
+    fields: ArrayAttr[StringAttr] = prop_def(ArrayAttr[StringAttr])
 
     traits = lazy_traits_def(
         lambda: (

--- a/xdsl/dialects/ematch.py
+++ b/xdsl/dialects/ematch.py
@@ -11,6 +11,8 @@ from xdsl.ir import (
 )
 from xdsl.irdl import (
     IRDLOperation,
+    Operand,
+    OpResult,
     irdl_op_definition,
     operand_def,
     result_def,
@@ -27,8 +29,8 @@ class GetClassValsOp(IRDLOperation):
     """
 
     name = "ematch.get_class_vals"
-    value = operand_def(ValueType)
-    result = result_def(RangeType[ValueType])
+    value: Operand = operand_def(ValueType)
+    result: OpResult[RangeType[ValueType]] = result_def(RangeType[ValueType])
 
     assembly_format = "$value attr-dict"
 
@@ -46,8 +48,8 @@ class GetClassRepresentativeOp(IRDLOperation):
     """
 
     name = "ematch.get_class_representative"
-    value = operand_def(ValueType)
-    result = result_def(ValueType)
+    value: Operand = operand_def(ValueType)
+    result: OpResult[ValueType] = result_def(ValueType)
 
     assembly_format = "$value attr-dict"
 
@@ -65,8 +67,8 @@ class GetClassResultOp(IRDLOperation):
     """
 
     name = "ematch.get_class_result"
-    value = operand_def(ValueType)
-    result = result_def(ValueType)
+    value: Operand = operand_def(ValueType)
+    result: OpResult[ValueType] = result_def(ValueType)
 
     assembly_format = "$value attr-dict"
 
@@ -85,8 +87,8 @@ class GetClassResultsOp(IRDLOperation):
     """
 
     name = "ematch.get_class_results"
-    values = operand_def(RangeType[ValueType])
-    result = result_def(RangeType[ValueType])
+    values: Operand = operand_def(RangeType[ValueType])
+    result: OpResult[RangeType[ValueType]] = result_def(RangeType[ValueType])
 
     assembly_format = "$values attr-dict"
 
@@ -110,8 +112,8 @@ class UnionOp(IRDLOperation):
     """
 
     name = "ematch.union"
-    lhs = operand_def(ValueType | OperationType | RangeType[ValueType])
-    rhs = operand_def(ValueType | RangeType[ValueType])
+    lhs: Operand = operand_def(ValueType | OperationType | RangeType[ValueType])
+    rhs: Operand = operand_def(ValueType | RangeType[ValueType])
 
     assembly_format = "$lhs `:` type($lhs) `,` $rhs `:` type($rhs) attr-dict"
 
@@ -128,8 +130,8 @@ class DedupOp(IRDLOperation):
     """
 
     name = "ematch.dedup"
-    input_op = operand_def(OperationType)
-    result_op = result_def(OperationType)
+    input_op: Operand = operand_def(OperationType)
+    result_op: OpResult[OperationType] = result_def(OperationType)
 
     assembly_format = "$input_op attr-dict"
 

--- a/xdsl/dialects/emitc.py
+++ b/xdsl/dialects/emitc.py
@@ -44,7 +44,11 @@ from xdsl.irdl import (
     ConstraintContext,
     IntConstraint,
     IRDLOperation,
+    Operand,
+    OpResult,
     ParsePropInAttrDict,
+    VarOperand,
+    VarOpResult,
     irdl_attr_definition,
     irdl_op_definition,
     irdl_to_attr_constraint,
@@ -313,9 +317,9 @@ class EmitC_PointerType(ParametrizedAttribute, TypeAttribute):
 class EmitC_BinaryOperation(IRDLOperation, abc.ABC):
     """Base class for EmitC binary operations."""
 
-    lhs = operand_def(EmitCTypeConstr)
-    rhs = operand_def(EmitCTypeConstr)
-    result = result_def(EmitCTypeConstr)
+    lhs: Operand = operand_def(EmitCTypeConstr)
+    rhs: Operand = operand_def(EmitCTypeConstr)
+    result: OpResult = result_def(EmitCTypeConstr)
 
     assembly_format = "operands attr-dict `:` functional-type(operands, results)"
 
@@ -388,11 +392,11 @@ class EmitC_ApplyOp(IRDLOperation):
         $applicableOperator `(` $operand `)` attr-dict `:` functional-type($operand, results)
       """
 
-    applicableOperator = prop_def(StringAttr)
+    applicableOperator: StringAttr = prop_def(StringAttr)
 
-    operand = operand_def(AnyAttr())
+    operand: Operand = operand_def(AnyAttr())
 
-    result = result_def(EmitCTypeConstr)
+    result: OpResult = result_def(EmitCTypeConstr)
 
     def verify_(self) -> None:
         applicable_operator = self.applicableOperator.data
@@ -437,12 +441,12 @@ class EmitC_CallOpaqueOp(IRDLOperation):
 
     name = "emitc.call_opaque"
 
-    callee = prop_def(StringAttr)
-    args = opt_prop_def(ArrayAttr)
-    template_args = opt_prop_def(ArrayAttr)
+    callee: StringAttr = prop_def(StringAttr)
+    args: ArrayAttr[Attribute] | None = opt_prop_def(ArrayAttr)
+    template_args: ArrayAttr[Attribute] | None = opt_prop_def(ArrayAttr)
     # The SSA-value operands of the call
-    call_args = var_operand_def()
-    res = var_result_def()
+    call_args: VarOperand = var_operand_def()
+    res: VarOpResult = var_result_def()
 
     irdl_options = (ParsePropInAttrDict(),)
     assembly_format = (

--- a/xdsl/dialects/eqsat_pdl_interp.py
+++ b/xdsl/dialects/eqsat_pdl_interp.py
@@ -30,6 +30,11 @@ from xdsl.ir import Attribute, Block, Dialect, SSAValue
 from xdsl.irdl import (
     AttrSizedOperandSegments,
     IRDLOperation,
+    Operand,
+    OpResult,
+    Successor,
+    VarOperand,
+    VarSuccessor,
     irdl_op_definition,
     operand_def,
     opt_prop_def,
@@ -52,9 +57,9 @@ class GetResultOp(IRDLOperation):
     """
 
     name = "eqsat_pdl_interp.get_result"
-    index = prop_def(IntegerAttr[I32])
-    input_op = operand_def(OperationType)
-    value = result_def(ValueType)
+    index: IntegerAttr[I32] = prop_def(IntegerAttr[I32])
+    input_op: Operand = operand_def(OperationType)
+    value: OpResult[ValueType] = result_def(ValueType)
 
     assembly_format = "$index `of` $input_op attr-dict"
 
@@ -73,9 +78,11 @@ class GetResultsOp(IRDLOperation):
     """
 
     name = "eqsat_pdl_interp.get_results"
-    index = opt_prop_def(IntegerAttr[I32])
-    input_op = operand_def(OperationType)
-    value = result_def(ValueType | RangeType[ValueType])
+    index: IntegerAttr[I32] | None = opt_prop_def(IntegerAttr[I32])
+    input_op: Operand = operand_def(OperationType)
+    value: OpResult[ValueType | RangeType[ValueType]] = result_def(
+        ValueType | RangeType[ValueType]
+    )
 
     # assembly_format = "($index^)? `of` $input_op `:` type($value) attr-dict"
     # TODO: Fix bug preventing this assebmly format from working: https://github.com/xdslproject/xdsl/issues/4136.
@@ -126,8 +133,8 @@ class GetDefiningOpOp(IRDLOperation):
     """
 
     name = "eqsat_pdl_interp.get_defining_op"
-    value = operand_def(ValueType | RangeType[ValueType])
-    input_op = result_def(OperationType)
+    value: Operand = operand_def(ValueType | RangeType[ValueType])
+    input_op: OpResult[OperationType] = result_def(OperationType)
 
     assembly_format = "`of` $value `:` type($value) attr-dict"
 
@@ -142,8 +149,8 @@ class ReplaceOp(IRDLOperation):
     """
 
     name = "eqsat_pdl_interp.replace"
-    input_op = operand_def(OperationType)
-    repl_values = var_operand_def(ValueType | RangeType[ValueType])
+    input_op: Operand = operand_def(OperationType)
+    repl_values: VarOperand = var_operand_def(ValueType | RangeType[ValueType])
 
     assembly_format = (
         "$input_op `with` ` ` `(` ($repl_values^ `:` type($repl_values))? `)` attr-dict"
@@ -160,17 +167,21 @@ class CreateOperationOp(IRDLOperation):
     """
 
     name = "eqsat_pdl_interp.create_operation"
-    constraint_name = prop_def(StringAttr, prop_name="name")
-    input_attribute_names = prop_def(
+    constraint_name: StringAttr = prop_def(StringAttr, prop_name="name")
+    input_attribute_names: ArrayAttr[StringAttr] = prop_def(
         ArrayAttr[StringAttr], prop_name="inputAttributeNames"
     )
-    inferred_result_types = opt_prop_def(UnitAttr, prop_name="inferredResultTypes")
+    inferred_result_types: UnitAttr | None = opt_prop_def(
+        UnitAttr, prop_name="inferredResultTypes"
+    )
 
-    input_operands = var_operand_def(ValueType | RangeType[ValueType])
-    input_attributes = var_operand_def(AttributeType | RangeType[AttributeType])
-    input_result_types = var_operand_def(TypeType | RangeType[TypeType])
+    input_operands: VarOperand = var_operand_def(ValueType | RangeType[ValueType])
+    input_attributes: VarOperand = var_operand_def(
+        AttributeType | RangeType[AttributeType]
+    )
+    input_result_types: VarOperand = var_operand_def(TypeType | RangeType[TypeType])
 
-    result_op = result_def(OperationType)
+    result_op: OpResult[OperationType] = result_def(OperationType)
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
@@ -334,15 +345,15 @@ class RecordMatchOp(IRDLOperation):
 
     name = "eqsat_pdl_interp.record_match"
     traits = traits_def(IsTerminator())
-    rewriter = prop_def(SymbolRefAttr)
-    rootKind = opt_prop_def(StringAttr)
-    generatedOps = opt_prop_def(ArrayAttr[StringAttr])
-    benefit = prop_def(IntegerAttr[I16])
+    rewriter: SymbolRefAttr = prop_def(SymbolRefAttr)
+    rootKind: StringAttr | None = opt_prop_def(StringAttr)
+    generatedOps: ArrayAttr[StringAttr] | None = opt_prop_def(ArrayAttr[StringAttr])
+    benefit: IntegerAttr[I16] = prop_def(IntegerAttr[I16])
 
-    inputs = var_operand_def(AnyPDLTypeConstr)
-    matched_ops = var_operand_def(OperationType)
+    inputs: VarOperand = var_operand_def(AnyPDLTypeConstr)
+    matched_ops: VarOperand = var_operand_def(OperationType)
 
-    dest = successor_def()
+    dest: Successor = successor_def()
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
@@ -408,8 +419,8 @@ class ChooseOp(IRDLOperation):
     """
 
     name = "eqsat_pdl_interp.choose"
-    default_dest = successor_def()
-    choices = var_successor_def()
+    default_dest: Successor = successor_def()
+    choices: VarSuccessor = var_successor_def()
     traits = traits_def(IsTerminator())
     assembly_format = "`from` $choices `then` $default_dest attr-dict"
 

--- a/xdsl/dialects/equivalence.py
+++ b/xdsl/dialects/equivalence.py
@@ -17,6 +17,8 @@ from xdsl.irdl import (
     AnyAttr,
     IRDLOperation,
     VarConstraint,
+    VarOperand,
+    VarOpResult,
     irdl_op_definition,
     lazy_traits_def,
     opt_attr_def,
@@ -58,10 +60,10 @@ class ConstantClassOp(IRDLOperation, HasFolderInterface):
     )
     traits = traits_def(Pure(), ConstantLike())
 
-    arguments = var_operand_def(T)
-    result = result_def(T)
-    value = prop_def()
-    min_cost_index = opt_attr_def(IntAttr)
+    arguments: VarOperand = var_operand_def(T)
+    result: OpResult = result_def(T)
+    value: Attribute = prop_def()
+    min_cost_index: IntAttr[int] | None = opt_attr_def(IntAttr)
 
     def fold(self) -> tuple[Attribute]:
         return (self.value,)
@@ -90,9 +92,9 @@ class ClassOp(IRDLOperation):
     T: ClassVar = VarConstraint("T", AnyAttr())
 
     name = "equivalence.class"
-    arguments = var_operand_def(T)
-    result = result_def(T)
-    min_cost_index = opt_attr_def(IntAttr)
+    arguments: VarOperand = var_operand_def(T)
+    result: OpResult = result_def(T)
+    min_cost_index: IntAttr[int] | None = opt_attr_def(IntAttr)
     traits = traits_def(Pure())
 
     assembly_format = "$arguments attr-dict `:` type($result)"
@@ -148,8 +150,8 @@ or a [constant e-class operation][xdsl.dialects.equivalence.ConstantClassOp].
 class GraphOp(IRDLOperation):
     name = "equivalence.graph"
 
-    outputs = var_result_def()
-    body = region_def()
+    outputs: VarOpResult = var_result_def()
+    body: Region = region_def()
 
     traits = lazy_traits_def(lambda: (SingleBlockImplicitTerminator(YieldOp),))
 
@@ -169,7 +171,7 @@ class GraphOp(IRDLOperation):
 @irdl_op_definition
 class YieldOp(IRDLOperation):
     name = "equivalence.yield"
-    values = var_operand_def()
+    values: VarOperand = var_operand_def()
 
     traits = traits_def(HasParent(GraphOp), IsTerminator())
 

--- a/xdsl/dialects/experimental/air.py
+++ b/xdsl/dialects/experimental/air.py
@@ -32,7 +32,13 @@ from xdsl.ir import (
 from xdsl.irdl import (
     AttrSizedOperandSegments,
     IRDLOperation,
+    Operand,
+    OpResult,
+    OptOpResult,
+    OptRegion,
     ParsePropInAttrDict,
+    VarOperand,
+    VarOpResult,
     attr_def,
     irdl_attr_definition,
     irdl_op_definition,
@@ -67,10 +73,10 @@ class AsyncTokenAttr(ParametrizedAttribute, TypeAttribute):
 class AllocOp(IRDLOperation):
     name = "air.alloc"
 
-    async_dependencies = var_operand_def(AsyncTokenAttr)
+    async_dependencies: VarOperand = var_operand_def(AsyncTokenAttr)
 
-    async_token = result_def(AsyncTokenAttr)
-    result = result_def(MemRefType)
+    async_token: OpResult[AsyncTokenAttr] = result_def(AsyncTokenAttr)
+    result: OpResult[MemRefType] = result_def(MemRefType)
 
     def __init__(
         self,
@@ -88,8 +94,8 @@ class AllocOp(IRDLOperation):
 class ChannelOp(IRDLOperation):
     name = "air.channel"
 
-    sym_name = prop_def(SymbolRefAttr)
-    size = prop_def(ArrayAttr)
+    sym_name: SymbolRefAttr = prop_def(SymbolRefAttr)
+    size: ArrayAttr[Attribute] = prop_def(ArrayAttr)
 
     def __init__(
         self, sym_name: SymbolRefAttr, size: ArrayAttr[IntegerAttr]
@@ -103,15 +109,15 @@ class ChannelOp(IRDLOperation):
 class ChannelGetOp(IRDLOperation):
     name = "air.channel.get"
 
-    chan_name = attr_def(SymbolRefAttr)
-    async_dependencies = var_operand_def(AsyncTokenAttr())
-    indices = var_operand_def(AsyncTokenAttr())
-    dst = operand_def(MemRefType)
-    dst_offsets = var_operand_def(IndexType())
-    dst_sizes = var_operand_def(IndexType())
-    dst_strides = var_operand_def(IndexType())
+    chan_name: SymbolRefAttr = attr_def(SymbolRefAttr)
+    async_dependencies: VarOperand = var_operand_def(AsyncTokenAttr())
+    indices: VarOperand = var_operand_def(AsyncTokenAttr())
+    dst: Operand = operand_def(MemRefType)
+    dst_offsets: VarOperand = var_operand_def(IndexType())
+    dst_sizes: VarOperand = var_operand_def(IndexType())
+    dst_strides: VarOperand = var_operand_def(IndexType())
 
-    async_token = result_def(AsyncTokenAttr())
+    async_token: OpResult[AsyncTokenAttr] = result_def(AsyncTokenAttr())
 
     irdl_options = (AttrSizedOperandSegments(),)
 
@@ -144,16 +150,16 @@ class ChannelGetOp(IRDLOperation):
 class ChannelPutOp(IRDLOperation):
     name = "air.channel.put"
 
-    chan_name = attr_def(SymbolRefAttr)
+    chan_name: SymbolRefAttr = attr_def(SymbolRefAttr)
 
-    async_dependencies = var_operand_def(AsyncTokenAttr())
-    indices = var_operand_def(IndexType())
-    src = operand_def(MemRefType)
-    src_offsets = var_operand_def(IndexType())
-    src_sizes = var_operand_def(IndexType())
-    src_strides = var_operand_def(IndexType())
+    async_dependencies: VarOperand = var_operand_def(AsyncTokenAttr())
+    indices: VarOperand = var_operand_def(IndexType())
+    src: Operand = operand_def(MemRefType)
+    src_offsets: VarOperand = var_operand_def(IndexType())
+    src_sizes: VarOperand = var_operand_def(IndexType())
+    src_strides: VarOperand = var_operand_def(IndexType())
 
-    async_token = result_def(AsyncTokenAttr())
+    async_token: OpResult[AsyncTokenAttr] = result_def(AsyncTokenAttr())
 
     irdl_options = (AttrSizedOperandSegments(),)
 
@@ -187,11 +193,11 @@ class ChannelPutOp(IRDLOperation):
 class CustomOp(IRDLOperation):
     name = "air.custom"
 
-    symbol = attr_def(SymbolRefAttr)
-    async_dependencies = var_operand_def(AsyncTokenAttr)
-    custom_operands = var_operand_def(Attribute)
+    symbol: SymbolRefAttr = attr_def(SymbolRefAttr)
+    async_dependencies: VarOperand = var_operand_def(AsyncTokenAttr)
+    custom_operands: VarOperand = var_operand_def(Attribute)
 
-    async_token = result_def(AsyncTokenAttr)
+    async_token: OpResult[AsyncTokenAttr] = result_def(AsyncTokenAttr)
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
@@ -212,10 +218,10 @@ class CustomOp(IRDLOperation):
 class DeallocOp(IRDLOperation):
     name = "air.dealloc"
 
-    async_dependencies = var_operand_def(AsyncTokenAttr)
-    memref = operand_def(MemRefType)
+    async_dependencies: VarOperand = var_operand_def(AsyncTokenAttr)
+    memref: Operand = operand_def(MemRefType)
 
-    async_token = result_def(AsyncTokenAttr)
+    async_token: OpResult[AsyncTokenAttr] = result_def(AsyncTokenAttr)
 
     def __init__(
         self,
@@ -231,17 +237,17 @@ class DeallocOp(IRDLOperation):
 class DmaMemcpyNdOp(IRDLOperation):
     name = "air.dma_memcpy_nd"
 
-    async_dependencies = var_operand_def(AsyncTokenAttr())
-    dst = operand_def(MemRefType)
-    dst_offsets = var_operand_def(IndexType())
-    dst_sizes = var_operand_def(IndexType())
-    dst_strides = var_operand_def(IndexType())
-    src = operand_def(MemRefType)
-    src_offsets = var_operand_def(IndexType())
-    src_sizes = var_operand_def(IndexType())
-    src_strides = var_operand_def(IndexType())
+    async_dependencies: VarOperand = var_operand_def(AsyncTokenAttr())
+    dst: Operand = operand_def(MemRefType)
+    dst_offsets: VarOperand = var_operand_def(IndexType())
+    dst_sizes: VarOperand = var_operand_def(IndexType())
+    dst_strides: VarOperand = var_operand_def(IndexType())
+    src: Operand = operand_def(MemRefType)
+    src_offsets: VarOperand = var_operand_def(IndexType())
+    src_sizes: VarOperand = var_operand_def(IndexType())
+    src_strides: VarOperand = var_operand_def(IndexType())
 
-    async_token = result_def(AsyncTokenAttr())
+    async_token: OpResult[AsyncTokenAttr] = result_def(AsyncTokenAttr())
 
     irdl_options = (
         AttrSizedOperandSegments(as_property=True),
@@ -293,10 +299,10 @@ class DmaMemcpyNdOp(IRDLOperation):
 class ExecuteOp(IRDLOperation):
     name = "air.execute"
 
-    async_dependencies = var_operand_def(AsyncTokenAttr)
-    async_token = result_def(AsyncTokenAttr)
-    results_ = var_result_def(Attribute)
-    body = region_def()
+    async_dependencies: VarOperand = var_operand_def(AsyncTokenAttr)
+    async_token: OpResult[AsyncTokenAttr] = result_def(AsyncTokenAttr)
+    results_: VarOpResult = var_result_def(Attribute)
+    body: Region = region_def()
 
     traits = lazy_traits_def(
         lambda: (SingleBlockImplicitTerminator(ExecuteTerminatorOp),)
@@ -336,7 +342,7 @@ class ExecuteTerminatorOp(IRDLOperation):
     name = "air.execute_terminator"
 
     # even though this is an operand they decided to name it "result" in the original specification
-    results_op = var_operand_def()
+    results_op: VarOperand = var_operand_def()
 
     traits = traits_def(HasParent(ExecuteOp), IsTerminator())
 
@@ -367,12 +373,12 @@ class HerdTerminatorOp(IRDLOperation):
 class HerdOp(IRDLOperation):
     name = "air.herd"
 
-    sym_name = opt_prop_def(StringAttr)
-    async_dependencies = var_operand_def(AsyncTokenAttr())
-    sizes = var_operand_def(IndexType())
-    herd_operands = var_operand_def()
-    async_token = opt_result_def(AsyncTokenAttr)
-    region = opt_region_def()
+    sym_name: StringAttr | None = opt_prop_def(StringAttr)
+    async_dependencies: VarOperand = var_operand_def(AsyncTokenAttr())
+    sizes: VarOperand = var_operand_def(IndexType())
+    herd_operands: VarOperand = var_operand_def()
+    async_token: OptOpResult[AsyncTokenAttr] = opt_result_def(AsyncTokenAttr)
+    region: OptRegion = opt_region_def()
 
     traits = traits_def(
         IsolatedFromAbove(), SingleBlockImplicitTerminator(HerdTerminatorOp)
@@ -524,12 +530,12 @@ class LaunchTerminatorOp(IRDLOperation):
 class LaunchOp(IRDLOperation):
     name = "air.launch"
 
-    sym_name = opt_prop_def(StringAttr)
-    async_dependencies = var_operand_def(AsyncTokenAttr())
-    sizes = var_operand_def(IndexType())
-    launch_operands = var_operand_def()
-    async_token = result_def(AsyncTokenAttr)
-    body = opt_region_def()
+    sym_name: StringAttr | None = opt_prop_def(StringAttr)
+    async_dependencies: VarOperand = var_operand_def(AsyncTokenAttr())
+    sizes: VarOperand = var_operand_def(IndexType())
+    launch_operands: VarOperand = var_operand_def()
+    async_token: OpResult[AsyncTokenAttr] = result_def(AsyncTokenAttr)
+    body: OptRegion = opt_region_def()
 
     traits = traits_def(
         IsolatedFromAbove(), SingleBlockImplicitTerminator(LaunchTerminatorOp)
@@ -624,7 +630,7 @@ class LaunchOp(IRDLOperation):
 class HerdPipelineOp(IRDLOperation):
     name = "air.pipeline"
 
-    body = opt_region_def()
+    body: OptRegion = opt_region_def()
 
     traits = traits_def(HasParent(HerdOp))
 
@@ -649,9 +655,9 @@ class HerdPipelineOp(IRDLOperation):
 class PipelineGetOp(IRDLOperation):
     name = "air.pipeline.get"
 
-    src0 = operand_def(Attribute)
-    src1 = operand_def(Attribute)
-    results = var_result_def(Attribute)
+    src0: Operand = operand_def(Attribute)
+    src1: Operand = operand_def(Attribute)
+    results: VarOpResult = var_result_def(Attribute)
 
     def __init__(
         self,
@@ -666,9 +672,9 @@ class PipelineGetOp(IRDLOperation):
 class PipelinePutOp(IRDLOperation):
     name = "air.pipeline.put"
 
-    dst0 = operand_def(Attribute)
-    dst1 = operand_def(Attribute)
-    opers = var_operand_def(Attribute)
+    dst0: Operand = operand_def(Attribute)
+    dst1: Operand = operand_def(Attribute)
+    opers: VarOperand = var_operand_def(Attribute)
 
     def __init__(
         self,
@@ -683,10 +689,10 @@ class PipelinePutOp(IRDLOperation):
 class PipelineStageOp(IRDLOperation):
     name = "air.pipeline.stage"
 
-    opers = var_operand_def(Attribute)
-    result = var_result_def()
+    opers: VarOperand = var_operand_def(Attribute)
+    result: VarOpResult = var_result_def()
 
-    body = opt_region_def()
+    body: OptRegion = opt_region_def()
 
     traits = traits_def(HasParent(HerdPipelineOp))
 
@@ -758,13 +764,13 @@ class SegmentTerminatorOp(IRDLOperation):
 class SegmentOp(IRDLOperation):
     name = "air.segment"
 
-    sym_name = opt_prop_def(StringAttr)
-    async_dependencies = var_operand_def(AsyncTokenAttr())
-    sizes = var_operand_def(IndexType())
-    segment_operands = var_operand_def()
-    async_token = result_def(AsyncTokenAttr)
+    sym_name: StringAttr | None = opt_prop_def(StringAttr)
+    async_dependencies: VarOperand = var_operand_def(AsyncTokenAttr())
+    sizes: VarOperand = var_operand_def(IndexType())
+    segment_operands: VarOperand = var_operand_def()
+    async_token: OpResult[AsyncTokenAttr] = result_def(AsyncTokenAttr)
 
-    body = opt_region_def()
+    body: OptRegion = opt_region_def()
 
     traits = traits_def(
         IsolatedFromAbove(), SingleBlockImplicitTerminator(SegmentTerminatorOp)
@@ -836,8 +842,8 @@ class SegmentOp(IRDLOperation):
 class WaitAllOp(IRDLOperation):
     name = "air.wait_all"
 
-    async_dependencies = var_operand_def(AsyncTokenAttr)
-    async_token = result_def(AsyncTokenAttr)
+    async_dependencies: VarOperand = var_operand_def(AsyncTokenAttr)
+    async_token: OpResult[AsyncTokenAttr] = result_def(AsyncTokenAttr)
 
     def __init__(self, async_dependencies: list[SSAValue] | None):
         super().__init__(operands=[async_dependencies], result_types=[AsyncTokenAttr()])

--- a/xdsl/dialects/experimental/dmp.py
+++ b/xdsl/dialects/experimental/dmp.py
@@ -25,6 +25,8 @@ from xdsl.ir import (
 )
 from xdsl.irdl import (
     IRDLOperation,
+    Operand,
+    OptOpResult,
     attr_def,
     irdl_attr_definition,
     irdl_op_definition,
@@ -679,12 +681,16 @@ class SwapOp(IRDLOperation):
 
     name = "dmp.swap"
 
-    input_stencil = operand_def(stencil.StencilTypeConstr)
-    swapped_values = opt_result_def(stencil.TempType[Attribute])
+    input_stencil: Operand = operand_def(stencil.StencilTypeConstr)
+    swapped_values: OptOpResult[stencil.TempType[Attribute]] = opt_result_def(
+        stencil.TempType[Attribute]
+    )
 
-    swaps = attr_def(builtin.ArrayAttr[ExchangeDeclarationAttr])
+    swaps: builtin.ArrayAttr[ExchangeDeclarationAttr] = attr_def(
+        builtin.ArrayAttr[ExchangeDeclarationAttr]
+    )
 
-    strategy = attr_def(DomainDecompositionStrategy)
+    strategy: DomainDecompositionStrategy = attr_def(DomainDecompositionStrategy)
 
     traits = traits_def(SwapOpHasShapeInferencePatterns(), SwapOpMemoryEffect())
 

--- a/xdsl/dialects/experimental/fir.py
+++ b/xdsl/dialects/experimental/fir.py
@@ -35,11 +35,19 @@ from xdsl.ir import (
     Data,
     Dialect,
     ParametrizedAttribute,
+    Region,
     TypeAttribute,
 )
 from xdsl.irdl import (
     AttrSizedOperandSegments,
     IRDLOperation,
+    Operand,
+    OpResult,
+    OptOperand,
+    OptRegion,
+    VarOperand,
+    VarOpResult,
+    VarSuccessor,
     attr_def,
     irdl_attr_definition,
     irdl_op_definition,
@@ -1236,16 +1244,16 @@ class AbsentOp(IRDLOperation):
     """
 
     name = "fir.absent"
-    intype = result_def()
+    intype: OpResult = result_def()
 
 
 @irdl_op_definition
 class AddcOp(IRDLOperation):
     name = "fir.addc"
-    lhs = operand_def()
-    rhs = operand_def()
-    fastmath = opt_prop_def(FastMathFlagsAttr)
-    result = result_def()
+    lhs: Operand = operand_def()
+    rhs: Operand = operand_def()
+    fastmath: FastMathFlagsAttr | None = opt_prop_def(FastMathFlagsAttr)
+    result: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -1259,8 +1267,8 @@ class AddressOfOp(IRDLOperation):
     """
 
     name = "fir.address_of"
-    symbol = prop_def(SymbolRefAttr)
-    resTy = result_def()
+    symbol: SymbolRefAttr = prop_def(SymbolRefAttr)
+    resTy: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -1276,13 +1284,13 @@ class AllocmemOp(IRDLOperation):
     """
 
     name = "fir.allocmem"
-    in_type = prop_def()
-    uniq_name = opt_prop_def(StringAttr)
-    bindc_name = opt_prop_def(StringAttr)
-    typeparams = var_operand_def()
-    shape = var_operand_def()
+    in_type: Attribute = prop_def()
+    uniq_name: StringAttr | None = opt_prop_def(StringAttr)
+    bindc_name: StringAttr | None = opt_prop_def(StringAttr)
+    typeparams: VarOperand = var_operand_def()
+    shape: VarOperand = var_operand_def()
 
-    result_0 = result_def()
+    result_0: OpResult = result_def()
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
@@ -1351,13 +1359,13 @@ class AllocaOp(IRDLOperation):
     """
 
     name = "fir.alloca"
-    in_type = prop_def()
-    uniq_name = opt_prop_def(StringAttr)
-    bindc_name = opt_prop_def(StringAttr)
-    typeparams = var_operand_def()
-    shape = var_operand_def()
-    result_0 = result_def()
-    pinned = opt_prop_def(UnitAttr)
+    in_type: Attribute = prop_def()
+    uniq_name: StringAttr | None = opt_prop_def(StringAttr)
+    bindc_name: StringAttr | None = opt_prop_def(StringAttr)
+    typeparams: VarOperand = var_operand_def()
+    shape: VarOperand = var_operand_def()
+    result_0: OpResult = result_def()
+    pinned: UnitAttr | None = opt_prop_def(UnitAttr)
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
@@ -1403,10 +1411,10 @@ class ArrayAccessOp(IRDLOperation):
     """
 
     name = "fir.array_access"
-    sequence = operand_def()
-    indices = var_operand_def()
-    typeparams = var_operand_def()
-    element = result_def()
+    sequence: Operand = operand_def()
+    indices: VarOperand = var_operand_def()
+    typeparams: VarOperand = var_operand_def()
+    element: OpResult = result_def()
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
@@ -1431,9 +1439,9 @@ class ArrayAmendOp(IRDLOperation):
     """
 
     name = "fir.array_amend"
-    sequence = operand_def()
-    memref = operand_def()
-    result_0 = result_def()
+    sequence: Operand = operand_def()
+    memref: Operand = operand_def()
+    result_0: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -1457,12 +1465,12 @@ class ArrayCoorOp(IRDLOperation):
     """
 
     name = "fir.array_coor"
-    memref = operand_def()
-    shape = opt_operand_def()
-    slice = opt_operand_def()
-    indices = var_operand_def()
-    typeparams = var_operand_def()
-    result_0 = result_def()
+    memref: Operand = operand_def()
+    shape: OptOperand = opt_operand_def()
+    slice: OptOperand = opt_operand_def()
+    indices: VarOperand = var_operand_def()
+    typeparams: VarOperand = var_operand_def()
+    result_0: OpResult = result_def()
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
@@ -1491,10 +1499,10 @@ class ArrayFetchOp(IRDLOperation):
     """
 
     name = "fir.array_fetch"
-    sequence = operand_def()
-    indices = var_operand_def()
-    typeparams = var_operand_def()
-    element = result_def()
+    sequence: Operand = operand_def()
+    indices: VarOperand = var_operand_def()
+    typeparams: VarOperand = var_operand_def()
+    element: OpResult = result_def()
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
@@ -1532,11 +1540,11 @@ class ArrayLoadOp(IRDLOperation):
     """
 
     name = "fir.array_load"
-    memref = operand_def()
-    shape = opt_operand_def()
-    slice = opt_operand_def()
-    typeparams = var_operand_def()
-    result_0 = result_def()
+    memref: Operand = operand_def()
+    shape: OptOperand = opt_operand_def()
+    slice: OptOperand = opt_operand_def()
+    typeparams: VarOperand = var_operand_def()
+    result_0: OpResult = result_def()
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
@@ -1562,11 +1570,11 @@ class ArrayMergeStoreOp(IRDLOperation):
     """
 
     name = "fir.array_merge_store"
-    original = operand_def()
-    sequence = operand_def()
-    memref = operand_def()
-    slice = opt_operand_def()
-    typeparams = var_operand_def()
+    original: Operand = operand_def()
+    sequence: Operand = operand_def()
+    memref: Operand = operand_def()
+    slice: OptOperand = opt_operand_def()
+    typeparams: VarOperand = var_operand_def()
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
@@ -1603,11 +1611,11 @@ class ArrayModifyOp(IRDLOperation):
     """
 
     name = "fir.array_modify"
-    sequence = operand_def()
-    indices = var_operand_def()
-    typeparams = var_operand_def()
-    result_0 = result_def()
-    result_1 = result_def()
+    sequence: Operand = operand_def()
+    indices: VarOperand = var_operand_def()
+    typeparams: VarOperand = var_operand_def()
+    result_0: OpResult = result_def()
+    result_1: OpResult = result_def()
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
@@ -1641,11 +1649,11 @@ class ArrayUpdateOp(IRDLOperation):
     """
 
     name = "fir.array_update"
-    sequence = operand_def()
-    merge = operand_def()
-    indices = var_operand_def()
-    typeparams = var_operand_def()
-    result_0 = result_def()
+    sequence: Operand = operand_def()
+    merge: Operand = operand_def()
+    indices: VarOperand = var_operand_def()
+    typeparams: VarOperand = var_operand_def()
+    result_0: OpResult = result_def()
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
@@ -1664,8 +1672,8 @@ class BoxAddrOp(IRDLOperation):
     """
 
     name = "fir.box_addr"
-    val = operand_def()
-    result_0 = result_def()
+    val: Operand = operand_def()
+    result_0: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -1678,8 +1686,8 @@ class BoxcharLenOp(IRDLOperation):
     """
 
     name = "fir.boxchar_len"
-    val = operand_def()
-    result_0 = result_def()
+    val: Operand = operand_def()
+    result_0: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -1699,11 +1707,11 @@ class BoxDimsOp(IRDLOperation):
     """
 
     name = "fir.box_dims"
-    val = operand_def()
-    dim = operand_def()
-    result_0 = result_def()
-    result_1 = result_def()
-    result_2 = result_def()
+    val: Operand = operand_def()
+    dim: Operand = operand_def()
+    result_0: OpResult = result_def()
+    result_1: OpResult = result_def()
+    result_2: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -1720,8 +1728,8 @@ class BoxElesizeOp(IRDLOperation):
     """
 
     name = "fir.box_elesize"
-    val = operand_def()
-    result_0 = result_def()
+    val: Operand = operand_def()
+    result_0: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -1740,8 +1748,8 @@ class BoxIsallocOp(IRDLOperation):
     """
 
     name = "fir.box_isalloc"
-    val = operand_def()
-    result_0 = result_def()
+    val: Operand = operand_def()
+    result_0: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -1759,8 +1767,8 @@ class BoxIsarrayOp(IRDLOperation):
     """
 
     name = "fir.box_isarray"
-    val = operand_def()
-    result_0 = result_def()
+    val: Operand = operand_def()
+    result_0: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -1774,8 +1782,8 @@ class BoxIsptrOp(IRDLOperation):
     """
 
     name = "fir.box_isptr"
-    val = operand_def()
-    result_0 = result_def()
+    val: Operand = operand_def()
+    result_0: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -1796,9 +1804,9 @@ class BoxOffsetOp(IRDLOperation):
     """
 
     name = "fir.box_offset"
-    box_ref = operand_def()
-    field = prop_def()
-    result_0 = result_def()
+    box_ref: Operand = operand_def()
+    field: Attribute = prop_def()
+    result_0: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -1816,8 +1824,8 @@ class BoxprocHostOp(IRDLOperation):
     """
 
     name = "fir.boxproc_host"
-    val = operand_def()
-    result_0 = result_def()
+    val: Operand = operand_def()
+    result_0: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -1835,8 +1843,8 @@ class BoxRankOp(IRDLOperation):
     """
 
     name = "fir.box_rank"
-    val = operand_def()
-    result_0 = result_def()
+    val: Operand = operand_def()
+    result_0: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -1850,8 +1858,8 @@ class BoxTdescOp(IRDLOperation):
     """
 
     name = "fir.box_tdesc"
-    val = operand_def()
-    result_0 = result_def()
+    val: Operand = operand_def()
+    result_0: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -1864,12 +1872,14 @@ class CallOp(IRDLOperation):
     """
 
     name = "fir.call"
-    callee = opt_prop_def(SymbolRefAttr)
-    fastmath = opt_prop_def(FastMathFlagsAttr)
-    procedure_attrs = opt_prop_def(FortranProcedureFlagsAttr)
-    inline_attr = opt_prop_def(FortranInlineFlagsAttr)
-    args = var_operand_def()
-    result_0 = var_result_def()
+    callee: SymbolRefAttr | None = opt_prop_def(SymbolRefAttr)
+    fastmath: FastMathFlagsAttr | None = opt_prop_def(FastMathFlagsAttr)
+    procedure_attrs: FortranProcedureFlagsAttr | None = opt_prop_def(
+        FortranProcedureFlagsAttr
+    )
+    inline_attr: FortranInlineFlagsAttr | None = opt_prop_def(FortranInlineFlagsAttr)
+    args: VarOperand = var_operand_def()
+    result_0: VarOpResult = var_result_def()
 
 
 @irdl_op_definition
@@ -1894,9 +1904,9 @@ class CharConvertOp(IRDLOperation):
     """
 
     name = "fir.char_convert"
-    _from = operand_def()
-    count = operand_def()
-    to = operand_def()
+    _from: Operand = operand_def()
+    count: Operand = operand_def()
+    to: Operand = operand_def()
 
 
 @irdl_op_definition
@@ -1906,11 +1916,11 @@ class CmpcOp(IRDLOperation):
     """
 
     name = "fir.cmpc"
-    predicate = prop_def(IntegerAttr)
-    fastmath = opt_prop_def(FastMathFlagsAttr)
-    lhs = operand_def()
-    rhs = operand_def()
-    result_0 = result_def()
+    predicate: IntegerAttr = prop_def(IntegerAttr)
+    fastmath: FastMathFlagsAttr | None = opt_prop_def(FastMathFlagsAttr)
+    lhs: Operand = operand_def()
+    rhs: Operand = operand_def()
+    result_0: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -1928,8 +1938,8 @@ class ConvertOp(IRDLOperation):
     """
 
     name = "fir.convert"
-    value = operand_def()
-    res = result_def()
+    value: Operand = operand_def()
+    res: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -1954,11 +1964,11 @@ class CoordinateOfOp(IRDLOperation):
     """
 
     name = "fir.coordinate_of"
-    baseType = prop_def()
-    field_indices = opt_prop_def()
-    ref = operand_def()
-    coor = var_operand_def()
-    result_0 = result_def()
+    baseType: Attribute = prop_def()
+    field_indices: Attribute | None = opt_prop_def()
+    ref: Operand = operand_def()
+    coor: VarOperand = var_operand_def()
+    result_0: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -1999,17 +2009,19 @@ class DeclareOp(IRDLOperation):
     """
 
     name = "fir.declare"
-    memref = operand_def()
-    shape = opt_operand_def()
-    typeparams = var_operand_def()
-    dummy_scope = opt_operand_def()
-    storage = opt_operand_def()
-    storage_offset = opt_prop_def(IntegerAttr)
-    uniq_name = prop_def(StringAttr)
-    fortran_attrs = opt_prop_def(FortranVariableFlagsAttr)
-    data_attr = opt_prop_def(Attribute)
-    dummy_arg_no = opt_prop_def(IntegerAttr)
-    result = result_def()
+    memref: Operand = operand_def()
+    shape: OptOperand = opt_operand_def()
+    typeparams: VarOperand = var_operand_def()
+    dummy_scope: OptOperand = opt_operand_def()
+    storage: OptOperand = opt_operand_def()
+    storage_offset: IntegerAttr | None = opt_prop_def(IntegerAttr)
+    uniq_name: StringAttr = prop_def(StringAttr)
+    fortran_attrs: FortranVariableFlagsAttr | None = opt_prop_def(
+        FortranVariableFlagsAttr
+    )
+    data_attr: Attribute | None = opt_prop_def(Attribute)
+    dummy_arg_no: IntegerAttr | None = opt_prop_def(IntegerAttr)
+    result: OpResult = result_def()
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
@@ -2027,9 +2039,9 @@ class DtEntryOp(IRDLOperation):
     """
 
     name = "fir.dt_entry"
-    method = prop_def(StringAttr)
-    proc = prop_def(SymbolRefAttr)
-    deferred = opt_prop_def(UnitAttr)
+    method: StringAttr = prop_def(StringAttr)
+    proc: SymbolRefAttr = prop_def(SymbolRefAttr)
+    deferred: UnitAttr | None = opt_prop_def(UnitAttr)
 
 
 @irdl_op_definition
@@ -2048,20 +2060,20 @@ class DispatchOp(IRDLOperation):
     """
 
     name = "fir.dispatch"
-    method = prop_def(StringAttr)
-    pass_arg_pos = opt_prop_def(IntegerAttr)
-    object = operand_def()
-    args = var_operand_def()
-    result_0 = var_result_def()
+    method: StringAttr = prop_def(StringAttr)
+    pass_arg_pos: IntegerAttr | None = opt_prop_def(IntegerAttr)
+    object: Operand = operand_def()
+    args: VarOperand = var_operand_def()
+    result_0: VarOpResult = var_result_def()
 
 
 @irdl_op_definition
 class DivcOp(IRDLOperation):
     name = "fir.divc"
-    lhs = operand_def()
-    rhs = operand_def()
-    fastmath = opt_prop_def(FastMathFlagsAttr)
-    result = result_def()
+    lhs: Operand = operand_def()
+    rhs: Operand = operand_def()
+    fastmath: FastMathFlagsAttr | None = opt_prop_def(FastMathFlagsAttr)
+    result: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -2085,17 +2097,17 @@ class DoLoopOp(IRDLOperation):
     """
 
     name = "fir.do_loop"
-    lowerBound = operand_def()
-    upperBound = operand_def()
-    step = operand_def()
-    reduceOperands = var_operand_def()
-    initArgs = var_operand_def()
-    unordered = opt_prop_def(UnitAttr)
-    finalValue = opt_prop_def(UnitAttr)
-    reduceAttrs = opt_prop_def(ArrayAttr)
-    loopAnnotation = opt_prop_def(Attribute)
-    _results = var_result_def()
-    region = region_def("single_block")
+    lowerBound: Operand = operand_def()
+    upperBound: Operand = operand_def()
+    step: Operand = operand_def()
+    reduceOperands: VarOperand = var_operand_def()
+    initArgs: VarOperand = var_operand_def()
+    unordered: UnitAttr | None = opt_prop_def(UnitAttr)
+    finalValue: UnitAttr | None = opt_prop_def(UnitAttr)
+    reduceAttrs: ArrayAttr[Attribute] | None = opt_prop_def(ArrayAttr)
+    loopAnnotation: Attribute | None = opt_prop_def(Attribute)
+    _results: VarOpResult = var_result_def()
+    region: Region = region_def("single_block")
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
@@ -2175,7 +2187,7 @@ class DummyScopeOp(IRDLOperation):
 
     name = "fir.dummy_scope"
 
-    result = result_def()
+    result: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -2197,9 +2209,9 @@ class EmboxcharOp(IRDLOperation):
     """
 
     name = "fir.emboxchar"
-    memref = operand_def()
-    len = operand_def()
-    result_0 = result_def()
+    memref: Operand = operand_def()
+    len: Operand = operand_def()
+    result_0: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -2226,14 +2238,14 @@ class EmboxOp(IRDLOperation):
     """
 
     name = "fir.embox"
-    memref = operand_def()
-    shape = var_operand_def()
-    slice = var_operand_def()
-    typeparams = var_operand_def()
-    sourceBox = var_operand_def()
-    accessMap = opt_prop_def(Attribute)
-    allocator_idx = opt_prop_def(IntegerAttr)
-    result_0 = result_def()
+    memref: Operand = operand_def()
+    shape: VarOperand = var_operand_def()
+    slice: VarOperand = var_operand_def()
+    typeparams: VarOperand = var_operand_def()
+    sourceBox: VarOperand = var_operand_def()
+    accessMap: Attribute | None = opt_prop_def(Attribute)
+    allocator_idx: IntegerAttr | None = opt_prop_def(IntegerAttr)
+    result_0: OpResult = result_def()
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
@@ -2261,9 +2273,9 @@ class EmboxprocOp(IRDLOperation):
     """
 
     name = "fir.emboxproc"
-    func = operand_def()
-    host = opt_operand_def()
-    result_0 = result_def()
+    func: Operand = operand_def()
+    host: OptOperand = opt_operand_def()
+    result_0: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -2284,9 +2296,9 @@ class ExtractValueOp(IRDLOperation):
     """
 
     name = "fir.extract_value"
-    adt = operand_def()
-    coor = prop_def(ArrayAttr)
-    res = result_def()
+    adt: Operand = operand_def()
+    coor: ArrayAttr[Attribute] = prop_def(ArrayAttr)
+    res: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -2303,10 +2315,10 @@ class FieldIndexOp(IRDLOperation):
     """
 
     name = "fir.field_index"
-    field_id = prop_def(StringAttr)
-    on_type = prop_def()
-    typeparams = var_operand_def()
-    res = result_def()
+    field_id: StringAttr = prop_def(StringAttr)
+    on_type: Attribute = prop_def()
+    typeparams: VarOperand = var_operand_def()
+    res: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -2338,7 +2350,7 @@ class FreememOp(IRDLOperation):
     """
 
     name = "fir.freemem"
-    heapref = operand_def()
+    heapref: Operand = operand_def()
 
 
 @irdl_op_definition
@@ -2356,8 +2368,8 @@ class GlobalLenOp(IRDLOperation):
     """
 
     name = "fir.global_len"
-    lenparam = prop_def(StringAttr)
-    intval = prop_def(IntegerAttr)
+    lenparam: StringAttr = prop_def(StringAttr)
+    intval: IntegerAttr = prop_def(IntegerAttr)
 
 
 @irdl_op_definition
@@ -2382,16 +2394,16 @@ class GlobalOp(IRDLOperation):
     """
 
     name = "fir.global"
-    region = opt_region_def()
-    sym_name = prop_def(SymbolNameConstraint())
-    symref = prop_def(SymbolRefAttr)
-    type = prop_def()
-    initVal = opt_prop_def()
-    constant = opt_prop_def(UnitAttr)
-    target = opt_prop_def(UnitAttr)
-    linkName = opt_prop_def(StringAttr)
-    data_attr = opt_prop_def()
-    alignment = opt_prop_def(IntegerAttr)
+    region: OptRegion = opt_region_def()
+    sym_name: StringAttr = prop_def(SymbolNameConstraint())
+    symref: SymbolRefAttr = prop_def(SymbolRefAttr)
+    type: Attribute = prop_def()
+    initVal: Attribute | None = opt_prop_def()
+    constant: UnitAttr | None = opt_prop_def(UnitAttr)
+    target: UnitAttr | None = opt_prop_def(UnitAttr)
+    linkName: StringAttr | None = opt_prop_def(StringAttr)
+    data_attr: Attribute | None = opt_prop_def()
+    alignment: IntegerAttr | None = opt_prop_def(IntegerAttr)
 
     traits = traits_def(SymbolOpInterface(), IsolatedFromAbove())
 
@@ -2414,7 +2426,7 @@ class HasValueOp(IRDLOperation):
     """
 
     name = "fir.has_value"
-    resval = operand_def()
+    resval: Operand = operand_def()
 
     traits = traits_def(IsTerminator())
 
@@ -2435,10 +2447,10 @@ class IfOp(IRDLOperation):
     """
 
     name = "fir.if"
-    condition = operand_def()
-    output = var_result_def()
-    then_region = region_def()
-    else_region = opt_region_def()
+    condition: Operand = operand_def()
+    output: VarOpResult = var_result_def()
+    then_region: Region = region_def()
+    else_region: OptRegion = opt_region_def()
 
 
 @irdl_op_definition
@@ -2460,10 +2472,10 @@ class InsertOnRangeOp(IRDLOperation):
     """
 
     name = "fir.insert_on_range"
-    coor = prop_def()
-    seq = operand_def()
-    val = operand_def()
-    result_0 = result_def()
+    coor: Attribute = prop_def()
+    seq: Operand = operand_def()
+    val: Operand = operand_def()
+    result_0: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -2486,10 +2498,10 @@ class InsertValueOp(IRDLOperation):
     """
 
     name = "fir.insert_value"
-    adt = operand_def()
-    val = operand_def()
-    coor = prop_def(ArrayAttr)
-    result_0 = result_def()
+    adt: Operand = operand_def()
+    val: Operand = operand_def()
+    coor: ArrayAttr[Attribute] = prop_def(ArrayAttr)
+    result_0: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -2504,8 +2516,8 @@ class IsPresentOp(IRDLOperation):
     """
 
     name = "fir.is_present"
-    val = operand_def()
-    result_0 = result_def()
+    val: Operand = operand_def()
+    result_0: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -2536,14 +2548,14 @@ class IterateWhileOp(IRDLOperation):
     """
 
     name = "fir.iterate_while"
-    finalValue = opt_prop_def(UnitAttr)
-    lowerBound = operand_def()
-    upperBound = operand_def()
-    step = operand_def()
-    iterateIn = operand_def()
-    initArgs = var_operand_def()
-    _results = var_result_def()
-    region = region_def("single_block")
+    finalValue: UnitAttr | None = opt_prop_def(UnitAttr)
+    lowerBound: Operand = operand_def()
+    upperBound: Operand = operand_def()
+    step: Operand = operand_def()
+    iterateIn: Operand = operand_def()
+    initArgs: VarOperand = var_operand_def()
+    _results: VarOpResult = var_result_def()
+    region: Region = region_def("single_block")
 
 
 @irdl_op_definition
@@ -2560,10 +2572,10 @@ class LenParamIndexOp(IRDLOperation):
     """
 
     name = "fir.len_param_index"
-    field_id = prop_def(StringAttr)
-    on_type = prop_def()
-    typeparams = var_operand_def()
-    res = result_def()
+    field_id: StringAttr = prop_def(StringAttr)
+    on_type: Attribute = prop_def()
+    typeparams: VarOperand = var_operand_def()
+    res: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -2581,24 +2593,24 @@ class LoadOp(IRDLOperation):
     """
 
     name = "fir.load"
-    memref = operand_def()
-    res = result_def()
+    memref: Operand = operand_def()
+    res: OpResult = result_def()
 
 
 @irdl_op_definition
 class MulcOp(IRDLOperation):
     name = "fir.mulc"
-    lhs = operand_def()
-    rhs = operand_def()
-    fastmath = opt_prop_def(FastMathFlagsAttr)
-    result = result_def()
+    lhs: Operand = operand_def()
+    rhs: Operand = operand_def()
+    fastmath: FastMathFlagsAttr | None = opt_prop_def(FastMathFlagsAttr)
+    result: OpResult = result_def()
 
 
 @irdl_op_definition
 class NegcOp(IRDLOperation):
     name = "fir.negc"
-    operand = operand_def()
-    result = result_def()
+    operand: Operand = operand_def()
+    result: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -2618,8 +2630,8 @@ class NoReassocOp(IRDLOperation):
     """
 
     name = "fir.no_reassoc"
-    val = operand_def()
-    res = result_def()
+    val: Operand = operand_def()
+    res: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -2655,10 +2667,10 @@ class ReboxOp(IRDLOperation):
     """
 
     name = "fir.rebox"
-    box = operand_def()
-    shape = opt_operand_def()
-    slice = opt_operand_def()
-    result_0 = result_def()
+    box: Operand = operand_def()
+    shape: OptOperand = opt_operand_def()
+    slice: OptOperand = opt_operand_def()
+    result_0: OpResult = result_def()
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
@@ -2673,7 +2685,7 @@ class ResultOp(IRDLOperation):
     """
 
     name = "fir.result"
-    _results = var_operand_def()
+    _results: VarOperand = var_operand_def()
 
     traits = traits_def(IsTerminator())
 
@@ -2687,7 +2699,7 @@ class YieldOp(IRDLOperation):
     """
 
     name = "fir.yield"
-    _results = var_operand_def()
+    _results: VarOperand = var_operand_def()
 
     traits = traits_def(IsTerminator())
 
@@ -2723,10 +2735,10 @@ class SaveResultOp(IRDLOperation):
     """
 
     name = "fir.save_result"
-    value = operand_def()
-    memref = operand_def()
-    shape = opt_operand_def()
-    typeparams = var_operand_def()
+    value: Operand = operand_def()
+    memref: Operand = operand_def()
+    shape: OptOperand = opt_operand_def()
+    typeparams: VarOperand = var_operand_def()
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
@@ -2749,11 +2761,11 @@ class SelectCaseOp(IRDLOperation):
     """
 
     name = "fir.select_case"
-    selector = operand_def()
-    compareArgs = var_operand_def()
-    targetArgs = var_operand_def()
-    case_tags = prop_def(ArrayAttr)
-    targets = var_successor_def()
+    selector: Operand = operand_def()
+    compareArgs: VarOperand = var_operand_def()
+    targetArgs: VarOperand = var_operand_def()
+    case_tags: ArrayAttr[Attribute] = prop_def(ArrayAttr)
+    targets: VarSuccessor = var_successor_def()
 
     traits = traits_def(IsTerminator())
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
@@ -2777,11 +2789,11 @@ class SelectOp(IRDLOperation):
     """
 
     name = "fir.select"
-    selector = operand_def()
-    compareArgs = var_operand_def()
-    targetArgs = var_operand_def()
-    case_tags = prop_def(ArrayAttr)
-    targets = var_successor_def()
+    selector: Operand = operand_def()
+    compareArgs: VarOperand = var_operand_def()
+    targetArgs: VarOperand = var_operand_def()
+    case_tags: ArrayAttr[Attribute] = prop_def(ArrayAttr)
+    targets: VarSuccessor = var_successor_def()
 
     traits = traits_def(IsTerminator())
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
@@ -2804,11 +2816,11 @@ class SelectRankOp(IRDLOperation):
     """
 
     name = "fir.select_rank"
-    selector = operand_def()
-    compareArgs = var_operand_def()
-    targetArgs = var_operand_def()
-    case_tags = prop_def(ArrayAttr)
-    targets = var_successor_def()
+    selector: Operand = operand_def()
+    compareArgs: VarOperand = var_operand_def()
+    targetArgs: VarOperand = var_operand_def()
+    case_tags: ArrayAttr[Attribute] = prop_def(ArrayAttr)
+    targets: VarSuccessor = var_successor_def()
 
     traits = traits_def(IsTerminator())
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
@@ -2832,11 +2844,11 @@ class SelectTypeOp(IRDLOperation):
     """
 
     name = "fir.select_type"
-    selector = operand_def()
-    compareArgs = var_operand_def()
-    targetArgs = var_operand_def()
-    case_tags = prop_def(ArrayAttr)
-    targets = var_successor_def()
+    selector: Operand = operand_def()
+    compareArgs: VarOperand = var_operand_def()
+    targetArgs: VarOperand = var_operand_def()
+    case_tags: ArrayAttr[Attribute] = prop_def(ArrayAttr)
+    targets: VarSuccessor = var_successor_def()
 
     traits = traits_def(IsTerminator())
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
@@ -2855,8 +2867,8 @@ class ShapeOp(IRDLOperation):
     """
 
     name = "fir.shape"
-    extents = var_operand_def()
-    result_0 = result_def()
+    extents: VarOperand = var_operand_def()
+    result_0: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -2873,8 +2885,8 @@ class ShapeShiftOp(IRDLOperation):
     """
 
     name = "fir.shape_shift"
-    pairs = var_operand_def()
-    result_0 = result_def()
+    pairs: VarOperand = var_operand_def()
+    result_0: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -2890,8 +2902,8 @@ class ShiftOp(IRDLOperation):
     """
 
     name = "fir.shift"
-    origins = var_operand_def()
-    result_0 = result_def()
+    origins: VarOperand = var_operand_def()
+    result_0: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -2923,10 +2935,10 @@ class SliceOp(IRDLOperation):
     """
 
     name = "fir.slice"
-    triples = var_operand_def()
-    fields = var_operand_def()
-    substr = var_operand_def()
-    result_0 = result_def()
+    triples: VarOperand = var_operand_def()
+    fields: VarOperand = var_operand_def()
+    substr: VarOperand = var_operand_def()
+    result_0: OpResult = result_def()
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
@@ -2948,8 +2960,8 @@ class StoreOp(IRDLOperation):
     """
 
     name = "fir.store"
-    value = operand_def()
-    memref = operand_def()
+    value: Operand = operand_def()
+    memref: Operand = operand_def()
 
 
 @irdl_op_definition
@@ -2966,19 +2978,19 @@ class StringLitOp(IRDLOperation):
     """
 
     name = "fir.string_lit"
-    size = attr_def(IntegerAttr[IntegerType])
-    value = opt_attr_def(StringAttr)
-    xlist = opt_attr_def(ArrayAttr)
-    result_0 = result_def()
+    size: IntegerAttr[IntegerType] = attr_def(IntegerAttr[IntegerType])
+    value: StringAttr | None = opt_attr_def(StringAttr)
+    xlist: ArrayAttr[Attribute] | None = opt_attr_def(ArrayAttr)
+    result_0: OpResult = result_def()
 
 
 @irdl_op_definition
 class SubcOp(IRDLOperation):
     name = "fir.subc"
-    lhs = operand_def()
-    rhs = operand_def()
-    fastmath = opt_prop_def(FastMathFlagsAttr)
-    result = result_def()
+    lhs: Operand = operand_def()
+    rhs: Operand = operand_def()
+    fastmath: FastMathFlagsAttr | None = opt_prop_def(FastMathFlagsAttr)
+    result: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -2992,9 +3004,9 @@ class UnboxcharOp(IRDLOperation):
     """
 
     name = "fir.unboxchar"
-    boxchar = operand_def()
-    result_0 = result_def()
-    result_1 = result_def()
+    boxchar: Operand = operand_def()
+    result_0: OpResult = result_def()
+    result_1: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -3008,9 +3020,9 @@ class UnboxprocOp(IRDLOperation):
     """
 
     name = "fir.unboxproc"
-    boxproc = operand_def()
-    result_0 = result_def()
-    refTuple = result_def()
+    boxproc: Operand = operand_def()
+    result_0: OpResult = result_def()
+    refTuple: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -3027,7 +3039,7 @@ class UndefinedOp(IRDLOperation):
     """
 
     name = "fir.undefined"
-    intype = result_def()
+    intype: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -3059,7 +3071,7 @@ class ZeroBitsOp(IRDLOperation):
     """
 
     name = "fir.zero_bits"
-    intype = result_def()
+    intype: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -3067,7 +3079,7 @@ class AssumedSizeExtentOp(IRDLOperation):
     """Returns the magic extent value used for the last assumed-size dimension."""
 
     name = "fir.assumed_size_extent"
-    result = result_def()
+    result: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -3075,8 +3087,8 @@ class BoxTotalElementsOp(IRDLOperation):
     """Returns the total number of elements described by a Fortran descriptor."""
 
     name = "fir.box_total_elements"
-    box = operand_def()
-    result = result_def()
+    box: Operand = operand_def()
+    result: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -3084,8 +3096,8 @@ class BoxTypeCodeOp(IRDLOperation):
     """Returns the CFI type code stored in a descriptor."""
 
     name = "fir.box_typecode"
-    box = operand_def()
-    result = result_def()
+    box: Operand = operand_def()
+    result: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -3093,9 +3105,9 @@ class CopyOp(IRDLOperation):
     """Copy a Fortran entity from source to destination, with optional no-overlap promise."""
 
     name = "fir.copy"
-    source = operand_def()
-    destination = operand_def()
-    no_overlap = opt_prop_def(UnitAttr)
+    source: Operand = operand_def()
+    destination: Operand = operand_def()
+    no_overlap: UnitAttr | None = opt_prop_def(UnitAttr)
 
 
 @irdl_op_definition
@@ -3103,15 +3115,15 @@ class DeclareReductionOp(IRDLOperation):
     """User-defined reduction declaration used by fir.do_concurrent.loop."""
 
     name = "fir.declare_reduction"
-    sym_name = prop_def(SymbolNameConstraint())
-    type = prop_def()
-    byref_element_type = opt_prop_def()
-    allocRegion = opt_region_def()
-    initializerRegion = region_def()
-    reductionRegion = region_def()
-    atomicReductionRegion = region_def()
-    cleanupRegion = region_def()
-    dataPtrPtrRegion = region_def()
+    sym_name: StringAttr = prop_def(SymbolNameConstraint())
+    type: Attribute = prop_def()
+    byref_element_type: Attribute | None = opt_prop_def()
+    allocRegion: OptRegion = opt_region_def()
+    initializerRegion: Region = region_def()
+    reductionRegion: Region = region_def()
+    atomicReductionRegion: Region = region_def()
+    cleanupRegion: Region = region_def()
+    dataPtrPtrRegion: Region = region_def()
 
     traits = traits_def(SymbolOpInterface(), IsolatedFromAbove())
 
@@ -3121,7 +3133,7 @@ class DoConcurrentOp(IRDLOperation):
     """Wrapper region for a Fortran DO CONCURRENT loop nest."""
 
     name = "fir.do_concurrent"
-    region = region_def("single_block")
+    region: Region = region_def("single_block")
 
 
 @irdl_op_definition
@@ -3129,17 +3141,17 @@ class DoConcurrentLoopOp(IRDLOperation):
     """Inner loop nest of a fir.do_concurrent."""
 
     name = "fir.do_concurrent.loop"
-    lowerBound = var_operand_def()
-    upperBound = var_operand_def()
-    step = var_operand_def()
-    local_vars = var_operand_def()
-    reduce_vars = var_operand_def()
-    loopAnnotation = opt_prop_def(Attribute)
-    local_syms = opt_prop_def(ArrayAttr)
-    reduce_byref = opt_prop_def(Attribute)
-    reduce_syms = opt_prop_def(ArrayAttr)
-    reduce_attrs = opt_prop_def(ArrayAttr)
-    region = region_def("single_block")
+    lowerBound: VarOperand = var_operand_def()
+    upperBound: VarOperand = var_operand_def()
+    step: VarOperand = var_operand_def()
+    local_vars: VarOperand = var_operand_def()
+    reduce_vars: VarOperand = var_operand_def()
+    loopAnnotation: Attribute | None = opt_prop_def(Attribute)
+    local_syms: ArrayAttr[Attribute] | None = opt_prop_def(ArrayAttr)
+    reduce_byref: Attribute | None = opt_prop_def(Attribute)
+    reduce_syms: ArrayAttr[Attribute] | None = opt_prop_def(ArrayAttr)
+    reduce_attrs: ArrayAttr[Attribute] | None = opt_prop_def(ArrayAttr)
+    region: Region = region_def("single_block")
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
@@ -3149,9 +3161,9 @@ class DTComponentOp(IRDLOperation):
     """A component descriptor entry inside a fir.type_info."""
 
     name = "fir.dt_component"
-    name_attr = prop_def(StringAttr, prop_name="name")
-    lower_bounds = opt_prop_def(Attribute)
-    init_val = opt_prop_def(SymbolRefAttr)
+    name_attr: StringAttr = prop_def(StringAttr, prop_name="name")
+    lower_bounds: Attribute | None = opt_prop_def(Attribute)
+    init_val: SymbolRefAttr | None = opt_prop_def(SymbolRefAttr)
 
 
 @irdl_op_definition
@@ -3159,8 +3171,8 @@ class IsAssumedSizeOp(IRDLOperation):
     """True iff the box describes a Fortran assumed-size array."""
 
     name = "fir.is_assumed_size"
-    val = operand_def()
-    result = result_def()
+    val: Operand = operand_def()
+    result: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -3168,8 +3180,8 @@ class IsAssumedSizeExtentOp(IRDLOperation):
     """True iff the integer is the magic assumed-size extent value."""
 
     name = "fir.is_assumed_size_extent"
-    val = operand_def()
-    result = result_def()
+    val: Operand = operand_def()
+    result: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -3177,9 +3189,9 @@ class IsContiguousBoxOp(IRDLOperation):
     """Runtime predicate: is the box contiguous (optionally only innermost)?"""
 
     name = "fir.is_contiguous_box"
-    box = operand_def()
-    innermost = opt_prop_def(UnitAttr)
-    result = result_def()
+    box: Operand = operand_def()
+    innermost: UnitAttr | None = opt_prop_def(UnitAttr)
+    result: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -3187,12 +3199,14 @@ class LocalitySpecifierOp(IRDLOperation):
     """LOCAL/LOCAL_INIT specifier for fir.do_concurrent."""
 
     name = "fir.local"
-    sym_name = prop_def(SymbolNameConstraint())
-    type = prop_def()
-    locality_specifier_type = prop_def(LocalitySpecifierTypeAttr)
-    init_region = region_def()
-    copy_region = region_def()
-    dealloc_region = region_def()
+    sym_name: StringAttr = prop_def(SymbolNameConstraint())
+    type: Attribute = prop_def()
+    locality_specifier_type: LocalitySpecifierTypeAttr = prop_def(
+        LocalitySpecifierTypeAttr
+    )
+    init_region: Region = region_def()
+    copy_region: Region = region_def()
+    dealloc_region: Region = region_def()
 
     traits = traits_def(SymbolOpInterface(), IsolatedFromAbove())
 
@@ -3202,17 +3216,17 @@ class PackArrayOp(IRDLOperation):
     """Repack an array into a contiguous temporary."""
 
     name = "fir.pack_array"
-    array = operand_def()
-    typeparams = var_operand_def()
-    stack = opt_prop_def(UnitAttr)
-    innermost = opt_prop_def(UnitAttr)
-    no_copy = opt_prop_def(UnitAttr)
-    max_size = opt_prop_def(IntegerAttr)
-    max_element_size = opt_prop_def(IntegerAttr)
-    min_stride = opt_prop_def(IntegerAttr)
-    heuristics = opt_prop_def(PackArrayHeuristicsAttr)
-    is_safe = opt_prop_def(ArrayAttr)
-    result = result_def()
+    array: Operand = operand_def()
+    typeparams: VarOperand = var_operand_def()
+    stack: UnitAttr | None = opt_prop_def(UnitAttr)
+    innermost: UnitAttr | None = opt_prop_def(UnitAttr)
+    no_copy: UnitAttr | None = opt_prop_def(UnitAttr)
+    max_size: IntegerAttr | None = opt_prop_def(IntegerAttr)
+    max_element_size: IntegerAttr | None = opt_prop_def(IntegerAttr)
+    min_stride: IntegerAttr | None = opt_prop_def(IntegerAttr)
+    heuristics: PackArrayHeuristicsAttr | None = opt_prop_def(PackArrayHeuristicsAttr)
+    is_safe: ArrayAttr[Attribute] | None = opt_prop_def(ArrayAttr)
+    result: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -3220,11 +3234,11 @@ class UnpackArrayOp(IRDLOperation):
     """Inverse of fir.pack_array."""
 
     name = "fir.unpack_array"
-    temp = operand_def()
-    original = operand_def()
-    stack = opt_prop_def(UnitAttr)
-    no_copy = opt_prop_def(UnitAttr)
-    is_safe = opt_prop_def(ArrayAttr)
+    temp: Operand = operand_def()
+    original: Operand = operand_def()
+    stack: UnitAttr | None = opt_prop_def(UnitAttr)
+    no_copy: UnitAttr | None = opt_prop_def(UnitAttr)
+    is_safe: ArrayAttr[Attribute] | None = opt_prop_def(ArrayAttr)
 
 
 @irdl_op_definition
@@ -3232,10 +3246,10 @@ class PrefetchOp(IRDLOperation):
     """Cache prefetch hint for a memory reference."""
 
     name = "fir.prefetch"
-    memref = operand_def()
-    rw = opt_prop_def(UnitAttr)
-    localityHint = prop_def(IntegerAttr)
-    cacheType = opt_prop_def(UnitAttr)
+    memref: Operand = operand_def()
+    rw: UnitAttr | None = opt_prop_def(UnitAttr)
+    localityHint: IntegerAttr = prop_def(IntegerAttr)
+    cacheType: UnitAttr | None = opt_prop_def(UnitAttr)
 
 
 @irdl_op_definition
@@ -3243,9 +3257,9 @@ class ReboxAssumedRankOp(IRDLOperation):
     """Rebox an assumed-rank descriptor with a different lower-bound modifier."""
 
     name = "fir.rebox_assumed_rank"
-    box = operand_def()
-    lbs_modifier = prop_def(Attribute)
-    result = result_def()
+    box: Operand = operand_def()
+    lbs_modifier: Attribute = prop_def(Attribute)
+    result: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -3253,8 +3267,8 @@ class TypeDescOp(IRDLOperation):
     """Get the SSA value of a derived type's runtime type descriptor."""
 
     name = "fir.type_desc"
-    in_type = prop_def()
-    result = result_def()
+    in_type: Attribute = prop_def()
+    result: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -3262,15 +3276,15 @@ class TypeInfoOp(IRDLOperation):
     """Container for a derived type's dispatch table and component info."""
 
     name = "fir.type_info"
-    sym_name = prop_def(SymbolNameConstraint())
-    type = prop_def()
-    parent_type = opt_prop_def()
-    abstract = opt_prop_def(UnitAttr)
-    no_init = opt_prop_def(UnitAttr)
-    no_destroy = opt_prop_def(UnitAttr)
-    no_final = opt_prop_def(UnitAttr)
-    dispatch_table = region_def()
-    component_info = region_def()
+    sym_name: StringAttr = prop_def(SymbolNameConstraint())
+    type: Attribute = prop_def()
+    parent_type: Attribute | None = opt_prop_def()
+    abstract: UnitAttr | None = opt_prop_def(UnitAttr)
+    no_init: UnitAttr | None = opt_prop_def(UnitAttr)
+    no_destroy: UnitAttr | None = opt_prop_def(UnitAttr)
+    no_final: UnitAttr | None = opt_prop_def(UnitAttr)
+    dispatch_table: Region = region_def()
+    component_info: Region = region_def()
 
     traits = traits_def(SymbolOpInterface(), IsolatedFromAbove())
 
@@ -3280,9 +3294,9 @@ class UseStmtOp(IRDLOperation):
     """Marker for Fortran USE-association (debug-info only)."""
 
     name = "fir.use_stmt"
-    module_name = prop_def(StringAttr)
-    only_symbols = opt_prop_def(ArrayAttr)
-    renames = opt_prop_def(ArrayAttr)
+    module_name: StringAttr = prop_def(StringAttr)
+    only_symbols: ArrayAttr[Attribute] | None = opt_prop_def(ArrayAttr)
+    renames: ArrayAttr[Attribute] | None = opt_prop_def(ArrayAttr)
 
 
 @irdl_op_definition
@@ -3290,8 +3304,8 @@ class VolatileCastOp(IRDLOperation):
     """Cast that adds or drops the descriptor 'volatile' flag."""
 
     name = "fir.volatile_cast"
-    value = operand_def()
-    res = result_def()
+    value: Operand = operand_def()
+    res: OpResult = result_def()
 
 
 FIR = Dialect(

--- a/xdsl/dialects/experimental/hlfir.py
+++ b/xdsl/dialects/experimental/hlfir.py
@@ -31,10 +31,15 @@ from xdsl.dialects.experimental.fir import (
     FortranVariableFlagsAttr,
     NoneType,
 )
-from xdsl.ir import Data, Dialect, TypeAttribute
+from xdsl.ir import Data, Dialect, Region, TypeAttribute
 from xdsl.irdl import (
     AttrSizedOperandSegments,
     IRDLOperation,
+    Operand,
+    OpResult,
+    OptOperand,
+    OptRegion,
+    VarOperand,
     irdl_attr_definition,
     irdl_op_definition,
     operand_def,
@@ -181,19 +186,21 @@ class DeclareOp(IRDLOperation):
     """  # noqa: E501
 
     name = "hlfir.declare"
-    memref = operand_def()
-    shape = opt_operand_def()
-    typeparams = var_operand_def()
-    dummy_scope = opt_operand_def()
-    storage = opt_operand_def()
-    storage_offset = opt_prop_def(IntegerAttr)
-    uniq_name = prop_def(StringAttr)
-    fortran_attrs = opt_prop_def(FortranVariableFlagsAttr)
-    data_attr = opt_prop_def(Attribute)
-    skip_rebox = opt_prop_def(UnitAttr)
-    dummy_arg_no = opt_prop_def(IntegerAttr)
-    result = result_def()
-    result2 = result_def()
+    memref: Operand = operand_def()
+    shape: OptOperand = opt_operand_def()
+    typeparams: VarOperand = var_operand_def()
+    dummy_scope: OptOperand = opt_operand_def()
+    storage: OptOperand = opt_operand_def()
+    storage_offset: IntegerAttr | None = opt_prop_def(IntegerAttr)
+    uniq_name: StringAttr = prop_def(StringAttr)
+    fortran_attrs: FortranVariableFlagsAttr | None = opt_prop_def(
+        FortranVariableFlagsAttr
+    )
+    data_attr: Attribute | None = opt_prop_def(Attribute)
+    skip_rebox: UnitAttr | None = opt_prop_def(UnitAttr)
+    dummy_arg_no: IntegerAttr | None = opt_prop_def(IntegerAttr)
+    result: OpResult = result_def()
+    result2: OpResult = result_def()
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
@@ -234,17 +241,19 @@ class DesignateOp(IRDLOperation):
     """
 
     name = "hlfir.designate"
-    memref = operand_def()
-    component_shape = opt_operand_def()
-    indices = var_operand_def()
-    substring = var_operand_def()
-    shape = opt_operand_def()
-    typeparams = var_operand_def()
-    component = opt_prop_def(StringAttr)
-    complex_part = opt_prop_def(BoolAttr)
-    is_triplet = prop_def(DenseArrayBase)
-    fortran_attrs = opt_prop_def(FortranVariableFlagsAttr)
-    result = result_def()
+    memref: Operand = operand_def()
+    component_shape: OptOperand = opt_operand_def()
+    indices: VarOperand = var_operand_def()
+    substring: VarOperand = var_operand_def()
+    shape: OptOperand = opt_operand_def()
+    typeparams: VarOperand = var_operand_def()
+    component: StringAttr | None = opt_prop_def(StringAttr)
+    complex_part: BoolAttr | None = opt_prop_def(BoolAttr)
+    is_triplet: DenseArrayBase = prop_def(DenseArrayBase)
+    fortran_attrs: FortranVariableFlagsAttr | None = opt_prop_def(
+        FortranVariableFlagsAttr
+    )
+    result: OpResult = result_def()
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
@@ -291,11 +300,11 @@ class AssignOp(IRDLOperation):
     """
 
     name = "hlfir.assign"
-    rhs = operand_def()
-    lhs = operand_def()
-    realloc = opt_prop_def(UnitAttr)
-    keep_lhs_length_if_realloc = opt_prop_def(UnitAttr)
-    temporary_lhs = opt_prop_def(UnitAttr)
+    rhs: Operand = operand_def()
+    lhs: Operand = operand_def()
+    realloc: UnitAttr | None = opt_prop_def(UnitAttr)
+    keep_lhs_length_if_realloc: UnitAttr | None = opt_prop_def(UnitAttr)
+    temporary_lhs: UnitAttr | None = opt_prop_def(UnitAttr)
 
 
 @irdl_op_definition
@@ -321,10 +330,10 @@ class ParentComponentOp(IRDLOperation):
     """
 
     name = "hlfir.parent_comp"
-    memref = operand_def()
-    shape = opt_operand_def()
-    typeparams = var_operand_def()
-    result = result_def()
+    memref: Operand = operand_def()
+    shape: OptOperand = opt_operand_def()
+    typeparams: VarOperand = var_operand_def()
+    result: OpResult = result_def()
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
@@ -338,9 +347,9 @@ class ConcatOp(IRDLOperation):
     """
 
     name = "hlfir.concat"
-    strings = var_operand_def()
-    length = operand_def()
-    result = result_def()
+    strings: VarOperand = var_operand_def()
+    length: Operand = operand_def()
+    result: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -353,9 +362,9 @@ class AllOp(IRDLOperation):
     """
 
     name = "hlfir.all"
-    mask = operand_def()
-    dim = opt_operand_def()
-    result = result_def()
+    mask: Operand = operand_def()
+    dim: OptOperand = opt_operand_def()
+    result: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -368,9 +377,9 @@ class AnyOp(IRDLOperation):
     """
 
     name = "hlfir.any"
-    mask = operand_def()
-    dim = opt_operand_def()
-    result = result_def()
+    mask: Operand = operand_def()
+    dim: OptOperand = opt_operand_def()
+    result: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -382,9 +391,9 @@ class CountOp(IRDLOperation):
     """
 
     name = "hlfir.count"
-    mask = operand_def()
-    dim = opt_operand_def()
-    result = result_def()
+    mask: Operand = operand_def()
+    dim: OptOperand = opt_operand_def()
+    result: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -398,11 +407,11 @@ class MaxvalOp(IRDLOperation):
     """
 
     name = "hlfir.maxval"
-    array = operand_def()
-    dim = opt_operand_def()
-    mask = opt_operand_def()
-    fastmath = opt_prop_def(FastMathFlagsAttr)
-    result = result_def()
+    array: Operand = operand_def()
+    dim: OptOperand = opt_operand_def()
+    mask: OptOperand = opt_operand_def()
+    fastmath: FastMathFlagsAttr | None = opt_prop_def(FastMathFlagsAttr)
+    result: OpResult = result_def()
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
@@ -418,11 +427,11 @@ class MinvalOp(IRDLOperation):
     """
 
     name = "hlfir.minval"
-    array = operand_def()
-    dim = opt_operand_def()
-    mask = opt_operand_def()
-    fastmath = opt_prop_def(FastMathFlagsAttr)
-    result = result_def()
+    array: Operand = operand_def()
+    dim: OptOperand = opt_operand_def()
+    mask: OptOperand = opt_operand_def()
+    fastmath: FastMathFlagsAttr | None = opt_prop_def(FastMathFlagsAttr)
+    result: OpResult = result_def()
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
@@ -437,11 +446,11 @@ class ProductOp(IRDLOperation):
     """
 
     name = "hlfir.product"
-    array = operand_def()
-    dim = opt_operand_def()
-    mask = opt_operand_def()
-    fastmath = opt_prop_def(FastMathFlagsAttr)
-    result = result_def()
+    array: Operand = operand_def()
+    dim: OptOperand = opt_operand_def()
+    mask: OptOperand = opt_operand_def()
+    fastmath: FastMathFlagsAttr | None = opt_prop_def(FastMathFlagsAttr)
+    result: OpResult = result_def()
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
@@ -456,9 +465,9 @@ class SetLengthOp(IRDLOperation):
     """
 
     name = "hlfir.set_length"
-    string = operand_def()
-    length = operand_def()
-    result = result_def()
+    string: Operand = operand_def()
+    length: Operand = operand_def()
+    result: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -470,8 +479,8 @@ class GetLengthOp(IRDLOperation):
     """
 
     name = "hlfir.get_length"
-    expr = operand_def()
-    result = result_def()
+    expr: Operand = operand_def()
+    result: OpResult = result_def()
 
     traits = traits_def(Pure())
 
@@ -486,11 +495,11 @@ class SumOp(IRDLOperation):
     """
 
     name = "hlfir.sum"
-    array = operand_def()
-    dim = opt_operand_def()
-    mask = opt_operand_def()
-    fastmath = opt_prop_def(FastMathFlagsAttr)
-    result = result_def()
+    array: Operand = operand_def()
+    dim: OptOperand = opt_operand_def()
+    mask: OptOperand = opt_operand_def()
+    fastmath: FastMathFlagsAttr | None = opt_prop_def(FastMathFlagsAttr)
+    result: OpResult = result_def()
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
@@ -504,10 +513,10 @@ class DotProductOp(IRDLOperation):
     """
 
     name = "hlfir.dot_product"
-    lhs = operand_def()
-    rhs = operand_def()
-    fastmath = opt_prop_def(FastMathFlagsAttr)
-    result = result_def()
+    lhs: Operand = operand_def()
+    rhs: Operand = operand_def()
+    fastmath: FastMathFlagsAttr | None = opt_prop_def(FastMathFlagsAttr)
+    result: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -519,10 +528,10 @@ class MatmulOp(IRDLOperation):
     """
 
     name = "hlfir.matmul"
-    lhs = operand_def()
-    rhs = operand_def()
-    fastmath = opt_prop_def(FastMathFlagsAttr)
-    result = result_def()
+    lhs: Operand = operand_def()
+    rhs: Operand = operand_def()
+    fastmath: FastMathFlagsAttr | None = opt_prop_def(FastMathFlagsAttr)
+    result: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -534,8 +543,8 @@ class TransposeOp(IRDLOperation):
     """
 
     name = "hlfir.transpose"
-    array = operand_def()
-    result = result_def()
+    array: Operand = operand_def()
+    result: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -547,10 +556,10 @@ class MatmulTransposeOp(IRDLOperation):
     """
 
     name = "hlfir.matmul_transpose"
-    lhs = operand_def()
-    rhs = operand_def()
-    fastmath = opt_prop_def(FastMathFlagsAttr)
-    result = result_def()
+    lhs: Operand = operand_def()
+    rhs: Operand = operand_def()
+    fastmath: FastMathFlagsAttr | None = opt_prop_def(FastMathFlagsAttr)
+    result: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -564,14 +573,16 @@ class AssociateOp(IRDLOperation):
     """
 
     name = "hlfir.associate"
-    source = operand_def()
-    shape = opt_operand_def()
-    typeparams = var_operand_def()
-    uniq_name = opt_prop_def(StringAttr)
-    fortran_attrs = opt_prop_def(FortranVariableFlagsAttr)
-    result = result_def()
-    fir_base = result_def()
-    must_free = result_def()
+    source: Operand = operand_def()
+    shape: OptOperand = opt_operand_def()
+    typeparams: VarOperand = var_operand_def()
+    uniq_name: StringAttr | None = opt_prop_def(StringAttr)
+    fortran_attrs: FortranVariableFlagsAttr | None = opt_prop_def(
+        FortranVariableFlagsAttr
+    )
+    result: OpResult = result_def()
+    fir_base: OpResult = result_def()
+    must_free: OpResult = result_def()
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
@@ -586,8 +597,8 @@ class EndAssociateOp(IRDLOperation):
     """
 
     name = "hlfir.end_associate"
-    var = operand_def()
-    must_free = operand_def()
+    var: Operand = operand_def()
+    must_free: Operand = operand_def()
 
 
 @irdl_op_definition
@@ -608,9 +619,9 @@ class AsExprOp(IRDLOperation):
     """
 
     name = "hlfir.as_expr"
-    var = operand_def()
-    must_free = opt_operand_def()
-    result = result_def()
+    var: Operand = operand_def()
+    must_free: OptOperand = opt_operand_def()
+    result: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -622,8 +633,8 @@ class NoReassocOp(IRDLOperation):
     """
 
     name = "hlfir.no_reassoc"
-    val = operand_def()
-    result = result_def()
+    val: Operand = operand_def()
+    result: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -667,12 +678,12 @@ class ElementalOp(IRDLOperation):
     """
 
     name = "hlfir.elemental"
-    shape = operand_def()
-    mold = opt_operand_def()
-    typeparams = var_operand_def()
-    unordered = opt_prop_def(UnitAttr)
-    result = result_def()
-    region = region_def("single_block")
+    shape: Operand = operand_def()
+    mold: OptOperand = opt_operand_def()
+    typeparams: VarOperand = var_operand_def()
+    unordered: UnitAttr | None = opt_prop_def(UnitAttr)
+    result: OpResult = result_def()
+    region: Region = region_def("single_block")
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
@@ -688,7 +699,7 @@ class YieldElementOp(IRDLOperation):
     """
 
     name = "hlfir.yield_element"
-    element_value = operand_def()
+    element_value: Operand = operand_def()
 
     traits = traits_def(IsTerminator(), HasParent(ElementalOp), Pure())
 
@@ -714,10 +725,10 @@ class ApplyOp(IRDLOperation):
     """
 
     name = "hlfir.apply"
-    expr = operand_def()
-    indices = var_operand_def()
-    typeparams = var_operand_def()
-    result = result_def()
+    expr: Operand = operand_def()
+    indices: VarOperand = var_operand_def()
+    typeparams: VarOperand = var_operand_def()
+    result: OpResult = result_def()
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
@@ -731,7 +742,7 @@ class NullOp(IRDLOperation):
     """
 
     name = "hlfir.null"
-    result = result_def()
+    result: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -762,8 +773,8 @@ class DestroyOp(IRDLOperation):
     """
 
     name = "hlfir.destroy"
-    expr = operand_def()
-    finalize = opt_prop_def(UnitAttr)
+    expr: Operand = operand_def()
+    finalize: UnitAttr | None = opt_prop_def(UnitAttr)
 
 
 @irdl_op_definition
@@ -789,11 +800,11 @@ class CopyInOp(IRDLOperation):
     """
 
     name = "hlfir.copy_in"
-    var = operand_def()
-    tempBox = operand_def()
-    var_is_present = opt_operand_def()
-    copied_in = result_def()
-    was_copied = result_def()
+    var: Operand = operand_def()
+    tempBox: Operand = operand_def()
+    var_is_present: OptOperand = opt_operand_def()
+    copied_in: OpResult = result_def()
+    was_copied: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -810,9 +821,9 @@ class CopyOutOp(IRDLOperation):
     """
 
     name = "hlfir.copy_out"
-    temp = operand_def()
-    was_copied = operand_def()
-    var = opt_operand_def()
+    temp: Operand = operand_def()
+    was_copied: Operand = operand_def()
+    var: OptOperand = opt_operand_def()
 
 
 @irdl_op_definition
@@ -826,8 +837,8 @@ class ShapeOfOp(IRDLOperation):
     """
 
     name = "hlfir.shape_of"
-    expr = operand_def()
-    result = result_def()
+    expr: Operand = operand_def()
+    result: OpResult = result_def()
 
     traits = traits_def(Pure())
 
@@ -842,9 +853,9 @@ class GetExtentOp(IRDLOperation):
     """
 
     name = "hlfir.get_extent"
-    shape = operand_def()
-    dim = prop_def(IntegerAttr)
-    result = result_def()
+    shape: Operand = operand_def()
+    dim: IntegerAttr = prop_def(IntegerAttr)
+    result: OpResult = result_def()
 
     traits = traits_def(Pure())
 
@@ -888,9 +899,9 @@ class RegionAssignOp(IRDLOperation):
     """
 
     name = "hlfir.region_assign"
-    rhs_region = region_def("single_block")
-    lhs_region = region_def("single_block")
-    user_defined_assignment = opt_region_def()
+    rhs_region: Region = region_def("single_block")
+    lhs_region: Region = region_def("single_block")
+    user_defined_assignment: OptRegion = opt_region_def()
 
 
 @irdl_op_definition
@@ -915,8 +926,8 @@ class YieldOp(IRDLOperation):
     """
 
     name = "hlfir.yield"
-    entity = operand_def()
-    cleanup = opt_region_def()
+    entity: Operand = operand_def()
+    cleanup: OptRegion = opt_region_def()
 
     traits = traits_def(IsTerminator())
 
@@ -960,12 +971,12 @@ class ElementalAddrOp(IRDLOperation):
     """
 
     name = "hlfir.elemental_addr"
-    shape = operand_def()
-    mold = opt_operand_def()
-    typeparams = var_operand_def()
-    unordered = opt_prop_def(UnitAttr)
-    body = region_def("single_block")
-    cleanup = opt_region_def()
+    shape: Operand = operand_def()
+    mold: OptOperand = opt_operand_def()
+    typeparams: VarOperand = var_operand_def()
+    unordered: UnitAttr | None = opt_prop_def(UnitAttr)
+    body: Region = region_def("single_block")
+    cleanup: OptRegion = opt_region_def()
 
     traits = traits_def(IsTerminator(), HasParent(RegionAssignOp))
 
@@ -1025,10 +1036,10 @@ class ForallOp(IRDLOperation):
     """
 
     name = "hlfir.forall"
-    lb_region = region_def("single_block")
-    ub_region = region_def("single_block")
-    step_region = opt_region_def()
-    body = region_def("single_block")
+    lb_region: Region = region_def("single_block")
+    ub_region: Region = region_def("single_block")
+    step_region: OptRegion = opt_region_def()
+    body: Region = region_def("single_block")
 
 
 @irdl_op_definition
@@ -1065,8 +1076,8 @@ class ForallMaskOp(IRDLOperation):
     """
 
     name = "hlfir.forall_mask"
-    mask_region = region_def("single_block")
-    body = region_def("single_block")
+    mask_region: Region = region_def("single_block")
+    body: Region = region_def("single_block")
 
 
 @irdl_op_definition
@@ -1090,8 +1101,8 @@ class AssignmentMaskOp(IRDLOperation):
     """
 
     name = "hlfir.where"
-    mask_region = region_def("single_block")
-    body = region_def("single_block")
+    mask_region: Region = region_def("single_block")
+    body: Region = region_def("single_block")
 
 
 @irdl_op_definition
@@ -1112,8 +1123,8 @@ class ElseWhereOp(IRDLOperation):
     """
 
     name = "hlfir.elsewhere"
-    mask_region = opt_region_def()
-    body = region_def("single_block")
+    mask_region: OptRegion = opt_region_def()
+    body: Region = region_def("single_block")
 
     traits = traits_def(IsTerminator())
 
@@ -1138,9 +1149,9 @@ class ForallIndexOp(IRDLOperation):
     """
 
     name = "hlfir.forall_index"
-    index = operand_def()
-    index_name = prop_def(StringAttr, prop_name="name")
-    result = result_def()
+    index: Operand = operand_def()
+    index_name: StringAttr = prop_def(StringAttr, prop_name="name")
+    result: OpResult = result_def()
 
     traits = traits_def(Pure())
 
@@ -1158,9 +1169,9 @@ class CharExtremumOp(IRDLOperation):
     """  # noqa E501
 
     name = "hlfir.char_extremum"
-    predicate = prop_def(CharExtremumPredicateAttr)
-    strings = var_operand_def()
-    result = result_def()
+    predicate: CharExtremumPredicateAttr = prop_def(CharExtremumPredicateAttr)
+    strings: VarOperand = var_operand_def()
+    result: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -1168,8 +1179,8 @@ class CharTrimOp(IRDLOperation):
     """TRIM intrinsic on a character string."""
 
     name = "hlfir.char_trim"
-    chr = operand_def()
-    result = result_def()
+    chr: Operand = operand_def()
+    result: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -1177,10 +1188,10 @@ class CmpCharOp(IRDLOperation):
     """Lexicographic compare of two character strings."""
 
     name = "hlfir.cmpchar"
-    predicate = prop_def(IntegerAttr)
-    lchr = operand_def()
-    rchr = operand_def()
-    result = result_def()
+    predicate: IntegerAttr = prop_def(IntegerAttr)
+    lchr: Operand = operand_def()
+    rchr: Operand = operand_def()
+    result: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -1188,10 +1199,10 @@ class CShiftOp(IRDLOperation):
     """CSHIFT intrinsic — circular shift along an array dimension."""
 
     name = "hlfir.cshift"
-    array = operand_def()
-    shift = operand_def()
-    dim = opt_operand_def()
-    result = result_def()
+    array: Operand = operand_def()
+    shift: Operand = operand_def()
+    dim: OptOperand = opt_operand_def()
+    result: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -1199,11 +1210,11 @@ class EOShiftOp(IRDLOperation):
     """EOSHIFT intrinsic — end-off shift with optional boundary value."""
 
     name = "hlfir.eoshift"
-    array = operand_def()
-    shift = operand_def()
-    boundary = opt_operand_def()
-    dim = opt_operand_def()
-    result = result_def()
+    array: Operand = operand_def()
+    shift: Operand = operand_def()
+    boundary: OptOperand = opt_operand_def()
+    dim: OptOperand = opt_operand_def()
+    result: OpResult = result_def()
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
@@ -1213,10 +1224,10 @@ class EvaluateInMemoryOp(IRDLOperation):
     """Materialise a Fortran expression into a fresh in-memory temporary."""
 
     name = "hlfir.eval_in_mem"
-    shape = opt_operand_def()
-    typeparams = var_operand_def()
-    result = result_def()
-    body = region_def("single_block")
+    shape: OptOperand = opt_operand_def()
+    typeparams: VarOperand = var_operand_def()
+    result: OpResult = result_def()
+    body: Region = region_def("single_block")
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
@@ -1226,8 +1237,8 @@ class ExactlyOnceOp(IRDLOperation):
     """Mark a region whose body is guaranteed to execute exactly once."""
 
     name = "hlfir.exactly_once"
-    result = result_def()
-    body = region_def("single_block")
+    result: OpResult = result_def()
+    body: Region = region_def("single_block")
 
 
 @irdl_op_definition
@@ -1235,10 +1246,10 @@ class IndexOp(IRDLOperation):
     """INDEX intrinsic — find substring position."""
 
     name = "hlfir.index"
-    substr = operand_def()
-    str = operand_def()
-    back = opt_operand_def()
-    result = result_def()
+    substr: Operand = operand_def()
+    str: Operand = operand_def()
+    back: OptOperand = opt_operand_def()
+    result: OpResult = result_def()
 
 
 @irdl_op_definition
@@ -1246,12 +1257,12 @@ class MaxlocOp(IRDLOperation):
     """MAXLOC reduction."""
 
     name = "hlfir.maxloc"
-    array = operand_def()
-    dim = opt_operand_def()
-    mask = opt_operand_def()
-    back = opt_operand_def()
-    fastmath = opt_prop_def(FastMathFlagsAttr)
-    result = result_def()
+    array: Operand = operand_def()
+    dim: OptOperand = opt_operand_def()
+    mask: OptOperand = opt_operand_def()
+    back: OptOperand = opt_operand_def()
+    fastmath: FastMathFlagsAttr | None = opt_prop_def(FastMathFlagsAttr)
+    result: OpResult = result_def()
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
@@ -1261,12 +1272,12 @@ class MinlocOp(IRDLOperation):
     """MINLOC reduction."""
 
     name = "hlfir.minloc"
-    array = operand_def()
-    dim = opt_operand_def()
-    mask = opt_operand_def()
-    back = opt_operand_def()
-    fastmath = opt_prop_def(FastMathFlagsAttr)
-    result = result_def()
+    array: Operand = operand_def()
+    dim: OptOperand = opt_operand_def()
+    mask: OptOperand = opt_operand_def()
+    back: OptOperand = opt_operand_def()
+    fastmath: FastMathFlagsAttr | None = opt_prop_def(FastMathFlagsAttr)
+    result: OpResult = result_def()
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
@@ -1276,11 +1287,11 @@ class ReshapeOp(IRDLOperation):
     """RESHAPE intrinsic."""
 
     name = "hlfir.reshape"
-    array = operand_def()
-    shape = operand_def()
-    pad = opt_operand_def()
-    order = opt_operand_def()
-    result = result_def()
+    array: Operand = operand_def()
+    shape: Operand = operand_def()
+    pad: OptOperand = opt_operand_def()
+    order: OptOperand = opt_operand_def()
+    result: OpResult = result_def()
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 

--- a/xdsl/dialects/experimental/hls.py
+++ b/xdsl/dialects/experimental/hls.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from xdsl.dialects.builtin import (
+    I64,
     Attribute,
     DenseArrayBase,
     IntegerType,
@@ -11,6 +12,9 @@ from xdsl.dialects.builtin import (
 from xdsl.ir import Dialect, Operation, Region, SSAValue, TypeAttribute
 from xdsl.irdl import (
     IRDLOperation,
+    Operand,
+    OpResult,
+    VarOperand,
     attr_def,
     irdl_attr_definition,
     irdl_op_definition,
@@ -27,7 +31,7 @@ from xdsl.traits import IsTerminator
 @irdl_op_definition
 class HLSYieldOp(IRDLOperation):
     name = "hls.yield"
-    arguments = var_operand_def()
+    arguments: VarOperand = var_operand_def()
 
     traits = traits_def(IsTerminator())
 
@@ -41,7 +45,7 @@ class HLSYieldOp(IRDLOperation):
 @irdl_op_definition
 class PragmaPipelineOp(IRDLOperation):
     name = "hls.pipeline"
-    ii = operand_def(IntegerType)
+    ii: Operand = operand_def(IntegerType)
 
     def __init__(self, ii: SSAValue | Operation):
         super().__init__(operands=[ii])
@@ -50,7 +54,7 @@ class PragmaPipelineOp(IRDLOperation):
 @irdl_op_definition
 class PragmaUnrollOp(IRDLOperation):
     name = "hls.unroll"
-    factor = operand_def(IntegerType)
+    factor: Operand = operand_def(IntegerType)
 
     def __init__(self, factor: SSAValue | Operation):
         super().__init__(operands=[factor])
@@ -60,7 +64,7 @@ class PragmaUnrollOp(IRDLOperation):
 class PragmaDataflowOp(IRDLOperation):
     name = "hls.dataflow"
 
-    body = region_def()
+    body: Region = region_def()
 
     def __init__(self, region: Region):
         super().__init__(regions=[region])
@@ -69,10 +73,10 @@ class PragmaDataflowOp(IRDLOperation):
 @irdl_op_definition
 class PragmaArrayPartitionOp(IRDLOperation):
     name = "hls.array_partition"
-    variable = opt_attr_def(StringAttr)
-    array_type = opt_attr_def()  # look at memref.Global
-    factor = operand_def()
-    dim = operand_def()
+    variable: StringAttr | None = opt_attr_def(StringAttr)
+    array_type: Attribute | None = opt_attr_def()  # look at memref.Global
+    factor: Operand = operand_def()
+    dim: Operand = operand_def()
 
     def __init__(
         self,
@@ -97,8 +101,10 @@ class HLSStreamType(ParametrizedAttribute, TypeAttribute):
 @irdl_op_definition
 class HLSStreamOp(IRDLOperation):
     name = "hls.stream"
-    elem_type = attr_def()
-    result = result_def(HLSStreamType)  # This should be changed to HLSStreamType
+    elem_type: Attribute = attr_def()
+    result: OpResult[HLSStreamType] = result_def(
+        HLSStreamType
+    )  # This should be changed to HLSStreamType
 
     @staticmethod
     def get(elem_type: Attribute) -> HLSStreamOp:
@@ -113,8 +119,8 @@ class HLSStreamOp(IRDLOperation):
 @irdl_op_definition
 class HLSStreamWriteOp(IRDLOperation):
     name = "hls.write"
-    element = operand_def()
-    stream = operand_def(HLSStreamType)
+    element: Operand = operand_def()
+    stream: Operand = operand_def(HLSStreamType)
 
     def __init__(self, element: SSAValue | Operation, stream: SSAValue | Operation):
         super().__init__(operands=[element, stream])
@@ -123,8 +129,8 @@ class HLSStreamWriteOp(IRDLOperation):
 @irdl_op_definition
 class HLSStreamReadOp(IRDLOperation):
     name = "hls.read"
-    stream = operand_def(HLSStreamType)
-    res = result_def()
+    stream: Operand = operand_def(HLSStreamType)
+    res: OpResult = result_def()
 
     def __init__(self, stream: SSAValue):
         assert isinstance(stream.type, HLSStreamType)
@@ -136,10 +142,10 @@ class HLSStreamReadOp(IRDLOperation):
 class HLSExtractStencilValueOp(IRDLOperation):
     name = "hls.extract_stencil_value"
 
-    position = attr_def(DenseArrayBase.constr(i64))
-    container = operand_def(Attribute)
+    position: DenseArrayBase[I64] = attr_def(DenseArrayBase.constr(i64))
+    container: Operand = operand_def(Attribute)
 
-    res = result_def(Attribute)
+    res: OpResult = result_def(Attribute)
 
     def __init__(
         self,

--- a/xdsl/dialects/fsm.py
+++ b/xdsl/dialects/fsm.py
@@ -31,6 +31,11 @@ from xdsl.ir import (
 )
 from xdsl.irdl import (
     IRDLOperation,
+    Operand,
+    OpResult,
+    OptOperand,
+    VarOperand,
+    VarOpResult,
     attr_def,
     irdl_attr_definition,
     irdl_op_definition,
@@ -68,15 +73,19 @@ class MachineOp(IRDLOperation):
 
     name = "fsm.machine"
 
-    body = region_def()
+    body: Region = region_def()
 
-    sym_name = attr_def(SymbolNameConstraint())
-    initialState = attr_def(StringAttr)
-    function_type = attr_def(FunctionType)
-    arg_attrs = opt_attr_def(ArrayAttr[DictionaryAttr])
-    res_attrs = opt_attr_def(ArrayAttr[DictionaryAttr])
-    arg_names = opt_attr_def(ArrayAttr[StringAttr])
-    res_names = opt_attr_def(ArrayAttr[StringAttr])
+    sym_name: StringAttr = attr_def(SymbolNameConstraint())
+    initialState: StringAttr = attr_def(StringAttr)
+    function_type: FunctionType = attr_def(FunctionType)
+    arg_attrs: ArrayAttr[DictionaryAttr] | None = opt_attr_def(
+        ArrayAttr[DictionaryAttr]
+    )
+    res_attrs: ArrayAttr[DictionaryAttr] | None = opt_attr_def(
+        ArrayAttr[DictionaryAttr]
+    )
+    arg_names: ArrayAttr[StringAttr] | None = opt_attr_def(ArrayAttr[StringAttr])
+    res_names: ArrayAttr[StringAttr] | None = opt_attr_def(ArrayAttr[StringAttr])
 
     traits = traits_def(NoTerminator(), SymbolTable(), SymbolOpInterface())
 
@@ -139,11 +148,11 @@ class StateOp(IRDLOperation):
 
     name = "fsm.state"
 
-    output = region_def()
+    output: Region = region_def()
 
-    transitions = region_def()
+    transitions: Region = region_def()
 
-    sym_name = attr_def(SymbolNameConstraint())
+    sym_name: StringAttr = attr_def(SymbolNameConstraint())
 
     traits = traits_def(NoTerminator(), SymbolOpInterface(), HasParent(MachineOp))
 
@@ -189,7 +198,7 @@ class OutputOp(IRDLOperation):
 
     name = "fsm.output"
 
-    operand = var_operand_def()
+    operand: VarOperand = var_operand_def()
 
     traits = traits_def(IsTerminator(), HasParent(StateOp))
 
@@ -227,11 +236,11 @@ class TransitionOp(IRDLOperation):
 
     name = "fsm.transition"
 
-    guard = region_def()
+    guard: Region = region_def()
 
-    action = region_def()
+    action: Region = region_def()
 
-    nextState = attr_def(FlatSymbolRefAttrConstr)
+    nextState: SymbolRefAttr = attr_def(FlatSymbolRefAttrConstr)
 
     traits = traits_def(NoTerminator(), HasParent(StateOp))
 
@@ -278,9 +287,9 @@ class UpdateOp(IRDLOperation):
 
     name = "fsm.update"
 
-    variable = operand_def(Attribute)
+    variable: Operand = operand_def(Attribute)
 
-    value = operand_def(Attribute)
+    value: Operand = operand_def(Attribute)
 
     traits = traits_def(HasParent(TransitionOp))
 
@@ -323,10 +332,10 @@ class VariableOp(IRDLOperation):
 
     name = "fsm.variable"
 
-    initValue = attr_def()
-    name_var = opt_attr_def(StringAttr)
+    initValue: Attribute = attr_def()
+    name_var: StringAttr | None = opt_attr_def(StringAttr)
 
-    result = var_result_def(Attribute)
+    result: VarOpResult = var_result_def(Attribute)
 
     def __init__(
         self,
@@ -354,7 +363,7 @@ class ReturnOp(IRDLOperation):
 
     name = "fsm.return"
 
-    operand = opt_operand_def(signlessIntegerLike)
+    operand: OptOperand = opt_operand_def(signlessIntegerLike)
 
     traits = traits_def(IsTerminator(), HasParent(TransitionOp))
 
@@ -376,11 +385,11 @@ class InstanceOp(IRDLOperation):
 
     name = "fsm.instance"
 
-    sym_name = attr_def(SymbolNameConstraint())
+    sym_name: StringAttr = attr_def(SymbolNameConstraint())
 
-    machine = attr_def(FlatSymbolRefAttrConstr)
+    machine: SymbolRefAttr = attr_def(FlatSymbolRefAttrConstr)
 
-    res = result_def(InstanceType)
+    res: OpResult[InstanceType] = result_def(InstanceType)
 
     def __init__(
         self, sym_name: str, machine: FlatSymbolRefAttr, instance: InstanceType
@@ -415,11 +424,11 @@ class TriggerOp(IRDLOperation):
 
     name = "fsm.trigger"
 
-    inputs = var_operand_def()
+    inputs: VarOperand = var_operand_def()
 
-    instance = operand_def(InstanceType)
+    instance: Operand = operand_def(InstanceType)
 
-    outputs = var_result_def()
+    outputs: VarOpResult = var_result_def()
 
     def __init__(
         self,
@@ -465,13 +474,13 @@ class HWInstanceOp(IRDLOperation):
 
     name = "fsm.hw_instance"
 
-    sym_name = attr_def(SymbolNameConstraint())
-    machine = attr_def(FlatSymbolRefAttrConstr)
-    inputs = var_operand_def()
-    clock = operand_def(signlessIntegerLike)
-    reset = operand_def(signlessIntegerLike)
+    sym_name: StringAttr = attr_def(SymbolNameConstraint())
+    machine: SymbolRefAttr = attr_def(FlatSymbolRefAttrConstr)
+    inputs: VarOperand = var_operand_def()
+    clock: Operand = operand_def(signlessIntegerLike)
+    reset: Operand = operand_def(signlessIntegerLike)
 
-    outputs = var_result_def()
+    outputs: VarOpResult = var_result_def()
 
     def __init__(
         self,

--- a/xdsl/dialects/func.py
+++ b/xdsl/dialects/func.py
@@ -26,6 +26,8 @@ from xdsl.ir import (
 )
 from xdsl.irdl import (
     IRDLOperation,
+    VarOperand,
+    VarOpResult,
     irdl_op_definition,
     opt_prop_def,
     prop_def,
@@ -110,12 +112,16 @@ class CallOpSymbolUserOpInterface(SymbolUserOpInterface):
 class FuncOp(IRDLOperation):
     name = "func.func"
 
-    body = region_def()
-    sym_name = prop_def(SymbolNameConstraint())
-    function_type = prop_def(FunctionType)
-    sym_visibility = opt_prop_def(StringAttr)
-    arg_attrs = opt_prop_def(ArrayAttr[DictionaryAttr])
-    res_attrs = opt_prop_def(ArrayAttr[DictionaryAttr])
+    body: Region = region_def()
+    sym_name: StringAttr = prop_def(SymbolNameConstraint())
+    function_type: FunctionType = prop_def(FunctionType)
+    sym_visibility: StringAttr | None = opt_prop_def(StringAttr)
+    arg_attrs: ArrayAttr[DictionaryAttr] | None = opt_prop_def(
+        ArrayAttr[DictionaryAttr]
+    )
+    res_attrs: ArrayAttr[DictionaryAttr] | None = opt_prop_def(
+        ArrayAttr[DictionaryAttr]
+    )
 
     traits = traits_def(
         IsolatedFromAbove(), SymbolOpInterface(), FuncOpCallableInterface()
@@ -320,9 +326,9 @@ class FuncOp(IRDLOperation):
 @irdl_op_definition
 class CallOp(IRDLOperation):
     name = "func.call"
-    arguments = var_operand_def()
-    callee = prop_def(FlatSymbolRefAttrConstr)
-    res = var_result_def()
+    arguments: VarOperand = var_operand_def()
+    callee: SymbolRefAttr = prop_def(FlatSymbolRefAttrConstr)
+    res: VarOpResult = var_result_def()
 
     traits = traits_def(
         CallOpSymbolUserOpInterface(),
@@ -350,7 +356,7 @@ class CallOp(IRDLOperation):
 @irdl_op_definition
 class ReturnOp(IRDLOperation):
     name = "func.return"
-    arguments = var_operand_def()
+    arguments: VarOperand = var_operand_def()
 
     traits = traits_def(HasParent(FuncOp), IsTerminator(), ReturnLike())
 

--- a/xdsl/dialects/gpu.py
+++ b/xdsl/dialects/gpu.py
@@ -6,10 +6,12 @@ from enum import auto
 from xdsl.dialects import memref
 from xdsl.dialects.builtin import (
     DYNAMIC_INDEX,
+    I32,
     AffineMapAttr,
     DenseArrayBase,
     FunctionType,
     IndexType,
+    MemRefType,
     StringAttr,
     SymbolNameConstraint,
     SymbolRefAttr,
@@ -34,6 +36,11 @@ from xdsl.irdl import (
     AnyOf,
     AttrSizedOperandSegments,
     IRDLOperation,
+    Operand,
+    OpResult,
+    OptOperand,
+    OptOpResult,
+    VarOperand,
     attr_def,
     irdl_attr_definition,
     irdl_op_definition,
@@ -145,15 +152,15 @@ class LoopDimMapAttr(ParametrizedAttribute):
 @irdl_op_definition
 class AllocOp(IRDLOperation):
     name = "gpu.alloc"
-    hostShared = opt_attr_def(UnitAttr)
-    asyncDependencies = var_operand_def(AsyncTokenType)
-    dynamicSizes = var_operand_def(IndexType)
-    symbolOperands = var_operand_def(IndexType)
+    hostShared: UnitAttr | None = opt_attr_def(UnitAttr)
+    asyncDependencies: VarOperand = var_operand_def(AsyncTokenType)
+    dynamicSizes: VarOperand = var_operand_def(IndexType)
+    symbolOperands: VarOperand = var_operand_def(IndexType)
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
-    result = result_def(memref.MemRefType)
-    asyncToken = opt_result_def(AsyncTokenType)
+    result: OpResult[MemRefType] = result_def(memref.MemRefType)
+    asyncToken: OptOpResult[AsyncTokenType] = opt_result_def(AsyncTokenType)
 
     def verify_(self) -> None:
         ndyn = len(self.dynamicSizes)
@@ -194,11 +201,11 @@ class AllocOp(IRDLOperation):
 @irdl_op_definition
 class AllReduceOp(IRDLOperation):
     name = "gpu.all_reduce"
-    op = opt_prop_def(AllReduceOpAttr)
-    uniform = opt_prop_def(UnitAttr)
-    operand = operand_def(Attribute)
-    result = result_def(Attribute)
-    body = region_def()
+    op: AllReduceOpAttr | None = opt_prop_def(AllReduceOpAttr)
+    uniform: UnitAttr | None = opt_prop_def(UnitAttr)
+    operand: Operand = operand_def(Attribute)
+    result: OpResult = result_def(Attribute)
+    body: Region = region_def()
 
     traits = traits_def(IsolatedFromAbove())
 
@@ -269,8 +276,8 @@ class BarrierOp(IRDLOperation):
 @irdl_op_definition
 class BlockDimOp(IRDLOperation):
     name = "gpu.block_dim"
-    dimension = prop_def(DimensionAttr)
-    result = result_def(IndexType)
+    dimension: DimensionAttr = prop_def(DimensionAttr)
+    result: OpResult[IndexType] = result_def(IndexType)
 
     def __init__(self, dim: DimensionAttr):
         super().__init__(result_types=[IndexType()], properties={"dimension": dim})
@@ -279,8 +286,8 @@ class BlockDimOp(IRDLOperation):
 @irdl_op_definition
 class BlockIdOp(IRDLOperation):
     name = "gpu.block_id"
-    dimension = prop_def(DimensionAttr)
-    result = result_def(IndexType)
+    dimension: DimensionAttr = prop_def(DimensionAttr)
+    result: OpResult[IndexType] = result_def(IndexType)
 
     def __init__(self, dim: DimensionAttr):
         super().__init__(result_types=[IndexType()], properties={"dimension": dim})
@@ -290,12 +297,12 @@ class BlockIdOp(IRDLOperation):
 class DeallocOp(IRDLOperation):
     name = "gpu.dealloc"
 
-    asyncDependencies = var_operand_def(AsyncTokenType)
-    buffer = operand_def(memref.MemRefType)
+    asyncDependencies: VarOperand = var_operand_def(AsyncTokenType)
+    buffer: Operand = operand_def(memref.MemRefType)
 
     irdl_options = (AttrSizedOperandSegments(),)
 
-    asyncToken = opt_result_def(AsyncTokenType)
+    asyncToken: OptOpResult[AsyncTokenType] = opt_result_def(AsyncTokenType)
 
     def __init__(
         self,
@@ -313,13 +320,13 @@ class DeallocOp(IRDLOperation):
 class MemcpyOp(IRDLOperation):
     name = "gpu.memcpy"
 
-    asyncDependencies = var_operand_def(AsyncTokenType)
-    dst = operand_def(memref.MemRefType)
-    src = operand_def(memref.MemRefType)
+    asyncDependencies: VarOperand = var_operand_def(AsyncTokenType)
+    dst: Operand = operand_def(memref.MemRefType)
+    src: Operand = operand_def(memref.MemRefType)
 
     irdl_options = (AttrSizedOperandSegments(),)
 
-    asyncToken = opt_result_def(AsyncTokenType)
+    asyncToken: OptOpResult[AsyncTokenType] = opt_result_def(AsyncTokenType)
 
     def __init__(
         self,
@@ -345,8 +352,8 @@ class MemcpyOp(IRDLOperation):
 class ModuleOp(IRDLOperation):
     name = "gpu.module"
 
-    body = region_def("single_block")
-    sym_name = prop_def(SymbolNameConstraint())
+    body: Region = region_def("single_block")
+    sym_name: StringAttr = prop_def(SymbolNameConstraint())
 
     traits = traits_def(
         IsolatedFromAbove(),
@@ -363,14 +370,14 @@ class ModuleOp(IRDLOperation):
 class FuncOp(IRDLOperation):
     name = "gpu.func"
 
-    body = region_def()
-    sym_name = attr_def(SymbolNameConstraint())
-    function_type = prop_def(FunctionType)
-    kernel = opt_prop_def(UnitAttr)
-    known_block_size = opt_attr_def(
+    body: Region = region_def()
+    sym_name: StringAttr = attr_def(SymbolNameConstraint())
+    function_type: FunctionType = prop_def(FunctionType)
+    kernel: UnitAttr | None = opt_prop_def(UnitAttr)
+    known_block_size: DenseArrayBase[I32] | None = opt_attr_def(
         DenseArrayBase.constr(i32), attr_name="gpu.known_block_size"
     )
-    known_grid_size = opt_attr_def(
+    known_grid_size: DenseArrayBase[I32] | None = opt_attr_def(
         DenseArrayBase.constr(i32), attr_name="gpu.known_grid_size"
     )
 
@@ -422,8 +429,8 @@ class FuncOp(IRDLOperation):
 @irdl_op_definition
 class GlobalIdOp(IRDLOperation):
     name = "gpu.global_id"
-    dimension = prop_def(DimensionAttr)
-    result = result_def(IndexType)
+    dimension: DimensionAttr = prop_def(DimensionAttr)
+    result: OpResult[IndexType] = result_def(IndexType)
 
     def __init__(self, dim: DimensionAttr):
         super().__init__(result_types=[IndexType()], properties={"dimension": dim})
@@ -432,8 +439,8 @@ class GlobalIdOp(IRDLOperation):
 @irdl_op_definition
 class GridDimOp(IRDLOperation):
     name = "gpu.grid_dim"
-    dimension = prop_def(DimensionAttr)
-    result = result_def(IndexType)
+    dimension: DimensionAttr = prop_def(DimensionAttr)
+    result: OpResult[IndexType] = result_def(IndexType)
 
     def __init__(self, dim: DimensionAttr):
         super().__init__(result_types=[IndexType()], properties={"dimension": dim})
@@ -453,7 +460,7 @@ class HostRegisterOp(IRDLOperation):
 
     name = "gpu.host_register"
 
-    value = operand_def(memref.UnrankedMemRefType)
+    value: Operand = operand_def(memref.UnrankedMemRefType)
 
     def __init__(self, memref: SSAValue | Operation):
         super().__init__(operands=[SSAValue.get(memref)])
@@ -467,7 +474,7 @@ class HostUnregisterOp(IRDLOperation):
 
     name = "gpu.host_unregister"
 
-    value = operand_def(memref.UnrankedMemRefType)
+    value: Operand = operand_def(memref.UnrankedMemRefType)
 
     def __init__(self, memref: SSAValue | Operation):
         super().__init__(operands=[SSAValue.get(memref)])
@@ -476,7 +483,7 @@ class HostUnregisterOp(IRDLOperation):
 @irdl_op_definition
 class LaneIdOp(IRDLOperation):
     name = "gpu.lane_id"
-    result = result_def(IndexType)
+    result: OpResult[IndexType] = result_def(IndexType)
 
     def __init__(self):
         super().__init__(result_types=[IndexType()])
@@ -485,19 +492,19 @@ class LaneIdOp(IRDLOperation):
 @irdl_op_definition
 class LaunchOp(IRDLOperation):
     name = "gpu.launch"
-    asyncDependencies = var_operand_def(AsyncTokenType)
-    gridSizeX = operand_def(IndexType)
-    gridSizeY = operand_def(IndexType)
-    gridSizeZ = operand_def(IndexType)
-    blockSizeX = operand_def(IndexType)
-    blockSizeY = operand_def(IndexType)
-    blockSizeZ = operand_def(IndexType)
-    clusterSizeX = opt_operand_def(IndexType)
-    clusterSizeY = opt_operand_def(IndexType)
-    clusterSizeZ = opt_operand_def(IndexType)
-    dynamicSharedMemorySize = opt_operand_def(i32)
-    asyncToken = opt_result_def(AsyncTokenType)
-    body = region_def()
+    asyncDependencies: VarOperand = var_operand_def(AsyncTokenType)
+    gridSizeX: Operand = operand_def(IndexType)
+    gridSizeY: Operand = operand_def(IndexType)
+    gridSizeZ: Operand = operand_def(IndexType)
+    blockSizeX: Operand = operand_def(IndexType)
+    blockSizeY: Operand = operand_def(IndexType)
+    blockSizeZ: Operand = operand_def(IndexType)
+    clusterSizeX: OptOperand = opt_operand_def(IndexType)
+    clusterSizeY: OptOperand = opt_operand_def(IndexType)
+    clusterSizeZ: OptOperand = opt_operand_def(IndexType)
+    dynamicSharedMemorySize: OptOperand = opt_operand_def(i32)
+    asyncToken: OptOpResult[AsyncTokenType] = opt_result_def(AsyncTokenType)
+    body: Region = region_def()
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
     def __init__(
@@ -589,23 +596,23 @@ class LaunchFuncOp(IRDLOperation):
     """
 
     name = "gpu.launch_func"
-    asyncDependencies = var_operand_def(AsyncTokenType)
-    gridSizeX = operand_def(AnyOf.get(IndexType, i32, i64))
-    gridSizeY = operand_def(AnyOf.get(IndexType, i32, i64))
-    gridSizeZ = operand_def(AnyOf.get(IndexType, i32, i64))
-    blockSizeX = operand_def(AnyOf.get(IndexType, i32, i64))
-    blockSizeY = operand_def(AnyOf.get(IndexType, i32, i64))
-    blockSizeZ = operand_def(AnyOf.get(IndexType, i32, i64))
-    clusterSizeX = opt_operand_def(AnyOf.get(IndexType, i32, i64))
-    clusterSizeY = opt_operand_def(AnyOf.get(IndexType, i32, i64))
-    clusterSizeZ = opt_operand_def(AnyOf.get(IndexType, i32, i64))
-    dynamicSharedMemorySize = opt_operand_def(i32)
-    kernelOperands = var_operand_def()
-    asyncObject = opt_operand_def()
+    asyncDependencies: VarOperand = var_operand_def(AsyncTokenType)
+    gridSizeX: Operand = operand_def(AnyOf.get(IndexType, i32, i64))
+    gridSizeY: Operand = operand_def(AnyOf.get(IndexType, i32, i64))
+    gridSizeZ: Operand = operand_def(AnyOf.get(IndexType, i32, i64))
+    blockSizeX: Operand = operand_def(AnyOf.get(IndexType, i32, i64))
+    blockSizeY: Operand = operand_def(AnyOf.get(IndexType, i32, i64))
+    blockSizeZ: Operand = operand_def(AnyOf.get(IndexType, i32, i64))
+    clusterSizeX: OptOperand = opt_operand_def(AnyOf.get(IndexType, i32, i64))
+    clusterSizeY: OptOperand = opt_operand_def(AnyOf.get(IndexType, i32, i64))
+    clusterSizeZ: OptOperand = opt_operand_def(AnyOf.get(IndexType, i32, i64))
+    dynamicSharedMemorySize: OptOperand = opt_operand_def(i32)
+    kernelOperands: VarOperand = var_operand_def()
+    asyncObject: OptOperand = opt_operand_def()
 
-    asyncToken = opt_result_def(AsyncTokenType)
+    asyncToken: OptOpResult[AsyncTokenType] = opt_result_def(AsyncTokenType)
 
-    kernel = prop_def(SymbolRefAttr)
+    kernel: SymbolRefAttr = prop_def(SymbolRefAttr)
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
@@ -654,7 +661,7 @@ class LaunchFuncOp(IRDLOperation):
 @irdl_op_definition
 class NumSubgroupsOp(IRDLOperation):
     name = "gpu.num_subgroups"
-    result = result_def(IndexType)
+    result: OpResult[IndexType] = result_def(IndexType)
 
     def __init__(self):
         super().__init__(result_types=[IndexType()])
@@ -664,7 +671,7 @@ class NumSubgroupsOp(IRDLOperation):
 class ReturnOp(IRDLOperation):
     name = "gpu.return"
 
-    args = var_operand_def()
+    args: VarOperand = var_operand_def()
 
     traits = traits_def(IsTerminator(), HasParent(FuncOp))
 
@@ -675,7 +682,7 @@ class ReturnOp(IRDLOperation):
 @irdl_op_definition
 class SetDefaultDeviceOp(IRDLOperation):
     name = "gpu.set_default_device"
-    devIndex = operand_def(i32)
+    devIndex: Operand = operand_def(i32)
 
     def __init__(self, devIndex: SSAValue | Operation):
         super().__init__(operands=[SSAValue.get(devIndex)])
@@ -684,7 +691,7 @@ class SetDefaultDeviceOp(IRDLOperation):
 @irdl_op_definition
 class SubgroupIdOp(IRDLOperation):
     name = "gpu.subgroup_id"
-    result = result_def(IndexType)
+    result: OpResult[IndexType] = result_def(IndexType)
 
     def __init__(self):
         super().__init__(result_types=[IndexType()])
@@ -693,7 +700,7 @@ class SubgroupIdOp(IRDLOperation):
 @irdl_op_definition
 class SubgroupSizeOp(IRDLOperation):
     name = "gpu.subgroup_size"
-    result = result_def(IndexType)
+    result: OpResult[IndexType] = result_def(IndexType)
 
     def __init__(self):
         super().__init__(result_types=[IndexType()])
@@ -712,8 +719,8 @@ class TerminatorOp(IRDLOperation):
 @irdl_op_definition
 class ThreadIdOp(IRDLOperation):
     name = "gpu.thread_id"
-    dimension = prop_def(DimensionAttr)
-    result = result_def(IndexType)
+    dimension: DimensionAttr = prop_def(DimensionAttr)
+    result: OpResult[IndexType] = result_def(IndexType)
 
     def __init__(self, dim: DimensionAttr):
         super().__init__(result_types=[IndexType()], properties={"dimension": dim})
@@ -722,8 +729,8 @@ class ThreadIdOp(IRDLOperation):
 @irdl_op_definition
 class WaitOp(IRDLOperation):
     name = "gpu.wait"
-    asyncDependencies = var_operand_def(AsyncTokenType)
-    asyncToken = opt_result_def(AsyncTokenType)
+    asyncDependencies: VarOperand = var_operand_def(AsyncTokenType)
+    asyncToken: OptOpResult[AsyncTokenType] = opt_result_def(AsyncTokenType)
 
     def __init__(
         self,
@@ -738,7 +745,7 @@ class WaitOp(IRDLOperation):
 @irdl_op_definition
 class YieldOp(IRDLOperation):
     name = "gpu.yield"
-    values = var_operand_def(Attribute)
+    values: VarOperand = var_operand_def(Attribute)
 
     def __init__(self, operands: Sequence[SSAValue | Operation]):
         super().__init__(operands=[operands])

--- a/xdsl/dialects/hw.py
+++ b/xdsl/dialects/hw.py
@@ -48,8 +48,12 @@ from xdsl.irdl import (
     AnyAttr,
     AtLeast,
     IRDLOperation,
+    Operand,
+    OpResult,
     RangeOf,
     VarConstraint,
+    VarOperand,
+    VarOpResult,
     attr_def,
     irdl_attr_definition,
     irdl_op_definition,
@@ -906,12 +910,12 @@ class HWModuleOp(IRDLOperation):
 
     name = "hw.module"
 
-    sym_name = attr_def(SymbolNameConstraint())
-    module_type = attr_def(ModuleType)
-    sym_visibility = opt_attr_def(StringAttr)
-    parameters = opt_attr_def(ArrayAttr[ParamDeclAttr])
+    sym_name: StringAttr = attr_def(SymbolNameConstraint())
+    module_type: ModuleType = attr_def(ModuleType)
+    sym_visibility: StringAttr | None = opt_attr_def(StringAttr)
+    parameters: ArrayAttr[ParamDeclAttr] | None = opt_attr_def(ArrayAttr[ParamDeclAttr])
 
-    body = region_def("single_block")
+    body: Region = region_def("single_block")
 
     traits = lazy_traits_def(
         lambda: (
@@ -1023,11 +1027,11 @@ class HWModuleExternOp(IRDLOperation):
 
     name = "hw.module.extern"
 
-    sym_name = attr_def(SymbolNameConstraint())
-    module_type = attr_def(ModuleType)
-    sym_visibility = opt_attr_def(StringAttr)
-    parameters = opt_attr_def(ArrayAttr[ParamDeclAttr])
-    verilog_name = opt_attr_def(StringAttr, attr_name="verilogName")
+    sym_name: StringAttr = attr_def(SymbolNameConstraint())
+    module_type: ModuleType = attr_def(ModuleType)
+    sym_visibility: StringAttr | None = opt_attr_def(StringAttr)
+    parameters: ArrayAttr[ParamDeclAttr] | None = opt_attr_def(ArrayAttr[ParamDeclAttr])
+    verilog_name: StringAttr | None = opt_attr_def(StringAttr, attr_name="verilogName")
 
     traits = lazy_traits_def(
         lambda: (
@@ -1108,13 +1112,19 @@ class InstanceOp(IRDLOperation):
 
     name = "hw.instance"
 
-    instance_name = attr_def(StringAttr, attr_name="instanceName")
-    module_name = attr_def(FlatSymbolRefAttrConstr, attr_name="moduleName")
-    inputs = var_operand_def()
-    outputs = var_result_def()
-    arg_names = attr_def(ArrayAttr[StringAttr], attr_name="argNames")
-    result_names = attr_def(ArrayAttr[StringAttr], attr_name="resultNames")
-    inner_sym = opt_attr_def(InnerSymAttr)
+    instance_name: StringAttr = attr_def(StringAttr, attr_name="instanceName")
+    module_name: SymbolRefAttr = attr_def(
+        FlatSymbolRefAttrConstr, attr_name="moduleName"
+    )
+    inputs: VarOperand = var_operand_def()
+    outputs: VarOpResult = var_result_def()
+    arg_names: ArrayAttr[StringAttr] = attr_def(
+        ArrayAttr[StringAttr], attr_name="argNames"
+    )
+    result_names: ArrayAttr[StringAttr] = attr_def(
+        ArrayAttr[StringAttr], attr_name="resultNames"
+    )
+    inner_sym: InnerSymAttr | None = opt_attr_def(InnerSymAttr)
 
     def __init__(
         self,
@@ -1329,7 +1339,7 @@ class InstanceOp(IRDLOperation):
 class OutputOp(IRDLOperation):
     name = "hw.output"
 
-    inputs = var_operand_def()
+    inputs: VarOperand = var_operand_def()
 
     traits = traits_def(IsTerminator(), HasParent(HWModuleOp))
 
@@ -1392,8 +1402,8 @@ class ArrayCreateOp(IRDLOperation):
     I: ClassVar = VarConstraint("I", AnyAttr())  # Constrain all types to be equal
 
     name = "hw.array_create"
-    inputs = var_operand_def(RangeOf(I).of_length(AtLeast(1)))
-    result = result_def(ArrayType)
+    inputs: VarOperand = var_operand_def(RangeOf(I).of_length(AtLeast(1)))
+    result: OpResult[ArrayType[Attribute]] = result_def(ArrayType)
 
     def __init__(
         self, first_input: Operation | SSAValue, *other_inputs: Operation | SSAValue
@@ -1432,9 +1442,11 @@ class ArrayGetOp(IRDLOperation):
     """
 
     name = "hw.array_get"
-    input = operand_def(ArrayType)
-    index = operand_def(IntegerType)
-    result = result_def(IntegerType | ArrayType)
+    input: Operand = operand_def(ArrayType)
+    index: Operand = operand_def(IntegerType)
+    result: OpResult[IntegerType | ArrayType[Attribute]] = result_def(
+        IntegerType | ArrayType
+    )
 
     def __init__(self, input: Operation | SSAValue, index: Operation | SSAValue):
         typ = SSAValue.get(input, type=ArrayType).type
@@ -1482,8 +1494,8 @@ class ArrayGetOp(IRDLOperation):
 class BitcastOp(IRDLOperation):
     name = "hw.bitcast"
 
-    input = operand_def()
-    result = result_def()
+    input: Operand = operand_def()
+    result: OpResult = result_def()
 
     assembly_format = "$input attr-dict `:` functional-type($input, $result)"
 
@@ -1498,8 +1510,8 @@ class BitcastOp(IRDLOperation):
 class ConstantOp(IRDLOperation, HasFolderInterface):
     name = "hw.constant"
     _T: ClassVar = VarConstraint("T", AnyAttr())
-    result = result_def(_T)
-    value = prop_def(IntegerAttr.constr((SignlessIntegerConstraint) & _T))
+    result: OpResult = result_def(_T)
+    value: IntegerAttr = prop_def(IntegerAttr.constr((SignlessIntegerConstraint) & _T))
 
     assembly_format = "attr-dict $value"
 

--- a/xdsl/dialects/irdl/irdl.py
+++ b/xdsl/dialects/irdl/irdl.py
@@ -28,6 +28,8 @@ from xdsl.ir import (
 )
 from xdsl.irdl import (
     IRDLOperation,
+    OpResult,
+    VarOperand,
     irdl_attr_definition,
     irdl_op_definition,
     opt_prop_def,
@@ -113,7 +115,7 @@ class DialectOp(IRDLOperation):
     name = "irdl.dialect"
 
     sym_name = prop_def(SymbolNameConstraint())
-    body = region_def("single_block")
+    body: Region = region_def("single_block")
 
     traits = traits_def(NoTerminator(), SymbolOpInterface(), SymbolTable())
 
@@ -144,8 +146,8 @@ class TypeOp(IRDLOperation):
 
     name = "irdl.type"
 
-    sym_name = prop_def(SymbolNameConstraint())
-    body = region_def("single_block")
+    sym_name: StringAttr = prop_def(SymbolNameConstraint())
+    body: Region = region_def("single_block")
 
     traits = traits_def(NoTerminator(), HasParent(DialectOp), SymbolOpInterface())
 
@@ -183,9 +185,9 @@ class CPredOp(IRDLOperation):
 
     name = "irdl.c_pred"
 
-    pred = prop_def(StringAttr)
+    pred: StringAttr = prop_def(StringAttr)
 
-    output = result_def(AttributeType())
+    output: OpResult[AttributeType] = result_def(AttributeType())
 
     assembly_format = "$pred attr-dict"
 
@@ -201,8 +203,8 @@ class AttributeOp(IRDLOperation):
 
     name = "irdl.attribute"
 
-    sym_name = prop_def(SymbolNameConstraint())
-    body = region_def("single_block")
+    sym_name: StringAttr = prop_def(SymbolNameConstraint())
+    body: Region = region_def("single_block")
 
     traits = traits_def(NoTerminator(), HasParent(DialectOp), SymbolOpInterface())
 
@@ -255,9 +257,9 @@ class ParametersOp(IRDLOperation):
 
     name = "irdl.parameters"
 
-    args = var_operand_def(AttributeType)
+    args: VarOperand = var_operand_def(AttributeType)
 
-    names = prop_def(ArrayAttr[StringAttr])
+    names: ArrayAttr[StringAttr] = prop_def(ArrayAttr[StringAttr])
 
     traits = traits_def(HasParent(TypeOp, AttributeOp))
 
@@ -287,8 +289,8 @@ class OperationOp(IRDLOperation):
 
     name = "irdl.operation"
 
-    sym_name = prop_def(SymbolNameConstraint())
-    body = region_def("single_block")
+    sym_name: StringAttr = prop_def(SymbolNameConstraint())
+    body: Region = region_def("single_block")
 
     traits = traits_def(NoTerminator(), HasParent(DialectOp), SymbolOpInterface())
 
@@ -362,11 +364,11 @@ class OperandsOp(IRDLOperation):
 
     name = "irdl.operands"
 
-    args = var_operand_def(AttributeType)
+    args: VarOperand = var_operand_def(AttributeType)
 
-    variadicity = prop_def(VariadicityArrayAttr)
+    variadicity: VariadicityArrayAttr = prop_def(VariadicityArrayAttr)
 
-    names = prop_def(ArrayAttr[StringAttr])
+    names: ArrayAttr[StringAttr] = prop_def(ArrayAttr[StringAttr])
 
     traits = traits_def(HasParent(OperationOp))
 
@@ -408,11 +410,11 @@ class ResultsOp(IRDLOperation):
 
     name = "irdl.results"
 
-    args = var_operand_def(AttributeType)
+    args: VarOperand = var_operand_def(AttributeType)
 
-    variadicity = prop_def(VariadicityArrayAttr)
+    variadicity: VariadicityArrayAttr = prop_def(VariadicityArrayAttr)
 
-    names = prop_def(ArrayAttr[StringAttr])
+    names: ArrayAttr[StringAttr] = prop_def(ArrayAttr[StringAttr])
 
     traits = traits_def(HasParent(OperationOp))
 
@@ -468,9 +470,9 @@ class AttributesOp(IRDLOperation):
 
     name = "irdl.attributes"
 
-    attribute_values = var_operand_def(AttributeType())
+    attribute_values: VarOperand = var_operand_def(AttributeType())
 
-    attribute_value_names = prop_def(ArrayAttr[StringAttr])
+    attribute_value_names: ArrayAttr[StringAttr] = prop_def(ArrayAttr[StringAttr])
 
     def __init__(
         self,
@@ -525,9 +527,9 @@ class RegionsOp(IRDLOperation):
 
     name = "irdl.regions"
 
-    args = var_operand_def(RegionType())
+    args: VarOperand = var_operand_def(RegionType())
 
-    names = prop_def(ArrayAttr[StringAttr])
+    names: ArrayAttr[StringAttr] = prop_def(ArrayAttr[StringAttr])
 
     def __init__(self, args: Sequence[SSAValue], names: ArrayAttr[StringAttr]):
         super().__init__(operands=[args], properties={"names": names})
@@ -560,8 +562,8 @@ class IsOp(IRDLOperation):
 
     name = "irdl.is"
 
-    expected = prop_def()
-    output = result_def(AttributeType)
+    expected: Attribute = prop_def()
+    output: OpResult[AttributeType] = result_def(AttributeType)
 
     def __init__(self, expected: Attribute):
         super().__init__(
@@ -584,9 +586,9 @@ class BaseOp(IRDLOperation):
 
     name = "irdl.base"
 
-    base_ref = opt_prop_def(SymbolRefAttr)
-    base_name = opt_prop_def(StringAttr)
-    output = result_def(AttributeType)
+    base_ref: SymbolRefAttr | None = opt_prop_def(SymbolRefAttr)
+    base_name: StringAttr | None = opt_prop_def(StringAttr)
+    output: OpResult[AttributeType] = result_def(AttributeType)
 
     def __init__(
         self,
@@ -637,9 +639,9 @@ class ParametricOp(IRDLOperation):
 
     name = "irdl.parametric"
 
-    base_type = prop_def(SymbolRefAttr)
-    args = var_operand_def(AttributeType)
-    output = result_def(AttributeType)
+    base_type: SymbolRefAttr = prop_def(SymbolRefAttr)
+    args: VarOperand = var_operand_def(AttributeType)
+    output: OpResult[AttributeType] = result_def(AttributeType)
 
     def __init__(
         self, base_type: str | StringAttr | SymbolRefAttr, args: Sequence[SSAValue]
@@ -675,13 +677,13 @@ class RegionOp(IRDLOperation):
 
     name = "irdl.region"
 
-    entry_block_args = var_operand_def(AttributeType())
+    entry_block_args: VarOperand = var_operand_def(AttributeType())
 
-    constrained_arguments = opt_prop_def(UnitAttr)
+    constrained_arguments: UnitAttr | None = opt_prop_def(UnitAttr)
 
-    number_of_blocks = opt_prop_def(IntegerAttr[I32])
+    number_of_blocks: IntegerAttr[I32] | None = opt_prop_def(IntegerAttr[I32])
 
-    output = result_def(RegionType())
+    output: OpResult[RegionType] = result_def(RegionType())
 
     assembly_format = (
         "(```(` $entry_block_args $constrained_arguments^ `)`)?"
@@ -714,7 +716,7 @@ class AnyOp(IRDLOperation):
 
     name = "irdl.any"
 
-    output = result_def(AttributeType)
+    output: OpResult[AttributeType] = result_def(AttributeType)
 
     def __init__(self):
         super().__init__(result_types=[AttributeType()])
@@ -733,8 +735,8 @@ class AnyOfOp(IRDLOperation):
 
     name = "irdl.any_of"
 
-    args = var_operand_def(AttributeType)
-    output = result_def(AttributeType)
+    args: VarOperand = var_operand_def(AttributeType)
+    output: OpResult[AttributeType] = result_def(AttributeType)
 
     def __init__(self, args: Sequence[SSAValue]):
         super().__init__(operands=[args], result_types=[AttributeType()])
@@ -757,8 +759,8 @@ class AllOfOp(IRDLOperation):
 
     name = "irdl.all_of"
 
-    args = var_operand_def(AttributeType)
-    output = result_def(AttributeType)
+    args: VarOperand = var_operand_def(AttributeType)
+    output: OpResult[AttributeType] = result_def(AttributeType)
 
     def __init__(self, args: Sequence[SSAValue]):
         super().__init__(operands=[args], result_types=[AttributeType()])

--- a/xdsl/dialects/linalg/abstract_ops.py
+++ b/xdsl/dialects/linalg/abstract_ops.py
@@ -22,6 +22,8 @@ from xdsl.irdl import (
     AttrSizedOperandSegments,
     IRDLOperation,
     ParsePropInAttrDict,
+    VarOperand,
+    VarOpResult,
     prop_def,
     region_def,
     var_operand_def,
@@ -53,22 +55,22 @@ class LinalgStructuredOperation(IRDLOperation, ABC):
     via a unified interface.
     """
 
-    inputs = var_operand_def()
+    inputs: VarOperand = var_operand_def()
     """
     The operands that won't be mutated.
     """
-    outputs = var_operand_def(ShapedType)
+    outputs: VarOperand = var_operand_def(ShapedType)
     """
     The operands that will be accumulated into.
     These inputs may be `memref`s, which will be mutated in-place, or `tensor`s, which will be returned as results.
     """
 
-    res = var_result_def(TensorType)
+    res: VarOpResult[TensorType] = var_result_def(TensorType)
     """
     The updated `outputs`, empty if the inputs are memrefs.
     """
 
-    body = region_def("single_block")
+    body: Region = region_def("single_block")
     """
     The body implementing the combination of scalar elements of the inputs, and
     yielding the scalar elements of the outputs.
@@ -383,8 +385,8 @@ class PoolingOperation(NamedOperation, ABC):
 
     PRINT_ATTRS_IN_FRONT: ClassVar[bool] = True
 
-    strides = prop_def(DenseIntElementsAttr)
-    dilations = prop_def(DenseIntElementsAttr)
+    strides: DenseIntElementsAttr = prop_def(DenseIntElementsAttr)
+    dilations: DenseIntElementsAttr = prop_def(DenseIntElementsAttr)
 
     def __init__(
         self,
@@ -417,8 +419,8 @@ class ConvOperation(NamedOperation, ABC):
 
     PRINT_ATTRS_IN_FRONT: ClassVar[bool] = True
 
-    strides = prop_def(DenseIntElementsAttr)
-    dilations = prop_def(DenseIntElementsAttr)
+    strides: DenseIntElementsAttr = prop_def(DenseIntElementsAttr)
+    dilations: DenseIntElementsAttr = prop_def(DenseIntElementsAttr)
 
     def __init__(
         self,

--- a/xdsl/dialects/linalg/ops.py
+++ b/xdsl/dialects/linalg/ops.py
@@ -8,6 +8,7 @@ from typing_extensions import Self
 from xdsl.builder import Builder
 from xdsl.dialects import arith, math
 from xdsl.dialects.builtin import (
+    I64,
     AffineMapAttr,
     AnyFloat,
     AnyTensorType,
@@ -35,8 +36,12 @@ from xdsl.ir.affine import AffineDimExpr, AffineMap
 from xdsl.irdl import (
     AttrSizedOperandSegments,
     IRDLOperation,
+    Operand,
+    OpResult,
     ParsePropInAttrDict,
     SameVariadicOperandSize,
+    VarOperand,
+    VarOpResult,
     attr_def,
     base,
     irdl_op_definition,
@@ -70,10 +75,10 @@ class GenericOp(LinalgStructuredOperation):
     name = "linalg.generic"
 
     # Trait attributes
-    indexing_maps = prop_def(ArrayAttr[AffineMapAttr])
-    iterator_types = prop_def(ArrayAttr[IteratorTypeAttr])
-    doc = opt_prop_def(StringAttr)
-    library_call = opt_prop_def(StringAttr)
+    indexing_maps: ArrayAttr[AffineMapAttr] = prop_def(ArrayAttr[AffineMapAttr])
+    iterator_types: ArrayAttr[IteratorTypeAttr] = prop_def(ArrayAttr[IteratorTypeAttr])
+    doc: StringAttr | None = opt_prop_def(StringAttr)
+    library_call: StringAttr | None = opt_prop_def(StringAttr)
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
@@ -300,9 +305,9 @@ class YieldOp(AbstractYieldOperation[Attribute]):
 class IndexOp(IRDLOperation):
     name = "linalg.index"
 
-    dim = prop_def(IntegerAttr[i64])
+    dim: IntegerAttr[I64] = prop_def(IntegerAttr[i64])
 
-    result = result_def(IndexTypeConstr)
+    result: OpResult[IndexType] = result_def(IndexTypeConstr)
 
     traits = traits_def(HasParent(GenericOp))
 
@@ -854,15 +859,15 @@ class TransposeOp(LinalgStructuredOperation):
 
     name = "linalg.transpose"
 
-    inputs = var_operand_def(base(MemRefType) | base(AnyTensorType))
-    outputs = var_operand_def(base(MemRefType) | base(AnyTensorType))
-    res = var_result_def(AnyTensorType)
+    inputs: VarOperand = var_operand_def(base(MemRefType) | base(AnyTensorType))
+    outputs: VarOperand = var_operand_def(base(MemRefType) | base(AnyTensorType))
+    res: VarOpResult[AnyTensorType] = var_result_def(AnyTensorType)
 
-    body = region_def("single_block")
+    body: Region = region_def("single_block")
 
     irdl_options = (SameVariadicOperandSize(), ParsePropInAttrDict())
 
-    permutation = prop_def(DenseArrayBase.constr(i64))
+    permutation: DenseArrayBase[I64] = prop_def(DenseArrayBase.constr(i64))
 
     def __init__(
         self,
@@ -1003,7 +1008,7 @@ class MatmulOp(NamedOperation):
 
     PRINT_ATTRS_IN_FRONT: ClassVar[bool] = True
 
-    indexing_maps = prop_def(
+    indexing_maps: ArrayAttr[AffineMapAttr] = prop_def(
         ArrayAttr[AffineMapAttr],
         default_value=ArrayAttr(
             [
@@ -1085,7 +1090,7 @@ class QuantizedMatmulOp(NamedOperation):
 
     PRINT_ATTRS_IN_FRONT: ClassVar[bool] = True
 
-    memoized_indexing_maps = attr_def(
+    memoized_indexing_maps: ArrayAttr[AffineMapAttr] = attr_def(
         ArrayAttr[AffineMapAttr],
         default_value=ArrayAttr(
             [
@@ -1230,13 +1235,13 @@ class BroadcastOp(IRDLOperation):
 
     name = "linalg.broadcast"
 
-    input = operand_def(base(MemRefType) | base(AnyTensorType))
-    init = operand_def(base(MemRefType) | base(AnyTensorType))
-    result = var_result_def(AnyTensorType)
+    input: Operand = operand_def(base(MemRefType) | base(AnyTensorType))
+    init: Operand = operand_def(base(MemRefType) | base(AnyTensorType))
+    result: VarOpResult[AnyTensorType] = var_result_def(AnyTensorType)
 
-    hidden_region = region_def("single_block")
+    hidden_region: Region = region_def("single_block")
 
-    dimensions = prop_def(DenseArrayBase.constr(i64))
+    dimensions: DenseArrayBase[I64] = prop_def(DenseArrayBase.constr(i64))
 
     def __init__(
         self,
@@ -1351,13 +1356,13 @@ class BroadcastOp(IRDLOperation):
 class ReduceOp(IRDLOperation):
     name = "linalg.reduce"
 
-    input = operand_def(base(MemRefType) | base(AnyTensorType))
-    init = operand_def(base(MemRefType) | base(AnyTensorType))
-    result = var_result_def(AnyTensorType)
+    input: Operand = operand_def(base(MemRefType) | base(AnyTensorType))
+    init: Operand = operand_def(base(MemRefType) | base(AnyTensorType))
+    result: VarOpResult[AnyTensorType] = var_result_def(AnyTensorType)
 
     region: Region = region_def("single_block")
 
-    dimensions = prop_def(DenseArrayBase.constr(i64))
+    dimensions: DenseArrayBase[I64] = prop_def(DenseArrayBase.constr(i64))
 
     def __init__(
         self,

--- a/xdsl/dialects/linalg/transforms/tiling.py
+++ b/xdsl/dialects/linalg/transforms/tiling.py
@@ -8,7 +8,7 @@ from xdsl.dialects.builtin import (
     IntegerAttr,
     MemRefType,
 )
-from xdsl.ir import Attribute, Block, Region, SSAValue
+from xdsl.ir import Block, Region, SSAValue
 from xdsl.ir.affine import AffineDimExpr, AffineMap
 from xdsl.pattern_rewriter import PatternRewriter
 from xdsl.rewriter import InsertPoint
@@ -25,14 +25,14 @@ class OperandTileInfo:
     - `result_shape` the shape that tiled subview should have.
     """
 
-    source_type: MemRefType[Attribute]
+    source_type: MemRefType
     loop_dims: tuple[int, ...]
     result_shape: tuple[int, ...]
 
     @staticmethod
     def analyze(
         indexing_map: AffineMap,
-        source_type: MemRefType[Attribute],
+        source_type: MemRefType,
         tile_sizes: Sequence[int],
     ) -> "OperandTileInfo":
         """

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -13,7 +13,9 @@ from xdsl.dialects.builtin import (
     I1,
     I32,
     I64,
+    AnyFloat,
     AnyFloatConstr,
+    AnySignlessIntegerType,
     ArrayAttr,
     BFloat16Type,
     DenseArrayBase,
@@ -70,9 +72,15 @@ from xdsl.irdl import (
     EqIntConstraint,
     IntConstraint,
     IRDLOperation,
+    Operand,
+    OpResult,
+    OptOperand,
+    OptOpResult,
     ParsePropInAttrDict,
     RangeOf,
+    Successor,
     VarConstraint,
+    VarOperand,
     base,
     irdl_attr_definition,
     irdl_op_definition,
@@ -419,9 +427,11 @@ class ArithmeticBinOperation(IRDLOperation, ABC):
         "T", SignlessIntegerConstraint | VectorType.constr(SignlessIntegerConstraint)
     )
 
-    lhs = operand_def(T)
-    rhs = operand_def(T)
-    res = result_def(T)
+    lhs: Operand = operand_def(T)
+    rhs: Operand = operand_def(T)
+    res: OpResult[AnySignlessIntegerType | VectorType[AnySignlessIntegerType]] = (
+        result_def(T)
+    )
 
     traits = traits_def(NoMemoryEffect())
 
@@ -515,10 +525,12 @@ class ArithmeticBinOpOverflow(IRDLOperation, ABC):
         "T", SignlessIntegerConstraint | VectorType.constr(SignlessIntegerConstraint)
     )
 
-    lhs = operand_def(T)
-    rhs = operand_def(T)
-    res = result_def(T)
-    overflowFlags = opt_prop_def(IntegerAttr[I32])
+    lhs: Operand = operand_def(T)
+    rhs: Operand = operand_def(T)
+    res: OpResult[AnySignlessIntegerType | VectorType[AnySignlessIntegerType]] = (
+        result_def(T)
+    )
+    overflowFlags: IntegerAttr[I32] | None = opt_prop_def(IntegerAttr[I32])
 
     traits = traits_def(NoMemoryEffect())
 
@@ -571,10 +583,12 @@ class ArithmeticBinOpExact(IRDLOperation, ABC):
         "T", SignlessIntegerConstraint | VectorType.constr(SignlessIntegerConstraint)
     )
 
-    lhs = operand_def(T)
-    rhs = operand_def(T)
-    res = result_def(T)
-    is_exact = opt_prop_def(UnitAttr, prop_name="isExact")
+    lhs: Operand = operand_def(T)
+    rhs: Operand = operand_def(T)
+    res: OpResult[AnySignlessIntegerType | VectorType[AnySignlessIntegerType]] = (
+        result_def(T)
+    )
+    is_exact: UnitAttr | None = opt_prop_def(UnitAttr, prop_name="isExact")
 
     traits = traits_def(NoMemoryEffect())
 
@@ -633,10 +647,12 @@ class ArithmeticBinOpDisjoint(IRDLOperation, ABC):
         "T", SignlessIntegerConstraint | VectorType.constr(SignlessIntegerConstraint)
     )
 
-    lhs = operand_def(T)
-    rhs = operand_def(T)
-    res = result_def(T)
-    is_disjoint = opt_prop_def(UnitAttr, prop_name="isDisjoint")
+    lhs: Operand = operand_def(T)
+    rhs: Operand = operand_def(T)
+    res: OpResult[AnySignlessIntegerType | VectorType[AnySignlessIntegerType]] = (
+        result_def(T)
+    )
+    is_disjoint: UnitAttr | None = opt_prop_def(UnitAttr, prop_name="isDisjoint")
 
     traits = traits_def(NoMemoryEffect())
 
@@ -662,12 +678,14 @@ class ArithmeticBinOpDisjoint(IRDLOperation, ABC):
 
 
 class IntegerConversionOp(IRDLOperation, ABC):
-    arg = operand_def(
+    arg: Operand = operand_def(
         SignlessIntegerConstraint | VectorType.constr(SignlessIntegerConstraint)
     )
 
-    res = result_def(
-        SignlessIntegerConstraint | VectorType.constr(SignlessIntegerConstraint)
+    res: OpResult[AnySignlessIntegerType | VectorType[AnySignlessIntegerType]] = (
+        result_def(
+            SignlessIntegerConstraint | VectorType.constr(SignlessIntegerConstraint)
+        )
     )
 
     traits = traits_def(NoMemoryEffect())
@@ -702,14 +720,16 @@ class IntegerConversionOp(IRDLOperation, ABC):
 
 
 class IntegerConversionOpNNeg(IRDLOperation, ABC):
-    arg = operand_def(
+    arg: Operand = operand_def(
         SignlessIntegerConstraint | VectorType.constr(SignlessIntegerConstraint)
     )
-    res = result_def(
-        SignlessIntegerConstraint | VectorType.constr(SignlessIntegerConstraint)
+    res: OpResult[AnySignlessIntegerType | VectorType[AnySignlessIntegerType]] = (
+        result_def(
+            SignlessIntegerConstraint | VectorType.constr(SignlessIntegerConstraint)
+        )
     )
     traits = traits_def(NoMemoryEffect())
-    non_neg = opt_prop_def(UnitAttr, prop_name="nonNeg")
+    non_neg: UnitAttr | None = opt_prop_def(UnitAttr, prop_name="nonNeg")
 
     assembly_format = "(`nneg` $nonNeg^)? $arg attr-dict `:` type($arg) `to` type($res)"
 
@@ -731,13 +751,15 @@ class IntegerConversionOpNNeg(IRDLOperation, ABC):
 
 
 class IntegerConversionOpOverflow(IRDLOperation, ABC):
-    arg = operand_def(
+    arg: Operand = operand_def(
         SignlessIntegerConstraint | VectorType.constr(SignlessIntegerConstraint)
     )
-    res = result_def(
-        SignlessIntegerConstraint | VectorType.constr(SignlessIntegerConstraint)
+    res: OpResult[AnySignlessIntegerType | VectorType[AnySignlessIntegerType]] = (
+        result_def(
+            SignlessIntegerConstraint | VectorType.constr(SignlessIntegerConstraint)
+        )
     )
-    overflowFlags = opt_prop_def(OverflowAttr)
+    overflowFlags: OverflowAttr | None = opt_prop_def(OverflowAttr)
     traits = traits_def(NoMemoryEffect())
 
     def __init__(
@@ -940,10 +962,10 @@ class ICmpOp(IRDLOperation):
         "T", SignlessIntegerConstraint | VectorType.constr(SignlessIntegerConstraint)
     )
 
-    lhs = operand_def(T)
-    rhs = operand_def(T)
-    res = result_def(I1 | VectorType[I1])
-    predicate = prop_def(IntegerAttr[i64])
+    lhs: Operand = operand_def(T)
+    rhs: Operand = operand_def(T)
+    res: OpResult[I1 | VectorType[I1]] = result_def(I1 | VectorType[I1])
+    predicate: IntegerAttr[I64] = prop_def(IntegerAttr[i64])
 
     traits = traits_def(NoMemoryEffect())
 
@@ -1119,15 +1141,15 @@ class GEPOp(IRDLOperation):
 
     name = "llvm.getelementptr"
 
-    ptr = operand_def(LLVMPointerType)
-    ssa_indices = var_operand_def(IntegerType)
-    elem_type = prop_def()
-    noWrapFlags = prop_def(IntegerAttr[I32])
+    ptr: Operand = operand_def(LLVMPointerType)
+    ssa_indices: VarOperand = var_operand_def(IntegerType)
+    elem_type: Attribute = prop_def()
+    noWrapFlags: IntegerAttr[I32] = prop_def(IntegerAttr[I32])
 
-    result = result_def(LLVMPointerType)
+    result: OpResult[LLVMPointerType] = result_def(LLVMPointerType)
 
-    rawConstantIndices = prop_def(DenseArrayBase.constr(i32))
-    inbounds = opt_prop_def(UnitAttr)
+    rawConstantIndices: DenseArrayBase[I32] = prop_def(DenseArrayBase.constr(i32))
+    inbounds: UnitAttr | None = opt_prop_def(UnitAttr)
 
     traits = traits_def(NoMemoryEffect())
 
@@ -1274,12 +1296,12 @@ class GEPOp(IRDLOperation):
 class AllocaOp(IRDLOperation):
     name = "llvm.alloca"
 
-    size = operand_def(IntegerType)
+    size: Operand = operand_def(IntegerType)
 
-    alignment = opt_prop_def(IntegerAttr)
-    elem_type = prop_def()
+    alignment: IntegerAttr | None = opt_prop_def(IntegerAttr)
+    elem_type: Attribute = prop_def()
 
-    res = result_def()
+    res: OpResult = result_def()
 
     def __init__(
         self,
@@ -1330,9 +1352,9 @@ class IntToPtrOp(IRDLOperation):
 
     assembly_format = "$input attr-dict `:` type($input) `to` type($output)"
 
-    input = operand_def(IntegerType)
+    input: Operand = operand_def(IntegerType)
 
-    output = result_def(LLVMPointerType)
+    output: OpResult[LLVMPointerType] = result_def(LLVMPointerType)
 
     traits = traits_def(NoMemoryEffect())
 
@@ -1388,24 +1410,24 @@ class InlineAsmOp(IRDLOperation):
 
     name = "llvm.inline_asm"
 
-    operands_ = var_operand_def()
+    operands_: VarOperand = var_operand_def()
 
-    res = opt_result_def()
+    res: OptOpResult = opt_result_def()
 
     # note: in MLIR upstream this is implemented as AsmDialectAttr;
     # which is an instantiation of an LLVM_EnumAttr
     # 0 for AT&T inline assembly dialect
     # 1 for Intel inline assembly dialect
     # In this context dialect does not refer to an MLIR dialect
-    asm_dialect = opt_prop_def(IntegerAttr[I64])
+    asm_dialect: IntegerAttr[I64] | None = opt_prop_def(IntegerAttr[I64])
 
-    asm_string = prop_def(StringAttr)
-    constraints = prop_def(StringAttr)
+    asm_string: StringAttr = prop_def(StringAttr)
+    constraints: StringAttr = prop_def(StringAttr)
 
-    has_side_effects = opt_prop_def(UnitAttr)
-    is_align_stack = opt_prop_def(UnitAttr)
+    has_side_effects: UnitAttr | None = opt_prop_def(UnitAttr)
+    is_align_stack: UnitAttr | None = opt_prop_def(UnitAttr)
 
-    tail_call_kind = prop_def(
+    tail_call_kind: TailCallKindAttr = prop_def(
         TailCallKindAttr, default_value=TailCallKindAttr(TailCallKind.NONE)
     )
 
@@ -1520,9 +1542,9 @@ class PtrToIntOp(IRDLOperation):
 
     assembly_format = "$input attr-dict `:` type($input) `to` type($output)"
 
-    input = operand_def(LLVMPointerType)
+    input: Operand = operand_def(LLVMPointerType)
 
-    output = result_def(IntegerType)
+    output: OpResult[IntegerType] = result_def(IntegerType)
 
     traits = traits_def(NoMemoryEffect())
 
@@ -1551,12 +1573,14 @@ for the corresponding MLIR enum values.
 class LoadOp(IRDLOperation):
     name = "llvm.load"
 
-    ptr = operand_def(LLVMPointerType)
+    ptr: Operand = operand_def(LLVMPointerType)
 
-    alignment = opt_prop_def(IntegerAttr[IntegerType])
-    ordering = prop_def(IntegerAttr[IntegerType], default_value=IntegerAttr(0, i64))
+    alignment: IntegerAttr[IntegerType] | None = opt_prop_def(IntegerAttr[IntegerType])
+    ordering: IntegerAttr[IntegerType] = prop_def(
+        IntegerAttr[IntegerType], default_value=IntegerAttr(0, i64)
+    )
 
-    dereferenced_value = result_def()
+    dereferenced_value: OpResult = result_def()
 
     def __init__(
         self,
@@ -1623,13 +1647,13 @@ class LoadOp(IRDLOperation):
 class StoreOp(IRDLOperation):
     name = "llvm.store"
 
-    value = operand_def()
-    ptr = operand_def(LLVMPointerType)
+    value: Operand = operand_def()
+    ptr: Operand = operand_def(LLVMPointerType)
 
-    alignment = opt_prop_def(IntegerAttr[IntegerType])
-    ordering = opt_prop_def(IntegerAttr[IntegerType])
-    volatile_ = opt_prop_def(UnitAttr)
-    nontemporal = opt_prop_def(UnitAttr)
+    alignment: IntegerAttr[IntegerType] | None = opt_prop_def(IntegerAttr[IntegerType])
+    ordering: IntegerAttr[IntegerType] | None = opt_prop_def(IntegerAttr[IntegerType])
+    volatile_: UnitAttr | None = opt_prop_def(UnitAttr)
+    nontemporal: UnitAttr | None = opt_prop_def(UnitAttr)
 
     def __init__(
         self,
@@ -1709,10 +1733,10 @@ class ExtractValueOp(IRDLOperation):
 
     name = "llvm.extractvalue"
 
-    position = prop_def(DenseArrayBase.constr(i64))
-    container = operand_def(Attribute)
+    position: DenseArrayBase[I64] = prop_def(DenseArrayBase.constr(i64))
+    container: Operand = operand_def(Attribute)
 
-    res = result_def(Attribute)
+    res: OpResult = result_def(Attribute)
 
     traits = traits_def(NoMemoryEffect())
 
@@ -1776,11 +1800,11 @@ class InsertValueOp(IRDLOperation):
 
     name = "llvm.insertvalue"
 
-    position = prop_def(DenseArrayBase.constr(i64))
-    container = operand_def(Attribute)
-    value = operand_def(Attribute)
+    position: DenseArrayBase[I64] = prop_def(DenseArrayBase.constr(i64))
+    container: Operand = operand_def(Attribute)
+    value: Operand = operand_def(Attribute)
 
-    res = result_def(Attribute)
+    res: OpResult = result_def(Attribute)
 
     traits = traits_def(NoMemoryEffect())
 
@@ -1857,10 +1881,10 @@ class InsertElementOp(IRDLOperation):
         ),
     )
 
-    vector = operand_def(VECTOR)
-    value = operand_def(ELEMENT)
-    index = operand_def(SignlessIntegerConstraint)
-    res = result_def(VECTOR)
+    vector: Operand = operand_def(VECTOR)
+    value: Operand = operand_def(ELEMENT)
+    index: Operand = operand_def(SignlessIntegerConstraint)
+    res: OpResult[VectorType[Attribute]] = result_def(VECTOR)
 
     assembly_format = (
         "$value `,` $vector `[` $index `:` type($index) `]` attr-dict `:` type($vector)"
@@ -1890,7 +1914,7 @@ class UndefOp(IRDLOperation):
 
     assembly_format = "attr-dict `:` type($res)"
 
-    res = result_def(Attribute)
+    res: OpResult = result_def(Attribute)
 
     traits = traits_def(NoMemoryEffect())
 
@@ -1961,10 +1985,12 @@ class ShuffleVectorOp(IRDLOperation):
     )
     MASK: ClassVar = VarConstraint("MASK", irdl_to_attr_constraint(DenseArrayBase[I32]))
 
-    v1 = operand_def(VEC_TYPE)
-    v2 = operand_def(VEC_TYPE)
-    mask = prop_def(MASK)
-    res = result_def(ShuffleVectorResultConstraint(T, MASK))
+    v1: Operand = operand_def(VEC_TYPE)
+    v2: Operand = operand_def(VEC_TYPE)
+    mask: DenseArrayBase[I32] = prop_def(MASK)
+    res: OpResult[VectorType[Attribute]] = result_def(
+        ShuffleVectorResultConstraint(T, MASK)
+    )
 
     traits = traits_def(NoMemoryEffect())
 
@@ -2019,21 +2045,23 @@ UNNAMED_ADDR_KEY_BY_KEYWORD: dict[str, int] = {
 class GlobalOp(IRDLOperation):
     name = "llvm.mlir.global"
 
-    global_type = prop_def()
-    constant = opt_prop_def(UnitAttr)
-    sym_name = prop_def(SymbolNameConstraint())
-    linkage = prop_def(LinkageAttr)
-    dso_local = opt_prop_def(UnitAttr)
-    thread_local_ = opt_prop_def(UnitAttr)
-    visibility_ = opt_prop_def(IntegerAttr[IntegerType])
-    value = opt_prop_def()
-    alignment = opt_prop_def(IntegerAttr)
-    addr_space = prop_def(IntegerAttr)
-    unnamed_addr = opt_prop_def(IntegerAttr)
-    section = opt_prop_def(StringAttr)
+    global_type: Attribute = prop_def()
+    constant: UnitAttr | None = opt_prop_def(UnitAttr)
+    sym_name: StringAttr = prop_def(SymbolNameConstraint())
+    linkage: LinkageAttr = prop_def(LinkageAttr)
+    dso_local: UnitAttr | None = opt_prop_def(UnitAttr)
+    thread_local_: UnitAttr | None = opt_prop_def(UnitAttr)
+    visibility_: IntegerAttr[IntegerType] | None = opt_prop_def(
+        IntegerAttr[IntegerType]
+    )
+    value: Attribute | None = opt_prop_def()
+    alignment: IntegerAttr | None = opt_prop_def(IntegerAttr)
+    addr_space: IntegerAttr = prop_def(IntegerAttr)
+    unnamed_addr: IntegerAttr | None = opt_prop_def(IntegerAttr)
+    section: StringAttr | None = opt_prop_def(StringAttr)
 
     # This always needs an empty region as it is in the top level module definition
-    body = region_def()
+    body: Region = region_def()
 
     traits = traits_def(SymbolOpInterface())
 
@@ -2186,8 +2214,8 @@ class AddressOfOp(IRDLOperation):
 
     assembly_format = "$global_name attr-dict `:` type($result)"
 
-    global_name = prop_def(SymbolRefAttr)
-    result = result_def(LLVMPointerType)
+    global_name: SymbolRefAttr = prop_def(SymbolRefAttr)
+    result: OpResult[LLVMPointerType] = result_def(LLVMPointerType)
 
     traits = traits_def(NoMemoryEffect())
 
@@ -2325,27 +2353,33 @@ class FuncOp(IRDLOperation):
 
     name = "llvm.func"
 
-    body = region_def()
-    sym_name = prop_def(SymbolNameConstraint())
-    function_type = prop_def(LLVMFunctionType)
-    CConv = prop_def(CallingConventionAttr)
-    linkage = prop_def(LinkageAttr)
-    sym_visibility = opt_prop_def(StringAttr)
-    visibility_ = prop_def(IntegerAttr[IntegerType], default_value=IntegerAttr(0, 64))
+    body: Region = region_def()
+    sym_name: StringAttr = prop_def(SymbolNameConstraint())
+    function_type: LLVMFunctionType = prop_def(LLVMFunctionType)
+    CConv: CallingConventionAttr = prop_def(CallingConventionAttr)
+    linkage: LinkageAttr = prop_def(LinkageAttr)
+    sym_visibility: StringAttr | None = opt_prop_def(StringAttr)
+    visibility_: IntegerAttr[IntegerType] = prop_def(
+        IntegerAttr[IntegerType], default_value=IntegerAttr(0, 64)
+    )
 
     # The following properties are not yet verified by the xDSL verifier, but
     # are verified to at least allow the IR to be parsed and printed correctly.
-    arg_attrs = opt_prop_def(ArrayAttr[DictionaryAttr])
-    res_attrs = opt_prop_def(ArrayAttr[DictionaryAttr])
-    frame_pointer = opt_prop_def(FramePointerKindAttr)
-    no_inline = opt_prop_def(UnitAttr)
-    no_unwind = opt_prop_def(UnitAttr)
-    optimize_none = opt_prop_def(UnitAttr)
-    passthrough = opt_prop_def(ArrayAttr[Attribute])
-    target_cpu = opt_prop_def(StringAttr)
-    target_features = opt_prop_def(TargetFeaturesAttr)
-    tune_cpu = opt_prop_def(StringAttr)
-    unnamed_addr = opt_prop_def(IntegerAttr)
+    arg_attrs: ArrayAttr[DictionaryAttr] | None = opt_prop_def(
+        ArrayAttr[DictionaryAttr]
+    )
+    res_attrs: ArrayAttr[DictionaryAttr] | None = opt_prop_def(
+        ArrayAttr[DictionaryAttr]
+    )
+    frame_pointer: FramePointerKindAttr | None = opt_prop_def(FramePointerKindAttr)
+    no_inline: UnitAttr | None = opt_prop_def(UnitAttr)
+    no_unwind: UnitAttr | None = opt_prop_def(UnitAttr)
+    optimize_none: UnitAttr | None = opt_prop_def(UnitAttr)
+    passthrough: ArrayAttr[Attribute] | None = opt_prop_def(ArrayAttr[Attribute])
+    target_cpu: StringAttr | None = opt_prop_def(StringAttr)
+    target_features: TargetFeaturesAttr | None = opt_prop_def(TargetFeaturesAttr)
+    tune_cpu: StringAttr | None = opt_prop_def(StringAttr)
+    unnamed_addr: IntegerAttr | None = opt_prop_def(IntegerAttr)
 
     traits = traits_def(SymbolOpInterface())
 
@@ -2558,7 +2592,7 @@ class ReturnOp(IRDLOperation):
 
     assembly_format = "($arg^ `:` type($arg))? attr-dict"
 
-    arg = opt_operand_def(Attribute)
+    arg: OptOperand = opt_operand_def(Attribute)
 
     traits = traits_def(IsTerminator(), NoMemoryEffect())
 
@@ -2569,8 +2603,10 @@ class ReturnOp(IRDLOperation):
 @irdl_op_definition
 class ConstantOp(IRDLOperation):
     name = "llvm.mlir.constant"
-    result = result_def(Attribute)
-    value = prop_def(IntegerAttr | FloatAttr | DenseIntOrFPElementsAttr)
+    result: OpResult = result_def(Attribute)
+    value: IntegerAttr | FloatAttr | DenseIntOrFPElementsAttr = prop_def(
+        IntegerAttr | FloatAttr | DenseIntOrFPElementsAttr
+    )
 
     traits = traits_def(NoMemoryEffect())
 
@@ -2619,15 +2655,17 @@ class CallIntrinsicOp(IRDLOperation):
 
     name = "llvm.call_intrinsic"
 
-    fastmathFlags = prop_def(FastMathAttr, default_value=FastMathAttr(None))
-    intrin = prop_def(StringAttr)
-    op_bundle_sizes = prop_def(
+    fastmathFlags: FastMathAttr = prop_def(
+        FastMathAttr, default_value=FastMathAttr(None)
+    )
+    intrin: StringAttr = prop_def(StringAttr)
+    op_bundle_sizes: DenseArrayBase[I32] = prop_def(
         DenseArrayBase.constr(i32),
         default_value=DenseArrayBase.from_list(i32, ()),
     )
-    args = var_operand_def()
-    op_bundle_operands = var_operand_def()
-    ress = opt_result_def()
+    args: VarOperand = var_operand_def()
+    op_bundle_operands: VarOperand = var_operand_def()
+    ress: OptOpResult = opt_result_def()
 
     assembly_format = (
         "$intrin `(` $args `)` (`[` $op_bundle_operands^ `:`"
@@ -2697,21 +2735,25 @@ class CallOpSymbolUserOpInterface(SymbolUserOpInterface):
 class CallOp(IRDLOperation):
     name = "llvm.call"
 
-    args = var_operand_def()
-    op_bundle_operands = var_operand_def()
+    args: VarOperand = var_operand_def()
+    op_bundle_operands: VarOperand = var_operand_def()
 
-    callee = opt_prop_def(SymbolRefAttr)
-    var_callee_type = opt_prop_def(LLVMFunctionType)
-    fastmathFlags = prop_def(FastMathAttr, default_value=FastMathAttr("none"))
-    CConv = prop_def(CallingConventionAttr, default_value=CallingConventionAttr("ccc"))
-    op_bundle_sizes = prop_def(
+    callee: SymbolRefAttr | None = opt_prop_def(SymbolRefAttr)
+    var_callee_type: LLVMFunctionType | None = opt_prop_def(LLVMFunctionType)
+    fastmathFlags: FastMathAttr = prop_def(
+        FastMathAttr, default_value=FastMathAttr("none")
+    )
+    CConv: CallingConventionAttr = prop_def(
+        CallingConventionAttr, default_value=CallingConventionAttr("ccc")
+    )
+    op_bundle_sizes: DenseArrayBase[I32] = prop_def(
         DenseArrayBase.constr(i32),
         default_value=DenseArrayBase.from_list(i32, ()),
     )
-    TailCallKind = prop_def(
+    TailCallKind: TailCallKindAttr = prop_def(
         TailCallKindAttr, default_value=TailCallKindAttr(TailCallKind.NONE)
     )
-    returned = opt_result_def()
+    returned: OptOpResult = opt_result_def()
 
     traits = traits_def(CallOpSymbolUserOpInterface())
 
@@ -2869,16 +2911,22 @@ class ZeroOp(IRDLOperation):
 
     traits = traits_def(NoMemoryEffect())
 
-    res = result_def(LLVMTypeConstr)
+    res: OpResult[
+        LLVMStructType
+        | LLVMPointerType
+        | LLVMArrayType
+        | LLVMVoidType
+        | LLVMFunctionType
+    ] = result_def(LLVMTypeConstr)
 
 
 class GenericCastOp(IRDLOperation, ABC):
-    arg = operand_def(Attribute)
+    arg: Operand = operand_def(Attribute)
     """
     LLVM-compatible non-aggregate type
     """
 
-    result = result_def(Attribute)
+    result: OpResult = result_def(Attribute)
     """
     LLVM-compatible non-aggregate type
     """
@@ -2897,11 +2945,13 @@ class GenericCastOp(IRDLOperation, ABC):
 class AbstractFloatArithOp(IRDLOperation, ABC):
     T: ClassVar = VarConstraint("T", AnyFloatConstr | VectorType.constr(AnyFloatConstr))
 
-    lhs = operand_def(T)
-    rhs = operand_def(T)
-    res = result_def(T)
+    lhs: Operand = operand_def(T)
+    rhs: Operand = operand_def(T)
+    res: OpResult[AnyFloat | VectorType[AnyFloat]] = result_def(T)
 
-    fastmathFlags = prop_def(FastMathAttr, default_value=FastMathAttr(None))
+    fastmathFlags: FastMathAttr = prop_def(
+        FastMathAttr, default_value=FastMathAttr(None)
+    )
 
     traits = traits_def(Pure(), SameOperandsAndResultType())
 
@@ -2988,12 +3038,14 @@ class FCmpOp(IRDLOperation):
 
     T: ClassVar = VarConstraint("T", AnyFloatConstr)
 
-    lhs = operand_def(T)
-    rhs = operand_def(T)
-    res = result_def(I1)
-    predicate = prop_def(IntegerAttr[i64])
+    lhs: Operand = operand_def(T)
+    rhs: Operand = operand_def(T)
+    res: OpResult[I1] = result_def(I1)
+    predicate: IntegerAttr[I64] = prop_def(IntegerAttr[i64])
 
-    fastmathFlags = prop_def(FastMathAttr, default_value=FastMathAttr(None))
+    fastmathFlags: FastMathAttr = prop_def(
+        FastMathAttr, default_value=FastMathAttr(None)
+    )
 
     traits = traits_def(Pure())
 
@@ -3062,10 +3114,12 @@ class FAbsOp(IRDLOperation):
 
     name = "llvm.intr.fabs"
 
-    input = operand_def(T)
-    result = result_def(T)
+    input: Operand = operand_def(T)
+    result: OpResult[AnyFloat | VectorType[AnyFloat]] = result_def(T)
 
-    fastmathFlags = prop_def(FastMathAttr, default_value=FastMathAttr(None))
+    fastmathFlags: FastMathAttr = prop_def(
+        FastMathAttr, default_value=FastMathAttr(None)
+    )
 
     assembly_format = (
         "`(` operands `)` attr-dict `:` functional-type(operands, results)"
@@ -3094,10 +3148,12 @@ class FCeilOp(IRDLOperation):
 
     name = "llvm.intr.ceil"
 
-    arg = operand_def(T)
-    res = result_def(T)
+    arg: Operand = operand_def(T)
+    res: OpResult[AnyFloat | VectorType[AnyFloat]] = result_def(T)
 
-    fastmathFlags = prop_def(FastMathAttr, default_value=FastMathAttr(None))
+    fastmathFlags: FastMathAttr = prop_def(
+        FastMathAttr, default_value=FastMathAttr(None)
+    )
 
     assembly_format = (
         "`(` operands `)` attr-dict `:` functional-type(operands, results)"
@@ -3127,10 +3183,12 @@ class FSqrtOp(IRDLOperation):
 
     name = "llvm.intr.sqrt"
 
-    arg = operand_def(T)
-    res = result_def(T)
+    arg: Operand = operand_def(T)
+    res: OpResult[AnyFloat | VectorType[AnyFloat]] = result_def(T)
 
-    fastmathFlags = prop_def(FastMathAttr, default_value=FastMathAttr(None))
+    fastmathFlags: FastMathAttr = prop_def(
+        FastMathAttr, default_value=FastMathAttr(None)
+    )
 
     assembly_format = (
         "`(` operands `)` attr-dict `:` functional-type(operands, results)"
@@ -3160,10 +3218,12 @@ class FFloorOp(IRDLOperation):
 
     name = "llvm.intr.floor"
 
-    arg = operand_def(T)
-    res = result_def(T)
+    arg: Operand = operand_def(T)
+    res: OpResult[AnyFloat | VectorType[AnyFloat]] = result_def(T)
 
-    fastmathFlags = prop_def(FastMathAttr, default_value=FastMathAttr(None))
+    fastmathFlags: FastMathAttr = prop_def(
+        FastMathAttr, default_value=FastMathAttr(None)
+    )
 
     assembly_format = (
         "`(` operands `)` attr-dict `:` functional-type(operands, results)"
@@ -3193,10 +3253,12 @@ class FExp2Op(IRDLOperation):
 
     name = "llvm.intr.exp2"
 
-    arg = operand_def(T)
-    res = result_def(T)
+    arg: Operand = operand_def(T)
+    res: OpResult[AnyFloat | VectorType[AnyFloat]] = result_def(T)
 
-    fastmathFlags = prop_def(FastMathAttr, default_value=FastMathAttr(None))
+    fastmathFlags: FastMathAttr = prop_def(
+        FastMathAttr, default_value=FastMathAttr(None)
+    )
 
     assembly_format = (
         "`(` operands `)` attr-dict `:` functional-type(operands, results)"
@@ -3226,10 +3288,12 @@ class FLogOp(IRDLOperation):
 
     name = "llvm.intr.log"
 
-    arg = operand_def(T)
-    res = result_def(T)
+    arg: Operand = operand_def(T)
+    res: OpResult[AnyFloat | VectorType[AnyFloat]] = result_def(T)
 
-    fastmathFlags = prop_def(FastMathAttr, default_value=FastMathAttr(None))
+    fastmathFlags: FastMathAttr = prop_def(
+        FastMathAttr, default_value=FastMathAttr(None)
+    )
 
     assembly_format = (
         "`(` operands `)` attr-dict `:` functional-type(operands, results)"
@@ -3259,10 +3323,12 @@ class FExpOp(IRDLOperation):
 
     name = "llvm.intr.exp"
 
-    arg = operand_def(T)
-    res = result_def(T)
+    arg: Operand = operand_def(T)
+    res: OpResult[AnyFloat | VectorType[AnyFloat]] = result_def(T)
 
-    fastmathFlags = prop_def(FastMathAttr, default_value=FastMathAttr(None))
+    fastmathFlags: FastMathAttr = prop_def(
+        FastMathAttr, default_value=FastMathAttr(None)
+    )
 
     assembly_format = (
         "`(` operands `)` attr-dict `:` functional-type(operands, results)"
@@ -3292,10 +3358,12 @@ class FSinOp(IRDLOperation):
 
     name = "llvm.intr.sin"
 
-    arg = operand_def(T)
-    res = result_def(T)
+    arg: Operand = operand_def(T)
+    res: OpResult[AnyFloat | VectorType[AnyFloat]] = result_def(T)
 
-    fastmathFlags = prop_def(FastMathAttr, default_value=FastMathAttr(None))
+    fastmathFlags: FastMathAttr = prop_def(
+        FastMathAttr, default_value=FastMathAttr(None)
+    )
 
     assembly_format = (
         "`(` operands `)` attr-dict `:` functional-type(operands, results)"
@@ -3325,10 +3393,12 @@ class FCosOp(IRDLOperation):
 
     name = "llvm.intr.cos"
 
-    arg = operand_def(T)
-    res = result_def(T)
+    arg: Operand = operand_def(T)
+    res: OpResult[AnyFloat | VectorType[AnyFloat]] = result_def(T)
 
-    fastmathFlags = prop_def(FastMathAttr, default_value=FastMathAttr(None))
+    fastmathFlags: FastMathAttr = prop_def(
+        FastMathAttr, default_value=FastMathAttr(None)
+    )
 
     assembly_format = (
         "`(` operands `)` attr-dict `:` functional-type(operands, results)"
@@ -3358,10 +3428,12 @@ class FLog2Op(IRDLOperation):
 
     name = "llvm.intr.log2"
 
-    arg = operand_def(T)
-    res = result_def(T)
+    arg: Operand = operand_def(T)
+    res: OpResult[AnyFloat | VectorType[AnyFloat]] = result_def(T)
 
-    fastmathFlags = prop_def(FastMathAttr, default_value=FastMathAttr(None))
+    fastmathFlags: FastMathAttr = prop_def(
+        FastMathAttr, default_value=FastMathAttr(None)
+    )
 
     assembly_format = (
         "`(` operands `)` attr-dict `:` functional-type(operands, results)"
@@ -3391,10 +3463,12 @@ class FNegOp(IRDLOperation):
 
     name = "llvm.fneg"
 
-    arg = operand_def(T)
-    res = result_def(T)
+    arg: Operand = operand_def(T)
+    res: OpResult[AnyFloat | VectorType[AnyFloat]] = result_def(T)
 
-    fastmathFlags = prop_def(FastMathAttr, default_value=FastMathAttr(None))
+    fastmathFlags: FastMathAttr = prop_def(
+        FastMathAttr, default_value=FastMathAttr(None)
+    )
 
     traits = traits_def(Pure(), SameOperandsAndResultType())
 
@@ -3420,10 +3494,10 @@ class FNegOp(IRDLOperation):
 class MaskedStoreOp(IRDLOperation):
     name = "llvm.intr.masked.store"
 
-    value = operand_def(VectorType.constr(AnyFloatConstr))
-    data = operand_def(LLVMPointerType)
-    mask = operand_def(VectorType[I1])
-    alignment = prop_def(IntegerAttr[i32])
+    value: Operand = operand_def(VectorType.constr(AnyFloatConstr))
+    data: Operand = operand_def(LLVMPointerType)
+    mask: Operand = operand_def(VectorType[I1])
+    alignment: IntegerAttr[I32] = prop_def(IntegerAttr[i32])
 
     assembly_format = (
         "$value `,` $data `,` $mask attr-dict `:`"
@@ -3454,12 +3528,14 @@ class SelectOp(IRDLOperation):
 
     T: ClassVar = VarConstraint("T", AnyAttr())
 
-    cond = operand_def(I1)
-    lhs = operand_def(T)
-    rhs = operand_def(T)
-    res = result_def(T)
+    cond: Operand = operand_def(I1)
+    lhs: Operand = operand_def(T)
+    rhs: Operand = operand_def(T)
+    res: OpResult = result_def(T)
 
-    fastmathFlags = prop_def(FastMathAttr, default_value=FastMathAttr(None))
+    fastmathFlags: FastMathAttr = prop_def(
+        FastMathAttr, default_value=FastMathAttr(None)
+    )
 
     traits = traits_def(Pure())
 
@@ -3483,9 +3559,9 @@ class SelectOp(IRDLOperation):
 class BrOp(IRDLOperation):
     name = "llvm.br"
 
-    arguments = var_operand_def()
+    arguments: VarOperand = var_operand_def()
 
-    successor = successor_def()
+    successor: Successor = successor_def()
 
     traits = traits_def(IsTerminator())
 
@@ -3499,14 +3575,14 @@ class BrOp(IRDLOperation):
 class CondBrOp(IRDLOperation):
     name = "llvm.cond_br"
 
-    cond = operand_def(IntegerType(1))
-    then_arguments = var_operand_def()
-    else_arguments = var_operand_def()
+    cond: Operand = operand_def(IntegerType(1))
+    then_arguments: VarOperand = var_operand_def()
+    else_arguments: VarOperand = var_operand_def()
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
-    then_block = successor_def()
-    else_block = successor_def()
+    then_block: Successor = successor_def()
+    else_block: Successor = successor_def()
 
     traits = traits_def(IsTerminator())
 
@@ -3537,11 +3613,13 @@ class VectorFMaxOp(IRDLOperation):
 
     name = "llvm.intr.maxnum"
 
-    lhs = operand_def(T)
-    rhs = operand_def(T)
-    res = result_def(T)
+    lhs: Operand = operand_def(T)
+    rhs: Operand = operand_def(T)
+    res: OpResult[AnyFloat | VectorType[AnyFloat]] = result_def(T)
 
-    fastmathFlags = prop_def(FastMathAttr, default_value=FastMathAttr(None))
+    fastmathFlags: FastMathAttr = prop_def(
+        FastMathAttr, default_value=FastMathAttr(None)
+    )
 
     assembly_format = (
         "`(` operands `)` attr-dict `:` functional-type(operands, results)"
@@ -3572,11 +3650,13 @@ class FCopySignOp(IRDLOperation):
 
     name = "llvm.intr.copysign"
 
-    lhs = operand_def(T)
-    rhs = operand_def(T)
-    res = result_def(T)
+    lhs: Operand = operand_def(T)
+    rhs: Operand = operand_def(T)
+    res: OpResult[AnyFloat | VectorType[AnyFloat]] = result_def(T)
 
-    fastmathFlags = prop_def(FastMathAttr, default_value=FastMathAttr(None))
+    fastmathFlags: FastMathAttr = prop_def(
+        FastMathAttr, default_value=FastMathAttr(None)
+    )
 
     assembly_format = (
         "`(` operands `)` attr-dict `:` functional-type(operands, results)"
@@ -3607,12 +3687,14 @@ class FMAOp(IRDLOperation):
 
     name = "llvm.intr.fma"
 
-    a = operand_def(T)
-    b = operand_def(T)
-    c = operand_def(T)
-    res = result_def(T)
+    a: Operand = operand_def(T)
+    b: Operand = operand_def(T)
+    c: Operand = operand_def(T)
+    res: OpResult[AnyFloat | VectorType[AnyFloat]] = result_def(T)
 
-    fastmathFlags = prop_def(FastMathAttr, default_value=FastMathAttr(None))
+    fastmathFlags: FastMathAttr = prop_def(
+        FastMathAttr, default_value=FastMathAttr(None)
+    )
 
     assembly_format = (
         "`(` operands `)` attr-dict `:` functional-type(operands, results)"
@@ -3644,11 +3726,13 @@ class VectorFMinOp(IRDLOperation):
 
     name = "llvm.intr.minnum"
 
-    lhs = operand_def(T)
-    rhs = operand_def(T)
-    res = result_def(T)
+    lhs: Operand = operand_def(T)
+    rhs: Operand = operand_def(T)
+    res: OpResult[AnyFloat | VectorType[AnyFloat]] = result_def(T)
 
-    fastmathFlags = prop_def(FastMathAttr, default_value=FastMathAttr(None))
+    fastmathFlags: FastMathAttr = prop_def(
+        FastMathAttr, default_value=FastMathAttr(None)
+    )
 
     assembly_format = (
         "`(` operands `)` attr-dict `:` functional-type(operands, results)"
@@ -3679,11 +3763,13 @@ class FPowOp(IRDLOperation):
 
     name = "llvm.intr.pow"
 
-    lhs = operand_def(T)
-    rhs = operand_def(T)
-    res = result_def(T)
+    lhs: Operand = operand_def(T)
+    rhs: Operand = operand_def(T)
+    res: OpResult[AnyFloat | VectorType[AnyFloat]] = result_def(T)
 
-    fastmathFlags = prop_def(FastMathAttr, default_value=FastMathAttr(None))
+    fastmathFlags: FastMathAttr = prop_def(
+        FastMathAttr, default_value=FastMathAttr(None)
+    )
 
     assembly_format = (
         "`(` operands `)` attr-dict `:` functional-type(operands, results)"
@@ -3712,7 +3798,7 @@ class FPowOp(IRDLOperation):
 class StackSaveOp(IRDLOperation):
     name = "llvm.intr.stacksave"
 
-    res = result_def(LLVMPointerType)
+    res: OpResult[LLVMPointerType] = result_def(LLVMPointerType)
 
     assembly_format = "attr-dict `:` type($res)"
 
@@ -3723,11 +3809,13 @@ class StackSaveOp(IRDLOperation):
 class VectorReduceOperation(IRDLOperation, ABC):
     T: ClassVar = VarConstraint("T", AnyFloatConstr)
 
-    start_value = operand_def(T)
-    vector = operand_def(VectorType.constr(T))
-    res = result_def(T)
+    start_value: Operand = operand_def(T)
+    vector: Operand = operand_def(VectorType.constr(T))
+    res: OpResult[AnyFloat] = result_def(T)
 
-    fastmathFlags = prop_def(FastMathAttr, default_value=FastMathAttr(None))
+    fastmathFlags: FastMathAttr = prop_def(
+        FastMathAttr, default_value=FastMathAttr(None)
+    )
 
     irdl_options = (ParsePropInAttrDict(),)
 
@@ -3762,7 +3850,7 @@ class VectorReduceFMulOp(VectorReduceOperation):
 class StackRestoreOp(IRDLOperation):
     name = "llvm.intr.stackrestore"
 
-    ptr = operand_def(LLVMPointerType)
+    ptr: Operand = operand_def(LLVMPointerType)
 
     assembly_format = "$ptr attr-dict `:` type($ptr)"
 

--- a/xdsl/dialects/ltl.py
+++ b/xdsl/dialects/ltl.py
@@ -8,12 +8,14 @@ from __future__ import annotations
 
 from typing import ClassVar
 
-from xdsl.dialects.builtin import i1
+from xdsl.dialects.builtin import I1, i1
 from xdsl.ir import Dialect, ParametrizedAttribute, SSAValue, TypeAttribute
 from xdsl.irdl import (
     AnyOf,
     IRDLOperation,
+    OpResult,
     VarConstraint,
+    VarOperand,
     irdl_attr_definition,
     irdl_op_definition,
     result_def,
@@ -53,9 +55,9 @@ class AndOp(IRDLOperation):
 
     T: ClassVar = VarConstraint("T", AnyOf.get(Sequence, Property, i1))
 
-    input = var_operand_def(T)
+    input: VarOperand = var_operand_def(T)
 
-    result = result_def(T)
+    result: OpResult[Sequence | Property | I1] = result_def(T)
 
     def __init__(
         self,

--- a/xdsl/dialects/math.py
+++ b/xdsl/dialects/math.py
@@ -15,11 +15,15 @@ from xdsl.dialects.builtin import (
     AnyFloat,
     AnySignlessIntegerType,
     IndexType,
+    TensorType,
+    VectorType,
     container_of,
 )
 from xdsl.ir import Dialect, Operation, SSAValue
 from xdsl.irdl import (
     IRDLOperation,
+    Operand,
+    OpResult,
     VarConstraint,
     irdl_op_definition,
     operand_def,
@@ -38,8 +42,13 @@ class SignlessIntegerLikeUnaryMathOperation(IRDLOperation, abc.ABC):
 
     T: ClassVar = VarConstraint("T", signlessIntegerLike)
 
-    operand = operand_def(T)
-    result = result_def(T)
+    operand: Operand = operand_def(T)
+    result: OpResult[
+        AnySignlessIntegerType
+        | IndexType
+        | VectorType[AnySignlessIntegerType | IndexType]
+        | TensorType[AnySignlessIntegerType | IndexType]
+    ] = result_def(T)
 
     assembly_format = "$operand attr-dict `:` type($result)"
 
@@ -56,10 +65,14 @@ class FloatingPointLikeUnaryMathOperation(IRDLOperation, abc.ABC):
 
     T: ClassVar = VarConstraint("T", floatingPointLike)
 
-    operand = operand_def(T)
-    result = result_def(T)
+    operand: Operand = operand_def(T)
+    result: OpResult[AnyFloat | VectorType[AnyFloat] | TensorType[AnyFloat]] = (
+        result_def(T)
+    )
 
-    fastmath = prop_def(FastMathFlagsAttr, default_value=FastMathFlagsAttr("none"))
+    fastmath: FastMathFlagsAttr = prop_def(
+        FastMathFlagsAttr, default_value=FastMathFlagsAttr("none")
+    )
 
     assembly_format = "$operand (`fastmath` `` $fastmath^)? attr-dict `:` type($result)"
 
@@ -79,9 +92,14 @@ class SignlessIntegerLikeBinaryMathOperation(IRDLOperation, abc.ABC):
 
     T: ClassVar = VarConstraint("T", signlessIntegerLike)
 
-    lhs = operand_def(T)
-    rhs = operand_def(T)
-    result = result_def(T)
+    lhs: Operand = operand_def(T)
+    rhs: Operand = operand_def(T)
+    result: OpResult[
+        AnySignlessIntegerType
+        | IndexType
+        | VectorType[AnySignlessIntegerType | IndexType]
+        | TensorType[AnySignlessIntegerType | IndexType]
+    ] = result_def(T)
 
     assembly_format = "$lhs `,` $rhs attr-dict `:` type($result)"
 
@@ -101,11 +119,15 @@ class FloatingPointLikeBinaryMathOperation(IRDLOperation, abc.ABC):
 
     T: ClassVar = VarConstraint("T", floatingPointLike)
 
-    lhs = operand_def(T)
-    rhs = operand_def(T)
-    result = result_def(T)
+    lhs: Operand = operand_def(T)
+    rhs: Operand = operand_def(T)
+    result: OpResult[AnyFloat | VectorType[AnyFloat] | TensorType[AnyFloat]] = (
+        result_def(T)
+    )
 
-    fastmath = prop_def(FastMathFlagsAttr, default_value=FastMathFlagsAttr("none"))
+    fastmath: FastMathFlagsAttr = prop_def(
+        FastMathFlagsAttr, default_value=FastMathFlagsAttr("none")
+    )
 
     assembly_format = (
         "$lhs `,` $rhs (`fastmath` `` $fastmath^)? attr-dict `:` type($result)"
@@ -541,10 +563,14 @@ class FPowIOp(IRDLOperation):
 
     T: ClassVar = VarConstraint("T1", floatingPointLike)
 
-    fastmath = prop_def(FastMathFlagsAttr, default_value=FastMathFlagsAttr("none"))
-    lhs = operand_def(T)
-    rhs = operand_def(signlessIntegerLike)
-    result = result_def(T)
+    fastmath: FastMathFlagsAttr = prop_def(
+        FastMathFlagsAttr, default_value=FastMathFlagsAttr("none")
+    )
+    lhs: Operand = operand_def(T)
+    rhs: Operand = operand_def(signlessIntegerLike)
+    result: OpResult[AnyFloat | VectorType[AnyFloat] | TensorType[AnyFloat]] = (
+        result_def(T)
+    )
 
     traits = traits_def(Pure())
 
@@ -604,11 +630,15 @@ class FmaOp(IRDLOperation):
 
     name = "math.fma"
 
-    fastmath = prop_def(FastMathFlagsAttr, default_value=FastMathFlagsAttr("none"))
-    a = operand_def(T)
-    b = operand_def(T)
-    c = operand_def(T)
-    result = result_def(T)
+    fastmath: FastMathFlagsAttr = prop_def(
+        FastMathFlagsAttr, default_value=FastMathFlagsAttr("none")
+    )
+    a: Operand = operand_def(T)
+    b: Operand = operand_def(T)
+    c: Operand = operand_def(T)
+    result: OpResult[AnyFloat | VectorType[AnyFloat] | TensorType[AnyFloat]] = (
+        result_def(T)
+    )
 
     traits = traits_def(Pure(), SameOperandsAndResultType())
 

--- a/xdsl/dialects/math_xdsl.py
+++ b/xdsl/dialects/math_xdsl.py
@@ -13,6 +13,7 @@ from enum import auto
 from xdsl.ir import Attribute, Dialect, EnumAttribute, SpacedOpaqueSyntaxAttribute
 from xdsl.irdl import (
     IRDLOperation,
+    OpResult,
     irdl_attr_definition,
     irdl_op_definition,
     prop_def,
@@ -47,9 +48,9 @@ class ConstantAttr(EnumAttribute[Constant], SpacedOpaqueSyntaxAttribute):
 class ConstantOp(IRDLOperation):
     name = "math_xdsl.constant"
 
-    symbol = prop_def(ConstantAttr)
+    symbol: ConstantAttr = prop_def(ConstantAttr)
 
-    value = result_def()
+    value: OpResult = result_def()
 
     assembly_format = "$symbol attr-dict `:` type($value)"
 

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -9,7 +9,9 @@ from typing_extensions import Self
 from xdsl.dialects.builtin import (
     DYNAMIC_INDEX,
     I64,
+    AnyFloat,
     AnyFloatConstr,
+    AnySignlessIntegerType,
     BoolAttr,
     DenseArrayBase,
     DenseIntOrFPElementsAttr,
@@ -37,16 +39,21 @@ from xdsl.dialects.utils import (
     verify_dynamic_index_list,
 )
 from xdsl.dialects.utils.reshape_ops_utils import (
+    ArrayOfIntArrayAttr,
     ContiguousArrayOfIntArray,
 )
-from xdsl.ir import Attribute, Dialect, Operation, SSAValue
+from xdsl.ir import Attribute, Dialect, Operation, Region, SSAValue
 from xdsl.irdl import (
     AnyAttr,
     AttrSizedOperandSegments,
     IRDLOperation,
+    Operand,
+    OpResult,
     ParsePropInAttrDict,
     SameVariadicResultSize,
     VarConstraint,
+    VarOperand,
+    VarOpResult,
     base,
     irdl_op_definition,
     lazy_traits_def,
@@ -94,11 +101,13 @@ class LoadOp(IRDLOperation):
 
     T: ClassVar = VarConstraint("T", AnyAttr())
 
-    nontemporal = opt_prop_def(BoolAttr, default_value=BoolAttr.from_bool(False))
+    nontemporal: BoolAttr = opt_prop_def(
+        BoolAttr, default_value=BoolAttr.from_bool(False)
+    )
 
-    memref = operand_def(MemRefType.constr(T))
-    indices = var_operand_def(IndexType())
-    res = result_def(T)
+    memref: Operand = operand_def(MemRefType.constr(T))
+    indices: VarOperand = var_operand_def(IndexType())
+    res: OpResult = result_def(T)
 
     traits = traits_def(MemoryReadEffect())
 
@@ -133,11 +142,13 @@ class StoreOp(IRDLOperation):
 
     name = "memref.store"
 
-    nontemporal = opt_prop_def(BoolAttr, default_value=BoolAttr.from_bool(False))
+    nontemporal: BoolAttr = opt_prop_def(
+        BoolAttr, default_value=BoolAttr.from_bool(False)
+    )
 
-    value = operand_def(T)
-    memref = operand_def(MemRefType.constr(T))
-    indices = var_operand_def(IndexType())
+    value: Operand = operand_def(T)
+    memref: Operand = operand_def(MemRefType.constr(T))
+    indices: VarOperand = var_operand_def(IndexType())
 
     traits = traits_def(MemoryWriteEffect())
 
@@ -175,13 +186,13 @@ class AllocOpHasCanonicalizationPatterns(HasCanonicalizationPatternsTrait):
 class AllocOp(IRDLOperation):
     name = "memref.alloc"
 
-    dynamic_sizes = var_operand_def(IndexType)
-    symbol_operands = var_operand_def(IndexType)
+    dynamic_sizes: VarOperand = var_operand_def(IndexType)
+    symbol_operands: VarOperand = var_operand_def(IndexType)
 
-    memref = result_def(MemRefType)
+    memref: OpResult[MemRefType] = result_def(MemRefType)
 
     # TODO how to constraint the IntegerAttr type?
-    alignment = opt_prop_def(IntegerAttr)
+    alignment: IntegerAttr | None = opt_prop_def(IntegerAttr)
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
@@ -302,16 +313,16 @@ class AllocOp(IRDLOperation):
 class AllocaScopeOp(IRDLOperation):
     name = "memref.alloca_scope"
 
-    res = var_result_def()
+    res: VarOpResult = var_result_def()
 
-    scope = region_def()
+    scope: Region = region_def()
 
 
 @irdl_op_definition
 class AllocaScopeReturnOp(IRDLOperation):
     name = "memref.alloca_scope.return"
 
-    ops = var_operand_def()
+    ops: VarOperand = var_operand_def()
 
     traits = traits_def(IsTerminator(), HasParent(AllocaScopeOp))
 
@@ -327,13 +338,13 @@ class AllocaScopeReturnOp(IRDLOperation):
 class AllocaOp(IRDLOperation):
     name = "memref.alloca"
 
-    dynamic_sizes = var_operand_def(IndexType)
-    symbol_operands = var_operand_def(IndexType)
+    dynamic_sizes: VarOperand = var_operand_def(IndexType)
+    symbol_operands: VarOperand = var_operand_def(IndexType)
 
-    memref = result_def(MemRefType)
+    memref: OpResult[MemRefType] = result_def(MemRefType)
 
     # TODO how to constraint the IntegerAttr type?
-    alignment = opt_prop_def(IntegerAttr)
+    alignment: IntegerAttr | None = opt_prop_def(IntegerAttr)
 
     traits = traits_def(MemoryAllocEffect())
 
@@ -386,13 +397,13 @@ class AtomicRMWOp(IRDLOperation):
 
     T: ClassVar = VarConstraint("T", AnyFloatConstr | SignlessIntegerConstraint)
 
-    value = operand_def(T)
-    memref = operand_def(MemRefType.constr(T))
-    indices = var_operand_def(IndexType)
+    value: Operand = operand_def(T)
+    memref: Operand = operand_def(MemRefType.constr(T))
+    indices: VarOperand = var_operand_def(IndexType)
 
-    kind = prop_def(IntegerAttr[I64])
+    kind: IntegerAttr[I64] = prop_def(IntegerAttr[I64])
 
-    result = result_def(T)
+    result: OpResult[AnyFloat | AnySignlessIntegerType] = result_def(T)
 
     traits = traits_def(MemoryWriteEffect(), MemoryReadEffect())
 
@@ -400,7 +411,7 @@ class AtomicRMWOp(IRDLOperation):
 @irdl_op_definition
 class DeallocOp(IRDLOperation):
     name = "memref.dealloc"
-    memref = operand_def(base(MemRefType) | base(UnrankedMemRefType))
+    memref: Operand = operand_def(base(MemRefType) | base(UnrankedMemRefType))
 
     traits = traits_def(MemoryFreeEffect())
 
@@ -414,8 +425,8 @@ class DeallocOp(IRDLOperation):
 @irdl_op_definition
 class GetGlobalOp(IRDLOperation):
     name = "memref.get_global"
-    memref = result_def(MemRefType)
-    name_ = prop_def(SymbolRefAttr, prop_name="name")
+    memref: OpResult[MemRefType] = result_def(MemRefType)
+    name_: SymbolRefAttr = prop_def(SymbolRefAttr, prop_name="name")
 
     traits = traits_def(NoMemoryEffect())
 
@@ -434,12 +445,14 @@ class GetGlobalOp(IRDLOperation):
 class GlobalOp(IRDLOperation):
     name = "memref.global"
 
-    sym_name = prop_def(SymbolNameConstraint())
-    sym_visibility = prop_def(StringAttr)
-    type = prop_def(MemRefType)
-    initial_value = prop_def(UnitAttr | DenseIntOrFPElementsAttr)
-    constant = opt_prop_def(UnitAttr)
-    alignment = opt_prop_def(IntegerAttr[I64])
+    sym_name: StringAttr = prop_def(SymbolNameConstraint())
+    sym_visibility: StringAttr = prop_def(StringAttr)
+    type: MemRefType = prop_def(MemRefType)
+    initial_value: UnitAttr | DenseIntOrFPElementsAttr = prop_def(
+        UnitAttr | DenseIntOrFPElementsAttr
+    )
+    constant: UnitAttr | None = opt_prop_def(UnitAttr)
+    alignment: IntegerAttr[I64] | None = opt_prop_def(IntegerAttr[I64])
 
     traits = traits_def(SymbolOpInterface(), MemoryAllocEffect())
 
@@ -480,10 +493,10 @@ class GlobalOp(IRDLOperation):
 class DimOp(IRDLOperation):
     name = "memref.dim"
 
-    source = operand_def(base(MemRefType) | base(UnrankedMemRefType))
-    index = operand_def(IndexType)
+    source: Operand = operand_def(base(MemRefType) | base(UnrankedMemRefType))
+    index: Operand = operand_def(IndexType)
 
-    result = result_def(IndexType)
+    result: OpResult[IndexType] = result_def(IndexType)
 
     traits = traits_def(NoMemoryEffect())
 
@@ -500,9 +513,9 @@ class DimOp(IRDLOperation):
 class RankOp(IRDLOperation):
     name = "memref.rank"
 
-    source = operand_def(MemRefType)
+    source: Operand = operand_def(MemRefType)
 
-    rank = result_def(IndexType)
+    rank: OpResult[IndexType] = result_def(IndexType)
 
     traits = traits_def(NoMemoryEffect())
 
@@ -512,8 +525,8 @@ class RankOp(IRDLOperation):
 
 
 class AlterShapeOperation(IRDLOperation, abc.ABC):
-    result = result_def(MemRefType)
-    reassociation = prop_def(ContiguousArrayOfIntArray())
+    result: OpResult[MemRefType] = result_def(MemRefType)
+    reassociation: ArrayOfIntArrayAttr = prop_def(ContiguousArrayOfIntArray())
 
     traits = traits_def(NoMemoryEffect())
 
@@ -526,7 +539,7 @@ class CollapseShapeOp(AlterShapeOperation):
 
     name = "memref.collapse_shape"
 
-    src = operand_def(MemRefType)
+    src: Operand = operand_def(MemRefType)
 
     assembly_format = (
         "$src $reassociation attr-dict `:` type($src) `into` type($result)"
@@ -541,10 +554,10 @@ class ExpandShapeOp(AlterShapeOperation):
 
     name = "memref.expand_shape"
 
-    src = operand_def(MemRefType)
-    output_shape = var_operand_def(IndexType)
+    src: Operand = operand_def(MemRefType)
+    output_shape: VarOperand = var_operand_def(IndexType)
 
-    static_output_shape = prop_def(DenseArrayBase.constr(i64))
+    static_output_shape: DenseArrayBase[I64] = prop_def(DenseArrayBase.constr(i64))
 
     assembly_format = (
         "$src $reassociation `output_shape`"
@@ -563,12 +576,12 @@ class ExtractStridedMetaDataOp(IRDLOperation):
 
     name = "memref.extract_strided_metadata"
 
-    source = operand_def(MemRefType)
+    source: Operand = operand_def(MemRefType)
 
-    base_buffer = result_def(MemRefType)
-    offset = result_def(IndexType)
-    sizes = var_result_def(IndexType)
-    strides = var_result_def(IndexType)
+    base_buffer: OpResult[MemRefType] = result_def(MemRefType)
+    offset: OpResult[IndexType] = result_def(IndexType)
+    sizes: VarOpResult[IndexType] = var_result_def(IndexType)
+    strides: VarOpResult[IndexType] = var_result_def(IndexType)
 
     traits = traits_def(NoMemoryEffect())
 
@@ -602,9 +615,9 @@ class ExtractStridedMetaDataOp(IRDLOperation):
 class ExtractAlignedPointerAsIndexOp(IRDLOperation):
     name = "memref.extract_aligned_pointer_as_index"
 
-    source = operand_def(MemRefType)
+    source: Operand = operand_def(MemRefType)
 
-    aligned_pointer = result_def(IndexType)
+    aligned_pointer: OpResult[IndexType] = result_def(IndexType)
 
     traits = traits_def(NoMemoryEffect())
 
@@ -629,14 +642,14 @@ class MemRefHasCanonicalizationPatternsTrait(HasCanonicalizationPatternsTrait):
 class SubviewOp(IRDLOperation):
     name = "memref.subview"
 
-    source = operand_def(MemRefType)
-    offsets = var_operand_def(IndexType)
-    sizes = var_operand_def(IndexType)
-    strides = var_operand_def(IndexType)
-    static_offsets = prop_def(DenseArrayBase.constr(i64))
-    static_sizes = prop_def(DenseArrayBase.constr(i64))
-    static_strides = prop_def(DenseArrayBase.constr(i64))
-    result = result_def(MemRefType)
+    source: Operand = operand_def(MemRefType)
+    offsets: VarOperand = var_operand_def(IndexType)
+    sizes: VarOperand = var_operand_def(IndexType)
+    strides: VarOperand = var_operand_def(IndexType)
+    static_offsets: DenseArrayBase[I64] = prop_def(DenseArrayBase.constr(i64))
+    static_sizes: DenseArrayBase[I64] = prop_def(DenseArrayBase.constr(i64))
+    static_strides: DenseArrayBase[I64] = prop_def(DenseArrayBase.constr(i64))
+    result: OpResult[MemRefType] = result_def(MemRefType)
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
@@ -720,13 +733,13 @@ class SubviewOp(IRDLOperation):
 
     @staticmethod
     def infer_result_type(
-        source_type: MemRefType[Attribute],
+        source_type: MemRefType,
         offsets: Sequence[SSAValue | int],
         sizes: Sequence[SSAValue | int],
         strides: Sequence[SSAValue | int],
         *,
         reduce_rank: bool = False,
-    ) -> MemRefType[Attribute]:
+    ) -> MemRefType:
         """
         Infer the result type of a memref.subview from its source type and
         offsets/sizes/strides.
@@ -851,8 +864,10 @@ class SubviewOp(IRDLOperation):
 class CastOp(IRDLOperation):
     name = "memref.cast"
 
-    source = operand_def(base(MemRefType) | base(UnrankedMemRefType))
-    dest = result_def(base(MemRefType) | base(UnrankedMemRefType))
+    source: Operand = operand_def(base(MemRefType) | base(UnrankedMemRefType))
+    dest: OpResult[MemRefType | UnrankedMemRefType] = result_def(
+        base(MemRefType) | base(UnrankedMemRefType)
+    )
 
     traits = traits_def(NoMemoryEffect())
 
@@ -868,8 +883,10 @@ class CastOp(IRDLOperation):
 class MemorySpaceCastOp(IRDLOperation):
     name = "memref.memory_space_cast"
 
-    source = operand_def(base(MemRefType) | base(UnrankedMemRefType))
-    dest = result_def(base(MemRefType) | base(UnrankedMemRefType))
+    source: Operand = operand_def(base(MemRefType) | base(UnrankedMemRefType))
+    dest: OpResult[MemRefType | UnrankedMemRefType] = result_def(
+        base(MemRefType) | base(UnrankedMemRefType)
+    )
 
     traits = traits_def(NoMemoryEffect())
 
@@ -913,17 +930,17 @@ class ReinterpretCastOp(IRDLOperation):
 
     name = "memref.reinterpret_cast"
 
-    source = operand_def(MemRefType)
+    source: Operand = operand_def(MemRefType)
 
-    offsets = var_operand_def(IndexType)
-    sizes = var_operand_def(IndexType)
-    strides = var_operand_def(IndexType)
+    offsets: VarOperand = var_operand_def(IndexType)
+    sizes: VarOperand = var_operand_def(IndexType)
+    strides: VarOperand = var_operand_def(IndexType)
 
-    static_offsets = prop_def(DenseArrayBase.constr(i64))
-    static_sizes = prop_def(DenseArrayBase.constr(i64))
-    static_strides = prop_def(DenseArrayBase.constr(i64))
+    static_offsets: DenseArrayBase[I64] = prop_def(DenseArrayBase.constr(i64))
+    static_sizes: DenseArrayBase[I64] = prop_def(DenseArrayBase.constr(i64))
+    static_strides: DenseArrayBase[I64] = prop_def(DenseArrayBase.constr(i64))
 
-    result = result_def(MemRefType)
+    result: OpResult[MemRefType] = result_def(MemRefType)
 
     traits = traits_def(NoMemoryEffect())
 
@@ -1051,11 +1068,11 @@ class ViewOp(IRDLOperation):
 
     name = "memref.view"
 
-    source = operand_def(MemRefType[i8])
-    byte_shift = operand_def(IndexType)
-    sizes = var_operand_def(IndexType)
+    source: Operand = operand_def(MemRefType[i8])
+    byte_shift: Operand = operand_def(IndexType)
+    sizes: VarOperand = var_operand_def(IndexType)
 
-    result = result_def(MemRefType)
+    result: OpResult[MemRefType] = result_def(MemRefType)
 
     traits = traits_def(NoMemoryEffect())
 
@@ -1114,16 +1131,16 @@ class ViewOp(IRDLOperation):
 class DmaStartOp(IRDLOperation):
     name = "memref.dma_start"
 
-    src = operand_def(MemRefType)
-    src_indices = var_operand_def(IndexType)
+    src: Operand = operand_def(MemRefType)
+    src_indices: VarOperand = var_operand_def(IndexType)
 
-    dest = operand_def(MemRefType)
-    dest_indices = var_operand_def(IndexType)
+    dest: Operand = operand_def(MemRefType)
+    dest_indices: VarOperand = var_operand_def(IndexType)
 
-    num_elements = operand_def(IndexType)
+    num_elements: Operand = operand_def(IndexType)
 
-    tag = operand_def(MemRefType[IntegerType])
-    tag_indices = var_operand_def(IndexType)
+    tag: Operand = operand_def(MemRefType[IntegerType])
+    tag_indices: VarOperand = var_operand_def(IndexType)
 
     traits = traits_def(MemoryWriteEffect(), MemoryReadEffect())
 
@@ -1182,10 +1199,10 @@ class DmaStartOp(IRDLOperation):
 class DmaWaitOp(IRDLOperation):
     name = "memref.dma_wait"
 
-    tag = operand_def(MemRefType)
-    tag_indices = var_operand_def(IndexType)
+    tag: Operand = operand_def(MemRefType)
+    tag_indices: VarOperand = var_operand_def(IndexType)
 
-    num_elements = operand_def(IndexType)
+    num_elements: Operand = operand_def(IndexType)
 
     traits = traits_def(MemoryWriteEffect(), MemoryReadEffect())
 
@@ -1218,8 +1235,8 @@ class DmaWaitOp(IRDLOperation):
 @irdl_op_definition
 class CopyOp(IRDLOperation):
     name = "memref.copy"
-    source = operand_def(MemRefType)
-    destination = operand_def(MemRefType)
+    source: Operand = operand_def(MemRefType)
+    destination: Operand = operand_def(MemRefType)
 
     traits = traits_def(MemoryWriteEffect(), MemoryReadEffect())
 

--- a/xdsl/dialects/memref_stream.py
+++ b/xdsl/dialects/memref_stream.py
@@ -22,7 +22,6 @@ from xdsl.dialects.builtin import (
     IndexType,
     IntAttr,
     IntegerAttr,
-    IntegerType,
     MemRefType,
     StringAttr,
 )
@@ -41,8 +40,11 @@ from xdsl.irdl import (
     AttrConstraint,
     AttrSizedOperandSegments,
     IRDLOperation,
+    Operand,
+    OpResult,
     ParamAttrConstraint,
     VarConstraint,
+    VarOperand,
     irdl_attr_definition,
     irdl_op_definition,
     operand_def,
@@ -242,8 +244,8 @@ class ReadOp(IRDLOperation):
 
     T: ClassVar = VarConstraint("T", AnyAttr())
 
-    stream = operand_def(ReadableStreamType.constr(T))
-    res = result_def(T)
+    stream: Operand = operand_def(ReadableStreamType.constr(T))
+    res: OpResult = result_def(T)
 
     assembly_format = "`from` $stream attr-dict `:` type($res)"
 
@@ -265,8 +267,8 @@ class WriteOp(IRDLOperation):
 
     T: ClassVar = VarConstraint("T", AnyAttr())
 
-    value = operand_def(T)
-    stream = operand_def(WritableStreamType.constr(T))
+    value: Operand = operand_def(T)
+    stream: Operand = operand_def(WritableStreamType.constr(T))
 
     assembly_format = "$value `to` $stream attr-dict `:` type($value)"
 
@@ -289,24 +291,24 @@ class StreamingRegionOp(IRDLOperation):
 
     name = "memref_stream.streaming_region"
 
-    inputs = var_operand_def(memref.MemRefType)
+    inputs: VarOperand = var_operand_def(memref.MemRefType)
     """
     Pointers to memory buffers that will be streamed. The corresponding stride pattern
     defines the order in which the elements of the input buffers will be read.
     """
-    outputs = var_operand_def(memref.MemRefType)
+    outputs: VarOperand = var_operand_def(memref.MemRefType)
     """
     Pointers to memory buffers that will be streamed. The corresponding stride pattern
     defines the order in which the elements of the input buffers will be written to.
     """
-    patterns = prop_def(ArrayAttr[StridePattern])
+    patterns: ArrayAttr[StridePattern] = prop_def(ArrayAttr[StridePattern])
     """
     Stride patterns that define the order of the input and output streams.
     Like in linalg.generic, the indexing maps corresponding to inputs are followed by the
     indexing maps for the outputs.
     """
 
-    body = region_def("single_block")
+    body: Region = region_def("single_block")
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
@@ -448,44 +450,48 @@ class GenericOpHasCanonicalizationPatternsTrait(HasCanonicalizationPatternsTrait
 class GenericOp(IRDLOperation):
     name = "memref_stream.generic"
 
-    inputs = var_operand_def()
+    inputs: VarOperand = var_operand_def()
     """
     Pointers to memory buffers or streams to be operated on. The corresponding stride
     pattern defines the order in which the elements of the input buffers will be read.
     """
-    outputs = var_operand_def(MemRefType.constr() | WritableStreamType.constr())
+    outputs: VarOperand = var_operand_def(
+        MemRefType.constr() | WritableStreamType.constr()
+    )
     """
     Pointers to memory buffers or streams to be operated on. The corresponding stride
     pattern defines the order in which the elements of the input buffers will be written
     to.
     """
-    inits = var_operand_def()
+    inits: VarOperand = var_operand_def()
     """
     Initial values for outputs. The outputs are at corresponding `init_indices`. The
     inits may be set only for the imperfectly nested form.
     """
-    indexing_maps = prop_def(ArrayAttr[AffineMapAttr])
+    indexing_maps: ArrayAttr[AffineMapAttr] = prop_def(ArrayAttr[AffineMapAttr])
     """
     Stride patterns that define the order of the input and output streams.
     Like in linalg.generic, the indexing maps corresponding to inputs are followed by
     the indexing maps for the outputs.
     """
-    bounds = prop_def(ArrayAttr[IntegerAttr[IndexType]])
+    bounds: ArrayAttr[IntegerAttr[IndexType]] = prop_def(
+        ArrayAttr[IntegerAttr[IndexType]]
+    )
     """
     The bounds of the iteration space, from the outermost loop inwards.
     All indexing maps must have the same number of dimensions as the length of `bounds`.
     """
 
-    iterator_types = prop_def(ArrayAttr[IteratorTypeAttr])
-    init_indices = prop_def(ArrayAttr[IntAttr])
+    iterator_types: ArrayAttr[IteratorTypeAttr] = prop_def(ArrayAttr[IteratorTypeAttr])
+    init_indices: ArrayAttr[IntAttr[int]] = prop_def(ArrayAttr[IntAttr])
     """
     Indices into the `outputs` that correspond to the initial values in `inits`.
     """
 
-    doc = opt_prop_def(StringAttr)
-    library_call = opt_prop_def(StringAttr)
+    doc: StringAttr | None = opt_prop_def(StringAttr)
+    library_call: StringAttr | None = opt_prop_def(StringAttr)
 
-    body = region_def("single_block")
+    body: Region = region_def("single_block")
 
     traits = traits_def(GenericOpHasCanonicalizationPatternsTrait())
 
@@ -692,7 +698,7 @@ class GenericOp(IRDLOperation):
 
         if "bounds" in attrs:
             bounds = attrs["bounds"]
-            assert isa(bounds, ArrayAttr[IntegerAttr[IntegerType | IndexType]]), bounds
+            assert isa(bounds, ArrayAttr[IntegerAttr | IntegerAttr]), bounds
             index = IndexType()
             bounds = ArrayAttr(
                 tuple(IntegerAttr(attr.value, index) for attr in bounds.data)
@@ -935,8 +941,8 @@ class FillOp(IRDLOperation):
 
     T: ClassVar = VarConstraint("T", AnyAttr())
 
-    memref = operand_def(memref.MemRefType.constr(T))
-    value = operand_def(T)
+    memref: Operand = operand_def(memref.MemRefType.constr(T))
+    value: Operand = operand_def(T)
 
     assembly_format = "$memref `with` $value attr-dict `:` type($memref)"
 

--- a/xdsl/dialects/ml_program.py
+++ b/xdsl/dialects/ml_program.py
@@ -16,6 +16,7 @@ from xdsl.ir import (
 )
 from xdsl.irdl import (
     IRDLOperation,
+    OpResult,
     attr_def,
     irdl_op_definition,
     opt_attr_def,
@@ -39,11 +40,11 @@ class GlobalOp(IRDLOperation):
 
     name = "ml_program.global"
 
-    sym_name = attr_def(SymbolNameConstraint())
-    type = attr_def(TypeAttribute)
-    is_mutable = opt_attr_def(UnitAttr)
-    value = opt_attr_def()
-    sym_visibility = attr_def(StringAttr)
+    sym_name: StringAttr = attr_def(SymbolNameConstraint())
+    type: TypeAttribute = attr_def(TypeAttribute)
+    is_mutable: UnitAttr | None = opt_attr_def(UnitAttr)
+    value: Attribute | None = opt_attr_def()
+    sym_visibility: StringAttr = attr_def(StringAttr)
 
     traits = traits_def(SymbolOpInterface())
 
@@ -124,8 +125,8 @@ class GlobalLoadConstantOp(IRDLOperation):
 
     name = "ml_program.global_load_const"
 
-    global_attr = attr_def(SymbolRefAttr)
-    result = result_def()
+    global_attr: SymbolRefAttr = attr_def(SymbolRefAttr)
+    result: OpResult = result_def()
 
     def __init__(
         self,

--- a/xdsl/dialects/mod_arith.py
+++ b/xdsl/dialects/mod_arith.py
@@ -7,10 +7,18 @@ from abc import ABC
 from typing import ClassVar
 
 from xdsl.dialects.arith import signlessIntegerLike
-from xdsl.dialects.builtin import IntegerAttr
+from xdsl.dialects.builtin import (
+    IndexType,
+    IntegerAttr,
+    IntegerType,
+    TensorType,
+    VectorType,
+)
 from xdsl.ir import Attribute, Dialect, Operation, SSAValue
 from xdsl.irdl import (
     IRDLOperation,
+    Operand,
+    OpResult,
     ParsePropInAttrDict,
     VarConstraint,
     irdl_op_definition,
@@ -29,10 +37,15 @@ class BinaryOp(IRDLOperation, ABC):
 
     T: ClassVar = VarConstraint("T", signlessIntegerLike)
 
-    lhs = operand_def(T)
-    rhs = operand_def(T)
-    output = result_def(T)
-    modulus = prop_def(IntegerAttr)
+    lhs: Operand = operand_def(T)
+    rhs: Operand = operand_def(T)
+    output: OpResult[
+        IntegerType
+        | IndexType
+        | VectorType[IntegerType | IndexType]
+        | TensorType[IntegerType | IndexType]
+    ] = result_def(T)
+    modulus: IntegerAttr = prop_def(IntegerAttr)
 
     irdl_options = (ParsePropInAttrDict(),)
 

--- a/xdsl/dialects/mpi.py
+++ b/xdsl/dialects/mpi.py
@@ -9,6 +9,7 @@ from typing_extensions import TypeVar
 
 from xdsl.dialects import llvm
 from xdsl.dialects.builtin import (
+    I32,
     AnyFloat,
     IntegerType,
     MemRefType,
@@ -27,6 +28,9 @@ from xdsl.ir import (
 from xdsl.irdl import (
     IRDLOperation,
     Operand,
+    OpResult,
+    OptOperand,
+    OptOpResult,
     attr_def,
     base,
     irdl_attr_definition,
@@ -170,12 +174,12 @@ class ReduceOp(MPIBaseOp):
 
     name = "mpi.reduce"
 
-    send_buffer = operand_def(Attribute)
-    recv_buffer = operand_def(Attribute)
-    count = operand_def(i32)
-    datatype = operand_def(DataType)
-    operationtype = attr_def(OperationType)
-    root = operand_def(i32)
+    send_buffer: Operand = operand_def(Attribute)
+    recv_buffer: Operand = operand_def(Attribute)
+    count: Operand = operand_def(i32)
+    datatype: Operand = operand_def(DataType)
+    operationtype: OperationType = attr_def(OperationType)
+    root: Operand = operand_def(i32)
 
     def __init__(
         self,
@@ -220,11 +224,11 @@ class AllreduceOp(MPIBaseOp):
 
     name = "mpi.allreduce"
 
-    send_buffer = opt_operand_def(Attribute)
-    recv_buffer = operand_def(Attribute)
-    count = operand_def(i32)
-    datatype = operand_def(DataType)
-    operationtype = attr_def(OperationType)
+    send_buffer: OptOperand = opt_operand_def(Attribute)
+    recv_buffer: Operand = operand_def(Attribute)
+    count: Operand = operand_def(i32)
+    datatype: Operand = operand_def(DataType)
+    operationtype: OperationType = attr_def(OperationType)
 
     def __init__(
         self,
@@ -276,10 +280,10 @@ class BcastOp(MPIBaseOp):
 
     name = "mpi.bcast"
 
-    buffer = operand_def(Attribute)
-    count = operand_def(i32)
-    datatype = operand_def(DataType)
-    root = operand_def(i32)
+    buffer: Operand = operand_def(Attribute)
+    count: Operand = operand_def(i32)
+    datatype: Operand = operand_def(DataType)
+    root: Operand = operand_def(i32)
 
     def __init__(
         self,
@@ -321,12 +325,12 @@ class IsendOp(MPIBaseOp):
 
     name = "mpi.isend"
 
-    buffer = operand_def(Attribute)
-    count = operand_def(i32)
-    datatype = operand_def(DataType)
-    dest = operand_def(i32)
-    tag = operand_def(i32)
-    request = operand_def(RequestType)
+    buffer: Operand = operand_def(Attribute)
+    count: Operand = operand_def(i32)
+    datatype: Operand = operand_def(DataType)
+    dest: Operand = operand_def(i32)
+    tag: Operand = operand_def(i32)
+    request: Operand = operand_def(RequestType)
 
     def __init__(
         self,
@@ -370,11 +374,11 @@ class SendOp(MPIBaseOp):
 
     name = "mpi.send"
 
-    buffer = operand_def(Attribute)
-    count = operand_def(i32)
-    datatype = operand_def(DataType)
-    dest = operand_def(i32)
-    tag = operand_def(i32)
+    buffer: Operand = operand_def(Attribute)
+    count: Operand = operand_def(i32)
+    datatype: Operand = operand_def(DataType)
+    dest: Operand = operand_def(i32)
+    tag: Operand = operand_def(i32)
 
     def __init__(
         self,
@@ -417,12 +421,12 @@ class IrecvOp(MPIBaseOp):
 
     name = "mpi.irecv"
 
-    buffer = operand_def(Attribute)
-    count = operand_def(i32)
-    datatype = operand_def(DataType)
-    source = operand_def(i32)
-    tag = operand_def(i32)
-    request = operand_def(RequestType)
+    buffer: Operand = operand_def(Attribute)
+    count: Operand = operand_def(i32)
+    datatype: Operand = operand_def(DataType)
+    source: Operand = operand_def(i32)
+    tag: Operand = operand_def(i32)
+    request: Operand = operand_def(RequestType)
 
     def __init__(
         self,
@@ -467,13 +471,13 @@ class RecvOp(MPIBaseOp):
 
     name = "mpi.recv"
 
-    buffer = operand_def(Attribute)
-    count = operand_def(i32)
-    datatype = operand_def(DataType)
-    source = operand_def(i32)
-    tag = operand_def(i32)
+    buffer: Operand = operand_def(Attribute)
+    count: Operand = operand_def(i32)
+    datatype: Operand = operand_def(DataType)
+    source: Operand = operand_def(i32)
+    tag: Operand = operand_def(i32)
 
-    status = opt_result_def(StatusType)
+    status: OptOpResult[StatusType] = opt_result_def(StatusType)
 
     def __init__(
         self,
@@ -508,10 +512,10 @@ class TestOp(MPIBaseOp):
 
     name = "mpi.test"
 
-    request = operand_def(RequestType)
+    request: Operand = operand_def(RequestType)
 
-    flag = result_def(t_bool)
-    status = result_def(StatusType)
+    flag: OpResult[IntegerType] = result_def(t_bool)
+    status: OpResult[StatusType] = result_def(StatusType)
 
     def __init__(self, request: Operand):
         return super().__init__(operands=[request], result_types=[t_bool, StatusType()])
@@ -534,8 +538,8 @@ class WaitOp(MPIBaseOp):
 
     name = "mpi.wait"
 
-    request = operand_def(RequestType)
-    status = opt_result_def(StatusType)
+    request: Operand = operand_def(RequestType)
+    status: OptOpResult[StatusType] = opt_result_def(StatusType)
 
     def __init__(self, request: Operand, ignore_status: bool = True):
         result_types: list[list[Attribute]] = [[StatusType()]]
@@ -564,9 +568,11 @@ class WaitallOp(MPIBaseOp):
 
     name = "mpi.waitall"
 
-    requests = operand_def(VectorType[RequestType])
-    count = operand_def(i32)
-    statuses = opt_result_def(VectorType[StatusType])
+    requests: Operand = operand_def(VectorType[RequestType])
+    count: Operand = operand_def(i32)
+    statuses: OptOpResult[VectorType[StatusType]] = opt_result_def(
+        VectorType[StatusType]
+    )
 
     def __init__(self, requests: Operand, count: Operand, ignore_status: bool = True):
         result_types: list[list[Attribute]] = [[VectorType(StatusType())]]
@@ -591,11 +597,11 @@ class GetStatusFieldOp(MPIBaseOp):
 
     name = "mpi.status.get"
 
-    status = operand_def(StatusType)
+    status: Operand = operand_def(StatusType)
 
-    field = attr_def(StringAttr)
+    field: StringAttr = attr_def(StringAttr)
 
-    result = result_def(i32)
+    result: OpResult[I32] = result_def(i32)
 
     def __init__(self, status_obj: Operand, field: StatusTypeField):
         return super().__init__(
@@ -616,7 +622,7 @@ class CommRankOp(MPIBaseOp):
 
     name = "mpi.comm.rank"
 
-    rank = result_def(i32)
+    rank: OpResult[I32] = result_def(i32)
 
     def __init__(self):
         return super().__init__(result_types=[i32])
@@ -633,7 +639,7 @@ class CommSizeOp(MPIBaseOp):
 
     name = "mpi.comm.size"
 
-    size = result_def(i32)
+    size: OpResult[I32] = result_def(i32)
 
     def __init__(self):
         return super().__init__(result_types=[i32])
@@ -667,11 +673,11 @@ class UnwrapMemRefOp(MPIBaseOp):
 
     name = "mpi.unwrap_memref"
 
-    ref = operand_def(MemRefType[AnyNumericType])
+    ref: Operand = operand_def(MemRefType[AnyNumericType])
 
-    ptr = result_def(llvm.LLVMPointerType)
-    len = result_def(i32)
-    type = result_def(DataType)
+    ptr: OpResult[llvm.LLVMPointerType] = result_def(llvm.LLVMPointerType)
+    len: OpResult[I32] = result_def(i32)
+    type: OpResult[DataType] = result_def(DataType)
 
     def __init__(self, ref: SSAValue | Operation):
         return super().__init__(
@@ -695,9 +701,9 @@ class GetDtypeOp(MPIBaseOp):
 
     name = "mpi.get_dtype"
 
-    dtype = attr_def()
+    dtype: Attribute = attr_def()
 
-    result = result_def(DataType)
+    result: OpResult[DataType] = result_def(DataType)
 
     def __init__(self, dtype: Attribute):
         return super().__init__(result_types=[DataType()], attributes={"dtype": dtype})
@@ -717,11 +723,11 @@ class AllocateTypeOp(MPIBaseOp):
 
     name = "mpi.allocate"
 
-    bindc_name = opt_attr_def(StringAttr)
-    dtype = attr_def(VectorWrappableConstr)
-    count = operand_def(i32)
+    bindc_name: StringAttr | None = opt_attr_def(StringAttr)
+    dtype: RequestType | StatusType | DataType = attr_def(VectorWrappableConstr)
+    count: Operand = operand_def(i32)
 
-    result = result_def(VectorType)
+    result: OpResult[VectorType[VectorWrappable]] = result_def(VectorType)
 
     def __init__(
         self,
@@ -748,10 +754,12 @@ class VectorGetOp(MPIBaseOp):
 
     name = "mpi.vector_get"
 
-    vect = operand_def(VectorType)
-    element = operand_def(i32)
+    vect: Operand = operand_def(VectorType)
+    element: Operand = operand_def(i32)
 
-    result = result_def(VectorWrappableConstr)
+    result: OpResult[RequestType | StatusType | DataType] = result_def(
+        VectorWrappableConstr
+    )
 
     def __init__(self, vect: SSAValue | Operation, element: SSAValue | Operation):
         ssa_val = SSAValue.get(vect)
@@ -774,7 +782,7 @@ class NullRequestOp(MPIBaseOp):
 
     name = "mpi.request_null"
 
-    request = operand_def(RequestType)
+    request: Operand = operand_def(RequestType)
 
     def __init__(self, req: SSAValue | Operation):
         return super().__init__(operands=[req])
@@ -804,15 +812,15 @@ class GatherOp(MPIBaseOp):
 
     name = "mpi.gather"
 
-    sendbuf = operand_def(llvm.LLVMPointerType)
-    sendcount = operand_def(i32)
-    sendtype = operand_def(DataType)
+    sendbuf: Operand = operand_def(llvm.LLVMPointerType)
+    sendcount: Operand = operand_def(i32)
+    sendtype: Operand = operand_def(DataType)
 
-    recvbuf = operand_def(llvm.LLVMPointerType)
-    recvcount = operand_def(i32)
-    recvtype = operand_def(DataType)
+    recvbuf: Operand = operand_def(llvm.LLVMPointerType)
+    recvcount: Operand = operand_def(i32)
+    recvtype: Operand = operand_def(DataType)
 
-    root = operand_def(i32)
+    root: Operand = operand_def(i32)
 
     def __init__(
         self,

--- a/xdsl/dialects/omp.py
+++ b/xdsl/dialects/omp.py
@@ -27,6 +27,7 @@ from xdsl.ir import (
     Dialect,
     EnumAttribute,
     ParametrizedAttribute,
+    Region,
     SpacedOpaqueSyntaxAttribute,
     StrEnum,
     TypeAttribute,
@@ -40,6 +41,7 @@ from xdsl.irdl import (
     IRDLOperation,
     Operand,
     Operation,
+    OptOperand,
     RangeOf,
     SameVariadicOperandSize,
     VarOperand,
@@ -524,7 +526,7 @@ class MapBoundsType(ParametrizedAttribute, TypeAttribute):
 class LoopNestOp(IRDLOperation):
     name = "omp.loop_nest"
 
-    lowerBound = var_operand_def(base(IntegerType) | base(IndexType))
+    lowerBound: VarOperand = var_operand_def(base(IntegerType) | base(IndexType))
     upperBound = var_operand_def(base(IntegerType) | base(IndexType))
     step = var_operand_def(base(IntegerType) | base(IndexType))
 
@@ -933,14 +935,16 @@ class DistributeOp(BlockArgOpenMPOperation):
     dist_schedule_chunk_size = opt_operand_def(IntegerType | IndexType)
     private_vars = var_operand_def()
 
-    dist_schedule_static = opt_prop_def(UnitAttr)
-    order = opt_prop_def(OrderKindAttr)
-    order_mod = opt_prop_def(OrderModifierAttr)
-    private_syms = opt_prop_def(ArrayAttr[SymbolRefAttr])
+    dist_schedule_static: UnitAttr | None = opt_prop_def(UnitAttr)
+    order: OrderKindAttr | None = opt_prop_def(OrderKindAttr)
+    order_mod: OrderModifierAttr | None = opt_prop_def(OrderModifierAttr)
+    private_syms: ArrayAttr[SymbolRefAttr] | None = opt_prop_def(
+        ArrayAttr[SymbolRefAttr]
+    )
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
-    body = region_def("single_block")
+    body: Region = region_def("single_block")
 
     traits = traits_def(LoopWrapper(), RecursiveMemoryEffect())
 
@@ -963,19 +967,19 @@ class TargetTaskBasedDataOp(IRDLOperation):
 
     DEP_COUNT: ClassVar = IntVarConstraint("DEP_COUNT", AnyInt())
 
-    depend_vars = var_operand_def(
+    depend_vars: VarOperand = var_operand_def(
         RangeOf(
             AnyAttr(),  # TODO: OpenMP_PointerLikeTypeInterface
         ).of_length(DEP_COUNT)
     )
-    device = opt_operand_def(IntegerType | IndexType)
-    if_expr = opt_operand_def(i1)
-    mapped_vars = var_operand_def()  # TODO: OpenMP_PointerLikeTypeInterface
+    device: OptOperand = opt_operand_def(IntegerType | IndexType)
+    if_expr: OptOperand = opt_operand_def(i1)
+    mapped_vars: VarOperand = var_operand_def()  # TODO: OpenMP_PointerLikeTypeInterface
 
-    depend_kinds = opt_prop_def(
+    depend_kinds: ArrayAttr[DependKindAttr] | None = opt_prop_def(
         ArrayAttr.constr(RangeOf(base(DependKindAttr)).of_length(DEP_COUNT))
     )
-    nowait = opt_prop_def(UnitAttr)
+    nowait: UnitAttr | None = opt_prop_def(UnitAttr)
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
@@ -1054,13 +1058,17 @@ class TargetDataOp(BlockArgOpenMPOperation):
 
     name = "omp.target_data"
 
-    device = opt_operand_def(IntegerType)
-    if_expr = opt_operand_def(i1)
-    mapped_vars = var_operand_def()  # TODO: OpenMP_PointerLikeTypeInterface
-    use_device_addr_vars = var_operand_def()  # TODO: OpenMP_PointerLikeTypeInterface
-    use_device_ptr_vars = var_operand_def()  # TODO: OpenMP_PointerLikeTypeInterface
+    device: OptOperand = opt_operand_def(IntegerType)
+    if_expr: OptOperand = opt_operand_def(i1)
+    mapped_vars: VarOperand = var_operand_def()  # TODO: OpenMP_PointerLikeTypeInterface
+    use_device_addr_vars: VarOperand = (
+        var_operand_def()
+    )  # TODO: OpenMP_PointerLikeTypeInterface
+    use_device_ptr_vars: VarOperand = (
+        var_operand_def()
+    )  # TODO: OpenMP_PointerLikeTypeInterface
 
-    region = region_def()
+    region: Region = region_def()
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 

--- a/xdsl/dialects/pdl.py
+++ b/xdsl/dialects/pdl.py
@@ -27,7 +27,12 @@ from xdsl.ir import (
 from xdsl.irdl import (
     AttrSizedOperandSegments,
     IRDLOperation,
+    Operand,
+    OpResult,
+    OptOperand,
     ParsePropInAttrDict,
+    VarOperand,
+    VarOpResult,
     base,
     irdl_attr_definition,
     irdl_op_definition,
@@ -182,12 +187,14 @@ class ApplyNativeConstraintOp(IRDLOperation):
     """
 
     name = "pdl.apply_native_constraint"
-    constraint_name = prop_def(StringAttr, prop_name="name")
-    is_negated = prop_def(
+    constraint_name: StringAttr = prop_def(StringAttr, prop_name="name")
+    is_negated: BoolAttr = prop_def(
         BoolAttr, prop_name="isNegated", default_value=BoolAttr.from_bool(False)
     )
-    args = var_operand_def(AnyPDLTypeConstr | base(RangeType[AnyPDLType]))
-    res = var_result_def(AnyPDLTypeConstr | base(RangeType[AnyPDLType]))
+    args: VarOperand = var_operand_def(AnyPDLTypeConstr | base(RangeType[AnyPDLType]))
+    res: VarOpResult[
+        AttributeType | OperationType | TypeType | ValueType | RangeType[AnyPDLType]
+    ] = var_result_def(AnyPDLTypeConstr | base(RangeType[AnyPDLType]))
 
     irdl_options = (ParsePropInAttrDict(),)
 
@@ -216,9 +223,11 @@ class ApplyNativeRewriteOp(IRDLOperation):
     """
 
     name = "pdl.apply_native_rewrite"
-    constraint_name = prop_def(StringAttr, prop_name="name")
-    args = var_operand_def(AnyPDLTypeConstr | base(RangeType[AnyPDLType]))
-    res = var_result_def(AnyPDLTypeConstr | base(RangeType[AnyPDLType]))
+    constraint_name: StringAttr = prop_def(StringAttr, prop_name="name")
+    args: VarOperand = var_operand_def(AnyPDLTypeConstr | base(RangeType[AnyPDLType]))
+    res: VarOpResult[
+        AttributeType | OperationType | TypeType | ValueType | RangeType[AnyPDLType]
+    ] = var_result_def(AnyPDLTypeConstr | base(RangeType[AnyPDLType]))
 
     def __init__(
         self,
@@ -265,9 +274,9 @@ class AttributeOp(IRDLOperation):
     """
 
     name = "pdl.attribute"
-    value = opt_prop_def()
-    value_type = opt_operand_def(TypeType)
-    output = result_def(AttributeType)
+    value: Attribute | None = opt_prop_def()
+    value_type: OptOperand = opt_operand_def(TypeType)
+    output: OpResult[AttributeType] = result_def(AttributeType)
 
     assembly_format = "(`:` $value_type^)? (`=` $value^)? attr-dict-with-keyword"
 
@@ -307,7 +316,7 @@ class EraseOp(IRDLOperation):
     """
 
     name = "pdl.erase"
-    op_value = operand_def(OperationType)
+    op_value: Operand = operand_def(OperationType)
 
     assembly_format = "$op_value attr-dict"
 
@@ -322,8 +331,8 @@ class OperandOp(IRDLOperation):
     """
 
     name = "pdl.operand"
-    value_type = opt_operand_def(TypeType)
-    value = result_def(ValueType)
+    value_type: OptOperand = opt_operand_def(TypeType)
+    value: OpResult[ValueType] = result_def(ValueType)
 
     assembly_format = "(`:` $value_type^)? attr-dict"
 
@@ -341,8 +350,8 @@ class OperandsOp(IRDLOperation):
     """
 
     name = "pdl.operands"
-    value_type = opt_operand_def(RangeType[TypeType])
-    value = result_def(RangeType[ValueType])
+    value_type: OptOperand = opt_operand_def(RangeType[TypeType])
+    value: OpResult[RangeType[ValueType]] = result_def(RangeType[ValueType])
 
     assembly_format = "(`:` $value_type^)? attr-dict"
 
@@ -360,13 +369,17 @@ class OperationOp(IRDLOperation):
     """
 
     name = "pdl.operation"
-    opName = opt_prop_def(StringAttr)
-    attributeValueNames = prop_def(ArrayAttr[StringAttr])
+    opName: StringAttr | None = opt_prop_def(StringAttr)
+    attributeValueNames: ArrayAttr[StringAttr] = prop_def(ArrayAttr[StringAttr])
 
-    operand_values = var_operand_def(base(ValueType) | base(RangeType[ValueType]))
-    attribute_values = var_operand_def(AttributeType)
-    type_values = var_operand_def(base(TypeType) | base(RangeType[TypeType]))
-    op = result_def(OperationType)
+    operand_values: VarOperand = var_operand_def(
+        base(ValueType) | base(RangeType[ValueType])
+    )
+    attribute_values: VarOperand = var_operand_def(AttributeType)
+    type_values: VarOperand = var_operand_def(
+        base(TypeType) | base(RangeType[TypeType])
+    )
+    op: OpResult[OperationType] = result_def(OperationType)
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
@@ -521,9 +534,9 @@ class PatternOp(IRDLOperation):
     """
 
     name = "pdl.pattern"
-    benefit = prop_def(IntegerAttr[I16])
-    sym_name = opt_prop_def(StringAttr)
-    body = region_def("single_block")
+    benefit: IntegerAttr[I16] = prop_def(IntegerAttr[I16])
+    sym_name: StringAttr | None = opt_prop_def(StringAttr)
+    body: Region = region_def("single_block")
 
     traits = traits_def(OptionalSymbolOpInterface())
 
@@ -607,8 +620,10 @@ class RangeOp(IRDLOperation):
     """
 
     name = "pdl.range"
-    arguments = var_operand_def(AnyPDLTypeConstr | base(RangeType[AnyPDLType]))
-    result = result_def(RangeType[AnyPDLType])
+    arguments: VarOperand = var_operand_def(
+        AnyPDLTypeConstr | base(RangeType[AnyPDLType])
+    )
+    result: OpResult[RangeType[AnyPDLType]] = result_def(RangeType[AnyPDLType])
 
     traits = lazy_traits_def(lambda: (HasParent(RewriteOp),))
 
@@ -683,9 +698,11 @@ class ReplaceOp(IRDLOperation):
     """
 
     name = "pdl.replace"
-    op_value = operand_def(OperationType)
-    repl_operation = opt_operand_def(OperationType)
-    repl_values = var_operand_def(base(ValueType) | base(RangeType[ValueType]))
+    op_value: Operand = operand_def(OperationType)
+    repl_operation: OptOperand = opt_operand_def(OperationType)
+    repl_values: VarOperand = var_operand_def(
+        base(ValueType) | base(RangeType[ValueType])
+    )
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
@@ -732,9 +749,9 @@ class ResultOp(IRDLOperation):
     """
 
     name = "pdl.result"
-    index = prop_def(IntegerAttr[I32])
-    parent_ = operand_def(OperationType)
-    val = result_def(ValueType)
+    index: IntegerAttr[I32] = prop_def(IntegerAttr[I32])
+    parent_: Operand = operand_def(OperationType)
+    val: OpResult[ValueType] = result_def(ValueType)
 
     assembly_format = "$index `of` $parent_ attr-dict"
 
@@ -753,9 +770,11 @@ class ResultsOp(IRDLOperation):
     """
 
     name = "pdl.results"
-    index = opt_prop_def(IntegerAttr[I32])
-    parent_ = operand_def(OperationType)
-    val = result_def(base(ValueType) | base(RangeType[ValueType]))
+    index: IntegerAttr[I32] | None = opt_prop_def(IntegerAttr[I32])
+    parent_: Operand = operand_def(OperationType)
+    val: OpResult[ValueType | RangeType[ValueType]] = result_def(
+        base(ValueType) | base(RangeType[ValueType])
+    )
 
     def __init__(
         self,
@@ -799,13 +818,13 @@ class RewriteOp(IRDLOperation):
     """
 
     name = "pdl.rewrite"
-    root = opt_operand_def(OperationType)
+    root: OptOperand = opt_operand_def(OperationType)
     # name of external rewriter function
-    name_ = opt_prop_def(StringAttr, prop_name="name")
+    name_: StringAttr | None = opt_prop_def(StringAttr, prop_name="name")
     # parameters of external rewriter function
-    external_args = var_operand_def(AnyPDLTypeConstr)
+    external_args: VarOperand = var_operand_def(AnyPDLTypeConstr)
     # body of inline rewriter function
-    body = region_def()
+    body: Region = region_def()
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
@@ -859,8 +878,8 @@ class TypeOp(IRDLOperation):
     """
 
     name = "pdl.type"
-    constantType = opt_prop_def(TypeAttribute)
-    result = result_def(TypeType)
+    constantType: TypeAttribute | None = opt_prop_def(TypeAttribute)
+    result: OpResult[TypeType] = result_def(TypeType)
 
     assembly_format = "attr-dict (`:` $constantType^)?"
 
@@ -880,8 +899,10 @@ class TypesOp(IRDLOperation):
     """
 
     name = "pdl.types"
-    constantTypes = opt_prop_def(ArrayAttr[TypeAttribute])
-    result = result_def(RangeType[TypeType])
+    constantTypes: ArrayAttr[TypeAttribute] | None = opt_prop_def(
+        ArrayAttr[TypeAttribute]
+    )
+    result: OpResult[RangeType[TypeType]] = result_def(RangeType[TypeType])
 
     assembly_format = "attr-dict (`:` $constantTypes^)?"
 

--- a/xdsl/dialects/pdl_interp.py
+++ b/xdsl/dialects/pdl_interp.py
@@ -56,8 +56,14 @@ from xdsl.irdl import (
     ConstraintContext,
     IntConstraint,
     IRDLOperation,
+    Operand,
+    OpResult,
     ParsePropInAttrDict,
+    Successor,
     VarConstraint,
+    VarOperand,
+    VarOpResult,
+    VarSuccessor,
     base,
     irdl_op_definition,
     operand_def,
@@ -102,9 +108,9 @@ class GetOperandOp(IRDLOperation):
     """
 
     name = "pdl_interp.get_operand"
-    index = prop_def(IntegerAttr[I32])
-    input_op = operand_def(OperationType)
-    value = result_def(ValueType)
+    index: IntegerAttr[I32] = prop_def(IntegerAttr[I32])
+    input_op: Operand = operand_def(OperationType)
+    value: OpResult[ValueType] = result_def(ValueType)
 
     assembly_format = "$index `of` $input_op attr-dict"
 
@@ -123,9 +129,11 @@ class GetOperandsOp(IRDLOperation):
     """
 
     name = "pdl_interp.get_operands"
-    index = opt_prop_def(IntegerAttr[I32])
-    input_op = operand_def(OperationType)
-    value = result_def(ValueType | RangeType[ValueType])
+    index: IntegerAttr[I32] | None = opt_prop_def(IntegerAttr[I32])
+    input_op: Operand = operand_def(OperationType)
+    value: OpResult[ValueType | RangeType[ValueType]] = result_def(
+        ValueType | RangeType[ValueType]
+    )
 
     # TODO: assembly format doesn't work due to a bug:
     # https://github.com/xdslproject/xdsl/issues/5562
@@ -193,10 +201,10 @@ class CheckOperationNameOp(IRDLOperation):
 
     name = "pdl_interp.check_operation_name"
     traits = traits_def(IsTerminator())
-    operation_name = prop_def(StringAttr, prop_name="name")
-    input_op = operand_def(OperationType)
-    true_dest = successor_def()
-    false_dest = successor_def()
+    operation_name: StringAttr = prop_def(StringAttr, prop_name="name")
+    input_op: Operand = operand_def(OperationType)
+    true_dest: Successor = successor_def()
+    false_dest: Successor = successor_def()
 
     assembly_format = (
         "`of` $input_op `is` $name attr-dict `->` $true_dest `, ` $false_dest"
@@ -226,11 +234,11 @@ class CheckOperandCountOp(IRDLOperation):
 
     name = "pdl_interp.check_operand_count"
     traits = traits_def(IsTerminator())
-    input_op = operand_def(OperationType)
-    count = prop_def(IntegerAttr[I32])
-    compareAtLeast = opt_prop_def(UnitAttr)
-    true_dest = successor_def()
-    false_dest = successor_def()
+    input_op: Operand = operand_def(OperationType)
+    count: IntegerAttr[I32] = prop_def(IntegerAttr[I32])
+    compareAtLeast: UnitAttr | None = opt_prop_def(UnitAttr)
+    true_dest: Successor = successor_def()
+    false_dest: Successor = successor_def()
 
     assembly_format = "`of` $input_op `is` (`at_least` $compareAtLeast^)? $count attr-dict `->` $true_dest `, ` $false_dest"
 
@@ -262,11 +270,11 @@ class CheckResultCountOp(IRDLOperation):
 
     name = "pdl_interp.check_result_count"
     traits = traits_def(IsTerminator())
-    input_op = operand_def(OperationType)
-    count = prop_def(IntegerAttr[I32])
-    compareAtLeast = opt_prop_def(UnitAttr)
-    true_dest = successor_def()
-    false_dest = successor_def()
+    input_op: Operand = operand_def(OperationType)
+    count: IntegerAttr[I32] = prop_def(IntegerAttr[I32])
+    compareAtLeast: UnitAttr | None = opt_prop_def(UnitAttr)
+    true_dest: Successor = successor_def()
+    false_dest: Successor = successor_def()
 
     assembly_format = "`of` $input_op `is` (`at_least` $compareAtLeast^)? $count attr-dict `->` $true_dest `, ` $false_dest"
 
@@ -298,9 +306,9 @@ class IsNotNullOp(IRDLOperation):
 
     name = "pdl_interp.is_not_null"
     traits = traits_def(IsTerminator())
-    value = operand_def(AnyPDLTypeConstr | base(RangeType[AnyPDLType]))
-    true_dest = successor_def()
-    false_dest = successor_def()
+    value: Operand = operand_def(AnyPDLTypeConstr | base(RangeType[AnyPDLType]))
+    true_dest: Successor = successor_def()
+    false_dest: Successor = successor_def()
 
     assembly_format = (
         "$value `:` type($value) attr-dict `->` $true_dest `, ` $false_dest"
@@ -317,9 +325,9 @@ class GetResultOp(IRDLOperation):
     """
 
     name = "pdl_interp.get_result"
-    index = prop_def(IntegerAttr[I32])
-    input_op = operand_def(OperationType)
-    value = result_def(ValueType)
+    index: IntegerAttr[I32] = prop_def(IntegerAttr[I32])
+    input_op: Operand = operand_def(OperationType)
+    value: OpResult[ValueType] = result_def(ValueType)
 
     assembly_format = "$index `of` $input_op attr-dict"
 
@@ -338,9 +346,11 @@ class GetResultsOp(IRDLOperation):
     """
 
     name = "pdl_interp.get_results"
-    index = opt_prop_def(IntegerAttr[I32])
-    input_op = operand_def(OperationType)
-    value = result_def(ValueType | RangeType[ValueType])
+    index: IntegerAttr[I32] | None = opt_prop_def(IntegerAttr[I32])
+    input_op: Operand = operand_def(OperationType)
+    value: OpResult[ValueType | RangeType[ValueType]] = result_def(
+        ValueType | RangeType[ValueType]
+    )
 
     # assembly_format = "($index^)? `of` $input_op `:` type($value) attr-dict"
     # TODO: Fix bug preventing this assebmly format from working: https://github.com/xdslproject/xdsl/issues/4136.
@@ -391,9 +401,9 @@ class GetAttributeOp(IRDLOperation):
     """
 
     name = "pdl_interp.get_attribute"
-    constraint_name = prop_def(StringAttr, prop_name="name")
-    input_op = operand_def(OperationType)
-    value = result_def(AttributeType)
+    constraint_name: StringAttr = prop_def(StringAttr, prop_name="name")
+    input_op: Operand = operand_def(OperationType)
+    value: OpResult[AttributeType] = result_def(AttributeType)
 
     assembly_format = "$name `of` $input_op attr-dict"
 
@@ -414,8 +424,8 @@ class GetAttributeTypeOp(IRDLOperation):
     """
 
     name = "pdl_interp.get_attribute_type"
-    value = operand_def(AttributeType)
-    result = result_def(TypeType)
+    value: Operand = operand_def(AttributeType)
+    result: OpResult[TypeType] = result_def(TypeType)
 
     assembly_format = "`of` $value attr-dict"
 
@@ -434,10 +444,10 @@ class CheckAttributeOp(IRDLOperation):
 
     name = "pdl_interp.check_attribute"
     traits = traits_def(IsTerminator())
-    constantValue = prop_def()
-    attribute = operand_def(AttributeType)
-    true_dest = successor_def()
-    false_dest = successor_def()
+    constantValue: Attribute = prop_def()
+    attribute: Operand = operand_def(AttributeType)
+    true_dest: Successor = successor_def()
+    false_dest: Successor = successor_def()
 
     assembly_format = (
         "$attribute `is` $constantValue attr-dict `->` $true_dest `, ` $false_dest"
@@ -465,10 +475,10 @@ class CheckTypeOp(IRDLOperation):
 
     name = "pdl_interp.check_type"
     traits = traits_def(IsTerminator())
-    type = prop_def(TypeAttribute)
-    value = operand_def(TypeType)
-    true_dest = successor_def()
-    false_dest = successor_def()
+    type: TypeAttribute = prop_def(TypeAttribute)
+    value: Operand = operand_def(TypeType)
+    true_dest: Successor = successor_def()
+    false_dest: Successor = successor_def()
 
     assembly_format = "$value `is` $type attr-dict `->` $true_dest `, ` $false_dest"
 
@@ -490,10 +500,10 @@ class CheckTypesOp(IRDLOperation):
 
     name = "pdl_interp.check_types"
     traits = traits_def(IsTerminator())
-    types = prop_def(ArrayAttr[TypeAttribute])
-    value = operand_def(RangeType[TypeType])
-    true_dest = successor_def()
-    false_dest = successor_def()
+    types: ArrayAttr[TypeAttribute] = prop_def(ArrayAttr[TypeAttribute])
+    value: Operand = operand_def(RangeType[TypeType])
+    true_dest: Successor = successor_def()
+    false_dest: Successor = successor_def()
 
     assembly_format = "$value `are` $types attr-dict `->` $true_dest `, ` $false_dest"
 
@@ -522,10 +532,10 @@ class AreEqualOp(IRDLOperation):
     name = "pdl_interp.are_equal"
     traits = traits_def(IsTerminator())
     T: ClassVar = VarConstraint("T", AnyPDLTypeConstr | base(RangeType[AnyPDLType]))
-    lhs = operand_def(T)
-    rhs = operand_def(T)
-    true_dest = successor_def()
-    false_dest = successor_def()
+    lhs: Operand = operand_def(T)
+    rhs: Operand = operand_def(T)
+    true_dest: Successor = successor_def()
+    false_dest: Successor = successor_def()
 
     assembly_format = (
         "operands `:` type($lhs) attr-dict `->` $true_dest `, ` $false_dest"
@@ -545,14 +555,16 @@ class ApplyConstraintOp(IRDLOperation):
 
     name = "pdl_interp.apply_constraint"
     traits = traits_def(IsTerminator())
-    constraint_name = prop_def(StringAttr, prop_name="name")
-    is_negated = prop_def(
+    constraint_name: StringAttr = prop_def(StringAttr, prop_name="name")
+    is_negated: BoolAttr = prop_def(
         BoolAttr, prop_name="isNegated", default_value=BoolAttr.from_bool(False)
     )
-    args = var_operand_def(AnyPDLTypeConstr | base(RangeType[AnyPDLType]))
-    results_ = var_result_def(AnyPDLTypeConstr | base(RangeType[AnyPDLType]))
-    true_dest = successor_def()
-    false_dest = successor_def()
+    args: VarOperand = var_operand_def(AnyPDLTypeConstr | base(RangeType[AnyPDLType]))
+    results_: VarOpResult[
+        AttributeType | OperationType | TypeType | ValueType | RangeType[AnyPDLType]
+    ] = var_result_def(AnyPDLTypeConstr | base(RangeType[AnyPDLType]))
+    true_dest: Successor = successor_def()
+    false_dest: Successor = successor_def()
     irdl_options = (ParsePropInAttrDict(),)
 
     assembly_format = "$name `(` $args `:` type($args) `)` (`:` type($results_)^)? attr-dict `->` $true_dest `,` $false_dest"
@@ -590,9 +602,11 @@ class ApplyRewriteOp(IRDLOperation):
     """
 
     name = "pdl_interp.apply_rewrite"
-    rewrite_name = prop_def(StringAttr, prop_name="name")
-    args = var_operand_def(AnyPDLTypeConstr | base(RangeType[AnyPDLType]))
-    results_ = var_result_def(AnyPDLTypeConstr | base(RangeType[AnyPDLType]))
+    rewrite_name: StringAttr = prop_def(StringAttr, prop_name="name")
+    args: VarOperand = var_operand_def(AnyPDLTypeConstr | base(RangeType[AnyPDLType]))
+    results_: VarOpResult[
+        AttributeType | OperationType | TypeType | ValueType | RangeType[AnyPDLType]
+    ] = var_result_def(AnyPDLTypeConstr | base(RangeType[AnyPDLType]))
     irdl_options = (ParsePropInAttrDict(),)
 
     assembly_format = (
@@ -626,15 +640,15 @@ class RecordMatchOp(IRDLOperation):
 
     name = "pdl_interp.record_match"
     traits = traits_def(IsTerminator())
-    rewriter = prop_def(SymbolRefAttr)
-    rootKind = opt_prop_def(StringAttr)
-    generatedOps = opt_prop_def(ArrayAttr[StringAttr])
-    benefit = prop_def(IntegerAttr[I16])
+    rewriter: SymbolRefAttr = prop_def(SymbolRefAttr)
+    rootKind: StringAttr | None = opt_prop_def(StringAttr)
+    generatedOps: ArrayAttr[StringAttr] | None = opt_prop_def(ArrayAttr[StringAttr])
+    benefit: IntegerAttr[I16] = prop_def(IntegerAttr[I16])
 
-    inputs = var_operand_def(AnyPDLTypeConstr | base(RangeType[AnyPDLType]))
-    matched_ops = var_operand_def(OperationType)
+    inputs: VarOperand = var_operand_def(AnyPDLTypeConstr | base(RangeType[AnyPDLType]))
+    matched_ops: VarOperand = var_operand_def(OperationType)
 
-    dest = successor_def()
+    dest: Successor = successor_def()
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
@@ -712,8 +726,8 @@ class GetValueTypeOp(IRDLOperation):
 
     name = "pdl_interp.get_value_type"
     T: ClassVar = VarConstraint("T", base(TypeType) | base(RangeType[TypeType]))
-    value = operand_def(ValueConstrFromResultConstr(T))
-    result = result_def(T)
+    value: Operand = operand_def(ValueConstrFromResultConstr(T))
+    result: OpResult[TypeType | RangeType[TypeType]] = result_def(T)
 
     assembly_format = "`of` $value `:` type($result) attr-dict"
 
@@ -735,8 +749,8 @@ class ReplaceOp(IRDLOperation):
     """
 
     name = "pdl_interp.replace"
-    input_op = operand_def(OperationType)
-    repl_values = var_operand_def(ValueType | RangeType[ValueType])
+    input_op: Operand = operand_def(OperationType)
+    repl_values: VarOperand = var_operand_def(ValueType | RangeType[ValueType])
 
     assembly_format = (
         "$input_op `with` ` ` `(` ($repl_values^ `:` type($repl_values))? `)` attr-dict"
@@ -753,7 +767,7 @@ class EraseOp(IRDLOperation):
     """
 
     name = "pdl_interp.erase"
-    input_op = operand_def(OperationType)
+    input_op: Operand = operand_def(OperationType)
 
     assembly_format = "$input_op attr-dict"
 
@@ -768,8 +782,8 @@ class CreateAttributeOp(IRDLOperation):
     """
 
     name = "pdl_interp.create_attribute"
-    value = prop_def(AnyAttr())
-    attribute = result_def(AttributeType)
+    value: Attribute = prop_def(AnyAttr())
+    attribute: OpResult[AttributeType] = result_def(AttributeType)
 
     assembly_format = "$value attr-dict-with-keyword"
 
@@ -784,17 +798,21 @@ class CreateOperationOp(IRDLOperation):
     """
 
     name = "pdl_interp.create_operation"
-    constraint_name = prop_def(StringAttr, prop_name="name")
-    input_attribute_names = prop_def(
+    constraint_name: StringAttr = prop_def(StringAttr, prop_name="name")
+    input_attribute_names: ArrayAttr[StringAttr] = prop_def(
         ArrayAttr[StringAttr], prop_name="inputAttributeNames"
     )
-    inferred_result_types = opt_prop_def(UnitAttr, prop_name="inferredResultTypes")
+    inferred_result_types: UnitAttr | None = opt_prop_def(
+        UnitAttr, prop_name="inferredResultTypes"
+    )
 
-    input_operands = var_operand_def(ValueType | RangeType[ValueType])
-    input_attributes = var_operand_def(AttributeType | RangeType[AttributeType])
-    input_result_types = var_operand_def(TypeType | RangeType[TypeType])
+    input_operands: VarOperand = var_operand_def(ValueType | RangeType[ValueType])
+    input_attributes: VarOperand = var_operand_def(
+        AttributeType | RangeType[AttributeType]
+    )
+    input_result_types: VarOperand = var_operand_def(TypeType | RangeType[TypeType])
 
-    result_op = result_def(OperationType)
+    result_op: OpResult[OperationType] = result_def(OperationType)
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
@@ -999,8 +1017,10 @@ class CreateRangeOp(IRDLOperation):
     """
 
     name = "pdl_interp.create_range"
-    arguments = var_operand_def(AnyPDLTypeConstr | base(RangeType[AnyPDLType]))
-    result = result_def(RangeType[AnyPDLType])
+    arguments: VarOperand = var_operand_def(
+        AnyPDLTypeConstr | base(RangeType[AnyPDLType])
+    )
+    result: OpResult[RangeType[AnyPDLType]] = result_def(RangeType[AnyPDLType])
 
     custom_directives = (RangeTypeDirective,)
 
@@ -1028,8 +1048,8 @@ class GetDefiningOpOp(IRDLOperation):
     """
 
     name = "pdl_interp.get_defining_op"
-    value = operand_def(ValueType | RangeType[ValueType])
-    input_op = result_def(OperationType)
+    value: Operand = operand_def(ValueType | RangeType[ValueType])
+    input_op: OpResult[OperationType] = result_def(OperationType)
 
     assembly_format = "`of` $value `:` type($value) attr-dict"
 
@@ -1045,12 +1065,14 @@ class SwitchOperationNameOp(IRDLOperation):
 
     name = "pdl_interp.switch_operation_name"
 
-    case_values = prop_def(ArrayAttr[StringAttr], prop_name="caseValues")
+    case_values: ArrayAttr[StringAttr] = prop_def(
+        ArrayAttr[StringAttr], prop_name="caseValues"
+    )
 
-    input_op = operand_def(OperationType)
+    input_op: Operand = operand_def(OperationType)
 
-    default_dest = successor_def()
-    cases = var_successor_def()
+    default_dest: Successor = successor_def()
+    cases: VarSuccessor = var_successor_def()
 
     traits = traits_def(IsTerminator())
     assembly_format = (
@@ -1080,12 +1102,14 @@ class SwitchOperandCountOp(IRDLOperation):
 
     name = "pdl_interp.switch_operand_count"
 
-    case_values = prop_def(DenseIntElementsAttr, prop_name="caseValues")
+    case_values: DenseIntElementsAttr = prop_def(
+        DenseIntElementsAttr, prop_name="caseValues"
+    )
 
-    input_op = operand_def(OperationType)
+    input_op: Operand = operand_def(OperationType)
 
-    default_dest = successor_def()
-    cases = var_successor_def()
+    default_dest: Successor = successor_def()
+    cases: VarSuccessor = var_successor_def()
 
     traits = traits_def(IsTerminator())
     assembly_format = (
@@ -1120,12 +1144,14 @@ class SwitchResultCountOp(IRDLOperation):
 
     name = "pdl_interp.switch_result_count"
 
-    case_values = prop_def(DenseIntElementsAttr, prop_name="caseValues")
+    case_values: DenseIntElementsAttr = prop_def(
+        DenseIntElementsAttr, prop_name="caseValues"
+    )
 
-    input_op = operand_def(OperationType)
+    input_op: Operand = operand_def(OperationType)
 
-    default_dest = successor_def()
-    cases = var_successor_def()
+    default_dest: Successor = successor_def()
+    cases: VarSuccessor = var_successor_def()
 
     traits = traits_def(IsTerminator())
     assembly_format = (
@@ -1159,12 +1185,14 @@ class SwitchTypeOp(IRDLOperation):
 
     name = "pdl_interp.switch_type"
 
-    case_values = prop_def(ArrayAttr[TypeAttribute], prop_name="caseValues")
+    case_values: ArrayAttr[TypeAttribute] = prop_def(
+        ArrayAttr[TypeAttribute], prop_name="caseValues"
+    )
 
-    value = operand_def(TypeType)
+    value: Operand = operand_def(TypeType)
 
-    default_dest = successor_def()
-    cases = var_successor_def()
+    default_dest: Successor = successor_def()
+    cases: VarSuccessor = var_successor_def()
 
     traits = traits_def(IsTerminator())
     assembly_format = (
@@ -1195,12 +1223,14 @@ class SwitchTypesOp(IRDLOperation):
 
     name = "pdl_interp.switch_types"
 
-    case_values = prop_def(ArrayAttr[ArrayAttr[TypeAttribute]], prop_name="caseValues")
+    case_values: ArrayAttr[ArrayAttr[TypeAttribute]] = prop_def(
+        ArrayAttr[ArrayAttr[TypeAttribute]], prop_name="caseValues"
+    )
 
-    value = operand_def(RangeType[TypeType])
+    value: Operand = operand_def(RangeType[TypeType])
 
-    default_dest = successor_def()
-    cases = var_successor_def()
+    default_dest: Successor = successor_def()
+    cases: VarSuccessor = var_successor_def()
 
     traits = traits_def(IsTerminator())
     assembly_format = (
@@ -1250,12 +1280,16 @@ class FuncOp(IRDLOperation):
     """
 
     name = "pdl_interp.func"
-    sym_name = prop_def(SymbolNameConstraint())
-    function_type = prop_def(FunctionType)
-    arg_attrs = opt_prop_def(ArrayAttr[DictionaryAttr])
-    res_attrs = opt_prop_def(ArrayAttr[DictionaryAttr])
+    sym_name: StringAttr = prop_def(SymbolNameConstraint())
+    function_type: FunctionType = prop_def(FunctionType)
+    arg_attrs: ArrayAttr[DictionaryAttr] | None = opt_prop_def(
+        ArrayAttr[DictionaryAttr]
+    )
+    res_attrs: ArrayAttr[DictionaryAttr] | None = opt_prop_def(
+        ArrayAttr[DictionaryAttr]
+    )
 
-    body = region_def()
+    body: Region = region_def()
 
     traits = traits_def(
         IsolatedFromAbove(), SymbolOpInterface(), FuncOpCallableInterface()
@@ -1336,10 +1370,10 @@ class SwitchAttributeOp(IRDLOperation):
 
     name = "pdl_interp.switch_attribute"
 
-    attribute = operand_def(AttributeType)
-    caseValues = prop_def(ArrayAttr)
-    defaultDest = successor_def()
-    cases = var_successor_def()
+    attribute: Operand = operand_def(AttributeType)
+    caseValues: ArrayAttr[Attribute] = prop_def(ArrayAttr)
+    defaultDest: Successor = successor_def()
+    cases: VarSuccessor = var_successor_def()
 
     traits = traits_def(IsTerminator())
 
@@ -1369,8 +1403,8 @@ class CreateTypeOp(IRDLOperation):
 
     name = "pdl_interp.create_type"
 
-    value = prop_def(TypeAttribute)
-    result = result_def(TypeType)
+    value: TypeAttribute = prop_def(TypeAttribute)
+    result: OpResult[TypeType] = result_def(TypeType)
 
     assembly_format = "$value attr-dict"
 
@@ -1389,8 +1423,8 @@ class CreateTypesOp(IRDLOperation):
 
     name = "pdl_interp.create_types"
 
-    value = prop_def(ArrayAttr)
-    result = result_def(RangeType[TypeType])
+    value: ArrayAttr[Attribute] = prop_def(ArrayAttr)
+    result: OpResult[RangeType[TypeType]] = result_def(RangeType[TypeType])
 
     assembly_format = "$value attr-dict"
 
@@ -1425,9 +1459,9 @@ class ForEachOp(IRDLOperation):
     name = "pdl_interp.foreach"
     traits = traits_def(IsTerminator())
 
-    values = operand_def(RangeType[AnyPDLType])
-    region = region_def()
-    successor = successor_def()
+    values: Operand = operand_def(RangeType[AnyPDLType])
+    region: Region = region_def()
+    successor: Successor = successor_def()
 
     def __init__(
         self,
@@ -1498,7 +1532,7 @@ class BranchOp(IRDLOperation):
     name = "pdl_interp.branch"
     traits = traits_def(IsTerminator())
 
-    dest = successor_def()
+    dest: Successor = successor_def()
 
     assembly_format = "$dest attr-dict"
 

--- a/xdsl/dialects/polynomial.py
+++ b/xdsl/dialects/polynomial.py
@@ -20,6 +20,8 @@ from xdsl.dialects.builtin import (
     ArrayAttr,
     FloatAttr,
     StringAttr,
+    TensorType,
+    VectorType,
     container_of,
     f64,
 )
@@ -33,6 +35,8 @@ from xdsl.ir import (
 )
 from xdsl.irdl import (
     IRDLOperation,
+    Operand,
+    OpResult,
     VarConstraint,
     attr_def,
     irdl_attr_definition,
@@ -233,14 +237,16 @@ class EvalOp(IRDLOperation):
 
     T: ClassVar = VarConstraint("T", container_of(AnyFloat))
 
-    value = operand_def(T)
-    result = result_def(T)
+    value: Operand = operand_def(T)
+    result: OpResult[AnyFloat | VectorType[AnyFloat] | TensorType[AnyFloat]] = (
+        result_def(T)
+    )
 
-    polynomial = prop_def(TypedChebyshevPolynomialAttr)
+    polynomial: TypedChebyshevPolynomialAttr = prop_def(TypedChebyshevPolynomialAttr)
 
-    scheme = attr_def(StringAttr)
-    domain_lower = opt_attr_def(FloatAttr)
-    domain_upper = opt_attr_def(FloatAttr)
+    scheme: StringAttr = attr_def(StringAttr)
+    domain_lower: FloatAttr[AnyFloat] | None = opt_attr_def(FloatAttr)
+    domain_upper: FloatAttr[AnyFloat] | None = opt_attr_def(FloatAttr)
 
     traits = traits_def(Pure(), SameOperandsAndResultType())
 

--- a/xdsl/dialects/printf.py
+++ b/xdsl/dialects/printf.py
@@ -4,6 +4,8 @@ from xdsl.dialects import arith, builtin
 from xdsl.ir import Dialect, Operation, SSAValue, VerifyException
 from xdsl.irdl import (
     IRDLOperation,
+    Operand,
+    VarOperand,
     attr_def,
     irdl_op_definition,
     operand_def,
@@ -29,8 +31,8 @@ class PrintFormatOp(IRDLOperation):
 
     name = "printf.print_format"
 
-    format_str = attr_def(builtin.StringAttr)
-    format_vals = var_operand_def()
+    format_str: builtin.StringAttr = attr_def(builtin.StringAttr)
+    format_vals: VarOperand = var_operand_def()
 
     def __init__(self, format_str: str, *vals: SSAValue | Operation):
         super().__init__(
@@ -97,7 +99,7 @@ class PrintCharOp(IRDLOperation):
     """
 
     name = "printf.print_char"
-    char = operand_def(i8)
+    char: Operand = operand_def(i8)
 
     def __init__(self, char: SSAValue | Operation):
         super().__init__(
@@ -128,7 +130,7 @@ class PrintIntOp(IRDLOperation):
     """
 
     name = "printf.print_int"
-    int = operand_def(builtin.IntegerType)
+    int: Operand = operand_def(builtin.IntegerType)
 
     def __init__(self, integer: SSAValue | Operation):
         super().__init__(

--- a/xdsl/dialects/ptr.py
+++ b/xdsl/dialects/ptr.py
@@ -23,6 +23,8 @@ from xdsl.dialects.builtin import (
 from xdsl.ir import Attribute, Dialect, ParametrizedAttribute, SSAValue, TypeAttribute
 from xdsl.irdl import (
     IRDLOperation,
+    Operand,
+    OpResult,
     irdl_attr_definition,
     irdl_op_definition,
     operand_def,
@@ -52,9 +54,9 @@ class PtrAddOpHasCanonicalizationPatterns(HasCanonicalizationPatternsTrait):
 class PtrAddOp(IRDLOperation):
     name = "ptr_xdsl.ptradd"
 
-    addr = operand_def(PtrType)
-    offset = operand_def(IntegerAttrTypeConstr)
-    result = result_def(PtrType)
+    addr: Operand = operand_def(PtrType)
+    offset: Operand = operand_def(IntegerAttrTypeConstr)
+    result: OpResult[PtrType] = result_def(PtrType)
 
     assembly_format = "$addr `,` $offset attr-dict `:` `(` type($addr) `,` type($offset) `)` `->` type($result)"
 
@@ -69,8 +71,8 @@ class PtrAddOp(IRDLOperation):
 class TypeOffsetOp(IRDLOperation):
     name = "ptr_xdsl.type_offset"
 
-    elem_type = prop_def(AnyAttr())
-    offset = result_def(IntegerAttrTypeConstr)
+    elem_type: Attribute = prop_def(AnyAttr())
+    offset: OpResult[IndexType | IntegerType] = result_def(IntegerAttrTypeConstr)
 
     assembly_format = "$elem_type attr-dict `:` type($offset)"
 
@@ -82,12 +84,12 @@ class TypeOffsetOp(IRDLOperation):
 class StoreOp(IRDLOperation):
     name = "ptr_xdsl.store"
 
-    addr = operand_def(PtrType)
-    value = operand_def()
+    addr: Operand = operand_def(PtrType)
+    value: Operand = operand_def()
 
-    volatile = opt_prop_def(UnitAttr)
-    syncscope = opt_prop_def(UnitAttr)
-    ordering = opt_prop_def(UnitAttr)
+    volatile: UnitAttr | None = opt_prop_def(UnitAttr)
+    syncscope: UnitAttr | None = opt_prop_def(UnitAttr)
+    ordering: UnitAttr | None = opt_prop_def(UnitAttr)
 
     assembly_format = "(`volatile` $volatile^)? $value `,` $addr (`atomic` (`syncscope` `(` $syncscope^ `)`)? $ordering^)? attr-dict `:` type($value) `,` type($addr)"  # noqa: E501
 
@@ -114,13 +116,13 @@ class StoreOp(IRDLOperation):
 class LoadOp(IRDLOperation):
     name = "ptr_xdsl.load"
 
-    addr = operand_def(PtrType)
-    res = result_def()
+    addr: Operand = operand_def(PtrType)
+    res: OpResult = result_def()
 
-    volatile = opt_prop_def(UnitAttr)
-    syncscope = opt_prop_def(UnitAttr)
-    ordering = opt_prop_def(UnitAttr)
-    invariant = opt_prop_def(UnitAttr)
+    volatile: UnitAttr | None = opt_prop_def(UnitAttr)
+    syncscope: UnitAttr | None = opt_prop_def(UnitAttr)
+    ordering: UnitAttr | None = opt_prop_def(UnitAttr)
+    invariant: UnitAttr | None = opt_prop_def(UnitAttr)
 
     assembly_format = "(`volatile` $volatile^)? $addr (`atomic` (`syncscope` `(` $syncscope^ `)`)? $ordering^)? (`invariant` $invariant^)? attr-dict `:` type($addr) `->` type($res)"  # noqa: E501
 
@@ -158,8 +160,8 @@ class ToPtrOpHasCanonicalizationPatternsTrait(HasCanonicalizationPatternsTrait):
 class ToPtrOp(IRDLOperation):
     name = "ptr_xdsl.to_ptr"
 
-    source = operand_def(MemRefType)
-    res = result_def(PtrType)
+    source: Operand = operand_def(MemRefType)
+    res: OpResult[PtrType] = result_def(PtrType)
 
     assembly_format = "$source attr-dict `:` type($source) `->` type($res)"
 
@@ -181,8 +183,8 @@ class FromPtrOpHasCanonicalizationPatternsTrait(HasCanonicalizationPatternsTrait
 class FromPtrOp(IRDLOperation):
     name = "ptr_xdsl.from_ptr"
 
-    source = operand_def(PtrType)
-    res = result_def(MemRefType)
+    source: Operand = operand_def(PtrType)
+    res: OpResult[MemRefType] = result_def(MemRefType)
 
     assembly_format = "$source attr-dict `:` type($source) `->` type($res)"
 

--- a/xdsl/dialects/py/__init__.py
+++ b/xdsl/dialects/py/__init__.py
@@ -18,11 +18,13 @@ from xdsl.dialects.builtin import (
 from xdsl.ir import (
     Dialect,
     ParametrizedAttribute,
+    Region,
     TypeAttribute,
 )
 from xdsl.irdl import (
     IRDLOperation,
     Operand,
+    OpResult,
     irdl_attr_definition,
     irdl_op_definition,
     operand_def,
@@ -70,7 +72,7 @@ class PyModuleOp(PyOperation):
     """
 
     name = "py.module"
-    body = region_def()
+    body: Region = region_def()
 
 
 @irdl_op_definition
@@ -83,8 +85,8 @@ class PyConstOp(PyOperation):
     assembly_format = "$const attr-dict"
 
     # We can expand this to other types later.
-    const = prop_def(IntegerAttr[I64])
-    res = result_def(PyObjectType())
+    const: IntegerAttr[I64] = prop_def(IntegerAttr[I64])
+    res: OpResult[PyObjectType] = result_def(PyObjectType())
 
     def __init__(self, const: IntegerAttr[I64]):
         super().__init__(properties={"const": const}, result_types=[PyObjectType()])
@@ -97,10 +99,10 @@ class PyBinOp(PyOperation):
     """
 
     name = "py.binop"
-    lhs = operand_def(PyObjectType())
-    rhs = operand_def(PyObjectType())
-    res = result_def(PyObjectType())
-    op = prop_def(StringAttr)
+    lhs: Operand = operand_def(PyObjectType())
+    rhs: Operand = operand_def(PyObjectType())
+    res: OpResult[PyObjectType] = result_def(PyObjectType())
+    op: StringAttr = prop_def(StringAttr)
     assembly_format = "$op $lhs $rhs attr-dict"
 
     def __init__(

--- a/xdsl/dialects/riscv/abstract_ops.py
+++ b/xdsl/dialects/riscv/abstract_ops.py
@@ -35,6 +35,7 @@ from xdsl.ir import (
 )
 from xdsl.irdl import (
     IRDLOperation,
+    Operand,
     attr_def,
     operand_def,
     opt_attr_def,
@@ -197,7 +198,7 @@ class RISCVInstruction(RISCVAsmOperation, RISCVRegallocOperation, ABC):
     The name of the operation will be used as the RISC-V assembly instruction name.
     """
 
-    comment = opt_attr_def(StringAttr)
+    comment: StringAttr | None = opt_attr_def(StringAttr)
     """
     An optional comment that will be printed along with the instruction.
     """
@@ -283,8 +284,8 @@ class RdRsRsOperation(
     """
 
     rd: OpResult[RDInvT] = result_def(RDInvT)
-    rs1 = operand_def(RS1InvT)
-    rs2 = operand_def(RS2InvT)
+    rs1: Operand = operand_def(RS1InvT)
+    rs2: Operand = operand_def(RS2InvT)
 
     def __init__(
         self,
@@ -343,9 +344,9 @@ class RsRsImmFloatOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC):
     (one integer and one floating-point) and an immediate.
     """
 
-    rs1 = operand_def(IntRegisterType)
-    rs2 = operand_def(FloatRegisterType)
-    immediate = attr_def(IntegerAttr[I12])
+    rs1: Operand = operand_def(IntRegisterType)
+    rs2: Operand = operand_def(FloatRegisterType)
+    immediate: IntegerAttr[I12] = attr_def(IntegerAttr[I12])
 
     def __init__(
         self,
@@ -392,9 +393,9 @@ class RdRsImmFloatOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC):
     one immediate operand.
     """
 
-    rd = result_def(FloatRegisterType)
-    rs1 = operand_def(IntRegisterType)
-    immediate = attr_def(IntegerAttr[I12] | LabelAttr)
+    rd: OpResult[FloatRegisterType] = result_def(FloatRegisterType)
+    rs1: Operand = operand_def(IntRegisterType)
+    immediate: IntegerAttr[I12] | LabelAttr = attr_def(IntegerAttr[I12] | LabelAttr)
 
     def __init__(
         self,
@@ -442,10 +443,10 @@ class RdRsRsRsFloatOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC):
     e.g: fused-multiply-add (FMA) instructions.
     """
 
-    rd = result_def(FloatRegisterType)
-    rs1 = operand_def(FloatRegisterType)
-    rs2 = operand_def(FloatRegisterType)
-    rs3 = operand_def(FloatRegisterType)
+    rd: OpResult[FloatRegisterType] = result_def(FloatRegisterType)
+    rs1: Operand = operand_def(FloatRegisterType)
+    rs2: Operand = operand_def(FloatRegisterType)
+    rs3: Operand = operand_def(FloatRegisterType)
 
     def __init__(
         self,
@@ -481,10 +482,10 @@ class RdRsRsFloatFloatIntegerOperationWithFastMath(
     This is called R-Type in the RISC-V specification.
     """
 
-    rd = result_def(IntRegisterType)
-    rs1 = operand_def(FloatRegisterType)
-    rs2 = operand_def(FloatRegisterType)
-    fastmath = attr_def(FastMathFlagsAttr)
+    rd: OpResult[IntRegisterType] = result_def(IntRegisterType)
+    rs1: Operand = operand_def(FloatRegisterType)
+    rs2: Operand = operand_def(FloatRegisterType)
+    fastmath: FastMathFlagsAttr = attr_def(FastMathFlagsAttr)
 
     def __init__(
         self,
@@ -536,10 +537,10 @@ class RdRsRsFloatOperationWithFastMath(
     This is called R-Type in the RISC-V specification.
     """
 
-    rd = result_def(FloatRegisterType)
-    rs1 = operand_def(FloatRegisterType)
-    rs2 = operand_def(FloatRegisterType)
-    fastmath = opt_attr_def(FastMathFlagsAttr)
+    rd: OpResult[FloatRegisterType] = result_def(FloatRegisterType)
+    rs1: Operand = operand_def(FloatRegisterType)
+    rs2: Operand = operand_def(FloatRegisterType)
+    fastmath: FastMathFlagsAttr | None = opt_attr_def(FastMathFlagsAttr)
 
     def __init__(
         self,
@@ -587,8 +588,8 @@ class RdImmIntegerOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC):
     immediate operand (e.g. U-Type and J-Type instructions in the RISC-V spec).
     """
 
-    rd = result_def(IntRegisterType)
-    immediate = attr_def(IntegerAttr[I20] | LabelAttr)
+    rd: OpResult[IntRegisterType] = result_def(IntRegisterType)
+    immediate: IntegerAttr[I20] | LabelAttr = attr_def(IntegerAttr[I20] | LabelAttr)
 
     def __init__(
         self,
@@ -635,12 +636,12 @@ class RdImmJumpOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC):
     most sense as an attribute.
     """
 
-    rd = opt_attr_def(IntRegisterType)
+    rd: IntRegisterType | None = opt_attr_def(IntRegisterType)
     """
     The rd register here is not a register storing the result, rather the register where
     the program counter is stored before jumping.
     """
-    immediate = attr_def(IntegerAttr[SI20] | LabelAttr)
+    immediate: IntegerAttr[SI20] | LabelAttr = attr_def(IntegerAttr[SI20] | LabelAttr)
 
     def __init__(
         self,
@@ -700,9 +701,9 @@ class RdRsImmIntegerOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC)
     This is called I-Type in the RISC-V specification.
     """
 
-    rd = result_def(IntRegisterType)
-    rs1 = operand_def(IntRegisterType)
-    immediate = attr_def(IntegerAttr[SI12] | LabelAttr)
+    rd: OpResult[IntRegisterType] = result_def(IntRegisterType)
+    rs1: Operand = operand_def(IntRegisterType)
+    immediate: IntegerAttr[SI12] | LabelAttr = attr_def(IntegerAttr[SI12] | LabelAttr)
 
     def __init__(
         self,
@@ -762,9 +763,9 @@ class RdRsImmShiftOperation(RISCVInstruction, ABC, Generic[ShiftImmT, ShiftImmAt
     imm[5] 6 != 0 but the shift amount is encoded in the lower 6 bits of the I-immediate field for RV64I.
     """
 
-    rd = result_def(IntRegisterType)
-    rs1 = operand_def(IntRegisterType)
-    immediate = attr_def(IntegerAttr[ShiftImmT])
+    rd: OpResult[IntRegisterType] = result_def(IntRegisterType)
+    rs1: Operand = operand_def(IntRegisterType)
+    immediate: IntegerAttr[ShiftImmT] = attr_def(IntegerAttr[ShiftImmT])
 
     assembly_format = (
         "$rs1 `,` $immediate attr-dict `:` `(` type($rs1) `)` `->` type($rd)"
@@ -851,9 +852,9 @@ class RdRsImmBitManipOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC
     See external [documentation](https://five-embeddev.com/riscv-bitmanip/1.0.0/bitmanip.html#).
     """
 
-    rd = result_def(IntRegisterType)
-    rs1 = operand_def(IntRegisterType)
-    immediate = attr_def(IntegerAttr[UI5] | LabelAttr)
+    rd: OpResult[IntRegisterType] = result_def(IntRegisterType)
+    rs1: Operand = operand_def(IntRegisterType)
+    immediate: IntegerAttr[UI5] | LabelAttr = attr_def(IntegerAttr[UI5] | LabelAttr)
 
     def __init__(
         self,
@@ -907,13 +908,13 @@ class RdRsImmJumpOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC):
     most sense as an attribute.
     """
 
-    rs1 = operand_def(IntRegisterType)
-    rd = opt_attr_def(IntRegisterType)
+    rs1: Operand = operand_def(IntRegisterType)
+    rd: IntRegisterType | None = opt_attr_def(IntRegisterType)
     """
     The rd register here is not a register storing the result, rather the register where
     the program counter is stored before jumping.
     """
-    immediate = attr_def(IntegerAttr[SI12] | LabelAttr)
+    immediate: IntegerAttr[SI12] | LabelAttr = attr_def(IntegerAttr[SI12] | LabelAttr)
 
     def __init__(
         self,
@@ -968,8 +969,8 @@ class RdRsOperation(
     source register.
     """
 
-    rd = result_def(RDInvT)
-    rs = operand_def(RSInvT)
+    rd: OpResult[RDInvT] = result_def(RDInvT)
+    rs: Operand = operand_def(RSInvT)
 
     def __init__(
         self,
@@ -1024,9 +1025,9 @@ class RsRsOffIntegerOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC)
     This is called B-Type in the RISC-V specification.
     """
 
-    rs1 = operand_def(IntRegisterType)
-    rs2 = operand_def(IntRegisterType)
-    offset = attr_def(IntegerAttr[SI12] | LabelAttr)
+    rs1: Operand = operand_def(IntRegisterType)
+    rs2: Operand = operand_def(IntRegisterType)
+    offset: IntegerAttr[SI12] | LabelAttr = attr_def(IntegerAttr[SI12] | LabelAttr)
 
     def __init__(
         self,
@@ -1074,9 +1075,9 @@ class RsRsImmIntegerOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC)
     This is called S-Type in the RISC-V specification.
     """
 
-    rs1 = operand_def(IntRegisterType)
-    rs2 = operand_def(IntRegisterType)
-    immediate = attr_def(IntegerAttr[SI12])
+    rs1: Operand = operand_def(IntRegisterType)
+    rs2: Operand = operand_def(IntRegisterType)
+    immediate: IntegerAttr[SI12] = attr_def(IntegerAttr[SI12])
 
     # All S-Type operations write to memory
     traits = traits_def(MemoryWriteEffect())
@@ -1125,8 +1126,8 @@ class RsRsIntegerOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC):
     registers.
     """
 
-    rs1 = operand_def(IntRegisterType)
-    rs2 = operand_def(IntRegisterType)
+    rs1: Operand = operand_def(IntRegisterType)
+    rs2: Operand = operand_def(IntRegisterType)
 
     def __init__(
         self,
@@ -1194,10 +1195,10 @@ class CsrReadWriteOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC):
       returned in rd
     """
 
-    rd = result_def(IntRegisterType)
-    rs1 = operand_def(IntRegisterType)
-    csr = attr_def(IntegerAttr)
-    writeonly = opt_attr_def(UnitAttr)
+    rd: OpResult[IntRegisterType] = result_def(IntRegisterType)
+    rs1: Operand = operand_def(IntRegisterType)
+    csr: IntegerAttr = attr_def(IntegerAttr)
+    writeonly: UnitAttr | None = opt_attr_def(UnitAttr)
 
     traits = traits_def(MemoryReadEffect(), MemoryWriteEffect())
 
@@ -1268,10 +1269,10 @@ class CsrBitwiseOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC):
       to writing to a CSR takes place even if the mask in rs has no actual bits set.
     """
 
-    rd = result_def(IntRegisterType)
-    rs1 = operand_def(IntRegisterType)
-    csr = attr_def(IntegerAttr)
-    readonly = opt_attr_def(UnitAttr)
+    rd: OpResult[IntRegisterType] = result_def(IntRegisterType)
+    rs1: Operand = operand_def(IntRegisterType)
+    csr: IntegerAttr = attr_def(IntegerAttr)
+    readonly: UnitAttr | None = opt_attr_def(UnitAttr)
 
     # Conservatively set the write effect, in the future we should be conditional on
     # the `readonly` flag.
@@ -1343,10 +1344,10 @@ class CsrReadWriteImmOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC
       returned in rd
     """
 
-    rd = result_def(IntRegisterType)
-    csr = attr_def(IntegerAttr)
-    immediate = attr_def(IntegerAttr)
-    writeonly = opt_attr_def(UnitAttr)
+    rd: OpResult[IntRegisterType] = result_def(IntRegisterType)
+    csr: IntegerAttr = attr_def(IntegerAttr)
+    immediate: IntegerAttr = attr_def(IntegerAttr)
+    writeonly: UnitAttr | None = opt_attr_def(UnitAttr)
 
     traits = traits_def(MemoryReadEffect(), MemoryWriteEffect())
 
@@ -1421,9 +1422,9 @@ class CsrBitwiseImmOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC):
       place.
     """
 
-    rd = result_def(IntRegisterType)
-    csr = attr_def(IntegerAttr)
-    immediate = attr_def(IntegerAttr)
+    rd: OpResult[IntRegisterType] = result_def(IntRegisterType)
+    csr: IntegerAttr = attr_def(IntegerAttr)
+    immediate: IntegerAttr = attr_def(IntegerAttr)
 
     traits = traits_def(MemoryReadEffect(), MemoryWriteEffect())
 
@@ -1491,8 +1492,10 @@ class LiOperation(
     See external [documentation](https://github.com/riscv-non-isa/riscv-asm-manual/blob/main/src/asm-manual.adoc).
     """
 
-    rd = result_def(IntRegisterType)
-    immediate = attr_def(IntegerAttr[IWidth] | LabelAttr)
+    rd: OpResult[IntRegisterType] = result_def(IntRegisterType)
+    immediate: IntegerAttr[IWidth] | LabelAttr = attr_def(
+        IntegerAttr[IWidth] | LabelAttr
+    )
 
     traits = traits_def(
         AlwaysSpeculatable(), ConstantLike(), LiOpHasCanonicalizationPatternTrait()
@@ -1573,7 +1576,7 @@ class GetAnyRegisterOperation(
     ```
     """
 
-    res = result_def(RDInvT)
+    res: OpResult[RDInvT] = result_def(RDInvT)
 
     traits = traits_def(Pure())
 

--- a/xdsl/dialects/riscv/attrs.py
+++ b/xdsl/dialects/riscv/attrs.py
@@ -56,7 +56,7 @@ class LabelAttr(Data[str]):
 
 def _parse_optional_immediate_value(
     parser: AttrParser, integer_type: IntegerType | IndexType
-) -> IntegerAttr[IntegerType | IndexType] | LabelAttr | None:
+) -> IntegerAttr | LabelAttr | None:
     """
     Parse an optional immediate value. If an integer is parsed, an integer attr with the specified type is created.
     """
@@ -72,7 +72,7 @@ def _parse_optional_immediate_value(
 
 def parse_immediate_value(
     parser: AttrParser, integer_type: IntegerType | IndexType
-) -> IntegerAttr[IntegerType | IndexType] | LabelAttr:
+) -> IntegerAttr | LabelAttr:
     return parser.expect(
         lambda: _parse_optional_immediate_value(parser, integer_type),
         "Expected immediate",

--- a/xdsl/dialects/riscv/ops.py
+++ b/xdsl/dialects/riscv/ops.py
@@ -29,6 +29,7 @@ from xdsl.irdl import (
     IRDLOperation,
     ParsePropInAttrDict,
     RangeOf,
+    VarOperand,
     VarOpResult,
     attr_def,
     irdl_op_definition,
@@ -2051,8 +2052,8 @@ class LabelOp(RISCVCustomFormatOperation, RISCVAsmOperation, RISCVRegallocOperat
     """
 
     name = "riscv.label"
-    label = attr_def(LabelAttr)
-    comment = opt_attr_def(StringAttr)
+    label: LabelAttr = attr_def(LabelAttr)
+    comment: StringAttr | None = opt_attr_def(StringAttr)
 
     def __init__(
         self,
@@ -2109,8 +2110,8 @@ class DirectiveOp(
     """
 
     name = "riscv.directive"
-    directive = attr_def(StringAttr)
-    value = opt_attr_def(StringAttr)
+    directive: StringAttr = attr_def(StringAttr)
+    value: StringAttr | None = opt_attr_def(StringAttr)
 
     def __init__(
         self,
@@ -2181,8 +2182,8 @@ class AssemblySectionOp(IRDLOperation, AssemblyPrintable):
     """
 
     name = "riscv.assembly_section"
-    directive = attr_def(StringAttr)
-    data = region_def("single_block")
+    directive: StringAttr = attr_def(StringAttr)
+    data: Region = region_def("single_block")
 
     traits = traits_def(NoTerminator(), IsolatedFromAbove())
 
@@ -2251,10 +2252,10 @@ class CustomAssemblyInstructionOp(RISCVCustomFormatOperation, RISCVInstruction):
     """
 
     name = "riscv.custom_assembly_instruction"
-    inputs = var_operand_def()
-    outputs = var_result_def()
-    instruction_name = attr_def(StringAttr)
-    comment = opt_attr_def(StringAttr)
+    inputs: VarOperand = var_operand_def()
+    outputs: VarOpResult = var_result_def()
+    instruction_name: StringAttr = attr_def(StringAttr)
+    comment: StringAttr | None = opt_attr_def(StringAttr)
 
     def __init__(
         self,
@@ -2288,7 +2289,7 @@ class CustomAssemblyInstructionOp(RISCVCustomFormatOperation, RISCVInstruction):
 @irdl_op_definition
 class CommentOp(RISCVCustomFormatOperation, RISCVAsmOperation, RISCVRegallocOperation):
     name = "riscv.comment"
-    comment = attr_def(StringAttr)
+    comment: StringAttr = attr_def(StringAttr)
 
     def __init__(self, comment: str | StringAttr):
         if isinstance(comment, str):
@@ -2344,12 +2345,14 @@ class ParallelMovOp(RISCVRegallocOperation):
     _L: ClassVar = IntVarConstraint("L", AnyInt())
 
     name = "riscv.parallel_mov"
-    inputs = var_operand_def(RangeOf(RISCVRegisterType).of_length(_L))
+    inputs: VarOperand = var_operand_def(RangeOf(RISCVRegisterType).of_length(_L))
     outputs: VarOpResult[RISCVRegisterType] = var_result_def(
         RangeOf(RISCVRegisterType).of_length(_L)
     )
-    input_widths = prop_def(DenseArrayBase.constr(i32))
-    free_registers = opt_prop_def(ArrayAttr[RISCVRegisterType])
+    input_widths: DenseArrayBase[I32] = prop_def(DenseArrayBase.constr(i32))
+    free_registers: ArrayAttr[RISCVRegisterType] | None = opt_prop_def(
+        ArrayAttr[RISCVRegisterType]
+    )
 
     assembly_format = (
         "$inputs $input_widths attr-dict `:` functional-type($inputs, $outputs)"

--- a/xdsl/dialects/riscv_cf.py
+++ b/xdsl/dialects/riscv_cf.py
@@ -15,7 +15,9 @@ from xdsl.interfaces import HasCanonicalizationPatternsInterface
 from xdsl.ir import Dialect, Operation, SSAValue
 from xdsl.irdl import (
     AttrSizedOperandSegments,
+    Operand,
     Successor,
+    VarOperand,
     irdl_op_definition,
     operand_def,
     opt_attr_def,
@@ -51,16 +53,16 @@ class ConditionalBranchOperation(
     A base class for RISC-V branch operations. Lowers to RsRsOffOperation.
     """
 
-    rs1 = operand_def(IntRegisterType)
-    rs2 = operand_def(IntRegisterType)
+    rs1: Operand = operand_def(IntRegisterType)
+    rs2: Operand = operand_def(IntRegisterType)
 
-    then_arguments = var_operand_def(RISCVRegisterType)
-    else_arguments = var_operand_def(RISCVRegisterType)
+    then_arguments: VarOperand = var_operand_def(RISCVRegisterType)
+    else_arguments: VarOperand = var_operand_def(RISCVRegisterType)
 
     irdl_options = (AttrSizedOperandSegments(),)
 
-    then_block = successor_def()
-    else_block = successor_def()
+    then_block: Successor = successor_def()
+    else_block: Successor = successor_def()
 
     traits = traits_def(IsTerminator())
 
@@ -305,9 +307,9 @@ class BranchOp(riscv.RISCVAsmOperation):
 
     name = "riscv_cf.branch"
 
-    block_arguments = var_operand_def(RISCVRegisterType)
-    successor = successor_def()
-    comment = opt_attr_def(StringAttr)
+    block_arguments: VarOperand = var_operand_def(RISCVRegisterType)
+    successor: Successor = successor_def()
+    comment: StringAttr | None = opt_attr_def(StringAttr)
     """
     An optional comment that will be printed along with the instruction.
     """
@@ -395,9 +397,9 @@ class JOp(RISCVInstruction):
 
     name = "riscv_cf.j"
 
-    block_arguments = var_operand_def(RISCVRegisterType)
+    block_arguments: VarOperand = var_operand_def(RISCVRegisterType)
 
-    successor = successor_def()
+    successor: Successor = successor_def()
 
     traits = traits_def(IsTerminator())
 
@@ -474,15 +476,15 @@ class BnezOp(RISCVInstruction):
 
     name = "riscv_cf.bnez"
 
-    rs = operand_def(IntRegisterType)
+    rs: Operand = operand_def(IntRegisterType)
 
-    then_arguments = var_operand_def(RISCVRegisterType)
-    else_arguments = var_operand_def(RISCVRegisterType)
+    then_arguments: VarOperand = var_operand_def(RISCVRegisterType)
+    else_arguments: VarOperand = var_operand_def(RISCVRegisterType)
 
     irdl_options = (AttrSizedOperandSegments(),)
 
-    then_block = successor_def()
-    else_block = successor_def()
+    then_block: Successor = successor_def()
+    else_block: Successor = successor_def()
 
     traits = traits_def(IsTerminator())
 

--- a/xdsl/dialects/riscv_debug.py
+++ b/xdsl/dialects/riscv_debug.py
@@ -4,7 +4,13 @@ from collections.abc import Set as AbstractSet
 from xdsl.dialects import riscv
 from xdsl.dialects.builtin import StringAttr
 from xdsl.ir import Attribute, Dialect, SSAValue
-from xdsl.irdl import attr_def, irdl_op_definition, traits_def, var_operand_def
+from xdsl.irdl import (
+    VarOperand,
+    attr_def,
+    irdl_op_definition,
+    traits_def,
+    var_operand_def,
+)
 from xdsl.parser import Parser
 from xdsl.printer import Printer
 from xdsl.traits import MemoryWriteEffect
@@ -30,8 +36,8 @@ class PrintfOp(riscv.RISCVCustomFormatOperation, riscv.RISCVInstruction):
     """
 
     name = "riscv_debug.printf"
-    format_str = attr_def(StringAttr)
-    inputs = var_operand_def()
+    format_str: StringAttr = attr_def(StringAttr)
+    inputs: VarOperand = var_operand_def()
     traits = traits_def(MemoryWriteEffect())
 
     def __init__(

--- a/xdsl/dialects/riscv_func.py
+++ b/xdsl/dialects/riscv_func.py
@@ -24,6 +24,9 @@ from xdsl.dialects.utils import (
 from xdsl.ir import Attribute, Dialect, Operation, Region, SSAValue
 from xdsl.irdl import (
     IRDLOperation,
+    OptOpResult,
+    VarOperand,
+    VarOpResult,
     attr_def,
     irdl_op_definition,
     opt_attr_def,
@@ -74,9 +77,9 @@ class RiscvFunctionCallMemoryEffect(MemoryEffect):
 @irdl_op_definition
 class SyscallOp(IRDLOperation):
     name = "riscv_func.syscall"
-    args = var_operand_def(riscv.IntRegisterType)
-    syscall_num = attr_def(IntegerAttr[I32])
-    result = opt_result_def(riscv.IntRegisterType)
+    args: VarOperand = var_operand_def(riscv.IntRegisterType)
+    syscall_num: IntegerAttr[I32] = attr_def(IntegerAttr[I32])
+    result: OptOpResult[riscv.IntRegisterType] = opt_result_def(riscv.IntRegisterType)
 
     # Function calls can have arbitrary memory effects, and may overwrite the
     # A, T, FA, and FT registers
@@ -118,9 +121,9 @@ class CallOp(riscv.RISCVInstruction):
     """RISC-V function call operation"""
 
     name = "riscv_func.call"
-    args = var_operand_def(riscv.RISCVRegisterType)
-    callee = attr_def(SymbolRefAttr)
-    ress = var_result_def(riscv.RISCVRegisterType)
+    args: VarOperand = var_operand_def(riscv.RISCVRegisterType)
+    callee: SymbolRefAttr = attr_def(SymbolRefAttr)
+    ress: VarOpResult[riscv.RISCVRegisterType] = var_result_def(riscv.RISCVRegisterType)
 
     assembly_format = (
         "$callee `(` $args `)` attr-dict `:` functional-type($args, $ress)"
@@ -192,11 +195,11 @@ class FuncOp(IRDLOperation, AssemblyPrintable):
     """RISC-V function definition operation"""
 
     name = "riscv_func.func"
-    sym_name = attr_def(SymbolNameConstraint())
-    body = region_def()
-    function_type = attr_def(FunctionType)
-    sym_visibility = opt_attr_def(StringAttr)
-    p2align = opt_attr_def(IntegerAttr[I8])
+    sym_name: StringAttr = attr_def(SymbolNameConstraint())
+    body: Region = region_def()
+    function_type: FunctionType = attr_def(FunctionType)
+    sym_visibility: StringAttr | None = opt_attr_def(StringAttr)
+    p2align: IntegerAttr[I8] | None = opt_attr_def(IntegerAttr[I8])
 
     traits = traits_def(
         SymbolOpInterface(),
@@ -289,8 +292,8 @@ class ReturnOp(riscv.RISCVInstruction):
     """RISC-V function return operation"""
 
     name = "riscv_func.return"
-    values = var_operand_def(riscv.RISCVRegisterType)
-    comment = opt_attr_def(StringAttr)
+    values: VarOperand = var_operand_def(riscv.RISCVRegisterType)
+    comment: StringAttr | None = opt_attr_def(StringAttr)
 
     traits = traits_def(
         IsTerminator(),

--- a/xdsl/dialects/riscv_scf.py
+++ b/xdsl/dialects/riscv_scf.py
@@ -25,9 +25,13 @@ from xdsl.irdl import (
     AttrSizedOperandSegments,
     Block,
     IRDLOperation,
+    Operand,
     Operation,
+    OptOperand,
     Region,
     SSAValue,
+    VarOperand,
+    VarOpResult,
     irdl_op_definition,
     lazy_traits_def,
     operand_def,
@@ -65,16 +69,16 @@ class YieldOp(AbstractYieldOperation[RISCVRegisterType]):
 
 
 class ForRofOperation(RegisterAllocatableOperation, IRDLOperation, ABC):
-    lb = operand_def(IntRegisterType)
-    ub = operand_def(IntRegisterType)
-    step_val = opt_operand_def(IntRegisterType)
-    step_attr = opt_prop_def(IntegerAttr[IntegerType])
+    lb: Operand = operand_def(IntRegisterType)
+    ub: Operand = operand_def(IntRegisterType)
+    step_val: OptOperand = opt_operand_def(IntRegisterType)
+    step_attr: IntegerAttr[IntegerType] | None = opt_prop_def(IntegerAttr[IntegerType])
 
-    iter_args = var_operand_def(RISCVRegisterType)
+    iter_args: VarOperand = var_operand_def(RISCVRegisterType)
 
-    res = var_result_def(RISCVRegisterType)
+    res: VarOpResult[RISCVRegisterType] = var_result_def(RISCVRegisterType)
 
-    body = region_def("single_block")
+    body: Region = region_def("single_block")
 
     traits = traits_def(SingleBlockImplicitTerminator(YieldOp), RecursiveMemoryEffect())
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
@@ -294,11 +298,11 @@ class RofOp(ForRofOperation):
 @irdl_op_definition
 class WhileOp(IRDLOperation):
     name = "riscv_scf.while"
-    arguments = var_operand_def(RISCVRegisterType)
+    arguments: VarOperand = var_operand_def(RISCVRegisterType)
 
-    res = var_result_def(RISCVRegisterType)
-    before_region = region_def()
-    after_region = region_def()
+    res: VarOpResult[RISCVRegisterType] = var_result_def(RISCVRegisterType)
+    before_region: Region = region_def()
+    after_region: Region = region_def()
 
     traits = traits_def(RecursiveMemoryEffect())
 
@@ -420,8 +424,8 @@ class WhileOp(IRDLOperation):
 @irdl_op_definition
 class ConditionOp(IRDLOperation):
     name = "riscv_scf.condition"
-    cond = operand_def(IntRegisterType)
-    arguments = var_operand_def(RISCVRegisterType)
+    cond: Operand = operand_def(IntRegisterType)
+    arguments: VarOperand = var_operand_def(RISCVRegisterType)
 
     traits = traits_def(HasParent(WhileOp), IsTerminator(), NoMemoryEffect())
 

--- a/xdsl/dialects/riscv_snitch.py
+++ b/xdsl/dialects/riscv_snitch.py
@@ -45,7 +45,11 @@ from xdsl.ir import Attribute, Block, Dialect, Operation, Region, SSAValue
 from xdsl.irdl import (
     AnyAttr,
     BaseAttr,
+    Operand,
+    OpResult,
     VarConstraint,
+    VarOperand,
+    VarOpResult,
     attr_def,
     base,
     irdl_op_definition,
@@ -119,8 +123,8 @@ class ScfgwiOp(RISCVCustomFormatOperation, RISCVInstruction):
 
     name = "riscv_snitch.scfgwi"
 
-    rs1 = operand_def(IntRegisterType)
-    immediate = attr_def(IntegerAttr[SI12])
+    rs1: Operand = operand_def(IntRegisterType)
+    immediate: IntegerAttr[SI12] = attr_def(IntegerAttr[SI12])
 
     traits = traits_def(MemoryWriteEffect())
 
@@ -182,8 +186,8 @@ class ReadOp(RISCVAsmOperation, RISCVRegallocOperation):
 
     T: ClassVar = VarConstraint("T", AnyAttr())
 
-    stream = operand_def(snitch.ReadableStreamType.constr(T))
-    res = result_def(T)
+    stream: Operand = operand_def(snitch.ReadableStreamType.constr(T))
+    res: OpResult = result_def(T)
 
     assembly_format = "`from` $stream attr-dict `:` type($res)"
 
@@ -218,8 +222,8 @@ class WriteOp(RISCVAsmOperation, RISCVRegallocOperation):
 
     T: ClassVar = VarConstraint("T", AnyAttr())
 
-    value = operand_def(T)
-    stream = operand_def(snitch.WritableStreamType.constr(T))
+    value: Operand = operand_def(T)
+    stream: Operand = operand_def(snitch.WritableStreamType.constr(T))
 
     assembly_format = "$value `to` $stream attr-dict `:` type($value)"
 
@@ -290,17 +294,17 @@ class FRepOperation(RISCVInstruction):
     Snitch paper: See external [documentation](https://arxiv.org/abs/2002.10143).
     """
 
-    max_rep = operand_def(IntRegisterType)
+    max_rep: Operand = operand_def(IntRegisterType)
     """Number of times to repeat the instructions."""
-    body = region_def("single_block")
+    body: Region = region_def("single_block")
     """
     Instructions to repeat, containing maximum 15 instructions, with no side effects.
     """
-    iter_args = var_operand_def(riscv.RISCVRegisterType)
+    iter_args: VarOperand = var_operand_def(riscv.RISCVRegisterType)
     """
     Loop-carried variable initial values.
     """
-    stagger_mask = attr_def(
+    stagger_mask: IntegerAttr[I4] = attr_def(
         IntegerAttr[I4],
         default_value=IntegerAttr(0, i4),
     )
@@ -308,7 +312,7 @@ class FRepOperation(RISCVInstruction):
     4 bits for each operand (rs1 rs2 rs3 rd). If the bit is set, the corresponding operand
     is staggered.
     """
-    stagger_count = attr_def(
+    stagger_count: IntegerAttr[I3] = attr_def(
         IntegerAttr[I3],
         default_value=IntegerAttr(0, i3),
     )
@@ -316,7 +320,7 @@ class FRepOperation(RISCVInstruction):
     3 bits, indicating for how many iterations the stagger should increment before it
     wraps again (up to 23 = 8).
     """
-    res = var_result_def(riscv.RISCVRegisterType)
+    res: VarOpResult[RISCVRegisterType] = var_result_def(riscv.RISCVRegisterType)
     """
     Loop-carried variable initial values.
     """
@@ -597,9 +601,11 @@ class FrepInnerOp(FRepOperation):
 class GetStreamOp(RISCVAsmOperation, RISCVRegallocOperation):
     name = "riscv_snitch.get_stream"
 
-    stream = result_def(
-        snitch.ReadableStreamType.constr(BaseAttr(riscv.FloatRegisterType))
-        | snitch.WritableStreamType.constr(BaseAttr(riscv.FloatRegisterType))
+    stream: OpResult[snitch.ReadableStreamType | snitch.WritableStreamType] = (
+        result_def(
+            snitch.ReadableStreamType.constr(BaseAttr(riscv.FloatRegisterType))
+            | snitch.WritableStreamType.constr(BaseAttr(riscv.FloatRegisterType))
+        )
     )
 
     traits = traits_def(NoMemoryEffect())
@@ -632,8 +638,8 @@ class GetStreamOp(RISCVAsmOperation, RISCVRegallocOperation):
 class DMSourceOp(RISCVInstruction):
     name = "riscv_snitch.dmsrc"
 
-    ptrlo = operand_def(riscv.IntRegisterType)
-    ptrhi = operand_def(riscv.IntRegisterType)
+    ptrlo: Operand = operand_def(riscv.IntRegisterType)
+    ptrhi: Operand = operand_def(riscv.IntRegisterType)
 
     assembly_format = "$ptrlo `,` $ptrhi attr-dict `:` `(` type($ptrlo) `,` type($ptrhi) `)` `->` `(` `)`"
 
@@ -653,8 +659,8 @@ class DMSourceOp(RISCVInstruction):
 class DMDestinationOp(RISCVInstruction):
     name = "riscv_snitch.dmdst"
 
-    ptrlo = operand_def(riscv.IntRegisterType)
-    ptrhi = operand_def(riscv.IntRegisterType)
+    ptrlo: Operand = operand_def(riscv.IntRegisterType)
+    ptrhi: Operand = operand_def(riscv.IntRegisterType)
 
     assembly_format = "$ptrlo `,` $ptrhi attr-dict `:` `(` type($ptrlo) `,` type($ptrhi) `)` `->` `(` `)`"
 
@@ -674,8 +680,8 @@ class DMDestinationOp(RISCVInstruction):
 class DMStrideOp(RISCVInstruction):
     name = "riscv_snitch.dmstr"
 
-    srcstrd = operand_def(riscv.IntRegisterType)
-    dststrd = operand_def(riscv.IntRegisterType)
+    srcstrd: Operand = operand_def(riscv.IntRegisterType)
+    dststrd: Operand = operand_def(riscv.IntRegisterType)
 
     assembly_format = "$srcstrd `,` $dststrd attr-dict `:` `(` type($srcstrd) `,` type($dststrd) `)` `->` `(` `)`"
 
@@ -695,7 +701,7 @@ class DMStrideOp(RISCVInstruction):
 class DMRepOp(RISCVInstruction):
     name = "riscv_snitch.dmrep"
 
-    reps = operand_def(riscv.IntRegisterType)
+    reps: Operand = operand_def(riscv.IntRegisterType)
 
     assembly_format = "$reps attr-dict `:` `(` type($reps) `)` `->` `(` `)`"
 
@@ -723,9 +729,9 @@ class DMCopyOp(RISCVInstruction):
 
     name = "riscv_snitch.dmcpy"
 
-    dest = result_def(riscv.IntRegisterType)
-    size = operand_def(riscv.IntRegisterType)
-    config = operand_def(riscv.IntRegisterType)
+    dest: OpResult[IntRegisterType] = result_def(riscv.IntRegisterType)
+    size: Operand = operand_def(riscv.IntRegisterType)
+    config: Operand = operand_def(riscv.IntRegisterType)
     """
     config* determines the following parameters of the
     transfer:
@@ -763,8 +769,8 @@ class DMCopyOp(RISCVInstruction):
 class DMStatOp(RISCVInstruction):
     name = "riscv_snitch.dmstat"
 
-    dest = result_def(riscv.IntRegisterType)
-    status = operand_def(riscv.IntRegisterType)
+    dest: OpResult[IntRegisterType] = result_def(riscv.IntRegisterType)
+    status: Operand = operand_def(riscv.IntRegisterType)
 
     assembly_format = "$status attr-dict `:` functional-type(operands, results)"
 
@@ -796,9 +802,9 @@ class DMCopyImmOp(RISCVInstruction):
 
     name = "riscv_snitch.dmcpyi"
 
-    dest = result_def(riscv.IntRegisterType)
-    size = operand_def(riscv.IntRegisterType)
-    config = prop_def(IntegerAttr[UI5])
+    dest: OpResult[IntRegisterType] = result_def(riscv.IntRegisterType)
+    size: Operand = operand_def(riscv.IntRegisterType)
+    config: IntegerAttr[UI5] = prop_def(IntegerAttr[UI5])
     """
     config* determines the following parameters of the
     transfer:
@@ -842,8 +848,8 @@ class DMCopyImmOp(RISCVInstruction):
 class DMStatImmOp(RISCVInstruction):
     name = "riscv_snitch.dmstati"
 
-    dest = result_def(riscv.IntRegisterType)
-    status = prop_def(IntegerAttr[UI5])
+    dest: OpResult[IntRegisterType] = result_def(riscv.IntRegisterType)
+    status: IntegerAttr[UI5] = prop_def(IntegerAttr[UI5])
 
     assembly_format = "$status attr-dict `:` `(` `)` `->` type($dest)"
 
@@ -1046,12 +1052,12 @@ class RdRsRsAccumulatingFloatOperationWithFastMath(
         "SAME_FLOAT_REGISTER_TYPE", base(FloatRegisterType)
     )
 
-    rd_out = result_def(SAME_FLOAT_REGISTER_TYPE)
-    rd_in = operand_def(SAME_FLOAT_REGISTER_TYPE)
-    rs1 = operand_def(FloatRegisterType)
-    rs2 = operand_def(FloatRegisterType)
+    rd_out: OpResult[FloatRegisterType] = result_def(SAME_FLOAT_REGISTER_TYPE)
+    rd_in: Operand = operand_def(SAME_FLOAT_REGISTER_TYPE)
+    rs1: Operand = operand_def(FloatRegisterType)
+    rs2: Operand = operand_def(FloatRegisterType)
 
-    fastmath = opt_attr_def(FastMathFlagsAttr)
+    fastmath: FastMathFlagsAttr | None = opt_attr_def(FastMathFlagsAttr)
 
     traits = traits_def(AlwaysSpeculatable())
 
@@ -1112,9 +1118,9 @@ class RdRsAccumulatingFloatOperation(RISCVCustomFormatOperation, RISCVInstructio
         "SAME_FLOAT_REGISTER_TYPE", base(FloatRegisterType)
     )
 
-    rd_out = result_def(SAME_FLOAT_REGISTER_TYPE)
-    rd_in = operand_def(SAME_FLOAT_REGISTER_TYPE)
-    rs = operand_def(FloatRegisterType)
+    rd_out: OpResult[FloatRegisterType] = result_def(SAME_FLOAT_REGISTER_TYPE)
+    rd_in: Operand = operand_def(SAME_FLOAT_REGISTER_TYPE)
+    rs: Operand = operand_def(FloatRegisterType)
 
     traits = traits_def(AlwaysSpeculatable())
 

--- a/xdsl/dialects/scf.py
+++ b/xdsl/dialects/scf.py
@@ -6,6 +6,7 @@ from typing import ClassVar
 from typing_extensions import Self
 
 from xdsl.dialects.builtin import (
+    I64,
     DenseArrayBase,
     IndexType,
     IntegerType,
@@ -29,7 +30,11 @@ from xdsl.ir import (
 from xdsl.irdl import (
     AttrSizedOperandSegments,
     IRDLOperation,
+    Operand,
     VarConstraint,
+    VarOperand,
+    VarOpResult,
+    VarRegion,
     base,
     irdl_op_definition,
     lazy_traits_def,
@@ -60,11 +65,11 @@ from xdsl.utils.exceptions import VerifyException
 @irdl_op_definition
 class WhileOp(IRDLOperation):
     name = "scf.while"
-    arguments = var_operand_def()
+    arguments: VarOperand = var_operand_def()
 
-    res = var_result_def()
-    before_region = region_def("single_block")
-    after_region = region_def("single_block")
+    res: VarOpResult = var_result_def()
+    before_region: Region = region_def("single_block")
+    after_region: Region = region_def("single_block")
 
     traits = traits_def(RecursiveMemoryEffect())
 
@@ -201,8 +206,8 @@ class ExecuteRegionOp(IRDLOperation):
 
     name = "scf.execute_region"
 
-    outs = var_result_def()
-    region = region_def()
+    outs: VarOpResult = var_result_def()
+    region: Region = region_def()
 
     traits = traits_def(
         ExecuteRegionOpHasCanonicalizationPatternsTrait(),
@@ -270,12 +275,12 @@ class IfOpHasCanonicalizationPatternsTrait(HasCanonicalizationPatternsTrait):
 @irdl_op_definition
 class IfOp(IRDLOperation):
     name = "scf.if"
-    output = var_result_def()
-    cond = operand_def(IntegerType(1))
+    output: VarOpResult = var_result_def()
+    cond: Operand = operand_def(IntegerType(1))
 
-    true_region = region_def("single_block")
+    true_region: Region = region_def("single_block")
     # TODO this should be optional under certain conditions
-    false_region = region_def()
+    false_region: Region = region_def()
 
     traits = traits_def(
         SingleBlockImplicitTerminator(YieldOp),
@@ -385,15 +390,15 @@ class ForOp(IRDLOperation):
 
     T: ClassVar = VarConstraint("T", base(IndexType) | SignlessIntegerConstraint)
 
-    lb = operand_def(T)
-    ub = operand_def(T)
-    step = operand_def(T)
+    lb: Operand = operand_def(T)
+    ub: Operand = operand_def(T)
+    step: Operand = operand_def(T)
 
-    iter_args = var_operand_def()
+    iter_args: VarOperand = var_operand_def()
 
-    res = var_result_def()
+    res: VarOpResult = var_result_def()
 
-    body = region_def("single_block")
+    body: Region = region_def("single_block")
 
     traits = traits_def(
         SingleBlockImplicitTerminator(YieldOp),
@@ -490,13 +495,13 @@ class ForOp(IRDLOperation):
 @irdl_op_definition
 class ParallelOp(IRDLOperation):
     name = "scf.parallel"
-    lowerBound = var_operand_def(IndexType)
-    upperBound = var_operand_def(IndexType)
-    step = var_operand_def(IndexType)
-    initVals = var_operand_def()
-    res = var_result_def()
+    lowerBound: VarOperand = var_operand_def(IndexType)
+    upperBound: VarOperand = var_operand_def(IndexType)
+    step: VarOperand = var_operand_def(IndexType)
+    initVals: VarOperand = var_operand_def()
+    res: VarOpResult = var_result_def()
 
-    body = region_def("single_block")
+    body: Region = region_def("single_block")
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
@@ -598,9 +603,9 @@ class ParallelOp(IRDLOperation):
 @irdl_op_definition
 class ReduceOp(IRDLOperation):
     name = "scf.reduce"
-    args = var_operand_def()
+    args: VarOperand = var_operand_def()
 
-    reductions = var_region_def("single_block")
+    reductions: VarRegion = var_region_def("single_block")
 
     traits = lazy_traits_def(
         lambda: (
@@ -661,7 +666,7 @@ class ReduceOp(IRDLOperation):
 @irdl_op_definition
 class ReduceReturnOp(IRDLOperation):
     name = "scf.reduce.return"
-    result = operand_def()
+    result: Operand = operand_def()
 
     traits = traits_def(HasParent(ReduceOp), IsTerminator(), Pure())
 
@@ -674,8 +679,8 @@ class ReduceReturnOp(IRDLOperation):
 @irdl_op_definition
 class ConditionOp(IRDLOperation):
     name = "scf.condition"
-    condition = operand_def(IntegerType(1))
-    args = var_operand_def()
+    condition: Operand = operand_def(IntegerType(1))
+    args: VarOperand = var_operand_def()
 
     traits = traits_def(HasParent(WhileOp), IsTerminator(), Pure())
 
@@ -693,13 +698,13 @@ class ConditionOp(IRDLOperation):
 class IndexSwitchOp(IRDLOperation):
     name = "scf.index_switch"
 
-    arg = operand_def(IndexType)
-    cases = prop_def(DenseArrayBase.constr(i64))
+    arg: Operand = operand_def(IndexType)
+    cases: DenseArrayBase[I64] = prop_def(DenseArrayBase.constr(i64))
 
-    output = var_result_def()
+    output: VarOpResult = var_result_def()
 
-    default_region = region_def("single_block")
-    case_regions = var_region_def("single_block")
+    default_region: Region = region_def("single_block")
+    case_regions: VarRegion = var_region_def("single_block")
 
     traits = traits_def(RecursiveMemoryEffect(), SingleBlockImplicitTerminator(YieldOp))
 

--- a/xdsl/dialects/seq.py
+++ b/xdsl/dialects/seq.py
@@ -19,6 +19,9 @@ from xdsl.irdl import (
     AnyAttr,
     AttrSizedOperandSegments,
     IRDLOperation,
+    Operand,
+    OpResult,
+    OptOperand,
     ParametrizedAttribute,
     VarConstraint,
     attr_def,
@@ -52,9 +55,9 @@ class ClockDividerOp(IRDLOperation):
 
     name = "seq.clock_div"
 
-    pow2 = attr_def(IntegerAttr)
-    clockIn = operand_def(ClockType)
-    clockOut = result_def(ClockType)
+    pow2: IntegerAttr = attr_def(IntegerAttr)
+    clockIn: Operand = operand_def(ClockType)
+    clockOut: OpResult[ClockType] = result_def(ClockType)
 
     def __init__(self, clockIn: SSAValue | Operation, pow2: int | IntegerAttr):
         if isinstance(pow2, int):
@@ -95,13 +98,13 @@ class CompRegOp(IRDLOperation):
 
     DATA_TYPE: ClassVar = VarConstraint("DataType", AnyAttr())
 
-    inner_sym = opt_attr_def(InnerSymAttr)
-    input = operand_def(DATA_TYPE)
-    clk = operand_def(clock)
-    reset = opt_operand_def(i1)
-    reset_value = opt_operand_def(DATA_TYPE)
-    power_on_value = opt_operand_def(DATA_TYPE)
-    data = result_def(DATA_TYPE)
+    inner_sym: InnerSymAttr | None = opt_attr_def(InnerSymAttr)
+    input: Operand = operand_def(DATA_TYPE)
+    clk: Operand = operand_def(clock)
+    reset: OptOperand = opt_operand_def(i1)
+    reset_value: OptOperand = opt_operand_def(DATA_TYPE)
+    power_on_value: OptOperand = opt_operand_def(DATA_TYPE)
+    data: OpResult = result_def(DATA_TYPE)
 
     irdl_options = (AttrSizedOperandSegments(),)
 
@@ -185,8 +188,8 @@ class ConstClockOp(IRDLOperation):
 
     name = "seq.const_clock"
 
-    value = attr_def(ClockConstAttr)
-    result = result_def(clock)
+    value: ClockConstAttr = attr_def(ClockConstAttr)
+    result: OpResult[ClockType] = result_def(clock)
 
     @classmethod
     def parse(cls, parser: Parser) -> "ConstClockOp":

--- a/xdsl/dialects/shard.py
+++ b/xdsl/dialects/shard.py
@@ -13,6 +13,7 @@ from xdsl.dialects.builtin import (
     IndexType,
     IndexTypeConstr,
     IntegerAttr,
+    StringAttr,
     SymbolNameConstraint,
     TensorType,
     UnitAttr,
@@ -34,7 +35,10 @@ from xdsl.ir import (
 from xdsl.irdl import (
     AttrSizedOperandSegments,
     IRDLOperation,
+    Operand,
+    OpResult,
     VarConstraint,
+    VarOperand,
     irdl_attr_definition,
     irdl_op_definition,
     operand_def,
@@ -166,8 +170,8 @@ class CollectiveCommunicationOp(IRDLOperation, ABC):
     Base class for collective communication ops.
     """
 
-    grid = prop_def(FlatSymbolRefAttr)
-    grid_axes = prop_def(
+    grid: FlatSymbolRefAttr = prop_def(FlatSymbolRefAttr)
+    grid_axes: ShardAxesAttr = prop_def(
         ShardAxesAttr, default_value=ShardAxesAttr(i16, BytesAttr(b""))
     )
 
@@ -182,11 +186,11 @@ class BroadcastOp(CollectiveCommunicationOp):
 
     name = "shard.broadcast"
 
-    input = operand_def(TensorType)
-    root = prop_def(DenseArrayBase[I64])
-    root_dynamic = var_operand_def(IndexType)
+    input: Operand = operand_def(TensorType)
+    root: DenseArrayBase[I64] = prop_def(DenseArrayBase[I64])
+    root_dynamic: VarOperand = var_operand_def(IndexType)
 
-    result = result_def(TensorType)
+    result: OpResult[TensorType] = result_def(TensorType)
 
     traits = traits_def(Pure())
 
@@ -209,12 +213,12 @@ class GatherOp(CollectiveCommunicationOp):
 
     name = "shard.gather"
 
-    input = operand_def(TensorType)
-    gather_axis = prop_def(IntegerAttr.constr(IndexTypeConstr))
-    root = prop_def(DenseArrayBase[I64])
-    root_dynamic = var_operand_def(IndexType)
+    input: Operand = operand_def(TensorType)
+    gather_axis: IntegerAttr = prop_def(IntegerAttr.constr(IndexTypeConstr))
+    root: DenseArrayBase[I64] = prop_def(DenseArrayBase[I64])
+    root_dynamic: VarOperand = var_operand_def(IndexType)
 
-    result = result_def(TensorType)
+    result: OpResult[TensorType] = result_def(TensorType)
 
     traits = traits_def(Pure())
 
@@ -241,13 +245,13 @@ class ScatterOp(CollectiveCommunicationOp):
 
     name = "shard.scatter"
 
-    input = operand_def(TensorType)
-    scatter_axis = prop_def(IntegerAttr.constr(IndexTypeConstr))
+    input: Operand = operand_def(TensorType)
+    scatter_axis: IntegerAttr = prop_def(IntegerAttr.constr(IndexTypeConstr))
 
-    root = prop_def(DenseArrayBase[I64])
-    root_dynamic = var_operand_def(IndexType)
+    root: DenseArrayBase[I64] = prop_def(DenseArrayBase[I64])
+    root_dynamic: VarOperand = var_operand_def(IndexType)
 
-    result = result_def(TensorType)
+    result: OpResult[TensorType] = result_def(TensorType)
 
     traits = traits_def(
         Pure(),
@@ -271,11 +275,11 @@ class RecvOp(CollectiveCommunicationOp):
 
     name = "shard.recv"
 
-    input = operand_def(TensorType)
-    source = opt_prop_def(DenseArrayBase[I64])
-    source_dynamic = var_operand_def(IndexType)
+    input: Operand = operand_def(TensorType)
+    source: DenseArrayBase[I64] | None = opt_prop_def(DenseArrayBase[I64])
+    source_dynamic: VarOperand = var_operand_def(IndexType)
 
-    result = result_def(TensorType)
+    result: OpResult[TensorType] = result_def(TensorType)
 
     assembly_format = (
         "$input `on` $grid (`grid_axes` `=` $grid_axes^)? "
@@ -294,12 +298,12 @@ class SendOp(CollectiveCommunicationOp):
 
     name = "shard.send"
 
-    input = operand_def(TensorType)
+    input: Operand = operand_def(TensorType)
 
-    destination = prop_def(DenseArrayBase[I64])
-    destination_dynamic = var_operand_def(IndexType)
+    destination: DenseArrayBase[I64] = prop_def(DenseArrayBase[I64])
+    destination_dynamic: VarOperand = var_operand_def(IndexType)
 
-    result = result_def(TensorType)
+    result: OpResult[TensorType] = result_def(TensorType)
 
     assembly_format = (
         "$input `on` $grid (`grid_axes` `=` $grid_axes^)? "
@@ -321,13 +325,13 @@ class ShiftOp(CollectiveCommunicationOp):
 
     name = "shard.shift"
 
-    input = operand_def(TensorType)
+    input: Operand = operand_def(TensorType)
 
-    shift_axis = prop_def(IntegerAttr.constr(IndexTypeConstr))
-    offset = prop_def(IntegerAttr[I64])
-    rotate = prop_def(UnitAttr)
+    shift_axis: IntegerAttr = prop_def(IntegerAttr.constr(IndexTypeConstr))
+    offset: IntegerAttr[I64] = prop_def(IntegerAttr[I64])
+    rotate: UnitAttr = prop_def(UnitAttr)
 
-    result = result_def(TensorType)
+    result: OpResult[TensorType] = result_def(TensorType)
 
     traits = traits_def(
         Pure(),
@@ -351,8 +355,8 @@ class ShiftOp(CollectiveCommunicationOp):
 class GridOp(IRDLOperation):
     name = "shard.grid"
 
-    sym_name = prop_def(SymbolNameConstraint())
-    shape = prop_def(DenseArrayBase[I64])
+    sym_name: StringAttr = prop_def(SymbolNameConstraint())
+    shape: DenseArrayBase[I64] = prop_def(DenseArrayBase[I64])
 
     traits = traits_def(SymbolOpInterface(), Pure())
 
@@ -386,18 +390,18 @@ class ShardingOp(IRDLOperation):
 
     name = "shard.sharding"
 
-    grid = prop_def(FlatSymbolRefAttr)
-    split_axes = prop_def(ShardAxesArrayAttr)
-    static_sharded_dims_offsets = prop_def(
+    grid: FlatSymbolRefAttr = prop_def(FlatSymbolRefAttr)
+    split_axes: ShardAxesArrayAttr = prop_def(ShardAxesArrayAttr)
+    static_sharded_dims_offsets: DenseArrayBase[I64] = prop_def(
         DenseArrayBase[I64], default_value=DenseArrayBase[I64](i64, BytesAttr(b""))
     )
-    dynamic_sharded_dims_offsets = var_operand_def(I64)
-    static_halo_sizes = prop_def(
+    dynamic_sharded_dims_offsets: VarOperand = var_operand_def(I64)
+    static_halo_sizes: DenseArrayBase[I64] = prop_def(
         DenseArrayBase[I64], default_value=DenseArrayBase[I64](i64, BytesAttr(b""))
     )
-    dynamic_halo_sizes = var_operand_def(I64)
+    dynamic_halo_sizes: VarOperand = var_operand_def(I64)
 
-    result = result_def(ShardingType)
+    result: OpResult[ShardingType] = result_def(ShardingType)
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
@@ -440,11 +444,11 @@ class ShardOp(IRDLOperation):
 
     T: ClassVar = VarConstraint("T", TensorType.constr())
 
-    src = operand_def(T)
-    sharding = operand_def(ShardingType)
-    annotate_for_users = opt_prop_def(UnitAttr)
+    src: Operand = operand_def(T)
+    sharding: Operand = operand_def(ShardingType)
+    annotate_for_users: UnitAttr | None = opt_prop_def(UnitAttr)
 
-    result = result_def(T)
+    result: OpResult[TensorType] = result_def(T)
 
     traits = traits_def(
         Pure(),

--- a/xdsl/dialects/smt.py
+++ b/xdsl/dialects/smt.py
@@ -22,11 +22,14 @@ from xdsl.irdl import (
     AtLeast,
     AttrConstraint,
     IRDLOperation,
+    Operand,
+    OpResult,
     ParamAttrConstraint,
     RangeConstraint,
     RangeOf,
     RangeVarConstraint,
     VarConstraint,
+    VarOperand,
     base,
     irdl_attr_definition,
     irdl_op_definition,
@@ -224,8 +227,8 @@ class DeclareFunOp(IRDLOperation):
 
     name = "smt.declare_fun"
 
-    name_prefix = opt_prop_def(StringAttr, prop_name="namePrefix")
-    result = result_def(SMTType)
+    name_prefix: StringAttr | None = opt_prop_def(StringAttr, prop_name="namePrefix")
+    result: OpResult[SMTType] = result_def(SMTType)
 
     assembly_format = "($namePrefix^)? attr-dict `:` type($result)"
 
@@ -251,10 +254,10 @@ class ApplyFuncOp(IRDLOperation):
     DOMAIN: ClassVar = RangeVarConstraint("DOMAIN", RangeOf(NonFuncSMTTypeConstr))
     RANGE: ClassVar = VarConstraint("RANGE", NonFuncSMTTypeConstr)
 
-    func = operand_def(FuncType.constr(DOMAIN, RANGE))
-    args = var_operand_def(DOMAIN)
+    func: Operand = operand_def(FuncType.constr(DOMAIN, RANGE))
+    args: VarOperand = var_operand_def(DOMAIN)
 
-    result = result_def(RANGE)
+    result: OpResult[NonFuncSMTType] = result_def(RANGE)
 
     assembly_format = "$func `(` $args `)` attr-dict `:` type($func)"
 
@@ -274,8 +277,8 @@ class ConstantBoolOp(IRDLOperation, HasFolderInterface):
 
     name = "smt.constant"
 
-    value_attr = prop_def(BoolAttr, prop_name="value")
-    result = result_def(BoolType())
+    value_attr: BoolAttr = prop_def(BoolAttr, prop_name="value")
+    result: OpResult[BoolType] = result_def(BoolType())
 
     traits = traits_def(Pure(), ConstantLike())
 
@@ -302,8 +305,8 @@ class NotOp(IRDLOperation):
 
     name = "smt.not"
 
-    input = operand_def(BoolType)
-    result = result_def(BoolType)
+    input: Operand = operand_def(BoolType)
+    result: OpResult[BoolType] = result_def(BoolType)
 
     assembly_format = "$input attr-dict"
 
@@ -319,8 +322,8 @@ class VariadicBoolOp(IRDLOperation):
     requires at least two.
     """
 
-    inputs = var_operand_def(RangeOf(base(BoolType)).of_length(AtLeast(2)))
-    result = result_def(BoolType())
+    inputs: VarOperand = var_operand_def(RangeOf(base(BoolType)).of_length(AtLeast(2)))
+    result: OpResult[BoolType] = result_def(BoolType())
 
     traits = traits_def(Pure())
 
@@ -375,9 +378,9 @@ class ImpliesOp(IRDLOperation):
 
     name = "smt.implies"
 
-    lhs = operand_def(BoolType)
-    rhs = operand_def(BoolType)
-    result = result_def(BoolType)
+    lhs: Operand = operand_def(BoolType)
+    rhs: Operand = operand_def(BoolType)
+    result: OpResult[BoolType] = result_def(BoolType)
 
     traits = traits_def(Pure())
 
@@ -432,8 +435,8 @@ class VariadicPredicateOp(IRDLOperation, ABC):
 
     T: ClassVar = VarConstraint("T", NonFuncSMTTypeConstr)
 
-    inputs = var_operand_def(RangeOf(T).of_length(AtLeast(2)))
-    result = result_def(BoolType())
+    inputs: VarOperand = var_operand_def(RangeOf(T).of_length(AtLeast(2)))
+    result: OpResult[BoolType] = result_def(BoolType())
 
     traits = traits_def(Pure())
 
@@ -503,11 +506,11 @@ class IteOp(IRDLOperation):
 
     T: ClassVar = VarConstraint("T", NonFuncSMTTypeConstr)
 
-    cond = operand_def(BoolType)
-    then_value = operand_def(T)
-    else_value = operand_def(T)
+    cond: Operand = operand_def(BoolType)
+    then_value: Operand = operand_def(T)
+    else_value: Operand = operand_def(T)
 
-    result = result_def(T)
+    result: OpResult[NonFuncSMTType] = result_def(T)
 
     assembly_format = (
         "$cond `,` $then_value `,` $else_value attr-dict `:` type($result)"
@@ -523,8 +526,8 @@ class IteOp(IRDLOperation):
 
 
 class QuantifierOp(IRDLOperation, ABC):
-    result = result_def(BoolType)
-    body = region_def("single_block")
+    result: OpResult[BoolType] = result_def(BoolType)
+    body: Region = region_def("single_block")
 
     traits = traits_def(Pure())
 
@@ -581,7 +584,7 @@ class ForallOp(QuantifierOp):
 class YieldOp(IRDLOperation):
     name = "smt.yield"
 
-    values = var_operand_def(NonFuncSMTType)
+    values: VarOperand = var_operand_def(NonFuncSMTType)
 
     assembly_format = "($values^ `:` type($values))? attr-dict"
 
@@ -597,7 +600,7 @@ class AssertOp(IRDLOperation):
 
     name = "smt.assert"
 
-    input = operand_def(BoolType)
+    input: Operand = operand_def(BoolType)
 
     assembly_format = "$input attr-dict"
 
@@ -616,8 +619,8 @@ class BvConstantOp(IRDLOperation, HasFolderInterface):
 
     T: ClassVar = VarConstraint("T", base(BitVectorType))
 
-    value = prop_def(BitVectorAttr.constr(T))
-    result = result_def(T)
+    value: BitVectorAttr = prop_def(BitVectorAttr.constr(T))
+    result: OpResult[BitVectorType] = result_def(T)
 
     assembly_format = "qualified($value) attr-dict"
 
@@ -654,8 +657,8 @@ class UnaryBVOp(IRDLOperation, ABC):
 
     T: ClassVar = VarConstraint("T", base(BitVectorType))
 
-    input = operand_def(T)
-    result = result_def(T)
+    input: Operand = operand_def(T)
+    result: OpResult[BitVectorType] = result_def(T)
 
     assembly_format = "$input attr-dict `:` type($result)"
 
@@ -693,9 +696,9 @@ class BinaryBVOp(IRDLOperation, ABC):
 
     T: ClassVar = VarConstraint("T", base(BitVectorType))
 
-    lhs = operand_def(T)
-    rhs = operand_def(T)
-    result = result_def(T)
+    lhs: Operand = operand_def(T)
+    rhs: Operand = operand_def(T)
+    result: OpResult[BitVectorType] = result_def(T)
 
     assembly_format = "$lhs `,` $rhs attr-dict `:` type($result)"
 

--- a/xdsl/dialects/snitch.py
+++ b/xdsl/dialects/snitch.py
@@ -31,7 +31,9 @@ from xdsl.irdl import (
     AnyAttr,
     AttrConstraint,
     IRDLOperation,
+    Operand,
     ParamAttrConstraint,
+    VarOpResult,
     attr_def,
     irdl_attr_definition,
     irdl_op_definition,
@@ -107,9 +109,9 @@ class SsrSetDimensionConfigOperation(IRDLOperation, ABC):
     configuration value for a specific dimension handled by a streamer.
     """
 
-    value = operand_def(IntRegisterType)
-    dm = attr_def(IntAttr)
-    dimension = attr_def(IntAttr)
+    value: Operand = operand_def(IntRegisterType)
+    dm: IntAttr[int] = attr_def(IntAttr)
+    dimension: IntAttr[int] = attr_def(IntAttr)
 
     def __init__(
         self,
@@ -139,8 +141,8 @@ class SsrSetStreamConfigOperation(IRDLOperation, ABC):
     configuration value for a streamer.
     """
 
-    value = operand_def(IntRegisterType)
-    dm = attr_def(IntAttr)
+    value: Operand = operand_def(IntRegisterType)
+    dm: IntAttr[int] = attr_def(IntAttr)
 
     def __init__(self, value: Operation | SSAValue, dm: IntAttr):
         super().__init__(
@@ -208,7 +210,9 @@ class SsrEnableOp(IRDLOperation):
 
     name = "snitch.ssr_enable"
 
-    streams = var_result_def(ReadableStreamType.constr() | WritableStreamType.constr())
+    streams: VarOpResult[
+        ReadableStreamType[Attribute] | WritableStreamType[Attribute]
+    ] = var_result_def(ReadableStreamType.constr() | WritableStreamType.constr())
 
     def __init__(self, stream_types: Sequence[Attribute]):
         super().__init__(result_types=[stream_types])

--- a/xdsl/dialects/snitch_runtime.py
+++ b/xdsl/dialects/snitch_runtime.py
@@ -5,6 +5,7 @@ from typing import Generic
 from typing_extensions import TypeVar
 
 from xdsl.dialects.builtin import (
+    I1,
     I32,
     I64,
     IndexType,
@@ -18,6 +19,9 @@ from xdsl.ir import Attribute, Dialect, Operation, SSAValue
 from xdsl.irdl import (
     AttrSizedOperandSegments,
     IRDLOperation,
+    Operand,
+    OpResult,
+    VarOperand,
     irdl_op_definition,
     operand_def,
     prop_def,
@@ -53,7 +57,7 @@ class SnitchRuntimeGetInfo(SnitchRuntimeBaseOperation, ABC):
     A base class for snitch runtime functions that get a certain value at runtime
     """
 
-    result = result_def(i32)
+    result: OpResult[I32] = result_def(i32)
 
     traits = traits_def(NoMemoryEffect())
 
@@ -68,7 +72,7 @@ class SnitchRuntimeGetInfoBool(SnitchRuntimeBaseOperation, ABC):
     A base class for snitch runtime functions that get a certain value at runtime
     """
 
-    result = result_def(i1)
+    result: OpResult[I1] = result_def(i1)
 
     traits = traits_def(NoMemoryEffect())
 
@@ -278,8 +282,8 @@ class GetMemoryInfoBaseOperation(SnitchRuntimeBaseOperation, ABC):
     Generic base class for operations returning memory slices
     """
 
-    slice_begin = result_def(slice_t_begin)
-    slice_end = result_def(slice_t_end)
+    slice_begin: OpResult[I64] = result_def(slice_t_begin)
+    slice_end: OpResult[I64] = result_def(slice_t_end)
 
     traits = traits_def(NoMemoryEffect())
 
@@ -321,11 +325,11 @@ class DmaStart1DBaseOperation(SnitchRuntimeBaseOperation, ABC, Generic[_T]):
     Initiate an asynchronous 1D DMA transfer
     """
 
-    dst = operand_def(_T)
-    src = operand_def(_T)
+    dst: Operand = operand_def(_T)
+    src: Operand = operand_def(_T)
 
-    size = operand_def(i32)
-    transfer_id = result_def(tx_id)
+    size: Operand = operand_def(i32)
+    transfer_id: OpResult[I32] = result_def(tx_id)
 
     def __init__(
         self,
@@ -341,13 +345,13 @@ class DmaStart2DBaseOperation(SnitchRuntimeBaseOperation, ABC, Generic[_T]):
     Generic base class for starting asynchronous 2D DMA transfers
     """
 
-    dst = operand_def(_T)
-    src = operand_def(_T)
-    dst_stride = operand_def(i32)
-    src_stride = operand_def(i32)
-    size = operand_def(i32)
-    repeat = operand_def(i32)
-    transfer_id = result_def(tx_id)
+    dst: Operand = operand_def(_T)
+    src: Operand = operand_def(_T)
+    dst_stride: Operand = operand_def(i32)
+    src_stride: Operand = operand_def(i32)
+    size: Operand = operand_def(i32)
+    repeat: Operand = operand_def(i32)
+    transfer_id: OpResult[I32] = result_def(tx_id)
 
     def __init__(
         self,
@@ -407,7 +411,7 @@ class DmaWaitOp(SnitchRuntimeBaseOperation):
     """
 
     name = "snrt.dma_wait"
-    transfer_id = operand_def(tx_id)
+    transfer_id: Operand = operand_def(tx_id)
 
     def __init__(self, transfer_id: Operation | SSAValue):
         super().__init__(operands=[transfer_id])
@@ -435,9 +439,9 @@ class SsrLoopBaseOp(SnitchRuntimeBaseOperation, ABC):
     }
     """
 
-    data_mover = operand_def(i32)
-    bounds = var_operand_def(IndexType)
-    strides = var_operand_def(IndexType)
+    data_mover: Operand = operand_def(i32)
+    bounds: VarOperand = var_operand_def(IndexType)
+    strides: VarOperand = var_operand_def(IndexType)
     irdl_options = (AttrSizedOperandSegments(),)
 
     def verify_(self) -> None:
@@ -523,8 +527,8 @@ class SsrRepeatOp(SnitchRuntimeBaseOperation, ABC):
     """
 
     name = "snrt.ssr_repeat"
-    dm = prop_def(IntegerAttr[IntegerType])
-    count = operand_def(i32)
+    dm: IntegerAttr[IntegerType] = prop_def(IntegerAttr[IntegerType])
+    count: Operand = operand_def(i32)
 
     def __init__(
         self,
@@ -556,9 +560,9 @@ class SsrDisableOp(NoOperandNoResultBaseOperation):
 
 
 class SsrReadWriteBaseOperation(SnitchRuntimeBaseOperation, ABC):
-    dm = prop_def(IntegerAttr[IntegerType])
-    dim = prop_def(IntegerAttr[IntegerType])
-    ptr = operand_def(i32)
+    dm: IntegerAttr[IntegerType] = prop_def(IntegerAttr[IntegerType])
+    dim: IntegerAttr[IntegerType] = prop_def(IntegerAttr[IntegerType])
+    ptr: Operand = operand_def(i32)
 
     def __init__(
         self,

--- a/xdsl/dialects/snitch_stream.py
+++ b/xdsl/dialects/snitch_stream.py
@@ -40,6 +40,7 @@ from xdsl.ir import (
 from xdsl.irdl import (
     AttrSizedOperandSegments,
     IRDLOperation,
+    VarOperand,
     irdl_attr_definition,
     irdl_op_definition,
     prop_def,
@@ -238,17 +239,17 @@ class StreamingRegionOp(IRDLOperation):
 
     name = "snitch_stream.streaming_region"
 
-    inputs = var_operand_def(riscv.IntRegisterType)
+    inputs: VarOperand = var_operand_def(riscv.IntRegisterType)
     """
     Pointers to memory buffers that will be streamed. The corresponding stride pattern
     defines the order in which the elements of the input buffers will be read.
     """
-    outputs = var_operand_def(riscv.IntRegisterType)
+    outputs: VarOperand = var_operand_def(riscv.IntRegisterType)
     """
     Pointers to memory buffers that will be streamed. The corresponding stride pattern
     defines the order in which the elements of the input buffers will be written to.
     """
-    stride_patterns = prop_def(ArrayAttr[StridePattern])
+    stride_patterns: ArrayAttr[StridePattern] = prop_def(ArrayAttr[StridePattern])
     """
     Stride patterns that define the order of the input and output streams. If there is
     one stride pattern, and more inputs and outputs, the stride pattern is applied to all

--- a/xdsl/dialects/stencil.py
+++ b/xdsl/dialects/stencil.py
@@ -38,9 +38,14 @@ from xdsl.irdl import (
     ConstraintContext,
     IRDLOperation,
     MessageConstraint,
+    Operand,
+    OpResult,
+    OptOperand,
     ParamAttrConstraint,
     RangeOf,
     VarConstraint,
+    VarOperand,
+    VarOpResult,
     attr_def,
     base,
     irdl_attr_definition,
@@ -498,12 +503,12 @@ class ApplyOp(IRDLOperation):
 
     name = "stencil.apply"
 
-    args = var_operand_def(Attribute)
-    dest = var_operand_def(FieldType)
-    region = region_def()
-    res = var_result_def(TempType)
+    args: VarOperand = var_operand_def(Attribute)
+    dest: VarOperand = var_operand_def(FieldType)
+    region: Region = region_def()
+    res: VarOpResult[TempType[Attribute]] = var_result_def(TempType)
 
-    bounds = opt_prop_def(StencilBoundsAttr)
+    bounds: StencilBoundsAttr | None = opt_prop_def(StencilBoundsAttr)
 
     def __init__(
         self,
@@ -715,7 +720,7 @@ class AllocOpEffect(MemoryEffect):
 class AllocOp(IRDLOperation):
     name = "stencil.alloc"
 
-    field = result_def(FieldType[Attribute])
+    field: OpResult[FieldType[Attribute]] = result_def(FieldType[Attribute])
 
     assembly_format = "attr-dict `:` type($field)"
 
@@ -743,7 +748,7 @@ class CastOp(IRDLOperation):
 
     name = "stencil.cast"
 
-    field = operand_def(
+    field: Operand = operand_def(
         FieldType[Attribute].constr(
             element_type=MessageConstraint(
                 VarConstraint("T", AnyAttr()),
@@ -751,7 +756,7 @@ class CastOp(IRDLOperation):
             )
         )
     )
-    result = result_def(
+    result: OpResult[StencilType[Attribute]] = result_def(
         FieldType[Attribute].constr(
             element_type=MessageConstraint(
                 VarConstraint("T", AnyAttr()),
@@ -839,13 +844,13 @@ class CombineOp(IRDLOperation):
 
     name = "stencil.combine"
 
-    dim = attr_def(IntegerAttr[IndexType])
-    index = attr_def(IntegerAttr[IndexType])
-    lower = var_operand_def(TempType)
-    upper = var_operand_def(TempType)
-    lowerext = var_operand_def(TempType)
-    upperext = var_operand_def(TempType)
-    results_ = var_result_def(TempType)
+    dim: IntegerAttr[IndexType] = attr_def(IntegerAttr[IndexType])
+    index: IntegerAttr[IndexType] = attr_def(IntegerAttr[IndexType])
+    lower: VarOperand = var_operand_def(TempType)
+    upper: VarOperand = var_operand_def(TempType)
+    lowerext: VarOperand = var_operand_def(TempType)
+    upperext: VarOperand = var_operand_def(TempType)
+    results_: VarOpResult[TempType[Attribute]] = var_result_def(TempType)
 
     traits = traits_def(
         Pure(),
@@ -881,7 +886,7 @@ class DynAccessOp(IRDLOperation):
 
     name = "stencil.dyn_access"
 
-    temp = operand_def(
+    temp: Operand = operand_def(
         StencilType[Attribute].constr(
             element_type=MessageConstraint(
                 VarConstraint("T", AnyAttr()),
@@ -890,11 +895,11 @@ class DynAccessOp(IRDLOperation):
         )
     )
 
-    offset = var_operand_def(builtin.IndexType())
-    lb = attr_def(IndexAttr)
-    ub = attr_def(IndexAttr)
+    offset: VarOperand = var_operand_def(builtin.IndexType())
+    lb: IndexAttr = attr_def(IndexAttr)
+    ub: IndexAttr = attr_def(IndexAttr)
 
-    res = result_def(
+    res: OpResult = result_def(
         MessageConstraint(
             VarConstraint("T", AnyAttr()),
             "Expected result type to be the accessed temp's element type.",
@@ -936,8 +941,10 @@ class ExternalLoadOp(IRDLOperation):
     """
 
     name = "stencil.external_load"
-    field = operand_def(Attribute)
-    result = result_def(base(FieldType[Attribute]) | MemRefType.constr())
+    field: Operand = operand_def(Attribute)
+    result: OpResult[FieldType[Attribute] | MemRefType] = result_def(
+        base(FieldType[Attribute]) | MemRefType.constr()
+    )
 
     assembly_format = (
         "$field attr-dict-with-keyword `:` type($field) `->` type($result)"
@@ -961,8 +968,8 @@ class ExternalStoreOp(IRDLOperation):
     """
 
     name = "stencil.external_store"
-    temp = operand_def(FieldType)
-    field = operand_def(Attribute)
+    temp: Operand = operand_def(FieldType)
+    field: Operand = operand_def(Attribute)
 
     assembly_format = (
         "$temp `to` $field attr-dict-with-keyword `:` type($temp) `to` type($field)"
@@ -981,9 +988,9 @@ class IndexOp(IRDLOperation):
     """
 
     name = "stencil.index"
-    dim = attr_def(IntegerAttr[IndexType])
-    offset = attr_def(IndexAttr)
-    idx = result_def(builtin.IndexType())
+    dim: IntegerAttr[IndexType] = attr_def(IntegerAttr[IndexType])
+    offset: IndexAttr = attr_def(IndexAttr)
+    idx: OpResult[IndexType] = result_def(builtin.IndexType())
 
     assembly_format = "$dim $offset attr-dict-with-keyword"
 
@@ -1029,7 +1036,7 @@ class AccessOp(IRDLOperation):
     """
 
     name = "stencil.access"
-    temp = operand_def(
+    temp: Operand = operand_def(
         StencilType[Attribute].constr(
             element_type=MessageConstraint(
                 VarConstraint("T", AnyAttr()),
@@ -1037,9 +1044,9 @@ class AccessOp(IRDLOperation):
             )
         )
     )
-    offset = attr_def(IndexAttr)
-    offset_mapping = opt_attr_def(IndexAttr)
-    res = result_def(
+    offset: IndexAttr = attr_def(IndexAttr)
+    offset_mapping: IndexAttr | None = opt_attr_def(IndexAttr)
+    res: OpResult = result_def(
         MessageConstraint(
             VarConstraint("T", AnyAttr()),
             "Expected return type to match the accessed temp's element type.",
@@ -1239,7 +1246,7 @@ class TensorIgnoreSizeConstraint(VarConstraint[Attribute]):
         ctx_attr = constraint_context.get_variable(self.name)
         if ctx_attr is not None:
             if isa(
-                attr, TensorType[Attribute]
+                attr, TensorType
             ) and TensorIgnoreSizeConstraint.ranks_and_element_types_match(
                 attr, ctx_attr
             ):
@@ -1258,7 +1265,7 @@ class LoadOp(IRDLOperation):
 
     name = "stencil.load"
 
-    field = operand_def(
+    field: Operand = operand_def(
         FieldType[Attribute].constr(
             bounds=base(StencilBoundsAttr),
             element_type=MessageConstraint(
@@ -1267,7 +1274,7 @@ class LoadOp(IRDLOperation):
             ),
         )
     )
-    res = result_def(
+    res: OpResult[StencilType[Attribute]] = result_def(
         TempType[Attribute].constr(
             element_type=MessageConstraint(
                 TensorIgnoreSizeConstraint("T", AnyAttr()),
@@ -1335,7 +1342,7 @@ class BufferOp(IRDLOperation):
 
     name = "stencil.buffer"
 
-    temp = operand_def(
+    temp: Operand = operand_def(
         TempType[Attribute].constr(
             bounds=MessageConstraint(
                 VarConstraint("B", AnyAttr()),
@@ -1347,7 +1354,7 @@ class BufferOp(IRDLOperation):
             ),
         )
     )
-    res = result_def(
+    res: OpResult[StencilType[Attribute]] = result_def(
         StencilType[Attribute].constr(
             bounds=MessageConstraint(
                 VarConstraint("B", AnyAttr()),
@@ -1417,7 +1424,7 @@ class StoreOp(IRDLOperation):
 
     name = "stencil.store"
 
-    temp = operand_def(
+    temp: Operand = operand_def(
         TempType[Attribute].constr(
             element_type=MessageConstraint(
                 TensorIgnoreSizeConstraint("T", AnyAttr()),
@@ -1425,7 +1432,7 @@ class StoreOp(IRDLOperation):
             ),
         )
     )
-    field = operand_def(
+    field: Operand = operand_def(
         FieldType[Attribute].constr(
             bounds=MessageConstraint(
                 StencilBoundsAttr, "Output type's size must be explicit"
@@ -1436,7 +1443,7 @@ class StoreOp(IRDLOperation):
             ),
         )
     )
-    bounds = attr_def(StencilBoundsAttr)
+    bounds: StencilBoundsAttr = attr_def(StencilBoundsAttr)
 
     assembly_format = "$temp `to` $field `` `(` $bounds `)` attr-dict-with-keyword `:` type($temp) `to` type($field)"
 
@@ -1463,13 +1470,13 @@ class StoreResultOp(IRDLOperation):
 
     name = "stencil.store_result"
 
-    arg = opt_operand_def(
+    arg: OptOperand = opt_operand_def(
         MessageConstraint(
             VarConstraint("T", AnyAttr()),
             "Expected return type to carry the operand type.",
         )
     )
-    res = result_def(
+    res: OpResult[ResultType] = result_def(
         ParamAttrConstraint.get(
             ResultType,
             MessageConstraint(
@@ -1501,8 +1508,8 @@ class ReturnOp(IRDLOperation):
 
     name = "stencil.return"
 
-    arg = var_operand_def(Attribute)
-    unroll = opt_prop_def(IndexAttr)
+    arg: VarOperand = var_operand_def(Attribute)
+    unroll: IndexAttr | None = opt_prop_def(IndexAttr)
 
     assembly_format = "$arg (`unroll` $unroll^)? attr-dict-with-keyword `:` type($arg)"
 
@@ -1560,9 +1567,9 @@ class ReduceOp(IRDLOperation):
 
     T: ClassVar = VarConstraint("T", AnyAttr())
 
-    acc = operand_def(T)
-    init = operand_def(T)
-    body = region_def("single_block", entry_args=RangeOf(T).of_length(2))
+    acc: Operand = operand_def(T)
+    init: Operand = operand_def(T)
+    body: Region = region_def("single_block", entry_args=RangeOf(T).of_length(2))
 
     assembly_format = "$acc `init` $init $body attr-dict `:` type($acc)"
 
@@ -1597,7 +1604,7 @@ class YieldOp(IRDLOperation):
 
     name = "stencil.yield"
 
-    operand = operand_def()
+    operand: Operand = operand_def()
 
     assembly_format = "$operand attr-dict `:` type($operand)"
 

--- a/xdsl/dialects/stim/ops.py
+++ b/xdsl/dialects/stim/ops.py
@@ -133,9 +133,11 @@ class StimCircuitOp(StimPrintable, IRDLOperation):
 
     name = "stim.circuit"
 
-    body = region_def("single_block")
+    body: Region = region_def("single_block")
 
-    qubitlayout = opt_prop_def(ArrayAttr[QubitMappingAttr])
+    qubitlayout: ArrayAttr[QubitMappingAttr] | None = opt_prop_def(
+        ArrayAttr[QubitMappingAttr]
+    )
 
     assembly_format = "(`qubitlayout` $qubitlayout^)? attr-dict-with-keyword $body"
 
@@ -190,7 +192,7 @@ class QubitCoordsOp(AnnotationOp):
 
     name = "stim.assign_qubit_coord"
 
-    qubitmapping = prop_def(QubitMappingAttr)
+    qubitmapping: QubitMappingAttr = prop_def(QubitMappingAttr)
 
     assembly_format = "$qubitmapping attr-dict"
 
@@ -216,7 +218,7 @@ class SingleQubitGateOp(StimPrintable, IRDLOperation, ABC):
 
     STIM_NAME: ClassVar[str]
 
-    targets = prop_def(ArrayAttr[QubitAttr])
+    targets: ArrayAttr[QubitAttr] = prop_def(ArrayAttr[QubitAttr])
 
     assembly_format = "$targets attr-dict"
 
@@ -311,7 +313,7 @@ class TwoQubitGateOp(StimPrintable, IRDLOperation, ABC):
 
     STIM_NAME: ClassVar[str]
 
-    targets = prop_def(ArrayAttr[QubitAttr])
+    targets: ArrayAttr[QubitAttr] = prop_def(ArrayAttr[QubitAttr])
 
     assembly_format = "$targets attr-dict"
 
@@ -380,8 +382,8 @@ class MeasurementOperation(StimPrintable, IRDLOperation, ABC):
 
     STIM_NAME: ClassVar[str]
 
-    targets = prop_def(ArrayAttr[QubitAttr])
-    flip_prob = opt_prop_def(FloatData)
+    targets: ArrayAttr[QubitAttr] = prop_def(ArrayAttr[QubitAttr])
+    flip_prob: FloatData | None = opt_prop_def(FloatData)
 
     assembly_format = "(`flip_prob` $flip_prob^)? $targets attr-dict"
 
@@ -436,7 +438,7 @@ class ResetOperation(StimPrintable, IRDLOperation, ABC):
 
     STIM_NAME: ClassVar[str]
 
-    targets = prop_def(ArrayAttr[QubitAttr])
+    targets: ArrayAttr[QubitAttr] = prop_def(ArrayAttr[QubitAttr])
 
     assembly_format = "$targets attr-dict"
 
@@ -481,8 +483,8 @@ class MeasureResetOperation(StimPrintable, IRDLOperation, ABC):
 
     STIM_NAME: ClassVar[str]
 
-    targets = prop_def(ArrayAttr[QubitAttr])
-    flip_prob = opt_prop_def(FloatData)
+    targets: ArrayAttr[QubitAttr] = prop_def(ArrayAttr[QubitAttr])
+    flip_prob: FloatData | None = opt_prop_def(FloatData)
 
     assembly_format = "(`flip_prob` $flip_prob^)? $targets attr-dict"
 

--- a/xdsl/dialects/symref.py
+++ b/xdsl/dialects/symref.py
@@ -4,6 +4,8 @@ from xdsl.dialects.builtin import StringAttr, SymbolRefAttr
 from xdsl.ir import Attribute, Dialect, Operation, SSAValue
 from xdsl.irdl import (
     IRDLOperation,
+    Operand,
+    OpResult,
     irdl_op_definition,
     operand_def,
     prop_def,
@@ -14,7 +16,7 @@ from xdsl.irdl import (
 @irdl_op_definition
 class DeclareOp(IRDLOperation):
     name = "symref.declare"
-    sym_name = prop_def(StringAttr)
+    sym_name: StringAttr = prop_def(StringAttr)
 
     assembly_format = "$sym_name attr-dict"
 
@@ -27,8 +29,8 @@ class DeclareOp(IRDLOperation):
 @irdl_op_definition
 class FetchOp(IRDLOperation):
     name = "symref.fetch"
-    value = result_def()
-    symbol = prop_def(SymbolRefAttr)
+    value: OpResult = result_def()
+    symbol: SymbolRefAttr = prop_def(SymbolRefAttr)
 
     assembly_format = "$symbol attr-dict `:` type($value)"
 
@@ -41,8 +43,8 @@ class FetchOp(IRDLOperation):
 @irdl_op_definition
 class UpdateOp(IRDLOperation):
     name = "symref.update"
-    value = operand_def()
-    symbol = prop_def(SymbolRefAttr)
+    value: Operand = operand_def()
+    symbol: SymbolRefAttr = prop_def(SymbolRefAttr)
 
     assembly_format = "$symbol `=` $value attr-dict `:` type($value)"
 

--- a/xdsl/dialects/tensor.py
+++ b/xdsl/dialects/tensor.py
@@ -29,6 +29,7 @@ from xdsl.dialects.utils import (
     print_dynamic_index_list,
 )
 from xdsl.dialects.utils.reshape_ops_utils import (
+    ArrayOfIntArrayAttr,
     ContiguousArrayOfIntArray,
     verify_reshape_like_types,
 )
@@ -42,8 +43,10 @@ from xdsl.irdl import (
     IntVarConstraint,
     IRDLOperation,
     Operand,
+    OpResult,
     RangeOf,
     VarConstraint,
+    VarOperand,
     base,
     irdl_op_definition,
     operand_def,
@@ -80,16 +83,16 @@ class CastOp(IRDLOperation):
 
     name = "tensor.cast"
 
-    source = operand_def(
-        base(TensorType[Attribute]) | base(UnrankedTensorType[Attribute])
+    source: Operand = operand_def(base(TensorType) | base(UnrankedTensorType))
+    dest: OpResult[TensorType | UnrankedTensorType] = result_def(
+        base(TensorType) | base(UnrankedTensorType)
     )
-    dest = result_def(base(TensorType[Attribute]) | base(UnrankedTensorType[Attribute]))
 
     assembly_format = "$source attr-dict `:` type($source) `to` type($dest)"
 
     traits = traits_def(Pure())
 
-    def __init__(self, source: SSAValue | Operation, dest: TensorType[Attribute]):
+    def __init__(self, source: SSAValue | Operation, dest: TensorType):
         super().__init__(operands=(source,), result_types=(dest,))
 
     def verify_(self):
@@ -128,15 +131,15 @@ class ConcatOp(IRDLOperation):
         "Tensor Element", AnyAttr()
     )
     _RANK: ClassVar[IntConstraint] = IntVarConstraint("Rank", AtLeast(1))
-    inputs = var_operand_def(
+    inputs: VarOperand = var_operand_def(
         RangeOf(
             TensorType.constr(
                 _TENSOR_ELEMENT, ArrayOfConstraint(RangeOf(AnyAttr()).of_length(_RANK))
             )
         ).of_length(AtLeast(1))
     )
-    dim = prop_def(IntegerAttr[I64])
-    result = result_def(
+    dim: IntegerAttr[I64] = prop_def(IntegerAttr[I64])
+    result: OpResult[TensorType] = result_def(
         TensorType.constr(
             _TENSOR_ELEMENT, ArrayOfConstraint(RangeOf(AnyAttr()).of_length(_RANK))
         )
@@ -240,11 +243,9 @@ class DimOp(IRDLOperation):
 
     name = "tensor.dim"
 
-    source = operand_def(
-        base(TensorType[Attribute]) | base(UnrankedTensorType[Attribute])
-    )
-    index = operand_def(IndexType)
-    result = result_def(IndexType)
+    source: Operand = operand_def(base(TensorType) | base(UnrankedTensorType))
+    index: Operand = operand_def(IndexType)
+    result: OpResult[IndexType] = result_def(IndexType)
 
     traits = traits_def(NoMemoryEffect())
 
@@ -281,9 +282,9 @@ class EmptyOp(IRDLOperation):
 
     name = "tensor.empty"
 
-    dynamic_sizes = var_operand_def(IndexType)
+    dynamic_sizes: VarOperand = var_operand_def(IndexType)
 
-    tensor = result_def(TensorType[Attribute])
+    tensor: OpResult[TensorType] = result_def(TensorType)
 
     traits = traits_def(NoMemoryEffect())
 
@@ -341,9 +342,9 @@ class CollapseShapeOp(IRDLOperation):
 
     name = "tensor.collapse_shape"
 
-    src = operand_def(TensorType[Attribute])
-    result = result_def(TensorType[Attribute])
-    reassociation = prop_def(ContiguousArrayOfIntArray())
+    src: Operand = operand_def(TensorType)
+    result: OpResult[TensorType] = result_def(TensorType)
+    reassociation: ArrayOfIntArrayAttr = prop_def(ContiguousArrayOfIntArray())
     assembly_format = (
         "$src $reassociation attr-dict `:` type($src) `into` type($result)"
     )
@@ -365,9 +366,9 @@ class ReshapeOp(IRDLOperation):
 
     name = "tensor.reshape"
 
-    source = operand_def(TensorType[Attribute])
-    shape = operand_def(TensorType[AnySignlessIntegerType | IndexType])
-    result = result_def(TensorType[Attribute])
+    source: Operand = operand_def(TensorType)
+    shape: Operand = operand_def(TensorType[AnySignlessIntegerType | IndexType])
+    result: OpResult[TensorType] = result_def(TensorType)
     assembly_format = "attr-dict $source `(` $shape `)` `:` `(` type($source) `,` type($shape) `)` `->` type($result)"
 
     traits = traits_def(Pure())
@@ -389,8 +390,8 @@ class ReshapeOp(IRDLOperation):
                 "tensor elementwise operation operands and result must be of type TensorType"
             )
 
-        source_type = cast(TensorType[Attribute], source_type)
-        shape_type = cast(TensorType[Attribute], shape_type)
+        source_type = cast(TensorType, source_type)
+        shape_type = cast(TensorType, shape_type)
         res_type = self.result.type
 
         if source_type.element_type != res_type.element_type:
@@ -435,14 +436,14 @@ class ExpandShapeOp(IRDLOperation):
 
     name = "tensor.expand_shape"
 
-    src = operand_def(TensorType)
-    dynamic_output_shape = var_operand_def(IndexType)
+    src: Operand = operand_def(TensorType)
+    dynamic_output_shape: VarOperand = var_operand_def(IndexType)
 
-    reassociation = prop_def(ContiguousArrayOfIntArray())
+    reassociation: ArrayOfIntArrayAttr = prop_def(ContiguousArrayOfIntArray())
 
-    static_output_shape = prop_def(DenseArrayBase.constr(i64))
+    static_output_shape: DenseArrayBase[I64] = prop_def(DenseArrayBase.constr(i64))
 
-    result = result_def(TensorType[Attribute])
+    result: OpResult[TensorType] = result_def(TensorType)
 
     traits = traits_def(Pure())
 
@@ -452,7 +453,7 @@ class ExpandShapeOp(IRDLOperation):
         dynamic_output_shape: Sequence[SSAValue],
         reassociation: ArrayAttr[ArrayAttr[IntegerAttr]],
         static_output_shape: Sequence[int] | DenseArrayBase,
-        result_type: TensorType[Attribute],
+        result_type: TensorType,
         attributes: dict[str, Attribute] | None = None,
     ):
         if not isinstance(static_output_shape, DenseArrayBase):
@@ -513,7 +514,7 @@ class ExpandShapeOp(IRDLOperation):
         shape_attr = DenseArrayBase.from_list(i64, static_shape)
 
         reassociation = cast(ArrayAttr[ArrayAttr[IntegerAttr]], reassociation)
-        result_type = cast(TensorType[Attribute], result_type)
+        result_type = cast(TensorType, result_type)
 
         return cls(src, dyn_shape, reassociation, shape_attr, result_type, attributes)
 
@@ -551,14 +552,14 @@ class ExtractSliceOp(IRDLOperation):
 
     name = "tensor.extract_slice"
 
-    source = operand_def(TensorType)
-    offsets = var_operand_def(IndexType)
-    sizes = var_operand_def(IndexType)
-    strides = var_operand_def(IndexType)
-    static_offsets = prop_def(DenseArrayBase.constr(i64))
-    static_sizes = prop_def(DenseArrayBase.constr(i64))
-    static_strides = prop_def(DenseArrayBase.constr(i64))
-    result = result_def(TensorType)
+    source: Operand = operand_def(TensorType)
+    offsets: VarOperand = var_operand_def(IndexType)
+    sizes: VarOperand = var_operand_def(IndexType)
+    strides: VarOperand = var_operand_def(IndexType)
+    static_offsets: DenseArrayBase[I64] = prop_def(DenseArrayBase.constr(i64))
+    static_sizes: DenseArrayBase[I64] = prop_def(DenseArrayBase.constr(i64))
+    static_strides: DenseArrayBase[I64] = prop_def(DenseArrayBase.constr(i64))
+    result: OpResult[TensorType] = result_def(TensorType)
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
@@ -609,15 +610,15 @@ class InsertSliceOp(IRDLOperation):
 
     name = "tensor.insert_slice"
 
-    source = operand_def(TensorType)
-    dest = operand_def(TensorType)
-    offsets = var_operand_def(IndexType)
-    sizes = var_operand_def(IndexType)
-    strides = var_operand_def(IndexType)
-    static_offsets = prop_def(DenseArrayBase.constr(i64))
-    static_sizes = prop_def(DenseArrayBase.constr(i64))
-    static_strides = prop_def(DenseArrayBase.constr(i64))
-    result = result_def(TensorType)
+    source: Operand = operand_def(TensorType)
+    dest: Operand = operand_def(TensorType)
+    offsets: VarOperand = var_operand_def(IndexType)
+    sizes: VarOperand = var_operand_def(IndexType)
+    strides: VarOperand = var_operand_def(IndexType)
+    static_offsets: DenseArrayBase[I64] = prop_def(DenseArrayBase.constr(i64))
+    static_sizes: DenseArrayBase[I64] = prop_def(DenseArrayBase.constr(i64))
+    static_strides: DenseArrayBase[I64] = prop_def(DenseArrayBase.constr(i64))
+    result: OpResult[TensorType] = result_def(TensorType)
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
@@ -712,9 +713,9 @@ class ExtractOp(IRDLOperation):
 
     name = "tensor.extract"
 
-    tensor = operand_def(TensorType)
-    indices = var_operand_def(IndexType)
-    result = result_def(Attribute)
+    tensor: Operand = operand_def(TensorType)
+    indices: VarOperand = var_operand_def(IndexType)
+    result: OpResult = result_def(Attribute)
     # assembly_format = "$tensor `[` $indices `]` attr-dict `:` type($tensor)"
     traits = traits_def(Pure())
 
@@ -745,7 +746,7 @@ class ExtractOp(IRDLOperation):
         )
         parser.parse_punctuation(":")
         source_tensor_type = parser.parse_type()
-        tensor_type = cast(TensorType[Attribute], source_tensor_type)
+        tensor_type = cast(TensorType, source_tensor_type)
         return cls(tensor, indices, tensor_type.get_element_type())
 
 
@@ -763,10 +764,10 @@ class InsertOp(IRDLOperation):
 
     name = "tensor.insert"
 
-    scalar = operand_def(Attribute)
-    dest = operand_def(TensorType)
-    indices = var_operand_def(IndexType)
-    result = result_def(TensorType)
+    scalar: Operand = operand_def(Attribute)
+    dest: Operand = operand_def(TensorType)
+    indices: VarOperand = var_operand_def(IndexType)
+    result: OpResult[TensorType] = result_def(TensorType)
     # assembly_format = "$scalar `into` $dest `[` $indices `]` attr-dict `:` type($dest)"
     traits = traits_def(Pure())
 
@@ -820,8 +821,8 @@ class FromElementsOp(IRDLOperation):
 
     ELEMENT_TYPE: ClassVar = VarConstraint("ELEMENT_TYPE", AnyAttr())
 
-    elements = var_operand_def(ELEMENT_TYPE)
-    result = result_def(TensorType.constr(ELEMENT_TYPE))
+    elements: VarOperand = var_operand_def(ELEMENT_TYPE)
+    result: OpResult[TensorType] = result_def(TensorType.constr(ELEMENT_TYPE))
     assembly_format = "$elements attr-dict `:` type($result)"
     traits = traits_def(Pure())
 
@@ -855,9 +856,9 @@ class SplatOp(IRDLOperation):
 
     SPLAT_TYPE: ClassVar = VarConstraint("SPLAT_TYPE", AnyAttr())
 
-    input = operand_def(SPLAT_TYPE)
-    dynamicSizes = var_operand_def(IndexType)
-    result = result_def(TensorType.constr(SPLAT_TYPE))
+    input: Operand = operand_def(SPLAT_TYPE)
+    dynamicSizes: VarOperand = var_operand_def(IndexType)
+    result: OpResult[TensorType] = result_def(TensorType.constr(SPLAT_TYPE))
     assembly_format = "$input (`[` $dynamicSizes^ `]`)? attr-dict `:` type($result)"
 
     traits = traits_def(Pure())
@@ -866,7 +867,7 @@ class SplatOp(IRDLOperation):
         self,
         input: SSAValue,
         dynamicSizes: Sequence[SSAValue | Operation],
-        result_type: TensorType[Attribute],
+        result_type: TensorType,
     ):
         super().__init__(operands=(input, dynamicSizes), result_types=(result_type,))
 
@@ -896,14 +897,14 @@ class PadOp(IRDLOperation):
 
     name = "tensor.pad"
 
-    source = operand_def(base(TensorType[Attribute]))
-    low = var_operand_def(IndexType)
-    high = var_operand_def(IndexType)
-    static_low = prop_def(DenseArrayBase.constr(i64))
-    static_high = prop_def(DenseArrayBase.constr(i64))
-    nofold = opt_prop_def(UnitAttr)
-    region = region_def("single_block")
-    result = result_def(TensorType[Attribute])
+    source: Operand = operand_def(base(TensorType))
+    low: VarOperand = var_operand_def(IndexType)
+    high: VarOperand = var_operand_def(IndexType)
+    static_low: DenseArrayBase[I64] = prop_def(DenseArrayBase.constr(i64))
+    static_high: DenseArrayBase[I64] = prop_def(DenseArrayBase.constr(i64))
+    nofold: UnitAttr | None = opt_prop_def(UnitAttr)
+    region: Region = region_def("single_block")
+    result: OpResult[TensorType] = result_def(TensorType)
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
@@ -926,7 +927,7 @@ class PadOp(IRDLOperation):
         region: Region,
         static_low: Sequence[int] | DenseArrayBase,
         static_high: Sequence[int] | DenseArrayBase,
-        result_type: TensorType[Attribute],
+        result_type: TensorType,
         nofold: UnitAttr | None = None,
         attributes: dict[str, Attribute] | None = None,
     ):
@@ -954,7 +955,7 @@ class PadOp(IRDLOperation):
                 f"pad sizes low ({len(self.static_low)}) and high ({len(self.static_high)})"
                 " must have an equal number of dimensions"
             )
-        source_type = cast(TensorType[Attribute], self.source.type)  # verified by IRDL
+        source_type = cast(TensorType, self.source.type)  # verified by IRDL
         source_shape = source_type.get_shape()
         if len(self.static_low) != len(source_shape):
             raise VerifyException(

--- a/xdsl/dialects/test.py
+++ b/xdsl/dialects/test.py
@@ -8,7 +8,12 @@ from xdsl.backend.register_allocatable import (
 )
 from xdsl.backend.register_type import RegisterAllocatedMemoryEffect, RegisterType
 from xdsl.dialect_interfaces.op_asm import OpAsmDialectInterface
-from xdsl.dialects.builtin import IntegerAttr, IntegerType, SymbolNameConstraint
+from xdsl.dialects.builtin import (
+    IntegerAttr,
+    IntegerType,
+    StringAttr,
+    SymbolNameConstraint,
+)
 from xdsl.interfaces import HasFolderInterface
 from xdsl.ir import (
     Attribute,
@@ -24,6 +29,11 @@ from xdsl.irdl import (
     AttrSizedOperandSegments,
     AttrSizedResultSegments,
     IRDLOperation,
+    OpResult,
+    VarOperand,
+    VarOpResult,
+    VarRegion,
+    VarSuccessor,
     irdl_attr_definition,
     irdl_op_definition,
     opt_prop_def,
@@ -58,13 +68,13 @@ class TestOp(IRDLOperation):
 
     name = "test.op"
 
-    res = var_result_def()
-    ops = var_operand_def()
-    regs = var_region_def()
+    res: VarOpResult = var_result_def()
+    ops: VarOperand = var_operand_def()
+    regs: VarRegion = var_region_def()
 
-    prop1 = opt_prop_def()
-    prop2 = opt_prop_def()
-    prop3 = opt_prop_def()
+    prop1: Attribute | None = opt_prop_def()
+    prop2: Attribute | None = opt_prop_def()
+    prop3: Attribute | None = opt_prop_def()
 
     def __init__(
         self,
@@ -96,14 +106,14 @@ class TestTermOp(IRDLOperation):
 
     name = "test.termop"
 
-    res = var_result_def()
-    ops = var_operand_def()
-    regs = var_region_def()
-    successor = var_successor_def()
+    res: VarOpResult = var_result_def()
+    ops: VarOperand = var_operand_def()
+    regs: VarRegion = var_region_def()
+    successor: VarSuccessor = var_successor_def()
 
-    prop1 = opt_prop_def()
-    prop2 = opt_prop_def()
-    prop3 = opt_prop_def()
+    prop1: Attribute | None = opt_prop_def()
+    prop2: Attribute | None = opt_prop_def()
+    prop3: Attribute | None = opt_prop_def()
 
     traits = traits_def(IsTerminator())
 
@@ -139,14 +149,14 @@ class TestPureOp(IRDLOperation):
 
     name = "test.pureop"
 
-    res = var_result_def()
-    ops = var_operand_def()
-    regs = var_region_def()
-    successor = var_successor_def()
+    res: VarOpResult = var_result_def()
+    ops: VarOperand = var_operand_def()
+    regs: VarRegion = var_region_def()
+    successor: VarSuccessor = var_successor_def()
 
-    prop1 = opt_prop_def()
-    prop2 = opt_prop_def()
-    prop3 = opt_prop_def()
+    prop1: Attribute | None = opt_prop_def()
+    prop2: Attribute | None = opt_prop_def()
+    prop3: Attribute | None = opt_prop_def()
 
     traits = traits_def(Pure())
 
@@ -182,14 +192,14 @@ class TestReadOp(IRDLOperation):
 
     name = "test.op_with_memread"
 
-    res = var_result_def()
-    ops = var_operand_def()
-    regs = var_region_def()
-    successor = var_successor_def()
+    res: VarOpResult = var_result_def()
+    ops: VarOperand = var_operand_def()
+    regs: VarRegion = var_region_def()
+    successor: VarSuccessor = var_successor_def()
 
-    prop1 = opt_prop_def()
-    prop2 = opt_prop_def()
-    prop3 = opt_prop_def()
+    prop1: Attribute | None = opt_prop_def()
+    prop2: Attribute | None = opt_prop_def()
+    prop3: Attribute | None = opt_prop_def()
 
     traits = traits_def(MemoryReadEffect())
 
@@ -225,14 +235,14 @@ class TestWriteOp(IRDLOperation):
 
     name = "test.op_with_memwrite"
 
-    res = var_result_def()
-    ops = var_operand_def()
-    regs = var_region_def()
-    successor = var_successor_def()
+    res: VarOpResult = var_result_def()
+    ops: VarOperand = var_operand_def()
+    regs: VarRegion = var_region_def()
+    successor: VarSuccessor = var_successor_def()
 
-    prop1 = opt_prop_def()
-    prop2 = opt_prop_def()
-    prop3 = opt_prop_def()
+    prop1: Attribute | None = opt_prop_def()
+    prop2: Attribute | None = opt_prop_def()
+    prop3: Attribute | None = opt_prop_def()
 
     traits = traits_def(MemoryWriteEffect())
 
@@ -263,8 +273,8 @@ class TestConstantOp(IRDLOperation, HasFolderInterface):
 
     name = "test.constant"
 
-    result = result_def(IntegerType)
-    value = prop_def(IntegerAttr)
+    result: OpResult[IntegerType] = result_def(IntegerType)
+    value: IntegerAttr = prop_def(IntegerAttr)
 
     traits = traits_def(Pure(), ConstantLike())
 
@@ -310,11 +320,11 @@ class TestSymbolOp(IRDLOperation):
 
     name = "test.op_with_symbol"
 
-    res = var_result_def()
-    ops = var_operand_def()
-    regs = var_region_def()
+    res: VarOpResult = var_result_def()
+    ops: VarOperand = var_operand_def()
+    regs: VarRegion = var_region_def()
 
-    sym_name = prop_def(SymbolNameConstraint())
+    sym_name: StringAttr = prop_def(SymbolNameConstraint())
     traits = traits_def(SymbolOpInterface())
 
     def __init__(
@@ -338,10 +348,10 @@ class TestSymbolOp(IRDLOperation):
 class TestAllocatableOp(IRDLOperation, HasRegisterConstraints):
     name = "test.allocatable"
 
-    in_operands = var_operand_def()
-    inout_operands = var_operand_def()
-    out_results = var_result_def()
-    inout_results = var_result_def()
+    in_operands: VarOperand = var_operand_def()
+    inout_operands: VarOperand = var_operand_def()
+    out_results: VarOpResult = var_result_def()
+    inout_results: VarOpResult = var_result_def()
 
     traits = traits_def(RegisterAllocatedMemoryEffect())
 

--- a/xdsl/dialects/tosa.py
+++ b/xdsl/dialects/tosa.py
@@ -25,14 +25,19 @@ from xdsl.ir import (
     Attribute,
     Dialect,
     EnumAttribute,
+    Region,
     SSAValue,
     TypeAttribute,
 )
 from xdsl.irdl import (
     AttrConstraint,
     IRDLOperation,
+    Operand,
+    OpResult,
     ParsePropInAttrDict,
     VarConstraint,
+    VarOperand,
+    VarOpResult,
     irdl_attr_definition,
     irdl_op_definition,
     lazy_traits_def,
@@ -153,13 +158,15 @@ class ClampOp(IRDLOperation):
         type=SignlessIntegerConstraint & T
     ) | FloatAttr.constr(type=AnyFloatConstr & T)
 
-    min_val = prop_def(VALUE)
-    max_val = prop_def(VALUE)
+    min_val: IntegerAttr | FloatAttr[AnyFloat] = prop_def(VALUE)
+    max_val: IntegerAttr | FloatAttr[AnyFloat] = prop_def(VALUE)
 
-    nan_mode = opt_prop_def(NanModeAttr, default_value=NanModeAttr(NanMode.PROPAGATE))
+    nan_mode: NanModeAttr = opt_prop_def(
+        NanModeAttr, default_value=NanModeAttr(NanMode.PROPAGATE)
+    )
 
-    input = operand_def(TensorType.constr(T))
-    output = result_def(TensorType.constr(T))
+    input: Operand = operand_def(TensorType.constr(T))
+    output: OpResult[TensorType] = result_def(TensorType.constr(T))
 
     irdl_options = (ParsePropInAttrDict(),)
 
@@ -176,9 +183,9 @@ class ConstOp(IRDLOperation):
 
     name = "tosa.const"
 
-    values = prop_def(DenseIntOrFPElementsAttr)
+    values: DenseIntOrFPElementsAttr = prop_def(DenseIntOrFPElementsAttr)
 
-    output = result_def(TensorType)
+    output: OpResult[TensorType] = result_def(TensorType)
 
     def __init__(self, values: DenseIntOrFPElementsAttr):
         super().__init__(
@@ -196,21 +203,21 @@ class RescaleOp(IRDLOperation):
 
     name = "tosa.rescale"
 
-    scale32 = prop_def(BoolAttr)
-    rounding_mode = prop_def(
+    scale32: BoolAttr = prop_def(BoolAttr)
+    rounding_mode: RoundingModeAttr = prop_def(
         RoundingModeAttr, default_value=RoundingModeAttr(RoundingMode.SINGLE_ROUND)
     )
-    per_channel = prop_def(BoolAttr)
-    input_unsigned = prop_def(BoolAttr)
-    output_unsigned = prop_def(BoolAttr)
+    per_channel: BoolAttr = prop_def(BoolAttr)
+    input_unsigned: BoolAttr = prop_def(BoolAttr)
+    output_unsigned: BoolAttr = prop_def(BoolAttr)
 
-    input = operand_def(TensorType)
-    multiplier = operand_def(TensorType)
-    shift = operand_def(TensorType)
-    input_zp = operand_def(TensorType)
-    output_zp = operand_def(TensorType)
+    input: Operand = operand_def(TensorType)
+    multiplier: Operand = operand_def(TensorType)
+    shift: Operand = operand_def(TensorType)
+    input_zp: Operand = operand_def(TensorType)
+    output_zp: Operand = operand_def(TensorType)
 
-    output = result_def(TensorType)
+    output: OpResult[TensorType] = result_def(TensorType)
 
     irdl_options = (ParsePropInAttrDict(),)
 
@@ -314,9 +321,9 @@ class ElementwiseBinaryOperation(ElementwiseOperation):
 
     T: ClassVar = VarConstraint("T", AnyAttr())
 
-    input1 = operand_def(TensorType.constr(T))
-    input2 = operand_def(TensorType.constr(T))
-    output = result_def(TensorType.constr(T))
+    input1: Operand = operand_def(TensorType.constr(T))
+    input2: Operand = operand_def(TensorType.constr(T))
+    output: OpResult[TensorType] = result_def(TensorType.constr(T))
 
     def verify_(self) -> None:
         t1 = self.input1.type
@@ -371,10 +378,10 @@ class MulOp(ElementwiseOperation):
 
     T: ClassVar = VarConstraint("T", AnyAttr())
 
-    input1 = operand_def(TensorType.constr(T))
-    input2 = operand_def(TensorType.constr(T))
-    shift = operand_def(TensorType[I8])
-    output = result_def(TensorType.constr(T))
+    input1: Operand = operand_def(TensorType.constr(T))
+    input2: Operand = operand_def(TensorType.constr(T))
+    shift: Operand = operand_def(TensorType[I8])
+    output: OpResult[TensorType] = result_def(TensorType.constr(T))
 
     def verify_(self) -> None:
         t1 = self.input1.type
@@ -395,8 +402,8 @@ class ElementwiseUnaryOperation(ElementwiseOperation, Generic[TInv]):
     Abstract base class for elementwise unary operations on tensors of floating-point types
     """
 
-    input1 = operand_def(TInv)
-    result = result_def(TInv)
+    input1: Operand = operand_def(TInv)
+    result: OpResult[TInv] = result_def(TInv)
 
 
 @irdl_op_definition
@@ -448,13 +455,13 @@ class MatMulOp(IRDLOperation):
 
     T: ClassVar = VarConstraint("T", AnyAttr())
 
-    a = operand_def(TensorType.constr(T))
-    b = operand_def(TensorType.constr(T))
+    a: Operand = operand_def(TensorType.constr(T))
+    b: Operand = operand_def(TensorType.constr(T))
 
-    a_zp = operand_def(TensorType.constr(T))
-    b_zp = operand_def(TensorType.constr(T))
+    a_zp: Operand = operand_def(TensorType.constr(T))
+    b_zp: Operand = operand_def(TensorType.constr(T))
 
-    output = result_def(TensorType.constr(T))
+    output: OpResult[TensorType] = result_def(TensorType.constr(T))
 
     assembly_format = "operands attr-dict `:` functional-type(operands, results)"
 
@@ -507,13 +514,15 @@ class MaxPool2DOp(IRDLOperation):
     name = "tosa.max_pool2d"
 
     T: ClassVar = VarConstraint("T", AnyAttr())
-    input = operand_def(TensorType.constr(T))
-    output = result_def(TensorType.constr(T))
+    input: Operand = operand_def(TensorType.constr(T))
+    output: OpResult[TensorType] = result_def(TensorType.constr(T))
 
-    kernel = prop_def(DenseArrayBase[I64])
-    stride = prop_def(DenseArrayBase[I64])
-    pad = prop_def(DenseArrayBase[I64])
-    nan_mode = opt_prop_def(NanModeAttr, default_value=NanModeAttr(NanMode.PROPAGATE))
+    kernel: DenseArrayBase[I64] = prop_def(DenseArrayBase[I64])
+    stride: DenseArrayBase[I64] = prop_def(DenseArrayBase[I64])
+    pad: DenseArrayBase[I64] = prop_def(DenseArrayBase[I64])
+    nan_mode: NanModeAttr = opt_prop_def(
+        NanModeAttr, default_value=NanModeAttr(NanMode.PROPAGATE)
+    )
 
     irdl_options = (ParsePropInAttrDict(),)
 
@@ -542,16 +551,16 @@ class AvgPool2DOp(IRDLOperation):
 
     name = "tosa.avg_pool2d"
 
-    input = operand_def(TensorType)
-    input_zp = operand_def(TensorType)
-    output_zp = operand_def(TensorType)
+    input: Operand = operand_def(TensorType)
+    input_zp: Operand = operand_def(TensorType)
+    output_zp: Operand = operand_def(TensorType)
 
-    kernel = prop_def(DenseArrayBase)
-    stride = prop_def(DenseArrayBase)
-    pad = prop_def(DenseArrayBase)
-    acc_type = prop_def(TypeAttribute)
+    kernel: DenseArrayBase = prop_def(DenseArrayBase)
+    stride: DenseArrayBase = prop_def(DenseArrayBase)
+    pad: DenseArrayBase = prop_def(DenseArrayBase)
+    acc_type: TypeAttribute = prop_def(TypeAttribute)
 
-    output = result_def(TensorType)
+    output: OpResult[TensorType] = result_def(TensorType)
 
     irdl_options = (ParsePropInAttrDict(),)
 
@@ -568,9 +577,9 @@ class ConcatOp(IRDLOperation):
 
     name = "tosa.concat"
 
-    tensors = var_operand_def(TensorType)
-    axis = prop_def(IntegerAttr[I32])
-    output = result_def(TensorType)
+    tensors: VarOperand = var_operand_def(TensorType)
+    axis: IntegerAttr[I32] = prop_def(IntegerAttr[I32])
+    output: OpResult[TensorType] = result_def(TensorType)
 
     def __init__(
         self, tensors: Sequence[SSAValue], axis: IntegerAttr, output_type: TensorType
@@ -596,7 +605,7 @@ class YieldOp(IRDLOperation):
 
     name = "tosa.yield"
 
-    inputs = var_operand_def(TensorType)
+    inputs: VarOperand = var_operand_def(TensorType)
 
     traits = lazy_traits_def(
         lambda: (
@@ -619,12 +628,12 @@ class IfOp(IRDLOperation):
 
     name = "tosa.cond_if"
 
-    cond = operand_def(TensorType(i1, []))
+    cond: Operand = operand_def(TensorType(i1, []))
 
-    output = var_result_def(TensorType)
+    output: VarOpResult[TensorType] = var_result_def(TensorType)
 
-    true_region = region_def("single_block")
-    false_region = region_def("single_block")
+    true_region: Region = region_def("single_block")
+    false_region: Region = region_def("single_block")
 
     traits = traits_def(
         RecursiveMemoryEffect(),
@@ -644,10 +653,10 @@ class ReductionOperation(IRDLOperation, ABC):
     Base class for all TOSA reduction operations
     """
 
-    input = operand_def(TensorType)
-    axis = prop_def(IntegerAttr[I32])
+    input: Operand = operand_def(TensorType)
+    axis: IntegerAttr[I32] = prop_def(IntegerAttr[I32])
 
-    output = result_def(TensorType)
+    output: OpResult[TensorType] = result_def(TensorType)
 
     assembly_format = "$input attr-dict `:` functional-type(operands, results)"
 
@@ -680,7 +689,9 @@ class ReduceMaxOp(ReductionOperation):
 
     name = "tosa.reduce_max"
 
-    nan_mode = opt_prop_def(NanModeAttr, default_value=NanModeAttr(NanMode.PROPAGATE))
+    nan_mode: NanModeAttr = opt_prop_def(
+        NanModeAttr, default_value=NanModeAttr(NanMode.PROPAGATE)
+    )
 
 
 @irdl_op_definition
@@ -691,7 +702,9 @@ class ReduceMinOp(ReductionOperation):
 
     name = "tosa.reduce_min"
 
-    nan_mode = opt_prop_def(NanModeAttr, default_value=NanModeAttr(NanMode.PROPAGATE))
+    nan_mode: NanModeAttr = opt_prop_def(
+        NanModeAttr, default_value=NanModeAttr(NanMode.PROPAGATE)
+    )
 
 
 @irdl_op_definition

--- a/xdsl/dialects/transform.py
+++ b/xdsl/dialects/transform.py
@@ -4,6 +4,8 @@ from abc import ABC
 from collections.abc import Mapping, Sequence
 
 from xdsl.dialects.builtin import (
+    I1,
+    I64,
     ArrayAttr,
     DenseArrayBase,
     DictionaryAttr,
@@ -35,6 +37,11 @@ from xdsl.ir import (
 from xdsl.irdl import (
     AttrSizedOperandSegments,
     IRDLOperation,
+    Operand,
+    OpResult,
+    OptOperand,
+    VarOperand,
+    VarOpResult,
     irdl_attr_definition,
     irdl_op_definition,
     operand_def,
@@ -155,12 +162,12 @@ class ApplyRegisteredPassOp(IRDLOperation):
 
     name = "transform.apply_registered_pass"
 
-    options = prop_def(DictionaryAttr, default_value=DictionaryAttr({}))
-    pass_name = prop_def(StringAttr)
-    target = operand_def(TransformHandleType)
+    options: DictionaryAttr = prop_def(DictionaryAttr, default_value=DictionaryAttr({}))
+    pass_name: StringAttr = prop_def(StringAttr)
+    target: Operand = operand_def(TransformHandleType)
     # TODO implement dynamic options and custom directive
     # dynamic_options = var_operand_def(TransformHandleType)
-    result = result_def(TransformHandleType)
+    result: OpResult[TransformHandleType] = result_def(TransformHandleType)
     assembly_format = "$pass_name (`with` `options` `=` $options^)? `to` $target attr-dict `:` functional-type(operands, results)"
 
     def __init__(
@@ -193,9 +200,9 @@ class GetConsumersOfResultOp(IRDLOperation):
 
     name = "transform.get_consumers_of_result"
 
-    result_number = prop_def(IntegerAttr)
-    target = operand_def(TransformOpHandleType)
-    consumers = result_def(TransformOpHandleType)
+    result_number: IntegerAttr = prop_def(IntegerAttr)
+    target: Operand = operand_def(TransformOpHandleType)
+    consumers: OpResult[TransformOpHandleType] = result_def(TransformOpHandleType)
 
     def __init__(
         self,
@@ -217,8 +224,8 @@ class GetDefiningOp(IRDLOperation):
 
     name = "transform.get_defining_op"
 
-    target = operand_def(TransformValueHandleType)
-    result = result_def(TransformOpHandleType)
+    target: Operand = operand_def(TransformValueHandleType)
+    result: OpResult[TransformOpHandleType] = result_def(TransformOpHandleType)
 
     def __init__(self, target: SSAValue):
         super().__init__(operands=[target], result_types=[AnyOpType()])
@@ -232,13 +239,13 @@ class GetParentOp(IRDLOperation):
 
     name = "transform.get_parent_op"
 
-    isolated_from_above = opt_prop_def(UnitAttr)
-    allow_empty_results = opt_prop_def(UnitAttr)
-    op_name = opt_prop_def(StringAttr)
-    deduplicate = opt_prop_def(UnitAttr)
-    nth_parent = prop_def(IntegerAttr)
-    target = operand_def(TransformOpHandleType)
-    parent_result = result_def(TransformOpHandleType)
+    isolated_from_above: UnitAttr | None = opt_prop_def(UnitAttr)
+    allow_empty_results: UnitAttr | None = opt_prop_def(UnitAttr)
+    op_name: StringAttr | None = opt_prop_def(StringAttr)
+    deduplicate: UnitAttr | None = opt_prop_def(UnitAttr)
+    nth_parent: IntegerAttr = prop_def(IntegerAttr)
+    target: Operand = operand_def(TransformOpHandleType)
+    parent_result: OpResult[TransformOpHandleType] = result_def(TransformOpHandleType)
 
     def __init__(
         self,
@@ -272,9 +279,9 @@ class GetProducerOfOperandOp(IRDLOperation):
 
     name = "transform.get_producer_of_operand"
 
-    operand_number = prop_def(IntegerAttr)
-    target = operand_def(TransformOpHandleType)
-    producer = result_def(TransformOpHandleType)
+    operand_number: IntegerAttr = prop_def(IntegerAttr)
+    target: Operand = operand_def(TransformOpHandleType)
+    producer: OpResult[TransformOpHandleType] = result_def(TransformOpHandleType)
 
     def __init__(
         self,
@@ -298,11 +305,11 @@ class GetResultOp(IRDLOperation):
 
     name = "transform.get_result"
 
-    raw_position_list = prop_def(DenseArrayBase)
-    is_inverted = opt_prop_def(UnitAttr)
-    is_all = opt_prop_def(UnitAttr)
-    target = operand_def(TransformOpHandleType)
-    result = result_def(TransformValueHandleType)
+    raw_position_list: DenseArrayBase = prop_def(DenseArrayBase)
+    is_inverted: UnitAttr | None = opt_prop_def(UnitAttr)
+    is_all: UnitAttr | None = opt_prop_def(UnitAttr)
+    target: Operand = operand_def(TransformOpHandleType)
+    result: OpResult[TransformValueHandleType] = result_def(TransformValueHandleType)
 
     def __init__(
         self,
@@ -334,9 +341,11 @@ class GetTypeOp(IRDLOperation):
 
     name = "transform.get_type"
 
-    elemental = opt_prop_def(UnitAttr)
-    value = operand_def(TransformValueHandleType)
-    type_param = result_def(TransformParamHandleType)
+    elemental: UnitAttr | None = opt_prop_def(UnitAttr)
+    value: Operand = operand_def(TransformValueHandleType)
+    type_param: OpResult[TransformParamHandleType] = result_def(
+        TransformParamHandleType
+    )
 
     def __init__(self, elemental: bool, value: SSAValue):
         super().__init__(
@@ -354,10 +363,10 @@ class IncludeOp(IRDLOperation):
 
     name = "transform.include"
 
-    target = prop_def(SymbolRefAttr)
-    failure_propagation_mode = prop_def()
-    operands_input = var_operand_def(TransformHandleType)
-    result = var_result_def(TransformHandleType)
+    target: SymbolRefAttr = prop_def(SymbolRefAttr)
+    failure_propagation_mode: Attribute = prop_def()
+    operands_input: VarOperand = var_operand_def(TransformHandleType)
+    result: VarOpResult[TransformHandleType] = var_result_def(TransformHandleType)
 
     def __init__(
         self,
@@ -387,7 +396,7 @@ class MatchOperationEmptyOp(IRDLOperation):
 
     name = "transform.match.operation_empty"
 
-    operand_handle = operand_def(TransformOpHandleType)
+    operand_handle: Operand = operand_def(TransformOpHandleType)
 
     def __init__(self, operand_handle: SSAValue):
         super().__init__(operands=[operand_handle])
@@ -401,8 +410,8 @@ class MatchOperationNameOp(IRDLOperation):
 
     name = "transform.match.operation_name"
 
-    op_names = prop_def(ArrayAttr[StringAttr])
-    operand_handle = operand_def(TransformOpHandleType)
+    op_names: ArrayAttr[StringAttr] = prop_def(ArrayAttr[StringAttr])
+    operand_handle: Operand = operand_def(TransformOpHandleType)
 
     def __init__(
         self,
@@ -430,11 +439,11 @@ class MatchParamCmpIOp(IRDLOperation):
 
     name = "transform.match.param.cmpi"
 
-    predicate = prop_def(
+    predicate: IntegerAttr = prop_def(
         IntegerAttr
     )  # Valid values given in xdsl/xdsl/dialects/arith.py
-    param = operand_def(TransformParamHandleType)
-    reference = operand_def(TransformParamHandleType)
+    param: Operand = operand_def(TransformParamHandleType)
+    reference: Operand = operand_def(TransformParamHandleType)
 
     def __init__(
         self, predicate: int | IntegerAttr, param: SSAValue, reference: SSAValue
@@ -455,9 +464,9 @@ class MergeHandlesOp(IRDLOperation):
 
     name = "transform.merge_handles"
 
-    deduplicate = opt_prop_def(UnitAttr)
-    handles = var_operand_def(TransformHandleType)
-    result = result_def(TransformHandleType)
+    deduplicate: UnitAttr | None = opt_prop_def(UnitAttr)
+    handles: VarOperand = var_operand_def(TransformHandleType)
+    result: OpResult[TransformHandleType] = result_def(TransformHandleType)
 
     def __init__(self, handles: Sequence[SSAValue], deduplicate: bool = False):
         super().__init__(
@@ -475,8 +484,8 @@ class ParamConstantOp(IRDLOperation):
 
     name = "transform.param.constant"
 
-    value = prop_def()
-    param = result_def(ParamType)
+    value: Attribute = prop_def()
+    param: OpResult[ParamType] = result_def(ParamType)
 
     def __init__(self, value: Attribute, param_type: TypeAttribute):
         super().__init__(
@@ -492,11 +501,11 @@ class SplitHandleOp(IRDLOperation):
 
     name = "transform.split_handle"
 
-    pass_through_empty_handle = prop_def(IntegerAttr)
-    fail_on_payload_too_small = prop_def(IntegerAttr)
-    overflow_result = opt_prop_def(IntegerAttr)
-    handle = operand_def(TransformHandleType)
-    results_ = var_result_def(TransformHandleType)
+    pass_through_empty_handle: IntegerAttr = prop_def(IntegerAttr)
+    fail_on_payload_too_small: IntegerAttr = prop_def(IntegerAttr)
+    overflow_result: IntegerAttr | None = opt_prop_def(IntegerAttr)
+    handle: Operand = operand_def(TransformHandleType)
+    results_: VarOpResult[TransformHandleType] = var_result_def(TransformHandleType)
 
     def __init__(
         self,
@@ -554,10 +563,10 @@ class SequenceOp(IRDLOperation):
 
     name = "transform.sequence"
 
-    body = region_def("single_block")
-    failure_propagation_mode = prop_def()
-    root = var_operand_def(AnyOpType)
-    extra_bindings = var_operand_def(TransformHandleType)
+    body: Region = region_def("single_block")
+    failure_propagation_mode: Attribute = prop_def()
+    root: VarOperand = var_operand_def(AnyOpType)
+    extra_bindings: VarOperand = var_operand_def(TransformHandleType)
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
     traits = traits_def(IsolatedFromAbove())
@@ -599,14 +608,14 @@ class TileOp(IRDLOperation):
 
     name = "transform.structured.tile_using_for"
 
-    target = operand_def(TransformHandleType)
-    dynamic_sizes = var_operand_def(TransformHandleType)
-    static_sizes = opt_prop_def(DenseArrayBase.constr(i64))
-    interchange = opt_prop_def(DenseArrayBase.constr(i64))
-    scalable_sizes = opt_prop_def(DenseArrayBase.constr(i1))
+    target: Operand = operand_def(TransformHandleType)
+    dynamic_sizes: VarOperand = var_operand_def(TransformHandleType)
+    static_sizes: DenseArrayBase[I64] | None = opt_prop_def(DenseArrayBase.constr(i64))
+    interchange: DenseArrayBase[I64] | None = opt_prop_def(DenseArrayBase.constr(i64))
+    scalable_sizes: DenseArrayBase[I1] | None = opt_prop_def(DenseArrayBase.constr(i1))
 
-    tiled_linalg_op = result_def(AnyOpType)
-    loops = var_result_def(AnyOpType)
+    tiled_linalg_op: OpResult[AnyOpType] = result_def(AnyOpType)
+    loops: VarOpResult[AnyOpType] = var_result_def(AnyOpType)
 
     def __init__(
         self,
@@ -654,17 +663,17 @@ class TileToForallOp(IRDLOperation):
 
     name = "transform.structured.tile_using_forall"
 
-    target = operand_def(TransformHandleType)
-    num_threads = var_operand_def(DenseArrayBase)
-    tile_sizes = var_operand_def(DenseArrayBase)
-    packed_num_threads = opt_operand_def(DenseArrayBase)
-    packed_tile_sizes = opt_operand_def(DenseArrayBase)
-    static_num_threads = opt_prop_def(DenseArrayBase)
-    static_tile_sizes = opt_prop_def(DenseArrayBase)
-    mapping = opt_attr_def(DenseArrayBase)
+    target: Operand = operand_def(TransformHandleType)
+    num_threads: VarOperand = var_operand_def(DenseArrayBase)
+    tile_sizes: VarOperand = var_operand_def(DenseArrayBase)
+    packed_num_threads: OptOperand = opt_operand_def(DenseArrayBase)
+    packed_tile_sizes: OptOperand = opt_operand_def(DenseArrayBase)
+    static_num_threads: DenseArrayBase | None = opt_prop_def(DenseArrayBase)
+    static_tile_sizes: DenseArrayBase | None = opt_prop_def(DenseArrayBase)
+    mapping: DenseArrayBase | None = opt_attr_def(DenseArrayBase)
 
-    forall_op = result_def(TransformHandleType)
-    tiled_op = result_def(TransformHandleType)
+    forall_op: OpResult[TransformHandleType] = result_def(TransformHandleType)
+    tiled_op: OpResult[TransformHandleType] = result_def(TransformHandleType)
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
@@ -715,9 +724,9 @@ class SelectOp(IRDLOperation):
 
     name = "transform.select"
 
-    op_name = prop_def(StringAttr)
-    target = operand_def(TransformHandleType)
-    result = result_def(TransformHandleType)
+    op_name: StringAttr = prop_def(StringAttr)
+    target: Operand = operand_def(TransformHandleType)
+    result: OpResult[TransformHandleType] = result_def(TransformHandleType)
 
     def __init__(self, op_name: str | StringAttr, target: SSAValue):
         if isinstance(op_name, str):
@@ -737,12 +746,16 @@ class NamedSequenceOp(IRDLOperation):
 
     name = "transform.named_sequence"
 
-    sym_name = prop_def(SymbolNameConstraint())
-    function_type = prop_def(FunctionType)
-    sym_visibility = opt_prop_def(StringAttr)
-    arg_attrs = opt_prop_def(ArrayAttr[DictionaryAttr])
-    res_attrs = opt_prop_def(ArrayAttr[DictionaryAttr])
-    body = region_def("single_block")
+    sym_name: StringAttr = prop_def(SymbolNameConstraint())
+    function_type: FunctionType = prop_def(FunctionType)
+    sym_visibility: StringAttr | None = opt_prop_def(StringAttr)
+    arg_attrs: ArrayAttr[DictionaryAttr] | None = opt_prop_def(
+        ArrayAttr[DictionaryAttr]
+    )
+    res_attrs: ArrayAttr[DictionaryAttr] | None = opt_prop_def(
+        ArrayAttr[DictionaryAttr]
+    )
+    body: Region = region_def("single_block")
 
     traits = traits_def(
         IsolatedFromAbove(), SymbolOpInterface(), FuncOpCallableInterface()
@@ -837,8 +850,8 @@ class CastOp(IRDLOperation):
 
     name = "transform.cast"
 
-    input = operand_def(TransformHandleType)
-    output = result_def(TransformHandleType)
+    input: Operand = operand_def(TransformHandleType)
+    output: OpResult[TransformHandleType] = result_def(TransformHandleType)
 
     def __init__(self, input: SSAValue):
         super().__init__(operands=[input], result_types=[AnyOpType()])
@@ -852,14 +865,14 @@ class MatchOp(IRDLOperation):
 
     name = "transform.structured.match"
 
-    ops = opt_prop_def(ArrayAttr[StringAttr])
-    interface = opt_prop_def(IntegerAttr)
-    op_attrs = opt_prop_def(DictionaryAttr)
-    filter_result_types = opt_prop_def(TypeAttribute)
-    filter_operand_types = opt_prop_def(TypeAttribute)
+    ops: ArrayAttr[StringAttr] | None = opt_prop_def(ArrayAttr[StringAttr])
+    interface: IntegerAttr | None = opt_prop_def(IntegerAttr)
+    op_attrs: DictionaryAttr | None = opt_prop_def(DictionaryAttr)
+    filter_result_types: TypeAttribute | None = opt_prop_def(TypeAttribute)
+    filter_operand_types: TypeAttribute | None = opt_prop_def(TypeAttribute)
 
-    target = operand_def(TransformOpHandleType)
-    result = result_def(TransformOpHandleType)
+    target: Operand = operand_def(TransformOpHandleType)
+    result: OpResult[TransformOpHandleType] = result_def(TransformOpHandleType)
 
     def __init__(
         self,

--- a/xdsl/dialects/ub.py
+++ b/xdsl/dialects/ub.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from xdsl.ir import Attribute, Dialect, ParametrizedAttribute
 from xdsl.irdl import (
     IRDLOperation,
+    OpResult,
     irdl_attr_definition,
     irdl_op_definition,
     prop_def,
@@ -60,9 +61,9 @@ class PoisonOp(IRDLOperation):
     # xDSL does not model that interface yet, so we accept any `Attribute` for
     # now; this should be tightened to a `PoisonAttrInterface` check once the
     # interface is available.
-    value = prop_def(Attribute, default_value=PoisonAttr())
+    value: Attribute = prop_def(Attribute, default_value=PoisonAttr())
 
-    result = result_def()
+    result: OpResult = result_def()
 
     traits = traits_def(ConstantLike(), Pure())
 

--- a/xdsl/dialects/utils/format.py
+++ b/xdsl/dialects/utils/format.py
@@ -18,7 +18,7 @@ from xdsl.ir import (
     SSAValue,
     TypeAttribute,
 )
-from xdsl.irdl import IRDLOperation, var_operand_def
+from xdsl.irdl import IRDLOperation, VarOperand, var_operand_def
 from xdsl.parser import Parser, UnresolvedOperand
 from xdsl.printer import Printer
 from xdsl.utils.hints import isa
@@ -30,7 +30,7 @@ class AbstractYieldOperation(IRDLOperation, Generic[AttributeInvT]):
     and a definition of the `arguments` variadic operand.
     """
 
-    arguments = var_operand_def(AttributeInvT)
+    arguments: VarOperand = var_operand_def(AttributeInvT)
 
     assembly_format = "attr-dict ($arguments^ `:` type($arguments))?"
 

--- a/xdsl/dialects/varith.py
+++ b/xdsl/dialects/varith.py
@@ -14,6 +14,7 @@ from xdsl.dialects.builtin import (
     Float128Type,
     IndexType,
     IntegerType,
+    TensorType,
     VectorType,
     container_of,
 )
@@ -21,7 +22,10 @@ from xdsl.ir import Attribute, Dialect, Operation, SSAValue
 from xdsl.irdl import (
     AnyAttr,
     IRDLOperation,
+    Operand,
+    OpResult,
     VarConstraint,
+    VarOperand,
     irdl_op_definition,
     operand_def,
     prop_def,
@@ -53,8 +57,37 @@ class VarithOp(IRDLOperation):
 
     T: ClassVar = VarConstraint("T", integerOrFloatLike)
 
-    args = var_operand_def(T)
-    res = result_def(T)
+    args: VarOperand = var_operand_def(T)
+    res: OpResult[
+        IntegerType
+        | IndexType
+        | BFloat16Type
+        | Float16Type
+        | Float32Type
+        | Float64Type
+        | Float80Type
+        | Float128Type
+        | VectorType[
+            IntegerType
+            | IndexType
+            | BFloat16Type
+            | Float16Type
+            | Float32Type
+            | Float64Type
+            | Float80Type
+            | Float128Type
+        ]
+        | TensorType[
+            IntegerType
+            | IndexType
+            | BFloat16Type
+            | Float16Type
+            | Float32Type
+            | Float64Type
+            | Float80Type
+            | Float128Type
+        ]
+    ] = result_def(T)
 
     traits = traits_def(Pure())
 
@@ -88,13 +121,13 @@ class VarithSwitchOp(IRDLOperation):
 
     T: ClassVar = VarConstraint("T", AnyAttr())
 
-    flag = operand_def(IntegerType | IndexType)
-    case_values = prop_def(DenseIntElementsAttr)
+    flag: Operand = operand_def(IntegerType | IndexType)
+    case_values: DenseIntElementsAttr = prop_def(DenseIntElementsAttr)
 
-    default_arg = operand_def(T)
-    args = var_operand_def(T)
+    default_arg: Operand = operand_def(T)
+    args: VarOperand = var_operand_def(T)
 
-    result = result_def(T)
+    result: OpResult = result_def(T)
 
     traits = traits_def(Pure())
 

--- a/xdsl/dialects/vector.py
+++ b/xdsl/dialects/vector.py
@@ -56,9 +56,14 @@ from xdsl.irdl import (
     IntConstraint,
     IRDLOperation,
     MessageConstraint,
+    Operand,
+    OpResult,
+    OptOperand,
+    OptOpResult,
     ParsePropInAttrDict,
     RangeOf,
     VarConstraint,
+    VarOperand,
     base,
     irdl_attr_definition,
     irdl_op_definition,
@@ -86,10 +91,12 @@ DYNAMIC_INDEX: int = -(2**63)
 @irdl_op_definition
 class LoadOp(IRDLOperation):
     name = "vector.load"
-    base = operand_def(MemRefType)
-    indices = var_operand_def(IndexType)
-    result = result_def(VectorType)
-    nontemporal = opt_prop_def(BoolAttr, default_value=BoolAttr.from_bool(False))
+    base: Operand = operand_def(MemRefType)
+    indices: VarOperand = var_operand_def(IndexType)
+    result: OpResult[VectorType[Attribute]] = result_def(VectorType)
+    nontemporal: BoolAttr = opt_prop_def(
+        BoolAttr, default_value=BoolAttr.from_bool(False)
+    )
 
     irdl_options = (ParsePropInAttrDict(),)
     assembly_format = (
@@ -123,10 +130,12 @@ class LoadOp(IRDLOperation):
 @irdl_op_definition
 class StoreOp(IRDLOperation):
     name = "vector.store"
-    vector = operand_def(VectorType)
-    base = operand_def(MemRefType)
-    indices = var_operand_def(IndexType)
-    nontemporal = opt_prop_def(BoolAttr, default_value=BoolAttr.from_bool(False))
+    vector: Operand = operand_def(VectorType)
+    base: Operand = operand_def(MemRefType)
+    indices: VarOperand = var_operand_def(IndexType)
+    nontemporal: BoolAttr = opt_prop_def(
+        BoolAttr, default_value=BoolAttr.from_bool(False)
+    )
 
     irdl_options = (ParsePropInAttrDict(),)
     assembly_format = (
@@ -271,10 +280,10 @@ class ShuffleOp(IRDLOperation):
     MASK: ClassVar = VarConstraint("MASK", _MaskConstr)
     RES: ClassVar = ShuffleResultConstraint(T, V1_SHAPE, V2_SHAPE, MASK)
 
-    v1 = operand_def(VectorType.constr(T, shape=V1_SHAPE))
-    v2 = operand_def(VectorType.constr(T, shape=V2_SHAPE))
-    mask = prop_def(MASK)
-    result = result_def(RES)
+    v1: Operand = operand_def(VectorType.constr(T, shape=V1_SHAPE))
+    v2: Operand = operand_def(VectorType.constr(T, shape=V2_SHAPE))
+    mask: DenseArrayBase[I64] = prop_def(MASK)
+    result: OpResult[VectorType[Attribute]] = result_def(RES)
 
     irdl_options = (ParsePropInAttrDict(),)
     traits = traits_def(NoMemoryEffect())
@@ -346,8 +355,8 @@ class BroadcastOp(IRDLOperation):
     """
 
     name = "vector.broadcast"
-    source = operand_def()
-    vector = result_def(VectorType)
+    source: Operand = operand_def()
+    vector: OpResult[VectorType[Attribute]] = result_def(VectorType)
     traits = traits_def(Pure())
 
     assembly_format = "$source attr-dict `:` type($source) `to` type($vector)"
@@ -373,10 +382,10 @@ class FMAOp(IRDLOperation):
 
     T: ClassVar = VarConstraint("T", VectorType.constr(AnyFloatConstr))
 
-    lhs = operand_def(T)
-    rhs = operand_def(T)
-    acc = operand_def(T)
-    res = result_def(T)
+    lhs: Operand = operand_def(T)
+    rhs: Operand = operand_def(T)
+    acc: Operand = operand_def(T)
+    res: OpResult[VectorType[AnyFloat]] = result_def(T)
     traits = traits_def(Pure())
 
     assembly_format = "$lhs `,` $rhs `,` $acc attr-dict `:` type($lhs)"
@@ -394,11 +403,11 @@ class FMAOp(IRDLOperation):
 @irdl_op_definition
 class MaskedLoadOp(IRDLOperation):
     name = "vector.maskedload"
-    base = operand_def(MemRefType)
-    indices = var_operand_def(IndexType)
-    mask = operand_def(VectorBaseTypeAndRankConstraint(i1, 1))
-    pass_thru = operand_def(VectorType)
-    result = result_def(VectorRankConstraint(1))
+    base: Operand = operand_def(MemRefType)
+    indices: VarOperand = var_operand_def(IndexType)
+    mask: Operand = operand_def(VectorBaseTypeAndRankConstraint(i1, 1))
+    pass_thru: Operand = operand_def(VectorType)
+    result: OpResult = result_def(VectorRankConstraint(1))
 
     assembly_format = "$base `[` $indices `]` `,` $mask `,` $pass_thru attr-dict `:` type($base) `,` type($mask) `,` type($pass_thru) `into` type($result)"  # noqa: E501
 
@@ -449,10 +458,10 @@ class MaskedLoadOp(IRDLOperation):
 @irdl_op_definition
 class MaskedStoreOp(IRDLOperation):
     name = "vector.maskedstore"
-    base = operand_def(MemRefType)
-    indices = var_operand_def(IndexType)
-    mask = operand_def(VectorBaseTypeAndRankConstraint(i1, 1))
-    value_to_store = operand_def(VectorRankConstraint(1))
+    base: Operand = operand_def(MemRefType)
+    indices: VarOperand = var_operand_def(IndexType)
+    mask: Operand = operand_def(VectorBaseTypeAndRankConstraint(i1, 1))
+    value_to_store: Operand = operand_def(VectorRankConstraint(1))
 
     assembly_format = "$base `[` $indices `]` `,` $mask `,` $value_to_store attr-dict `:` type($base) `,` type($mask) `,` type($value_to_store)"  # noqa: E501
 
@@ -493,7 +502,7 @@ class MaskedStoreOp(IRDLOperation):
 @irdl_op_definition
 class PrintOp(IRDLOperation):
     name = "vector.print"
-    source = operand_def()
+    source: Operand = operand_def()
 
     def __init__(self, source: SSAValue | Operation):
         super().__init__(operands=[SSAValue.get(source)])
@@ -502,8 +511,8 @@ class PrintOp(IRDLOperation):
 @irdl_op_definition
 class CreateMaskOp(IRDLOperation):
     name = "vector.create_mask"
-    mask_dim_sizes = var_operand_def(IndexType)
-    mask_vector = result_def(VectorBaseTypeConstraint(i1))
+    mask_dim_sizes: VarOperand = var_operand_def(IndexType)
+    mask_vector: OpResult = result_def(VectorBaseTypeConstraint(i1))
 
     assembly_format = "$mask_dim_sizes attr-dict `:` type(results)"
 
@@ -529,12 +538,17 @@ class ExtractOp(IRDLOperation):
     )
     _V: ClassVar = VarConstraint("V", VectorType.constr(_T))
 
-    static_position = prop_def(DenseArrayBase.constr(i64))
+    static_position: DenseArrayBase[I64] = prop_def(DenseArrayBase.constr(i64))
 
-    vector = operand_def(_V)
-    dynamic_position = var_operand_def(IndexTypeConstr)
+    vector: Operand = operand_def(_V)
+    dynamic_position: VarOperand = var_operand_def(IndexTypeConstr)
 
-    result = result_def(
+    result: OpResult[
+        VectorType[IntegerType | IndexType | AnyFloat]
+        | IntegerType
+        | IndexType
+        | AnyFloat
+    ] = result_def(
         VectorType.constr(
             _T,
             shape=MessageConstraint(
@@ -627,9 +641,9 @@ class InsertOp(IRDLOperation):
     )
     _V: ClassVar = VarConstraint("V", VectorType.constr(_T))
 
-    static_position = prop_def(DenseArrayBase.constr(i64))
+    static_position: DenseArrayBase[I64] = prop_def(DenseArrayBase.constr(i64))
 
-    source = operand_def(
+    source: Operand = operand_def(
         VectorType.constr(
             _T,
             shape=MessageConstraint(
@@ -639,10 +653,10 @@ class InsertOp(IRDLOperation):
         )
         | _T
     )
-    dest = operand_def(_V)
-    dynamic_position = var_operand_def(IndexTypeConstr)
+    dest: Operand = operand_def(_V)
+    dynamic_position: VarOperand = var_operand_def(IndexTypeConstr)
 
-    result = result_def(_V)
+    result: OpResult[VectorType[IntegerType | IndexType | AnyFloat]] = result_def(_V)
 
     traits = traits_def(Pure())
 
@@ -749,7 +763,7 @@ class VectorTransferOperation(IRDLOperation, ABC):
     Mirrors VectorTransferOpInterface from [MLIR](https://github.com/llvm/llvm-project/blob/main/mlir/include/mlir/Interfaces/VectorInterfaces.td)
     """
 
-    permutation_map = prop_def(AffineMapAttr)
+    permutation_map: AffineMapAttr = prop_def(AffineMapAttr)
     """
     The permutation map that describes the mapping of vector
     dimensions to source dimensions, as well as broadcast dimensions.
@@ -770,7 +784,7 @@ class VectorTransferOperation(IRDLOperation, ABC):
     ```
     """
 
-    in_bounds = prop_def(ArrayAttr[BoolAttr])
+    in_bounds: ArrayAttr[BoolAttr] = prop_def(ArrayAttr[BoolAttr])
     """
     For every vector dimension, the boolean array attribute `in_bounds` specifies if the
     transfer is guaranteed to be within the source bounds. If set to `“false”`, accesses
@@ -1017,14 +1031,14 @@ class TransferReadOp(VectorTransferOperation):
 
     name = "vector.transfer_read"
 
-    source = operand_def(TensorType | MemRefType)
-    indices = var_operand_def(IndexType)
-    padding = operand_def()
-    mask = opt_operand_def(VectorType[I1])
+    source: Operand = operand_def(TensorType | MemRefType)
+    indices: VarOperand = var_operand_def(IndexType)
+    padding: Operand = operand_def()
+    mask: OptOperand = opt_operand_def(VectorType[I1])
 
-    permutation_map = prop_def(AffineMapAttr)
+    permutation_map: AffineMapAttr = prop_def(AffineMapAttr)
 
-    result = result_def(VectorType)
+    result: OpResult[VectorType[Attribute]] = result_def(VectorType)
 
     irdl_options = (
         AttrSizedOperandSegments(as_property=True),
@@ -1170,14 +1184,14 @@ class TransferReadOp(VectorTransferOperation):
 class TransferWriteOp(VectorTransferOperation):
     name = "vector.transfer_write"
 
-    vector = operand_def(VectorType)
-    source = operand_def(TensorType | MemRefType)
-    indices = var_operand_def(IndexType)
-    mask = opt_operand_def(VectorType[I1])
+    vector: Operand = operand_def(VectorType)
+    source: Operand = operand_def(TensorType | MemRefType)
+    indices: VarOperand = var_operand_def(IndexType)
+    mask: OptOperand = opt_operand_def(VectorType[I1])
 
-    permutation_map = prop_def(AffineMapAttr)
+    permutation_map: AffineMapAttr = prop_def(AffineMapAttr)
 
-    result = opt_result_def(TensorType)
+    result: OptOpResult[TensorType] = opt_result_def(TensorType)
 
     irdl_options = (
         AttrSizedOperandSegments(as_property=True),
@@ -1359,11 +1373,13 @@ class ReductionOp(IRDLOperation):
 
     _T: ClassVar = VarConstraint("T", AnyAttr())
 
-    vector = operand_def(VectorType.constr(_T))
-    acc = opt_operand_def(_T)
-    dest = result_def(_T)
-    kind = prop_def(CombiningKindAttr)
-    fastmath = prop_def(FastMathFlagsAttr, default_value=FastMathFlagsAttr("none"))
+    vector: Operand = operand_def(VectorType.constr(_T))
+    acc: OptOperand = opt_operand_def(_T)
+    dest: OpResult = result_def(_T)
+    kind: CombiningKindAttr = prop_def(CombiningKindAttr)
+    fastmath: FastMathFlagsAttr = prop_def(
+        FastMathFlagsAttr, default_value=FastMathFlagsAttr("none")
+    )
 
     assembly_format = "$kind `,` $vector (`,` $acc^)? (`fastmath` `` $fastmath^)? attr-dict `:` type($vector) `into` type($dest)"
 
@@ -1395,10 +1411,10 @@ class BitcastOp(IRDLOperation):
 
     name = "vector.bitcast"
 
-    source = operand_def(
+    source: Operand = operand_def(
         VectorType.constr(base(IntegerType) | base(IndexType) | AnyFloatConstr)
     )
-    result = result_def(
+    result: OpResult[VectorType[IntegerType | IndexType | AnyFloat]] = result_def(
         VectorType.constr(base(IntegerType) | base(IndexType) | AnyFloatConstr)
     )
 

--- a/xdsl/dialects/wasmssa.py
+++ b/xdsl/dialects/wasmssa.py
@@ -22,6 +22,8 @@ from xdsl.ir import (
 )
 from xdsl.irdl import (
     IRDLOperation,
+    Operand,
+    OpResult,
     VarConstraint,
     irdl_attr_definition,
     irdl_op_definition,
@@ -145,9 +147,9 @@ class BinaryNumericalOperation(IRDLOperation, ABC):
 
     T: ClassVar = VarConstraint.get("T", NumericType)
 
-    lhs = operand_def(T)
-    rhs = operand_def(T)
-    result = result_def(T)
+    lhs: Operand = operand_def(T)
+    rhs: Operand = operand_def(T)
+    result: OpResult = result_def(T)
 
     assembly_format = "$lhs $rhs `:` type($lhs) attr-dict"
 

--- a/xdsl/dialects/x86/ops.py
+++ b/xdsl/dialects/x86/ops.py
@@ -66,9 +66,11 @@ from xdsl.ir import (
 from xdsl.irdl import (
     AttrSizedOperandSegments,
     IRDLOperation,
+    Operand,
     ParsePropInAttrDict,
     Successor,
     VarConstraint,
+    VarOperand,
     VarOpResult,
     attr_def,
     base,
@@ -115,6 +117,7 @@ from .registers import (
     AVX512RegisterType,
     GeneralRegisterType,
     Reg32Type,
+    Reg64Type,
     RFLAGSRegisterType,
     X86RegisterType,
     X86VectorRegisterType,
@@ -247,7 +250,7 @@ class X86Instruction(X86AsmOperation, X86HasRegisterConstraints):
 
     traits = traits_def(RegisterAllocatedMemoryEffect())
 
-    comment = opt_attr_def(StringAttr)
+    comment: StringAttr | None = opt_attr_def(StringAttr)
     """
     An optional comment that will be printed along with the instruction.
     """
@@ -287,10 +290,10 @@ class RS_Operation(X86Instruction, ABC, Generic[R1InvT, R2InvT]):
     and one source register.
     """
 
-    register_in = operand_def(R1InvT)
+    register_in: Operand = operand_def(R1InvT)
     register_out: OpResult[R1InvT] = result_def(R1InvT)
 
-    source = operand_def(R2InvT)
+    source: Operand = operand_def(R2InvT)
 
     assembly_format = (
         "$register_in `,` $source attr-dict `:` "
@@ -335,7 +338,7 @@ class DS_Operation(X86Instruction, ABC, Generic[R1InvT, R2InvT]):
     """
 
     destination: OpResult[R1InvT] = result_def(R1InvT)
-    source = operand_def(R2InvT)
+    source: Operand = operand_def(R2InvT)
 
     assembly_format = (
         "$source attr-dict `:` `(` type($source) `)` `->` type($destination)"
@@ -370,9 +373,9 @@ class DSK_Operation(X86Instruction, ABC):
     """
 
     destination: OpResult[AVX512RegisterType] = result_def(AVX512RegisterType)
-    source = operand_def(AVX512RegisterType)
-    mask_reg = operand_def(AVX512MaskRegisterType)
-    z = opt_attr_def(UnitAttr)
+    source: Operand = operand_def(AVX512RegisterType)
+    mask_reg: Operand = operand_def(AVX512MaskRegisterType)
+    z: UnitAttr | None = opt_attr_def(UnitAttr)
 
     assembly_format = (
         "$source `,` $mask_reg attr-dict `:` "
@@ -414,7 +417,7 @@ class DK_Operation(
     """
 
     destination: OpResult[GeneralRegisterType] = result_def(GeneralRegisterType)
-    source = operand_def(AVX512MaskRegisterType)
+    source: Operand = operand_def(AVX512MaskRegisterType)
 
     def __init__(
         self,
@@ -450,7 +453,7 @@ class KS_Operation(
     """
 
     destination: OpResult[AVX512MaskRegisterType] = result_def(AVX512MaskRegisterType)
-    source = operand_def(GeneralRegisterType)
+    source: Operand = operand_def(GeneralRegisterType)
 
     def __init__(
         self,
@@ -482,7 +485,7 @@ class R_Operation(X86Instruction, ABC, Generic[R1InvT]):
     A base class for x86 operations that have one register that is read and written to.
     """
 
-    register_in = operand_def(R1InvT)
+    register_in: Operand = operand_def(R1InvT)
     register_out: OpResult[R1InvT] = result_def(R1InvT)
 
     assembly_format = (
@@ -521,11 +524,13 @@ class RM_Operation(X86Instruction, ABC, Generic[R1InvT, R2InvT]):
     memory access with an optional offset.
     """
 
-    register_in = operand_def(R1InvT)
+    register_in: Operand = operand_def(R1InvT)
     register_out: OpResult[R1InvT] = result_def(R1InvT)
 
-    memory = operand_def(R2InvT)
-    memory_offset = attr_def(IntegerAttr[I64], default_value=IntegerAttr(0, i64))
+    memory: Operand = operand_def(R2InvT)
+    memory_offset: IntegerAttr[I64] = attr_def(
+        IntegerAttr[I64], default_value=IntegerAttr(0, i64)
+    )
 
     traits = traits_def(MemoryReadEffect())
 
@@ -587,8 +592,10 @@ class DM_Operation(X86Instruction, ABC, Generic[R1InvT, R2InvT]):
     """
 
     destination: OpResult[R1InvT] = result_def(R1InvT)
-    memory = operand_def(R2InvT)
-    memory_offset = attr_def(IntegerAttr[I64], default_value=IntegerAttr(0, i64))
+    memory: Operand = operand_def(R2InvT)
+    memory_offset: IntegerAttr[I64] = attr_def(
+        IntegerAttr[I64], default_value=IntegerAttr(0, i64)
+    )
 
     traits = traits_def(
         DM_OperationHasCanonicalizationPatterns(),
@@ -635,11 +642,13 @@ class DMK_Operation(X86Instruction, ABC, Generic[R1InvT]):
     the destination register to zero where the corresponding bit in the mask is zero.
     """
 
-    destination = result_def(AVX512RegisterType)
-    memory = operand_def(R1InvT)
-    memory_offset = attr_def(IntegerAttr[I64], default_value=IntegerAttr(0, i64))
-    mask_reg = operand_def(AVX512MaskRegisterType)
-    z = opt_attr_def(UnitAttr)
+    destination: OpResult[AVX512RegisterType] = result_def(AVX512RegisterType)
+    memory: Operand = operand_def(R1InvT)
+    memory_offset: IntegerAttr[I64] = attr_def(
+        IntegerAttr[I64], default_value=IntegerAttr(0, i64)
+    )
+    mask_reg: Operand = operand_def(AVX512MaskRegisterType)
+    z: UnitAttr | None = opt_attr_def(UnitAttr)
 
     traits = traits_def(MemoryReadEffect())
 
@@ -687,7 +696,7 @@ class DI_Operation(X86Instruction, ABC, Generic[R1InvT]):
 
     # In the future, we should look into the legal bitwidths in the binary
     # representation.
-    immediate = attr_def(IntegerAttr[SI32])
+    immediate: IntegerAttr[SI32] = attr_def(IntegerAttr[SI32])
     destination: OpResult[R1InvT] = result_def(R1InvT)
 
     assembly_format = "$immediate attr-dict `:` `(` `)` `->` type($destination)"
@@ -722,12 +731,12 @@ class RI_Operation(X86Instruction, ABC, Generic[R1InvT]):
     and an immediate value.
     """
 
-    register_in = operand_def(R1InvT)
+    register_in: Operand = operand_def(R1InvT)
     register_out: OpResult[R1InvT] = result_def(R1InvT)
 
     # In the future, we should look into the legal bitwidths in the binary
     # representation.
-    immediate = attr_def(IntegerAttr[SI32])
+    immediate: IntegerAttr[SI32] = attr_def(IntegerAttr[SI32])
 
     assembly_format = (
         "$register_in `,` $immediate attr-dict `:` "
@@ -782,9 +791,11 @@ class MS_Operation(X86Instruction, ABC, Generic[R1InvT, R2InvT]):
     register.
     """
 
-    memory = operand_def(R1InvT)
-    memory_offset = attr_def(IntegerAttr[I64], default_value=IntegerAttr(0, i64))
-    source = operand_def(R2InvT)
+    memory: Operand = operand_def(R1InvT)
+    memory_offset: IntegerAttr[I64] = attr_def(
+        IntegerAttr[I64], default_value=IntegerAttr(0, i64)
+    )
+    source: Operand = operand_def(R2InvT)
 
     traits = traits_def(
         MS_OperationHasCanonicalizationPatterns(),
@@ -836,11 +847,13 @@ class MSK_Operation(X86Instruction, ABC, Generic[R1InvT, R2InvT]):
     addressed by the base register and offset, s is the source register, and k is the mask.
     """
 
-    memory = operand_def(R1InvT)
-    memory_offset = attr_def(IntegerAttr[I64], default_value=IntegerAttr(0, i64))
-    source = operand_def(R2InvT)
-    mask_reg = operand_def(AVX512MaskRegisterType)
-    z = opt_attr_def(UnitAttr)
+    memory: Operand = operand_def(R1InvT)
+    memory_offset: IntegerAttr[I64] = attr_def(
+        IntegerAttr[I64], default_value=IntegerAttr(0, i64)
+    )
+    source: Operand = operand_def(R2InvT)
+    mask_reg: Operand = operand_def(AVX512MaskRegisterType)
+    z: UnitAttr | None = opt_attr_def(UnitAttr)
 
     traits = traits_def(MemoryWriteEffect())
 
@@ -886,11 +899,13 @@ class MI_Operation(X86Instruction, ABC, Generic[R1InvT]):
     value.
     """
 
-    memory = operand_def(R1InvT)
+    memory: Operand = operand_def(R1InvT)
     # In the future, we should look into the legal bitwidths in the binary
     # representation.
-    memory_offset = attr_def(IntegerAttr[SI64], default_value=IntegerAttr(0, si64))
-    immediate = attr_def(IntegerAttr[SI32])
+    memory_offset: IntegerAttr[SI64] = attr_def(
+        IntegerAttr[SI64], default_value=IntegerAttr(0, si64)
+    )
+    immediate: IntegerAttr[SI32] = attr_def(IntegerAttr[SI32])
 
     traits = traits_def(MemoryReadEffect(), MemoryWriteEffect())
 
@@ -937,10 +952,10 @@ class DSI_Operation(X86Instruction, ABC, Generic[R1InvT, R2InvT]):
     """
 
     destination: OpResult[R1InvT] = result_def(R1InvT)
-    source = operand_def(R2InvT)
+    source: Operand = operand_def(R2InvT)
     # In the future, we should look into the legal bitwidths in the binary
     # representation.
-    immediate = attr_def(IntegerAttr[SI32])
+    immediate: IntegerAttr[SI32] = attr_def(IntegerAttr[SI32])
 
     assembly_format = (
         "$source `,` $immediate attr-dict `:` "
@@ -980,11 +995,13 @@ class DMI_Operation(X86Instruction, ABC, Generic[R1InvT, R2InvT]):
     """
 
     destination: OpResult[R1InvT] = result_def(R1InvT)
-    memory = operand_def(R2InvT)
+    memory: Operand = operand_def(R2InvT)
     # In the future, we should look into the legal bitwidths in the binary
     # representation.
-    memory_offset = attr_def(IntegerAttr[SI64], default_value=IntegerAttr(0, si64))
-    immediate = attr_def(IntegerAttr[SI32])
+    memory_offset: IntegerAttr[SI64] = attr_def(
+        IntegerAttr[SI64], default_value=IntegerAttr(0, si64)
+    )
+    immediate: IntegerAttr[SI32] = attr_def(IntegerAttr[SI32])
     traits = traits_def(MemoryReadEffect())
 
     assembly_format = (
@@ -1030,8 +1047,10 @@ class M_Operation(X86Instruction, ABC, Generic[R1InvT]):
     A base class for x86 operations with a memory reference.
     """
 
-    memory = operand_def(R1InvT)
-    memory_offset = attr_def(IntegerAttr[SI64], default_value=IntegerAttr(0, si64))
+    memory: Operand = operand_def(R1InvT)
+    memory_offset: IntegerAttr[SI64] = attr_def(
+        IntegerAttr[SI64], default_value=IntegerAttr(0, si64)
+    )
     traits = traits_def(MemoryWriteEffect(), MemoryReadEffect())
 
     assembly_format = (
@@ -1072,15 +1091,15 @@ class ConditionalJumpOperation(X86Instruction, X86CustomFormatOperation, ABC):
     See external [documentation](https://www.felixcloutier.com/x86/jcc).
     """
 
-    rflags = operand_def(RFLAGS)
+    rflags: Operand = operand_def(RFLAGS)
 
-    then_values = var_operand_def(X86RegisterType)
-    else_values = var_operand_def(X86RegisterType)
+    then_values: VarOperand = var_operand_def(X86RegisterType)
+    else_values: VarOperand = var_operand_def(X86RegisterType)
 
     irdl_options = (AttrSizedOperandSegments(),)
 
-    then_block = successor_def()
-    else_block = successor_def()
+    then_block: Successor = successor_def()
+    else_block: Successor = successor_def()
 
     traits = traits_def(IsTerminator())
 
@@ -1199,10 +1218,10 @@ class RSS_Operation(X86Instruction, ABC, Generic[R1InvT, R2InvT, R3InvT]):
     and two source registers.
     """
 
-    register_in = operand_def(R1InvT)
+    register_in: Operand = operand_def(R1InvT)
     register_out: OpResult[R1InvT] = result_def(R1InvT)
-    source1 = operand_def(R2InvT)
-    source2 = operand_def(R3InvT)
+    source1: Operand = operand_def(R2InvT)
+    source2: Operand = operand_def(R3InvT)
 
     assembly_format = (
         "$register_in `,` $source1 `,` $source2 attr-dict `:` "
@@ -1255,12 +1274,12 @@ class RSSK_Operation(X86Instruction, ABC):
 
     T: ClassVar[VarConstraint] = VarConstraint("T", base(AVX512RegisterType))
 
-    register_in = operand_def(T)
-    register_out = result_def(T)
-    source1 = operand_def(AVX512RegisterType)
-    source2 = operand_def(AVX512RegisterType)
-    mask_reg = operand_def(AVX512MaskRegisterType)
-    z = opt_attr_def(UnitAttr)
+    register_in: Operand = operand_def(T)
+    register_out: OpResult[AVX512RegisterType] = result_def(T)
+    source1: Operand = operand_def(AVX512RegisterType)
+    source2: Operand = operand_def(AVX512RegisterType)
+    mask_reg: Operand = operand_def(AVX512MaskRegisterType)
+    z: UnitAttr | None = opt_attr_def(UnitAttr)
 
     assembly_format = (
         "$register_in `,` $source1 `,` $source2 `,` $mask_reg attr-dict `:` "
@@ -1312,8 +1331,8 @@ class DSS_Operation(X86Instruction, ABC, Generic[R1InvT, R2InvT, R3InvT]):
     """
 
     destination: OpResult[R1InvT] = result_def(R1InvT)
-    source1 = operand_def(R2InvT)
-    source2 = operand_def(R3InvT)
+    source1: Operand = operand_def(R2InvT)
+    source2: Operand = operand_def(R3InvT)
 
     assembly_format = (
         "$source1 `,` $source2 attr-dict `:` "
@@ -1354,11 +1373,13 @@ class RSM_Operation(X86Instruction, ABC, Generic[R1InvT, R2InvT, R4InvT]):
     one source register and one memory source operand.
     """
 
-    register_in = operand_def(R1InvT)
+    register_in: Operand = operand_def(R1InvT)
     register_out: OpResult[R1InvT] = result_def(R1InvT)
-    source1 = operand_def(R2InvT)
-    memory = operand_def(R4InvT)
-    memory_offset = attr_def(IntegerAttr[SI64], default_value=IntegerAttr(0, si64))
+    source1: Operand = operand_def(R2InvT)
+    memory: Operand = operand_def(R4InvT)
+    memory_offset: IntegerAttr[SI64] = attr_def(
+        IntegerAttr[SI64], default_value=IntegerAttr(0, si64)
+    )
 
     traits = traits_def(MemoryReadEffect())
 
@@ -1414,12 +1435,14 @@ class RSMB_Operation(X86Instruction, ABC, Generic[R1InvT, R2InvT, R4InvT]):
     set, the memory operand uses EVEX broadcast encoding.
     """
 
-    register_in = operand_def(R1InvT)
+    register_in: Operand = operand_def(R1InvT)
     register_out: OpResult[R1InvT] = result_def(R1InvT)
-    source1 = operand_def(R2InvT)
-    memory = operand_def(R4InvT)
-    memory_offset = attr_def(IntegerAttr[SI64], default_value=IntegerAttr(0, si64))
-    broadcast = opt_attr_def(UnitAttr)
+    source1: Operand = operand_def(R2InvT)
+    memory: Operand = operand_def(R4InvT)
+    memory_offset: IntegerAttr[SI64] = attr_def(
+        IntegerAttr[SI64], default_value=IntegerAttr(0, si64)
+    )
+    broadcast: UnitAttr | None = opt_attr_def(UnitAttr)
 
     traits = traits_def(MemoryReadEffect())
 
@@ -1492,9 +1515,9 @@ class DSSI_Operation(X86Instruction, ABC, Generic[R1InvT, R2InvT, R3InvT]):
     """
 
     destination: OpResult[R1InvT] = result_def(R1InvT)
-    source0 = operand_def(R2InvT)
-    source1 = operand_def(R3InvT)
-    immediate = attr_def(IntegerAttr[UI8])
+    source0: Operand = operand_def(R2InvT)
+    source1: Operand = operand_def(R3InvT)
+    immediate: IntegerAttr[UI8] = attr_def(IntegerAttr[UI8])
 
     assembly_format = (
         "$source0 `,` $source1 `,` $immediate attr-dict "
@@ -1721,9 +1744,9 @@ class S_PushOp(X86Instruction):
 
     name = "x86.s.push"
 
-    rsp_in = operand_def(RSP)
-    rsp_out = result_def(RSP)
-    source = operand_def(GeneralRegisterType)
+    rsp_in: Operand = operand_def(RSP)
+    rsp_out: OpResult[Reg64Type] = result_def(RSP)
+    source: Operand = operand_def(GeneralRegisterType)
 
     assembly_format = (
         "$rsp_in `,` $source attr-dict `:` "
@@ -1762,8 +1785,8 @@ class D_PopOp(X86Instruction):
 
     name = "x86.d.pop"
 
-    rsp_in = operand_def(RSP)
-    rsp_out = result_def(RSP)
+    rsp_in: Operand = operand_def(RSP)
+    rsp_out: OpResult[Reg64Type] = result_def(RSP)
     destination: OpResult[GeneralRegisterType] = result_def(GeneralRegisterType)
 
     assembly_format = (
@@ -1860,12 +1883,12 @@ class S_IDivOp(X86Instruction):
 
     name = "x86.s.idiv"
 
-    source = operand_def(X86RegisterType)
-    rdx_input = operand_def(RDX)
-    rax_input = operand_def(RAX)
+    source: Operand = operand_def(X86RegisterType)
+    rdx_input: Operand = operand_def(RDX)
+    rax_input: Operand = operand_def(RAX)
 
-    rdx_output = result_def(RDX)
-    rax_output = result_def(RAX)
+    rdx_output: OpResult[Reg64Type] = result_def(RDX)
+    rax_output: OpResult[Reg64Type] = result_def(RAX)
 
     assembly_format = (
         "$source `,` $rdx_input `,` $rax_input attr-dict `:` "
@@ -1912,11 +1935,11 @@ class S_ImulOp(X86Instruction):
 
     name = "x86.s.imul"
 
-    source = operand_def(GeneralRegisterType)
-    rax_input = operand_def(RAX)
+    source: Operand = operand_def(GeneralRegisterType)
+    rax_input: Operand = operand_def(RAX)
 
-    rdx_output = result_def(RDX)
-    rax_output = result_def(RAX)
+    rdx_output: OpResult[Reg64Type] = result_def(RDX)
+    rax_output: OpResult[Reg64Type] = result_def(RAX)
 
     assembly_format = (
         "$source `,` $rax_input attr-dict `:` "
@@ -2335,11 +2358,13 @@ class M_PushOp(X86Instruction):
 
     name = "x86.m.push"
 
-    rsp_in = operand_def(RSP)
-    rsp_out = result_def(RSP)
+    rsp_in: Operand = operand_def(RSP)
+    rsp_out: OpResult[Reg64Type] = result_def(RSP)
 
-    memory = operand_def(X86RegisterType)
-    memory_offset = attr_def(IntegerAttr[I64], default_value=IntegerAttr(0, i64))
+    memory: Operand = operand_def(X86RegisterType)
+    memory_offset: IntegerAttr[I64] = attr_def(
+        IntegerAttr[I64], default_value=IntegerAttr(0, i64)
+    )
 
     traits = traits_def(MemoryWriteEffect())
 
@@ -2388,10 +2413,12 @@ class M_PopOp(X86Instruction):
 
     name = "x86.m.pop"
 
-    rsp_in = operand_def(RSP)
-    memory = operand_def(GeneralRegisterType)
-    memory_offset = attr_def(IntegerAttr[I64], default_value=IntegerAttr(0, i64))
-    rsp_out = result_def(RSP)
+    rsp_in: Operand = operand_def(RSP)
+    memory: Operand = operand_def(GeneralRegisterType)
+    memory_offset: IntegerAttr[I64] = attr_def(
+        IntegerAttr[I64], default_value=IntegerAttr(0, i64)
+    )
+    rsp_out: OpResult[Reg64Type] = result_def(RSP)
 
     traits = traits_def(MemoryWriteEffect())
 
@@ -2490,12 +2517,14 @@ class M_IDivOp(X86Instruction):
 
     name = "x86.m.idiv"
 
-    memory = operand_def(X86RegisterType)
-    memory_offset = attr_def(IntegerAttr[I64], default_value=IntegerAttr(0, i64))
-    rdx_in = operand_def(RDX)
-    rdx_out = result_def(RDX)
-    rax_in = operand_def(RAX)
-    rax_out = result_def(RAX)
+    memory: Operand = operand_def(X86RegisterType)
+    memory_offset: IntegerAttr[I64] = attr_def(
+        IntegerAttr[I64], default_value=IntegerAttr(0, i64)
+    )
+    rdx_in: Operand = operand_def(RDX)
+    rdx_out: OpResult[Reg64Type] = result_def(RDX)
+    rax_in: Operand = operand_def(RAX)
+    rax_out: OpResult[Reg64Type] = result_def(RAX)
 
     traits = traits_def(MemoryReadEffect())
 
@@ -2546,12 +2575,14 @@ class M_ImulOp(X86Instruction):
 
     name = "x86.m.imul"
 
-    memory = operand_def(GeneralRegisterType)
-    memory_offset = attr_def(IntegerAttr[I64], default_value=IntegerAttr(0, i64))
+    memory: Operand = operand_def(GeneralRegisterType)
+    memory_offset: IntegerAttr[I64] = attr_def(
+        IntegerAttr[I64], default_value=IntegerAttr(0, i64)
+    )
 
-    rdx_out = result_def(RDX)
-    rax_in = operand_def(RAX)
-    rax_out = result_def(RAX)
+    rdx_out: OpResult[Reg64Type] = result_def(RDX)
+    rax_in: Operand = operand_def(RAX)
+    rax_out: OpResult[Reg64Type] = result_def(RAX)
 
     traits = traits_def(MemoryReadEffect())
 
@@ -2598,8 +2629,8 @@ class LabelOp(X86AsmOperation, X86HasRegisterConstraints):
     """
 
     name = "x86.label"
-    label = attr_def(StringAttr)
-    comment = opt_attr_def(StringAttr)
+    label: StringAttr = attr_def(StringAttr)
+    comment: StringAttr | None = opt_attr_def(StringAttr)
 
     assembly_format = "$label attr-dict"
 
@@ -2633,8 +2664,8 @@ class DirectiveOp(X86AsmOperation, X86HasRegisterConstraints, X86CustomFormatOpe
 
     name = "x86.directive"
 
-    directive = attr_def(StringAttr)
-    value = opt_attr_def(StringAttr)
+    directive: StringAttr = attr_def(StringAttr)
+    value: StringAttr | None = opt_attr_def(StringAttr)
 
     def __init__(
         self,
@@ -2701,9 +2732,9 @@ class C_JmpOp(X86Instruction, X86CustomFormatOperation):
 
     name = "x86.c.jmp"
 
-    block_values = var_operand_def(X86RegisterType)
+    block_values: VarOperand = var_operand_def(X86RegisterType)
 
-    successor = successor_def()
+    successor: Successor = successor_def()
 
     traits = traits_def(IsTerminator())
 
@@ -2787,9 +2818,9 @@ class FallthroughOp(
 
     name = "x86.fallthrough"
 
-    block_values = var_operand_def(X86RegisterType)
+    block_values: VarOperand = var_operand_def(X86RegisterType)
 
-    successor = successor_def()
+    successor: Successor = successor_def()
 
     traits = traits_def(IsTerminator(), NoMemoryEffect())
 
@@ -2863,10 +2894,10 @@ class SS_CmpOp(X86Instruction):
 
     name = "x86.ss.cmp"
 
-    source1 = operand_def(X86RegisterType)
-    source2 = operand_def(X86RegisterType)
+    source1: Operand = operand_def(X86RegisterType)
+    source2: Operand = operand_def(X86RegisterType)
 
-    result = result_def(RFLAGSRegisterType)
+    result: OpResult[RFLAGSRegisterType] = result_def(RFLAGSRegisterType)
 
     assembly_format = (
         "$source1 `,` $source2 attr-dict `:` "
@@ -2907,11 +2938,13 @@ class SM_CmpOp(X86Instruction):
 
     name = "x86.sm.cmp"
 
-    source = operand_def(GeneralRegisterType)
-    memory = operand_def(GeneralRegisterType)
-    memory_offset = attr_def(IntegerAttr[I64], default_value=IntegerAttr(0, i64))
+    source: Operand = operand_def(GeneralRegisterType)
+    memory: Operand = operand_def(GeneralRegisterType)
+    memory_offset: IntegerAttr[I64] = attr_def(
+        IntegerAttr[I64], default_value=IntegerAttr(0, i64)
+    )
 
-    result = result_def(RFLAGSRegisterType)
+    result: OpResult[RFLAGSRegisterType] = result_def(RFLAGSRegisterType)
 
     traits = traits_def(MemoryReadEffect())
 
@@ -2959,10 +2992,10 @@ class SI_CmpOp(X86Instruction):
 
     name = "x86.si.cmp"
 
-    source = operand_def(GeneralRegisterType)
-    immediate = attr_def(IntegerAttr[SI32])
+    source: Operand = operand_def(GeneralRegisterType)
+    immediate: IntegerAttr[SI32] = attr_def(IntegerAttr[SI32])
 
-    result = result_def(RFLAGS)
+    result: OpResult[RFLAGSRegisterType] = result_def(RFLAGS)
 
     assembly_format = (
         "$source `,` $immediate attr-dict `:` `(` type($source) `)` `->` type($result)"
@@ -3004,11 +3037,13 @@ class MS_CmpOp(X86Instruction):
 
     name = "x86.ms.cmp"
 
-    memory = operand_def(GeneralRegisterType)
-    memory_offset = attr_def(IntegerAttr[I64], default_value=IntegerAttr(0, i64))
-    source = operand_def(GeneralRegisterType)
+    memory: Operand = operand_def(GeneralRegisterType)
+    memory_offset: IntegerAttr[I64] = attr_def(
+        IntegerAttr[I64], default_value=IntegerAttr(0, i64)
+    )
+    source: Operand = operand_def(GeneralRegisterType)
 
-    result = result_def(RFLAGSRegisterType)
+    result: OpResult[RFLAGSRegisterType] = result_def(RFLAGSRegisterType)
 
     traits = traits_def(MemoryReadEffect())
 
@@ -3056,11 +3091,13 @@ class MI_CmpOp(X86Instruction):
 
     name = "x86.mi.cmp"
 
-    memory = operand_def(GeneralRegisterType)
-    memory_offset = attr_def(IntegerAttr[SI64], default_value=IntegerAttr(0, si64))
-    immediate = attr_def(IntegerAttr[SI32])
+    memory: Operand = operand_def(GeneralRegisterType)
+    memory_offset: IntegerAttr[SI64] = attr_def(
+        IntegerAttr[SI64], default_value=IntegerAttr(0, si64)
+    )
+    immediate: IntegerAttr[SI32] = attr_def(IntegerAttr[SI32])
 
-    result = result_def(RFLAGSRegisterType)
+    result: OpResult[RFLAGSRegisterType] = result_def(RFLAGSRegisterType)
 
     traits = traits_def(MemoryReadEffect())
 
@@ -4098,9 +4135,11 @@ class GetMaskRegisterOp(GetAnyRegisterOperation[AVX512MaskRegisterType]):
 @irdl_op_definition
 class ParallelMovOp(X86HasRegisterConstraints):
     name = "x86.parallel_mov"
-    inputs = var_operand_def(X86RegisterType)
+    inputs: VarOperand = var_operand_def(X86RegisterType)
     outputs: VarOpResult[X86RegisterType] = var_result_def(X86RegisterType)
-    free_registers = opt_prop_def(ArrayAttr[X86RegisterType])
+    free_registers: ArrayAttr[X86RegisterType] | None = opt_prop_def(
+        ArrayAttr[X86RegisterType]
+    )
 
     assembly_format = "$inputs attr-dict `:` functional-type($inputs, $outputs)"
     irdl_options = (ParsePropInAttrDict(),)

--- a/xdsl/dialects/x86_func.py
+++ b/xdsl/dialects/x86_func.py
@@ -52,10 +52,10 @@ class FuncOp(IRDLOperation, AssemblyPrintable):
     """x86 function definition operation"""
 
     name = "x86_func.func"
-    sym_name = attr_def(SymbolNameConstraint())
-    body = region_def()
-    function_type = attr_def(FunctionType)
-    sym_visibility = opt_attr_def(StringAttr)
+    sym_name: StringAttr = attr_def(SymbolNameConstraint())
+    body: Region = region_def()
+    function_type: FunctionType = attr_def(FunctionType)
+    sym_visibility: StringAttr | None = opt_attr_def(StringAttr)
 
     traits = traits_def(
         SymbolOpInterface(),

--- a/xdsl/dialects/x86_scf.py
+++ b/xdsl/dialects/x86_scf.py
@@ -22,9 +22,13 @@ from xdsl.ir import Dialect
 from xdsl.irdl import (
     AttrSizedOperandSegments,
     Block,
+    Operand,
     Operation,
+    OptOperand,
     Region,
     SSAValue,
+    VarOperand,
+    VarOpResult,
     irdl_op_definition,
     lazy_traits_def,
     operand_def,
@@ -62,17 +66,17 @@ class YieldOp(AbstractYieldOperation[X86RegisterType]):
 
 
 class ForRofOperation(X86HasRegisterConstraints, ABC):
-    lb = operand_def(GeneralRegisterType)
-    ub_val = opt_operand_def(GeneralRegisterType)
-    ub_attr = opt_prop_def(IntegerAttr[SI32])
-    step_val = opt_operand_def(GeneralRegisterType)
-    step_attr = opt_prop_def(IntegerAttr[SI32])
+    lb: Operand = operand_def(GeneralRegisterType)
+    ub_val: OptOperand = opt_operand_def(GeneralRegisterType)
+    ub_attr: IntegerAttr[SI32] | None = opt_prop_def(IntegerAttr[SI32])
+    step_val: OptOperand = opt_operand_def(GeneralRegisterType)
+    step_attr: IntegerAttr[SI32] | None = opt_prop_def(IntegerAttr[SI32])
 
-    iter_args = var_operand_def(X86RegisterType)
+    iter_args: VarOperand = var_operand_def(X86RegisterType)
 
-    res = var_result_def(X86RegisterType)
+    res: VarOpResult[X86RegisterType] = var_result_def(X86RegisterType)
 
-    body = region_def("single_block")
+    body: Region = region_def("single_block")
 
     traits = traits_def(SingleBlockImplicitTerminator(YieldOp), RecursiveMemoryEffect())
     irdl_options = (AttrSizedOperandSegments(as_property=True),)

--- a/xdsl/frontend/listlang/list_dialect.py
+++ b/xdsl/frontend/listlang/list_dialect.py
@@ -11,6 +11,8 @@ from xdsl.ir import (
 from xdsl.irdl import (
     AnyOf,
     IRDLOperation,
+    Operand,
+    OpResult,
     irdl_attr_definition,
     irdl_op_definition,
     lazy_traits_def,
@@ -35,8 +37,8 @@ class ListType(ParametrizedAttribute, TypeAttribute):
 class LengthOp(IRDLOperation):
     name = "list.length"
 
-    li = operand_def(ListType)
-    result = result_def(builtin.i32)
+    li: Operand = operand_def(ListType)
+    result: OpResult[builtin.I32] = result_def(builtin.i32)
 
     def __init__(self, li: SSAValue):
         super().__init__(
@@ -51,9 +53,9 @@ class LengthOp(IRDLOperation):
 class MapOp(IRDLOperation):
     name = "list.map"
 
-    li = operand_def(ListType)
-    body = region_def("single_block")
-    result = result_def(ListType)
+    li: Operand = operand_def(ListType)
+    body: Region = region_def("single_block")
+    result: OpResult[ListType] = result_def(ListType)
 
     def __init__(
         self,
@@ -129,7 +131,7 @@ class MapOp(IRDLOperation):
 class PrintOp(IRDLOperation):
     name = "list.print"
 
-    li = operand_def(ListType)
+    li: Operand = operand_def(ListType)
 
     def __init__(self, li: SSAValue):
         super().__init__(
@@ -143,9 +145,9 @@ class PrintOp(IRDLOperation):
 class RangeOp(IRDLOperation):
     name = "list.range"
 
-    lower = operand_def(builtin.i32)
-    upper = operand_def(builtin.i32)
-    result = result_def(ListType)
+    lower: Operand = operand_def(builtin.i32)
+    upper: Operand = operand_def(builtin.i32)
+    result: OpResult[ListType] = result_def(ListType)
 
     def __init__(self, lower: SSAValue, upper: SSAValue, result_type: ListType):
         super().__init__(
@@ -160,7 +162,7 @@ class RangeOp(IRDLOperation):
 class YieldOp(IRDLOperation):
     name = "list.yield"
 
-    yielded = operand_def(AnyOf.get(builtin.IntegerType, ListType))
+    yielded: Operand = operand_def(AnyOf.get(builtin.IntegerType, ListType))
 
     traits = lazy_traits_def(
         lambda: (

--- a/xdsl/interpreters/riscv.py
+++ b/xdsl/interpreters/riscv.py
@@ -8,9 +8,7 @@ from typing_extensions import TypeVar
 from xdsl.dialects import builtin, riscv
 from xdsl.dialects.builtin import (
     DenseIntOrFPElementsAttr,
-    IndexType,
     IntegerAttr,
-    IntegerType,
     ModuleOp,
     StringAttr,
 )
@@ -285,7 +283,7 @@ class RiscvFunctions(InterpreterFunctions):
         op: riscv.AddiOp,
         args: tuple[Any, ...],
     ):
-        immediate = cast(IntegerAttr[IntegerType | IndexType], op.immediate).value.data
+        immediate = cast(IntegerAttr, op.immediate).value.data
         args = RiscvFunctions.get_reg_values(interpreter, op.operands, args)
         results = (args[0] + immediate,)
         return RiscvFunctions.set_reg_values(interpreter, op.results, results)

--- a/xdsl/parser/attribute_parser.py
+++ b/xdsl/parser/attribute_parser.py
@@ -1468,7 +1468,7 @@ class AttrParser(BaseParser):
 
     def try_parse_builtin_boolean_attr(
         self,
-    ) -> IntegerAttr[IntegerType | IndexType] | None:
+    ) -> IntegerAttr | None:
         if (value := self.parse_optional_boolean()) is not None:
             return IntegerAttr(1 if value else 0, IntegerType(1))
         return None

--- a/xdsl/transforms/convert_stencil_to_csl_stencil.py
+++ b/xdsl/transforms/convert_stencil_to_csl_stencil.py
@@ -70,7 +70,7 @@ def get_stencil_access_operands(op: Operand) -> set[Operand]:
 def _get_prefetch_buf_idx(op: stencil.ApplyOp) -> int | None:
     # calculate memory cost of all prefetch operands
     def get_prefetch_overhead(o: OpResult):
-        assert isa(o.type, TensorType[Attribute])
+        assert isa(o.type, TensorType)
         return prod(o.type.get_shape())
 
     candidate_prefetches = [
@@ -178,7 +178,7 @@ class ConvertSwapToPrefetchPattern(RewritePattern):
             op.input_stencil.type
         )
         t_type = op.input_stencil.type.get_element_type()
-        assert isa(t_type, TensorType[Attribute])
+        assert isa(t_type, TensorType)
         assert op.strategy.comm_layout() is not None, (
             f"topology on {type(op)} is not given"
         )
@@ -397,7 +397,7 @@ class ConvertApplyOpPattern(RewritePattern):
         assert isinstance(prefetch.op, csl_stencil.PrefetchOp)
         field_idx = op.operands.index(prefetch.op.input_stencil)
         assert isinstance(prefetch.op, csl_stencil.PrefetchOp)
-        assert isa(prefetch.type, TensorType[Attribute])
+        assert isa(prefetch.type, TensorType)
         field_op_arg = prefetch.op.input_stencil
 
         # add empty tensor before op to be used as `accumulator`

--- a/xdsl/transforms/csl_stencil_bufferize.py
+++ b/xdsl/transforms/csl_stencil_bufferize.py
@@ -26,7 +26,6 @@ from xdsl.dialects.builtin import (
     i64,
 )
 from xdsl.ir import (
-    Attribute,
     AttributeInvT,
     Block,
     BlockArgument,
@@ -83,9 +82,7 @@ class StencilTypeConversion(TypeConversionPattern):
     """
 
     @attr_type_rewrite_pattern
-    def convert_type(
-        self, typ: stencil.FieldType[TensorType[Attribute]]
-    ) -> memref.MemRefType:
+    def convert_type(self, typ: stencil.FieldType[TensorType]) -> memref.MemRefType:
         # todo should this convert to `memref` or `stencil.field<..xmemref<..>>`?
         return tensor_to_memref_type(typ.get_element_type())
 
@@ -113,7 +110,7 @@ class ApplyOpBufferize(RewritePattern):
             lambda use: use.operation != buf_iter_arg,
         )
         for arg in [*op.args_rchunk, *op.args_dexchng]:
-            if isa(arg.type, TensorType[Attribute]):
+            if isa(arg.type, TensorType):
                 to_memrefs.append(new_arg := to_buffer_op(arg))
                 buf_args.append(new_arg.memref)
             else:
@@ -168,7 +165,7 @@ class ApplyOpBufferize(RewritePattern):
                 done_exchange_arg_mapping.append(arg)
 
         typ = op.receive_chunk.block.args[0].type
-        assert isa(typ, TensorType[Attribute])
+        assert isa(typ, TensorType)
         chunk_type = TensorType(typ.get_element_type(), typ.get_shape()[1:])
 
         # inline blocks from old into new regions
@@ -211,7 +208,7 @@ class ApplyOpBufferize(RewritePattern):
     def _inject_iter_arg_into_linalg_outs(
         op: csl_stencil.ApplyOp,
         rewriter: PatternRewriter,
-        chunk_type: TensorType[Attribute],
+        chunk_type: TensorType,
         iter_arg: SSAValue,
     ):
         """
@@ -269,7 +266,7 @@ class ApplyOpBufferize(RewritePattern):
 
         # this is the unbufferized `tensor<(neighbours)x(ZDim)x(type)>` value
         typ = op.receive_chunk.block.args[0].type
-        assert isa(typ, TensorType[Attribute])
+        assert isa(typ, TensorType)
 
         return tensor.ExtractSliceOp(
             operands=[to_tensor.tensor, [offset], [], []],
@@ -294,7 +291,7 @@ class AccessOpBufferize(RewritePattern):
 
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: csl_stencil.AccessOp, rewriter: PatternRewriter, /):
-        if not isa(op.result.type, TensorType[Attribute]):
+        if not isa(op.result.type, TensorType):
             return
         r_type = tensor_to_memref_type(op.result.type)
 
@@ -334,7 +331,7 @@ class YieldOpBufferize(RewritePattern):
         to_memrefs: list[Operation] = []
         args: list[SSAValue] = []
         for arg in op.arguments:
-            if isa(arg.type, TensorType[Attribute]):
+            if isa(arg.type, TensorType):
                 to_memrefs.append(new_arg := to_buffer_op(arg))
                 args.append(new_arg.memref)
             else:
@@ -358,7 +355,7 @@ class FuncOpBufferize(RewritePattern):
             [
                 (
                     tensor_to_memref_type(t.get_element_type())
-                    if isa(t, stencil.FieldType[TensorType[Attribute]])
+                    if isa(t, stencil.FieldType[TensorType])
                     else t
                 )
                 for t in op.function_type.inputs
@@ -366,7 +363,7 @@ class FuncOpBufferize(RewritePattern):
             [
                 (
                     tensor_to_memref_type(t.get_element_type())
-                    if isa(t, stencil.FieldType[TensorType[Attribute]])
+                    if isa(t, stencil.FieldType[TensorType])
                     else t
                 )
                 for t in op.function_type.outputs
@@ -394,7 +391,7 @@ class ArithConstBufferize(RewritePattern):
 
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: arith.ConstantOp, rewriter: PatternRewriter, /):
-        if not isa(op.result.type, TensorType[Attribute]):
+        if not isa(op.result.type, TensorType):
             return
         assert isa(op.value, DenseIntOrFPElementsAttr)
         assert isa(op.value.type, TensorType[AnyDenseElement])

--- a/xdsl/transforms/csl_stencil_to_csl_wrapper.py
+++ b/xdsl/transforms/csl_stencil_to_csl_wrapper.py
@@ -26,7 +26,7 @@ from xdsl.dialects.builtin import (
     StringAttr,
     TensorType,
 )
-from xdsl.ir import Attribute, BlockArgument, Operation, OpResult, SSAValue
+from xdsl.ir import BlockArgument, Operation, OpResult, SSAValue
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
     GreedyRewritePatternApplier,
@@ -219,14 +219,14 @@ class ConvertStencilFuncToModuleWrappedPattern(RewritePattern):
         for arg in args:
             arg_name = arg.name_hint or ("arg" + str(args.index(arg)))
 
-            if isa(arg.type, stencil.FieldType[TensorType[Attribute]]) or isa(
+            if isa(arg.type, stencil.FieldType[TensorType]) or isa(
                 arg.type, memref.MemRefType
             ):
                 arg_t = (
                     csl_stencil_bufferize.tensor_to_memref_type(
                         arg.type.get_element_type()
                     )
-                    if isa(arg.type, stencil.FieldType[TensorType[Attribute]])
+                    if isa(arg.type, stencil.FieldType[TensorType])
                     else arg.type
                 )
                 arg_ops.append(alloc := memref.AllocOp([], [], arg_t))

--- a/xdsl/transforms/experimental/function_constant_pinning.py
+++ b/xdsl/transforms/experimental/function_constant_pinning.py
@@ -5,9 +5,7 @@ from xdsl.context import Context
 from xdsl.dialects import arith, builtin, func, scf
 from xdsl.dialects.builtin import (
     ArrayAttr,
-    IndexType,
     IntegerAttr,
-    IntegerType,
     StringAttr,
 )
 from xdsl.ir import Block, Operation, Region
@@ -119,7 +117,7 @@ class FunctionConstantPinning(RewritePattern):
 
 def generate_func_with_pinned_val(
     func_op: func.FuncOp,
-    pin: IntegerAttr[IntegerType | IndexType],
+    pin: IntegerAttr,
     rewriter: PatternRewriter,
 ):
     """
@@ -179,7 +177,7 @@ def func_contains_pinning_annotation(funcop: func.FuncOp) -> Operation | None:
 
 def get_pinned_vals_for_op(
     op: Operation,
-) -> list[IntegerAttr[IntegerType | IndexType]] | None:
+) -> list[IntegerAttr] | None:
     """
     Reads the "pin_to_constants" attribute of an operation, checks for valid
     formatting, and return the list of attribute values that should be pinned.
@@ -190,7 +188,7 @@ def get_pinned_vals_for_op(
     if not isinstance(pin_attr, ArrayAttr):
         return None
 
-    return list(cast(ArrayAttr[IntegerAttr[IntegerType | IndexType]], pin_attr))
+    return list(cast(ArrayAttr[IntegerAttr], pin_attr))
 
 
 def ops_between_op_and_func_start(

--- a/xdsl/transforms/experimental/stencil_tensorize_z_dimension.py
+++ b/xdsl/transforms/experimental/stencil_tensorize_z_dimension.py
@@ -89,9 +89,7 @@ def get_required_result_type(op: Operation) -> TensorType[Any] | None:
                     return r_type
 
 
-def needs_update_shape(
-    op_type: Attribute, succ_req_type: TensorType[Attribute]
-) -> bool:
+def needs_update_shape(op_type: Attribute, succ_req_type: TensorType) -> bool:
     assert isa(op_type, TensorType)
     return op_type.get_shape() != succ_req_type.get_shape()
 
@@ -346,8 +344,7 @@ class CslStencilAccessOpUpdateShape(RewritePattern):
     def match_and_rewrite(self, op: csl_stencil.AccessOp, rewriter: PatternRewriter, /):
         if typ := get_required_result_type(op):
             if needs_update_shape(op.result.type, typ) and (
-                isa(op.op.type, TempType[TensorType[Attribute]])
-                or isa(op.op.type, TensorType[Attribute])
+                isa(op.op.type, TempType[TensorType]) or isa(op.op.type, TensorType)
             ):
                 rewriter.replace(
                     op,
@@ -356,7 +353,7 @@ class CslStencilAccessOpUpdateShape(RewritePattern):
                         op.offset,
                         (
                             op.op.type.get_element_type()
-                            if isa(op.op.type, TempType[TensorType[Attribute]])
+                            if isa(op.op.type, TempType[TensorType])
                             else typ
                         ),
                         op.offset_mapping,

--- a/xdsl/transforms/lift_arith_to_linalg.py
+++ b/xdsl/transforms/lift_arith_to_linalg.py
@@ -3,7 +3,6 @@ from dataclasses import dataclass
 from xdsl.context import Context
 from xdsl.dialects import arith, linalg
 from xdsl.dialects.builtin import ModuleOp, TensorType
-from xdsl.ir import Attribute
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
     GreedyRewritePatternApplier,
@@ -18,7 +17,7 @@ from xdsl.utils.hints import isa
 class LiftAddfPass(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: arith.AddfOp, rewriter: PatternRewriter, /):
-        if isa(op.result.type, TensorType[Attribute]):
+        if isa(op.result.type, TensorType):
             rewriter.replace(
                 op, linalg.ops.AddOp(op.operands, [op.lhs], [op.result.type])
             )
@@ -27,7 +26,7 @@ class LiftAddfPass(RewritePattern):
 class LiftSubfPass(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: arith.SubfOp, rewriter: PatternRewriter, /):
-        if isa(op.result.type, TensorType[Attribute]):
+        if isa(op.result.type, TensorType):
             rewriter.replace(
                 op, linalg.ops.SubOp(op.operands, [op.lhs], [op.result.type])
             )
@@ -36,7 +35,7 @@ class LiftSubfPass(RewritePattern):
 class LiftMulfPass(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: arith.MulfOp, rewriter: PatternRewriter, /):
-        if isa(op.result.type, TensorType[Attribute]):
+        if isa(op.result.type, TensorType):
             rewriter.replace(
                 op, linalg.ops.MulOp(op.operands, [op.lhs], [op.result.type])
             )


### PR DESCRIPTION
Here's an idea of what would need to happen to make `irdl_op_definition` a dataclass_transform.

I managed to make an editor script which queries pyright for the current type at point, and inserts this in the correct place, but this still left a lot of problems to be manually fixed:
- Lots of things need to be imported, most notably `Operand`/`OpResult` etc. I think this could be automated, but this still leaves some things to do manually.
- Pyright often seems to display overly verbose type hints, for example including default type arguments. I caught some of the basic ones with some regexes, but maybe it would be good to get a good list of all of them.
- using pyright to import things often imported them from the wrong place, which took ages to fix

I feel this process needs to be simpler if we're going to inflict it on people downstream. On top of this, it is unideal that this was done by an emacs script, rather than some more generic shell script, but I couldn't concoct a better way to interact with pyright. The pyright docs have section on a "type server" which might be usable, but you still need to interact with jsonrpc. Perhaps this can be streamlined into a single python script that adds annotations everywhere.

Also merge conflicts will be horrific with this, so my thought is that if this step is automated enough, we can simply regenerate it once everything else is ready. The other thing to note is that this doesn't break anything, so it can go in in stages/before if that makes things easier or if we wanted to allow some deprecation period.