### PR TITLE
core: (builtin) Check operand is not owned by IsolatedFromAbove op itself

### DIFF
--- a/tests/test_builtin_traits.py
+++ b/tests/test_builtin_traits.py
@@ -16,6 +16,7 @@ from xdsl.irdl import (
     opt_region_def,
     opt_successor_def,
     region_def,
+    result_def,
     traits_def,
 )
 from xdsl.traits import (
@@ -444,6 +445,20 @@ class IsolatedFromAboveOp(IRDLOperation):
     traits = traits_def(IsolatedFromAbove(), NoTerminator())
 
 
+@irdl_op_definition
+class IsolatedFromAboveWithResultOp(IRDLOperation):
+    """
+    An isolated from above operation with a result.
+    """
+
+    name = "test.isolated_from_above_with_result"
+
+    region = region_def()
+    result = result_def()
+
+    traits = traits_def(IsolatedFromAbove(), NoTerminator())
+
+
 def test_isolated_from_above():
     # Empty Isolated is fine
     op = IsolatedFromAboveOp(regions=[Region()])
@@ -466,8 +481,21 @@ def test_isolated_from_above():
             ),
         ]
     )
-    message = r"Operation using value defined out of its IsolatedFromAbove parent: AddiOp\(%\d+ = arith.addi %\d+, %\d+ : i32\)"
-    with pytest.raises(VerifyException, match=message):
+    illegal_addiop_message = r"Operation using value defined out of its IsolatedFromAbove parent: AddiOp\(%\d+ = arith.addi %\d+, %\d+ : i32\)"
+    with pytest.raises(VerifyException, match=illegal_addiop_message):
+        out_block.verify()
+
+    # Check an isolated op cannot use its own result within itself
+    cst_op = arith.ConstantOp.from_int_and_width(0, builtin.i32)
+    isolated_op = IsolatedFromAboveWithResultOp(
+        result_types=[builtin.i32],
+        regions=[Region(Block([cst_op]))],
+    )
+    # create and add to block an op which uses the output of isolated_op itself
+    add_op = arith.AddiOp(isolated_op.results[0], cst_op.results[0])
+    isolated_op.region.block.add_op(add_op)
+    out_block = Block([isolated_op])
+    with pytest.raises(VerifyException, match=illegal_addiop_message):
         out_block.verify()
 
     # Check a nested isolation violation
@@ -495,11 +523,10 @@ def test_isolated_from_above():
         ]
     )
     # Check that the IR as a whole is wrong
-    message = r"Operation using value defined out of its IsolatedFromAbove parent: AddiOp\(%\d+ = arith.addi %\d+, %\d+ : i32\)"
-    with pytest.raises(VerifyException, match=message):
+    with pytest.raises(VerifyException, match=illegal_addiop_message):
         out_block.verify()
     # Check that the outer one in itself is fine
     out_isolated.verify(verify_nested_ops=False)
     # Check that the inner one is indeed failing to verify.
-    with pytest.raises(VerifyException, match=message):
+    with pytest.raises(VerifyException, match=illegal_addiop_message):
         in_isolated.verify()

--- a/xdsl/traits.py
+++ b/xdsl/traits.py
@@ -288,7 +288,9 @@ class IsolatedFromAbove(OpTrait):
                     # Check every operand of the operation
                     for operand in child_op.operands:
                         # The operand must not be defined out of the IsolatedFromAbove op.
-                        if not op.is_ancestor(operand.owner):
+                        # Since op.is_ancestor(op) evaluates to True, also check if the operand is
+                        # owned by the op itself (not allowed).
+                        if not op.is_ancestor(operand.owner) or operand.owner is op:
                             raise VerifyException(
                                 "Operation using value defined out of its "
                                 f"IsolatedFromAbove parent: {child_op}"


### PR DESCRIPTION
`verify` incorrectly passed for `IsolatedFromAbove` ops which reference their own result in their body, such as `%0` in this example:
```mlir
%0 = "test.isolated_from_above_with_result"() ({
  %1 = arith.constant 0 : i32
  %2 = arith.addi %0, %1 : i32
}) : () -> i32
```
This fix adds a new test case for this setup and updates `verify` for the `IsolatedFromAbove` trait to fail verification in these cases.

This is because `op.is_ancestor(op)` is `True`: https://github.com/xdslproject/xdsl/blob/ea17ede40122a07bc8c1cd94972cb8e68b35ba82/xdsl/ir/core.py#L757-L764 [MLIR upstream implementation](https://github.com/llvm/llvm-project/blob/81cd5b6217f12ada97e0f1791ba8545120c13230/mlir/include/mlir/IR/Region.h#L247-L251)

This is a regression from the MLIR implementation ([spec](https://mlir.llvm.org/docs/Traits/#isolatedfromabove)) since there region ancestry is checked rather than op ancestry: [MLIR upstream](https://github.com/llvm/llvm-project/blob/81cd5b6217f12ada97e0f1791ba8545120c13230/mlir/lib/IR/Operation.cpp#L1365-L1382)