### PR TITLE
dialects: (WasmSSA) Added Conversion Ops

### DIFF
--- a/tests/dialects/test_wasmssa.py
+++ b/tests/dialects/test_wasmssa.py
@@ -1,17 +1,24 @@
 import pytest
 
-from xdsl.dialects.builtin import f32, i32
+from xdsl.dialects.builtin import f32, f64, i32, i64
 from xdsl.dialects.wasmssa import (
     AddOp,
     AndOp,
     BinaryComparisonOperation,
     BinaryNumericalOperation,
+    ConversionOperation,
+    ConvertSOp,
+    ConvertUOp,
     CopySignOp,
+    DemoteOp,
     DivOp,
     DivSIOp,
     DivUIOp,
     EqOp,
     EqzOp,
+    ExtendLowBitsSOp,
+    ExtendSI32Op,
+    ExtendUI32Op,
     GeOp,
     GeSIOp,
     GeUIOp,
@@ -28,10 +35,14 @@ from xdsl.dialects.wasmssa import (
     MinOp,
     MulOp,
     NeOp,
+    NumericType,
     OrOp,
+    PromoteOp,
+    ReinterpretOp,
     RemSIOp,
     RemUIOp,
     SubOp,
+    WrapOp,
     XOrOp,
 )
 from xdsl.ir import Attribute
@@ -100,3 +111,39 @@ def test_eqz_traits():
     input = create_ssa_value(i32)
 
     _assert_traits(EqzOp(input), [Pure()], [Commutative()])
+
+
+@pytest.mark.parametrize(
+    "op_type, input_type, result_type, required_traits, forbidden_traits",
+    [
+        (ConvertSOp, i32, f32, [Pure()], [Commutative()]),
+        (ConvertUOp, i64, f64, [Pure()], [Commutative()]),
+        (DemoteOp, f64, f32, [Pure()], [Commutative()]),
+        (PromoteOp, f32, f64, [Pure()], [Commutative()]),
+        (WrapOp, i64, i32, [Pure()], [Commutative()]),
+        (ReinterpretOp, i32, f32, [Pure()], [Commutative()]),
+    ],
+)
+def test_conversion_traits(
+    op_type: type[ConversionOperation],
+    input_type: NumericType,
+    result_type: NumericType,
+    required_traits: list[OpTrait],
+    forbidden_traits: list[OpTrait],
+):
+    input = create_ssa_value(input_type)
+
+    _assert_traits(op_type(input, result_type), required_traits, forbidden_traits)
+
+
+@pytest.mark.parametrize("op_type", [ExtendSI32Op, ExtendUI32Op])
+def test_extend_i32_traits(op_type: type[ExtendSI32Op] | type[ExtendUI32Op]):
+    input = create_ssa_value(i32)
+
+    _assert_traits(op_type(input), [Pure()], [Commutative()])
+
+
+def test_extend_low_bits_traits():
+    input = create_ssa_value(i32)
+
+    _assert_traits(ExtendLowBitsSOp(input, 8), [Pure()], [Commutative()])

--- a/tests/dialects/test_wasmssa.py
+++ b/tests/dialects/test_wasmssa.py
@@ -1,6 +1,6 @@
 import pytest
 
-from xdsl.dialects.builtin import f32, f64, i32, i64
+from xdsl.dialects.builtin import IntegerAttr, f32, f64, i32, i64
 from xdsl.dialects.wasmssa import (
     AddOp,
     AndOp,
@@ -143,7 +143,8 @@ def test_extend_i32_traits(op_type: type[ExtendSI32Op] | type[ExtendUI32Op]):
     _assert_traits(op_type(input), [Pure()], [Commutative()])
 
 
-def test_extend_low_bits_traits():
+@pytest.mark.parametrize("bits_to_take", [8, IntegerAttr(8, i64)])
+def test_extend_low_bits_traits(bits_to_take: int | IntegerAttr):
     input = create_ssa_value(i32)
 
-    _assert_traits(ExtendLowBitsSOp(input, 8), [Pure()], [Commutative()])
+    _assert_traits(ExtendLowBitsSOp(input, bits_to_take), [Pure()], [Commutative()])

--- a/tests/filecheck/dialects/wasmssa/ops.mlir
+++ b/tests/filecheck/dialects/wasmssa/ops.mlir
@@ -91,6 +91,33 @@
 // CHECK-NEXT: %i64_eqz = wasmssa.eqz %i64 : i64 -> i32
 %i64_eqz = wasmssa.eqz %i64 : i64 -> i32
 
+// CHECK-NEXT: %f32_convert_s = wasmssa.convert_s %i32 : i32 to f32
+%f32_convert_s = wasmssa.convert_s %i32 : i32 to f32
+// CHECK-NEXT: %f64_convert_u = wasmssa.convert_u %i64 : i64 to f64
+%f64_convert_u = wasmssa.convert_u %i64 : i64 to f64
+// CHECK-NEXT: %f32_demote = wasmssa.demote %f64 : f64 to f32
+%f32_demote = wasmssa.demote %f64 : f64 to f32
+// CHECK-NEXT: %i64_extend_i32_s = wasmssa.extend_i32_s %i32 to i64
+%i64_extend_i32_s = wasmssa.extend_i32_s %i32 to i64
+// CHECK-NEXT: %i64_extend_i32_u = wasmssa.extend_i32_u %i32 to i64
+%i64_extend_i32_u = wasmssa.extend_i32_u %i32 to i64
+// CHECK-NEXT: %i32_extend_eight = wasmssa.extend 8 : i64 low bits from %i32 : i32
+%i32_extend_eight = wasmssa.extend 8 : i64 low bits from %i32 : i32
+// CHECK-NEXT: %i32_extend_sixteen = wasmssa.extend 16 : i64 low bits from %i32 : i32
+%i32_extend_sixteen = wasmssa.extend 16 : i64 low bits from %i32 : i32
+// CHECK-NEXT: %i64_extend_eight = wasmssa.extend 8 : i64 low bits from %i64 : i64
+%i64_extend_eight = wasmssa.extend 8 : i64 low bits from %i64 : i64
+// CHECK-NEXT: %i64_extend_sixteen = wasmssa.extend 16 : i64 low bits from %i64 : i64
+%i64_extend_sixteen = wasmssa.extend 16 : i64 low bits from %i64 : i64
+// CHECK-NEXT: %i64_extend_thirty_two = wasmssa.extend 32 : i64 low bits from %i64 : i64
+%i64_extend_thirty_two = wasmssa.extend 32 : i64 low bits from %i64 : i64
+// CHECK-NEXT: %f64_promote = wasmssa.promote %f32 : f32 to f64
+%f64_promote = wasmssa.promote %f32 : f32 to f64
+// CHECK-NEXT: %i32_wrap = wasmssa.wrap %i64 : i64 to i32
+%i32_wrap = wasmssa.wrap %i64 : i64 to i32
+// CHECK-NEXT: %f32_reinterpret = wasmssa.reinterpret %i32 : i32 as f32
+%f32_reinterpret = wasmssa.reinterpret %i32 : i32 as f32
+
 // CHECK-GENERIC: "wasmssa.const"() <{value = 1 : i32}> : () -> i32
 // CHECK-GENERIC: "wasmssa.const"() <{value = 2 : i64}> : () -> i64
 // CHECK-GENERIC: "wasmssa.const"() <{value = 3.000000e+00 : f32}> : () -> f32
@@ -134,3 +161,16 @@
 // CHECK-GENERIC: "wasmssa.gt"(%f64, %f64) : (f64, f64) -> i32
 // CHECK-GENERIC: "wasmssa.ge"(%f64, %f64) : (f64, f64) -> i32
 // CHECK-GENERIC: "wasmssa.eqz"(%i64) : (i64) -> i32
+// CHECK-GENERIC: "wasmssa.convert_s"(%i32) : (i32) -> f32
+// CHECK-GENERIC: "wasmssa.convert_u"(%i64) : (i64) -> f64
+// CHECK-GENERIC: "wasmssa.demote"(%f64) : (f64) -> f32
+// CHECK-GENERIC: "wasmssa.extend_i32_s"(%i32) : (i32) -> i64
+// CHECK-GENERIC: "wasmssa.extend_i32_u"(%i32) : (i32) -> i64
+// CHECK-GENERIC: "wasmssa.extend"(%i32) <{bitsToTake = 8 : i64}> : (i32) -> i32
+// CHECK-GENERIC: "wasmssa.extend"(%i32) <{bitsToTake = 16 : i64}> : (i32) -> i32
+// CHECK-GENERIC: "wasmssa.extend"(%i64) <{bitsToTake = 8 : i64}> : (i64) -> i64
+// CHECK-GENERIC: "wasmssa.extend"(%i64) <{bitsToTake = 16 : i64}> : (i64) -> i64
+// CHECK-GENERIC: "wasmssa.extend"(%i64) <{bitsToTake = 32 : i64}> : (i64) -> i64
+// CHECK-GENERIC: "wasmssa.promote"(%f32) : (f32) -> f64
+// CHECK-GENERIC: "wasmssa.wrap"(%i64) : (i64) -> i32
+// CHECK-GENERIC: "wasmssa.reinterpret"(%i32) : (i32) -> f32

--- a/tests/filecheck/dialects/wasmssa/ops_invalid.mlir
+++ b/tests/filecheck/dialects/wasmssa/ops_invalid.mlir
@@ -84,3 +84,66 @@
 %comparison = "wasmssa.ne"(%lhs, %rhs) : (i32, i32) -> i64
 
 // CHECK: Expected attribute i32 but got i64
+
+// -----
+
+%input = "test.op"() : () -> f32
+%result = "wasmssa.convert_s"(%input) : (f32) -> f64
+
+// CHECK: Expected one of i32, i64, but got f32
+
+// -----
+
+%input = "test.op"() : () -> i32
+%result = "wasmssa.convert_u"(%input) : (i32) -> i64
+
+// CHECK: Unexpected attribute i64
+
+// -----
+
+%input = "test.op"() : () -> f32
+%result = "wasmssa.demote"(%input) : (f32) -> f32
+
+// CHECK: f32 should be of base attribute f64
+
+// -----
+
+%input = "test.op"() : () -> f32
+%result = "wasmssa.extend_i32_s"(%input) : (f32) -> i64
+
+// CHECK: Expected attribute i32 but got f32
+
+// -----
+
+%input = "test.op"() : () -> i32
+%result = wasmssa.extend 67 : i64 low bits from %input : i32
+
+// CHECK: extend op can only take 8, 16 or 32 bits. Got 67
+
+// -----
+
+%input = "test.op"() : () -> i32
+%result = wasmssa.extend 32 : i64 low bits from %input : i32
+
+// CHECK: trying to extend the 32 low bits from a i32 value is illegal
+
+// -----
+
+%input = "test.op"() : () -> i32
+%result = "wasmssa.extend"(%input) <{bitsToTake = 8 : i64}> : (i32) -> i64
+
+// CHECK: attribute i32 expected from variable 'T', but got i64
+
+// -----
+
+%input = "test.op"() : () -> i32
+%result = wasmssa.reinterpret %input : i32 as i32
+
+// CHECK: reinterpret input and output type should be distinct
+
+// -----
+
+%input = "test.op"() : () -> i32
+%result = wasmssa.reinterpret %input : i32 as f64
+
+// CHECK: input type (i32) and output type (f64) have incompatible bit widths

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/wasmssa/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/wasmssa/ops.mlir
@@ -89,3 +89,22 @@
 %f64_ge = wasmssa.ge %f64 %f64 : f64 -> i32
 // CHECK-NEXT: %{{.*}} = wasmssa.eqz %[[I64]] : i64 -> i32
 %i64_eqz = wasmssa.eqz %i64 : i64 -> i32
+
+// CHECK-NEXT: %{{.*}} = wasmssa.convert_s %[[I32]] : i32 to f32
+%f32_convert_s = wasmssa.convert_s %i32 : i32 to f32
+// CHECK-NEXT: %{{.*}} = wasmssa.convert_u %[[I64]] : i64 to f64
+%f64_convert_u = wasmssa.convert_u %i64 : i64 to f64
+// CHECK-NEXT: %{{.*}} = wasmssa.demote %[[F64]] : f64 to f32
+%f32_demote = wasmssa.demote %f64 : f64 to f32
+// CHECK-NEXT: %{{.*}} = wasmssa.extend_i32_s %[[I32]] to i64
+%i64_extend_i32_s = wasmssa.extend_i32_s %i32 to i64
+// CHECK-NEXT: %{{.*}} = wasmssa.extend_i32_u %[[I32]] to i64
+%i64_extend_i32_u = wasmssa.extend_i32_u %i32 to i64
+// CHECK-NEXT: %{{.*}} = wasmssa.extend 8 : i64 low bits from %[[I32]] : i32
+%i32_extend = wasmssa.extend 8 : i64 low bits from %i32 : i32
+// CHECK-NEXT: %{{.*}} = wasmssa.promote %[[F32]] : f32 to f64
+%f64_promote = wasmssa.promote %f32 : f32 to f64
+// CHECK-NEXT: %{{.*}} = wasmssa.wrap %[[I64]] : i64 to i32
+%i32_wrap = wasmssa.wrap %i64 : i64 to i32
+// CHECK-NEXT: %{{.*}} = wasmssa.reinterpret %[[I32]] : i32 as f32
+%f32_reinterpret = wasmssa.reinterpret %i32 : i32 as f32

--- a/xdsl/dialects/wasmssa.py
+++ b/xdsl/dialects/wasmssa.py
@@ -14,9 +14,11 @@ from xdsl.dialects.builtin import (
     FloatAttr,
     IntAttr,
     IntegerAttr,
+    IntegerType,
     NoneAttr,
     SymbolRefAttr,
     i32,
+    i64,
 )
 from xdsl.ir import (
     Dialect,
@@ -43,6 +45,7 @@ from xdsl.irdl import (
 from xdsl.parser import AttrParser
 from xdsl.printer import Printer
 from xdsl.traits import Commutative, ConstantLike, NoMemoryEffect, Pure
+from xdsl.utils.exceptions import VerifyException
 
 
 @irdl_attr_definition
@@ -75,6 +78,9 @@ ValType: TypeAlias = I128 | NumericType | FuncRefType | ExternRefType
 """Type alias for value types that are supported by WebAssembly"""
 
 _NumericTypeInvT = TypeVar("_NumericTypeInvT", bound=NumericType, default=NumericType)
+_NumericResultTypeInvT = TypeVar(
+    "_NumericResultTypeInvT", bound=NumericType, default=NumericType
+)
 
 
 @irdl_attr_definition
@@ -518,18 +524,197 @@ class EqzOp(IRDLOperation):
         super().__init__(operands=[input], result_types=[i32])
 
 
+class ConversionOperation(
+    IRDLOperation,
+    ABC,
+    Generic[_NumericTypeInvT, _NumericResultTypeInvT],
+):
+    """Base class for WebAssembly conversion operations."""
+
+    input = operand_def(irdl_to_attr_constraint(_NumericTypeInvT, allow_type_var=True))
+    result = result_def(
+        irdl_to_attr_constraint(_NumericResultTypeInvT, allow_type_var=True)
+    )
+
+    assembly_format = "$input `:` type($input) `to` type($result) attr-dict"
+
+    def __init__(
+        self,
+        input: SSAValue | Operation,
+        result_type: NumericType,
+    ):
+        super().__init__(operands=[input], result_types=[result_type])
+
+
+@irdl_op_definition
+class ConvertUOp(ConversionOperation[WasmIntegerType, WasmFPType]):
+    """Convert an unsigned integer value to a floating-point value."""
+
+    name = "wasmssa.convert_u"
+
+    traits = traits_def(Pure())
+
+
+@irdl_op_definition
+class ConvertSOp(ConversionOperation[WasmIntegerType, WasmFPType]):
+    """Convert a signed integer value to a floating-point value."""
+
+    name = "wasmssa.convert_s"
+
+    traits = traits_def(Pure())
+
+
+@irdl_op_definition
+class DemoteOp(ConversionOperation[Float64Type, Float32Type]):
+    """Convert an f64 value to f32."""
+
+    name = "wasmssa.demote"
+
+    traits = traits_def(Pure())
+
+
+@irdl_op_definition
+class ExtendSI32Op(IRDLOperation):
+    """Sign-extend an i32 value to i64."""
+
+    name = "wasmssa.extend_i32_s"
+
+    input = operand_def(I32)
+    result = result_def(I64)
+
+    traits = traits_def(Pure())
+
+    assembly_format = "$input `to` type($result) attr-dict"
+
+    def __init__(self, input: SSAValue | Operation):
+        super().__init__(operands=[input], result_types=[i64])
+
+
+@irdl_op_definition
+class ExtendUI32Op(IRDLOperation):
+    """Zero-extend an i32 value to i64."""
+
+    name = "wasmssa.extend_i32_u"
+
+    input = operand_def(I32)
+    result = result_def(I64)
+
+    traits = traits_def(Pure())
+
+    assembly_format = "$input `to` type($result) attr-dict"
+
+    def __init__(self, input: SSAValue | Operation):
+        super().__init__(operands=[input], result_types=[i64])
+
+
+@irdl_op_definition
+class ExtendLowBitsSOp(IRDLOperation):
+    """Sign-extend the low bits of an integer value to its full width."""
+
+    name = "wasmssa.extend"
+
+    T: ClassVar = VarConstraint.get("T", WasmIntegerType)
+
+    input = operand_def(T)
+    bitsToTake = prop_def(IntegerAttr)
+    result = result_def(T)
+
+    traits = traits_def(Pure())
+
+    assembly_format = (
+        "$bitsToTake `low` `bits` `from` $input `:` type($input) attr-dict"
+    )
+
+    def __init__(
+        self,
+        input: SSAValue | Operation,
+        bits_to_take: int | IntegerAttr,
+    ):
+        input = SSAValue.get(input)
+        if isinstance(bits_to_take, int):
+            bits_to_take = IntegerAttr(bits_to_take, i64)
+        super().__init__(
+            operands=[input],
+            result_types=[input.type],
+            properties={"bitsToTake": bits_to_take},
+        )
+
+    def verify_(self) -> None:
+        bits_to_take = self.bitsToTake.value.data
+        if bits_to_take not in (8, 16, 32):
+            raise VerifyException(
+                f"extend op can only take 8, 16 or 32 bits. Got {bits_to_take}"
+            )
+
+        input_type = self.input.type
+        assert isinstance(input_type, IntegerType)
+        if bits_to_take >= input_type.bitwidth:
+            raise VerifyException(
+                f"trying to extend the {bits_to_take} low bits from a "
+                f"{input_type} value is illegal"
+            )
+
+
+@irdl_op_definition
+class PromoteOp(ConversionOperation[Float32Type, Float64Type]):
+    """Convert an f32 value to f64."""
+
+    name = "wasmssa.promote"
+
+    traits = traits_def(Pure())
+
+
+@irdl_op_definition
+class WrapOp(ConversionOperation[I64, I32]):
+    """Wrap an i64 value to i32."""
+
+    name = "wasmssa.wrap"
+
+    traits = traits_def(Pure())
+
+
+@irdl_op_definition
+class ReinterpretOp(ConversionOperation):
+    """Reinterpret a numeric value as a different type of the same bit width."""
+
+    name = "wasmssa.reinterpret"
+
+    traits = traits_def(Pure())
+
+    assembly_format = "$input `:` type($input) `as` type($result) attr-dict"
+
+    def verify_(self) -> None:
+        input_type = cast(NumericType, self.input.type)
+        result_type = cast(NumericType, self.result.type)
+        if input_type == result_type:
+            raise VerifyException(
+                "reinterpret input and output type should be distinct"
+            )
+        if input_type.bitwidth != result_type.bitwidth:
+            raise VerifyException(
+                f"input type ({input_type}) and output type ({result_type}) "
+                "have incompatible bit widths"
+            )
+
+
 WasmSSA = Dialect(
     "wasmssa",
     [
         AddOp,
         AndOp,
         ConstOp,
+        ConvertSOp,
+        ConvertUOp,
         CopySignOp,
+        DemoteOp,
         DivOp,
         DivSIOp,
         DivUIOp,
         EqOp,
         EqzOp,
+        ExtendLowBitsSOp,
+        ExtendSI32Op,
+        ExtendUI32Op,
         GeOp,
         GeSIOp,
         GeUIOp,
@@ -548,9 +733,12 @@ WasmSSA = Dialect(
         MulOp,
         NeOp,
         OrOp,
+        PromoteOp,
         RemSIOp,
         RemUIOp,
+        ReinterpretOp,
         SubOp,
+        WrapOp,
         XOrOp,
     ],
     [


### PR DESCRIPTION
There are three ops in WebAssembly that MLIR's WasmSSA does not implement: [trunc_si](https://developer.mozilla.org/en-US/docs/WebAssembly/Reference/Numeric/trunc_f32_s), [trunc_ui](https://developer.mozilla.org/en-US/docs/WebAssembly/Reference/Numeric/trunc_f32_u) and [nearest](https://developer.mozilla.org/en-US/docs/WebAssembly/Reference/Numeric/nearest). I think feature parity with MLIR is our priority. I suppose we should think about making a PR upstream to introduce those ops?

The remaining work for numeric ops are: shift/rotation ops, unary numerical ops, and conversion ops (this PR).

We are implementing the `wasmssa` dialect over the following phases:
1. [Types](https://github.com/llvm/llvm-project/blob/main/mlir/include/mlir/Dialect/WasmSSA/IR/WasmSSATypes.td)
2. [Ops](https://github.com/llvm/llvm-project/blob/main/mlir/include/mlir/Dialect/WasmSSA/IR/WasmSSAOps.td)
  2.1 Numeric Ops (**this PR**, amongst others)
  2.2 Non-numeric Ops, involving modules and control flow

Co-authored by: Codex