### PR TITLE
CI: enable ruff RUF043 rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,6 @@ lint.ignore = [
   "RUF002", # https://docs.astral.sh/ruff/rules/ambiguous-unicode-character-docstring
   "RUF005", # https://docs.astral.sh/ruff/rules/collection-literal-concatenation
   "RUF012", # https://docs.astral.sh/ruff/rules/mutable-class-default
-  "RUF043", # https://docs.astral.sh/ruff/rules/pytest-raises-ambiguous-pattern
 ]
 lint.per-file-ignores."**/filecheck/*" = [ "E501", "F811", "F841" ]
 lint.per-file-ignores."__init__.py" = [ "F403" ]

--- a/tests/analysis/test_dataflow.py
+++ b/tests/analysis/test_dataflow.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from unittest.mock import Mock
 
@@ -105,7 +106,8 @@ def test_program_point_after(
 def test_program_point_after_detached():
     detached_op = test.TestOp()
     with pytest.raises(
-        ValueError, match="Cannot get ProgramPoint after a detached operation."
+        ValueError,
+        match=re.escape("Cannot get ProgramPoint after a detached operation."),
     ):
         ProgramPoint.after(detached_op)
 
@@ -214,7 +216,9 @@ def test_data_flow_solver_load_while_running_raises(solver: DataFlowSolver):
             # Try to load while running
             with pytest.raises(
                 RuntimeError,
-                match="Cannot load new analyses while the solver is running.",
+                match=re.escape(
+                    "Cannot load new analyses while the solver is running."
+                ),
             ):
                 self.solver.load(MyAnalysis)
 
@@ -250,7 +254,8 @@ def test_data_flow_solver_get_lookup_state(solver: DataFlowSolver):
 def test_data_flow_solver_enqueue_not_running(solver: DataFlowSolver):
     # This tests the public contract - enqueue should only work while running
     with pytest.raises(
-        RuntimeError, match="Cannot enqueue work items when the solver is not running."
+        RuntimeError,
+        match=re.escape("Cannot enqueue work items when the solver is not running."),
     ):
         solver.enqueue((Mock(), Mock()))
 
@@ -258,7 +263,8 @@ def test_data_flow_solver_enqueue_not_running(solver: DataFlowSolver):
 def test_data_flow_solver_propagate_not_running(solver: DataFlowSolver):
     # This tests the public contract - propagate should only work while running
     with pytest.raises(
-        RuntimeError, match="Cannot propagate changes when the solver is not running."
+        RuntimeError,
+        match=re.escape("Cannot propagate changes when the solver is not running."),
     ):
         solver.propagate_if_changed(Mock(), ChangeResult.CHANGE)
 
@@ -268,7 +274,9 @@ def test_data_flow_solver_run_twice_raises(solver: DataFlowSolver):
     class ReentrantAnalysis(DataFlowAnalysis):
         def initialize(self, op: Operation) -> None:
             # Try to run again while already running
-            with pytest.raises(RuntimeError, match="Solver is already running."):
+            with pytest.raises(
+                RuntimeError, match=re.escape("Solver is already running.")
+            ):
                 self.solver.initialize_and_run(Mock())
 
         def visit(self, point: ProgramPoint) -> None:

--- a/tests/backend/llvm/test_convert.py
+++ b/tests/backend/llvm/test_convert.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 
 from xdsl.dialects import llvm
@@ -27,7 +29,8 @@ def test_convert_module_with_op_raises():
     module = ModuleOp([op])
 
     with pytest.raises(
-        NotImplementedError, match="Conversion not implemented for op: test.op"
+        NotImplementedError,
+        match=re.escape("Conversion not implemented for op: test.op"),
     ):
         convert_module(module, fallback_target_triple=None)
 

--- a/tests/backend/riscv/test_func_to_riscv_func.py
+++ b/tests/backend/riscv/test_func_to_riscv_func.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 
 from xdsl.backend.riscv.lowering.convert_func_to_riscv_func import (
@@ -22,7 +24,7 @@ def test_func_too_many_inputs_failure():
             func.ReturnOp()
 
     with pytest.raises(
-        ValueError, match="Cannot lower func.func with more than 8 inputs"
+        ValueError, match=re.escape("Cannot lower func.func with more than 8 inputs")
     ):
         ConvertFuncToRiscvFuncPass().apply(Context(), non_empty_return)
 
@@ -35,7 +37,7 @@ def test_func_too_many_outputs_failure():
             func.ReturnOp()
 
     with pytest.raises(
-        ValueError, match="Cannot lower func.func with more than 2 outputs"
+        ValueError, match=re.escape("Cannot lower func.func with more than 2 outputs")
     ):
         ConvertFuncToRiscvFuncPass().apply(Context(), non_empty_return)
 
@@ -48,7 +50,8 @@ def test_return_too_many_values_failure():
             func.ReturnOp(*(create_ssa_value(t) for t in THREE_TYPES))
 
     with pytest.raises(
-        ValueError, match="Cannot lower func.return with more than 2 arguments"
+        ValueError,
+        match=re.escape("Cannot lower func.return with more than 2 arguments"),
     ):
         ConvertFuncToRiscvFuncPass().apply(Context(), non_empty_return)
 
@@ -62,7 +65,7 @@ def test_call_too_many_operands_failure():
             func.ReturnOp()
 
     with pytest.raises(
-        ValueError, match="Cannot lower func.call with more than 8 operands"
+        ValueError, match=re.escape("Cannot lower func.call with more than 8 operands")
     ):
         ConvertFuncToRiscvFuncPass().apply(Context(), non_empty_return)
 
@@ -76,6 +79,6 @@ def test_call_too_many_results_failure():
             func.ReturnOp()
 
     with pytest.raises(
-        ValueError, match="Cannot lower func.call with more than 2 results"
+        ValueError, match=re.escape("Cannot lower func.call with more than 2 results")
     ):
         ConvertFuncToRiscvFuncPass().apply(Context(), non_empty_return)

--- a/tests/backend/test_register.py
+++ b/tests/backend/test_register.py
@@ -51,42 +51,44 @@ def test_register_from_string():
     # Infinite prefix but not a number
     with pytest.raises(
         VerifyException,
-        match="Invalid register name yy for register type test.reg",
+        match=re.escape("Invalid register name yy for register type test.reg"),
     ):
         TestRegisterType.from_name("yy")
 
     # Incorrect name
     with pytest.raises(
-        VerifyException, match="Invalid register name z0 for register type test.reg"
+        VerifyException,
+        match=re.escape("Invalid register name z0 for register type test.reg"),
     ):
         TestRegisterType.from_name("z0")
 
 
 def test_invalid_register_name():
     with pytest.raises(
-        VerifyException, match="Invalid register name foo for register type test.reg."
+        VerifyException,
+        match=re.escape("Invalid register name foo for register type test.reg."),
     ):
         TestRegisterType.from_name("foo")
 
 
 def test_invalid_index():
     with pytest.raises(
-        AssertionError, match="Infinite index must be positive, got -1."
+        AssertionError, match=re.escape("Infinite index must be positive, got -1.")
     ):
         TestRegisterType.infinite_register(-1)
 
     with pytest.raises(
-        VerifyException, match="Invalid index 1 for unallocated register."
+        VerifyException, match=re.escape("Invalid index 1 for unallocated register.")
     ):
         TestRegisterType(IntAttr(1), StringAttr(""))
 
     with pytest.raises(
-        VerifyException, match="Missing index for register x1, expected 1."
+        VerifyException, match=re.escape("Missing index for register x1, expected 1.")
     ):
         TestRegisterType(NoneAttr(), StringAttr("x1"))
 
     with pytest.raises(
-        VerifyException, match="Invalid index 2 for register x1, expected 1."
+        VerifyException, match=re.escape("Invalid index 2 for register x1, expected 1.")
     ):
         TestRegisterType(IntAttr(2), StringAttr("x1"))
 

--- a/tests/backend/test_register_allocation.py
+++ b/tests/backend/test_register_allocation.py
@@ -505,7 +505,7 @@ def test_fail_error_message():
 
 def test_out_of_registers():
     register_stack = RegisterStack()
-    with pytest.raises(OutOfRegisters, match="Out of registers."):
+    with pytest.raises(OutOfRegisters, match=re.escape("Out of registers.")):
         register_stack.pop(TestRegisterType)
 
 

--- a/tests/dialects/stim/test_stim_printer_parser.py
+++ b/tests/dialects/stim/test_stim_printer_parser.py
@@ -1,3 +1,4 @@
+import re
 from io import StringIO
 
 import pytest
@@ -146,7 +147,9 @@ def test_name_regex_single_char(name: str):
 
 
 def test_no_spaces_before_target():
-    with pytest.raises(StimParseError, match="Targets must be separated by spacing."):
+    with pytest.raises(
+        StimParseError, match=re.escape("Targets must be separated by spacing.")
+    ):
         program = "QUBIT_COORDS(1, 1)1"
         parser = StimParser(program)
         parser.parse_circuit()

--- a/tests/dialects/test_affine.py
+++ b/tests/dialects/test_affine.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 
 from xdsl.dialects.affine import ForOp, YieldOp
@@ -27,7 +29,7 @@ def test_for_mismatch_operands_results_counts():
     )
     with pytest.raises(
         VerifyException,
-        match="Expected as many init operands as results.",
+        match=re.escape("Expected as many init operands as results."),
     ):
         f.verify()
 

--- a/tests/dialects/test_builtin.py
+++ b/tests/dialects/test_builtin.py
@@ -702,7 +702,10 @@ def test_IntegerType_packing():
         i8.pack((255,))
     with pytest.raises(
         Exception,
-        match="format requires (-32768)|(\\(-0x7fff -1\\)|\\(-32767 -1\\)) <= number <= (32767)|(0x7fff)",
+        match=re.compile(
+            "format requires (-32768)|(\\(-0x7fff -1\\)|\\(-32767 -1\\)) "
+            "<= number <= (32767)|(0x7fff)"
+        ),
     ):
         i16.pack((32768,))
     with pytest.raises(
@@ -711,7 +714,10 @@ def test_IntegerType_packing():
         i32.pack((2147483648,))
     with pytest.raises(
         Exception,
-        match="argument out of range|format requires -9223372036854775808 <= number <= 9223372036854775807",
+        match=re.compile(
+            "argument out of range|format requires "
+            "-9223372036854775808 <= number <= 9223372036854775807"
+        ),
     ):
         i64.pack((9223372036854775808,))
 
@@ -808,7 +814,7 @@ def test_DenseIntOrFPElementsAttr_initialization():
     # illegal zero-rank tensor
     with pytest.raises(
         VerifyException,
-        match="A zero-rank tensor can only hold 1 value but 2 were given.",
+        match=re.escape("A zero-rank tensor can only hold 1 value but 2 were given."),
     ):
         DenseIntOrFPElementsAttr.from_list(TensorType(f32, []), [5.5, 5.6])
 
@@ -1034,7 +1040,9 @@ def test_vector_rank_constraint_rank_mismatch():
     vector_type = VectorType(i32, [1, 2])
     constraint = VectorRankConstraint(3)
 
-    with pytest.raises(VerifyException, match="Expected vector rank to be 3, got 2."):
+    with pytest.raises(
+        VerifyException, match=re.escape("Expected vector rank to be 3, got 2.")
+    ):
         constraint.verify(vector_type, ConstraintContext())
 
 
@@ -1043,7 +1051,8 @@ def test_vector_rank_constraint_attr_mismatch():
     constraint = VectorRankConstraint(3)
 
     with pytest.raises(
-        VerifyException, match="memref<1x2xi32> should be of type VectorType."
+        VerifyException,
+        match=re.escape("memref<1x2xi32> should be of type VectorType."),
     ):
         constraint.verify(memref_type, ConstraintContext())
 
@@ -1060,7 +1069,7 @@ def test_vector_base_type_constraint_type_mismatch():
     constraint = VectorBaseTypeConstraint(i64)
 
     with pytest.raises(
-        VerifyException, match="Expected vector type to be i64, got i32."
+        VerifyException, match=re.escape("Expected vector type to be i64, got i32.")
     ):
         constraint.verify(vector_type, ConstraintContext())
 
@@ -1070,7 +1079,8 @@ def test_vector_base_type_constraint_attr_mismatch():
     constraint = VectorBaseTypeConstraint(i32)
 
     with pytest.raises(
-        VerifyException, match="memref<1x2xi32> should be of type VectorType."
+        VerifyException,
+        match=re.escape("memref<1x2xi32> should be of type VectorType."),
     ):
         constraint.verify(memref_type, ConstraintContext())
 
@@ -1087,7 +1097,7 @@ def test_vector_base_type_and_rank_constraint_base_type_mismatch():
     constraint = VectorBaseTypeAndRankConstraint(i64, 2)
 
     with pytest.raises(
-        VerifyException, match="Expected vector type to be i64, got i32."
+        VerifyException, match=re.escape("Expected vector type to be i64, got i32.")
     ):
         constraint.verify(vector_type, ConstraintContext())
 
@@ -1096,7 +1106,9 @@ def test_vector_base_type_and_rank_constraint_rank_mismatch():
     vector_type = VectorType(i32, [1, 2])
     constraint = VectorBaseTypeAndRankConstraint(i32, 3)
 
-    with pytest.raises(VerifyException, match="Expected vector rank to be 3, got 2."):
+    with pytest.raises(
+        VerifyException, match=re.escape("Expected vector rank to be 3, got 2.")
+    ):
         constraint.verify(vector_type, ConstraintContext())
 
 
@@ -1106,9 +1118,9 @@ def test_vector_base_type_and_rank_constraint_attr_mismatch():
 
     with pytest.raises(
         VerifyException,
-        match="""The following constraints were not satisfied:
+        match=re.escape("""The following constraints were not satisfied:
 memref<1x2xi32> should be of type VectorType.
-memref<1x2xi32> should be of type VectorType.""",
+memref<1x2xi32> should be of type VectorType."""),
     ):
         constraint.verify(memref_type, ConstraintContext())
 

--- a/tests/dialects/test_equivalence.py
+++ b/tests/dialects/test_equivalence.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 
 from xdsl.dialects import arith, equivalence, test
@@ -18,6 +20,8 @@ def test_const_class_construction():
     non_constant_op = test.TestOp(result_types=(i32,))
     with pytest.raises(
         DiagnosticException,
-        match="The argument of a ConstantClass must be a `ConstantLike` operation implementing `HasFolderInterface`.",
+        match=re.escape(
+            "The argument of a ConstantClass must be a `ConstantLike` operation implementing `HasFolderInterface`."
+        ),
     ):
         equivalence.ConstantClassOp(non_constant_op.results[0])

--- a/tests/dialects/test_llvm.py
+++ b/tests/dialects/test_llvm.py
@@ -1,3 +1,4 @@
+import re
 from io import StringIO
 
 import pytest
@@ -440,7 +441,9 @@ def test_overflow_attr_int_conversion():
     assert attr_both.to_int() == 3
 
     # verify out of bounds raises
-    with pytest.raises(ValueError, match="OverflowAttr given out of bounds integer."):
+    with pytest.raises(
+        ValueError, match=re.escape("OverflowAttr given out of bounds integer.")
+    ):
         llvm.OverflowAttr.from_int(4)
 
 

--- a/tests/dialects/test_memref.py
+++ b/tests/dialects/test_memref.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 
 from xdsl.builder import Builder
@@ -551,12 +553,15 @@ def test_memref_memory_space_cast():
 
     with pytest.raises(
         VerifyException,
-        match="Expected source and destination to have the same element type.",
+        match=re.escape(
+            "Expected source and destination to have the same element type."
+        ),
     ):
         MemorySpaceCastOp(memref_ssa_value, res_type_wrong_type).verify()
 
     with pytest.raises(
-        VerifyException, match="Expected source and destination to have the same shape."
+        VerifyException,
+        match=re.escape("Expected source and destination to have the same shape."),
     ):
         MemorySpaceCastOp(memref_ssa_value, res_type_wrong_shape).verify()
 
@@ -672,7 +677,8 @@ def test_memref_copy():
     copy = CopyOp(source, destination)
 
     with pytest.raises(
-        VerifyException, match="Expected source and destination to have the same shape."
+        VerifyException,
+        match=re.escape("Expected source and destination to have the same shape."),
     ):
         copy.verify()
 
@@ -682,7 +688,9 @@ def test_memref_copy():
 
     with pytest.raises(
         VerifyException,
-        match="Expected source and destination to have the same element type.",
+        match=re.escape(
+            "Expected source and destination to have the same element type."
+        ),
     ):
         copy.verify()
 

--- a/tests/dialects/test_omp.py
+++ b/tests/dialects/test_omp.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 
 from xdsl.dialects import omp
@@ -101,7 +103,9 @@ def test_loop_wrapper_many_ops():
 def test_loop_wrapper_wrong_op():
     with pytest.raises(
         VerifyException,
-        match="is not a LoopWrapper: should have a single operation which is either another LoopWrapper or omp.loop_nest",
+        match=re.escape(
+            "is not a LoopWrapper: should have a single operation which is either another LoopWrapper or omp.loop_nest"
+        ),
     ):
         mod = dummy_wrapper_module(DummyLoopWrapper, [[omp.TerminatorOp()]])
         mod.verify()

--- a/tests/dialects/test_pdl.py
+++ b/tests/dialects/test_pdl.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 
 import xdsl.dialects.pdl as pdl
@@ -118,7 +120,8 @@ def test_build_pattern():
         traits = traits_def(HasParent(pdl.PatternOp), IsTerminator())
 
     with pytest.raises(
-        VerifyException, match="expected body to terminate with a `pdl.rewrite`"
+        VerifyException,
+        match=re.escape("expected body to terminate with a `pdl.rewrite`"),
     ):
 
         @Builder.implicit_region
@@ -129,7 +132,8 @@ def test_build_pattern():
         pattern.verify()
 
     with pytest.raises(
-        VerifyException, match="the pattern must contain at least one `pdl.operation`"
+        VerifyException,
+        match=re.escape("the pattern must contain at least one `pdl.operation`"),
     ):
         root = pdl.OperationOp("test.op")
 
@@ -215,6 +219,6 @@ def test_empty_range():
 
 def test_range_cannot_infer():
     with pytest.raises(
-        ValueError, match="Empty range constructions require a return type."
+        ValueError, match=re.escape("Empty range constructions require a return type.")
     ):
         pdl.RangeOp(())  # Cannot infer return type

--- a/tests/dialects/test_riscv.py
+++ b/tests/dialects/test_riscv.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 
 from xdsl.backend.register_type import RegisterAllocatedMemoryEffect
@@ -218,11 +220,13 @@ def test_immediate_jalr_inst():
 
 def test_float_register():
     with pytest.raises(
-        VerifyException, match="Invalid register name ft9 for register type riscv.reg."
+        VerifyException,
+        match=re.escape("Invalid register name ft9 for register type riscv.reg."),
     ):
         riscv.IntRegisterType.from_name("ft9")
     with pytest.raises(
-        VerifyException, match="Invalid register name a0 for register type riscv.freg."
+        VerifyException,
+        match=re.escape("Invalid register name a0 for register type riscv.freg."),
     ):
         riscv.FloatRegisterType.from_name("a0")
 

--- a/tests/dialects/test_scf.py
+++ b/tests/dialects/test_scf.py
@@ -2,6 +2,7 @@
 Test the usage of scf dialect.
 """
 
+import re
 from typing import cast
 
 import pytest
@@ -299,7 +300,7 @@ def test_reduce_op_num_block_args():
 
     with pytest.raises(
         VerifyException,
-        match="scf.reduce block must have exactly two arguments, but ",
+        match=re.escape("scf.reduce block must have exactly two arguments, but "),
     ):
         rro = ReduceReturnOp(reduce_constant)
         ReduceOp(
@@ -308,14 +309,14 @@ def test_reduce_op_num_block_args():
 
     with pytest.raises(
         VerifyException,
-        match="scf.reduce block must have exactly two arguments, but ",
+        match=re.escape("scf.reduce block must have exactly two arguments, but "),
     ):
         rro = ReduceReturnOp(reduce_constant)
         ReduceOp((init_val,), (Region(Block([rro], arg_types=[i32])),)).verify()
 
     with pytest.raises(
         VerifyException,
-        match="scf.reduce block must have exactly two arguments, but ",
+        match=re.escape("scf.reduce block must have exactly two arguments, but "),
     ):
         rro = ReduceReturnOp(reduce_constant)
         ReduceOp((init_val,), (Region(Block([rro], arg_types=[])),)).verify()
@@ -327,14 +328,14 @@ def test_reduce_op_num_block_arg_types():
 
     with pytest.raises(
         VerifyException,
-        match="scf.reduce block argument types must be the same but have",
+        match=re.escape("scf.reduce block argument types must be the same but have"),
     ):
         rro = ReduceReturnOp(reduce_constant)
         ReduceOp((init_val,), (Region(Block([rro], arg_types=[i32, i64])),)).verify()
 
     with pytest.raises(
         VerifyException,
-        match="scf.reduce block argument types must be the same but have",
+        match=re.escape("scf.reduce block argument types must be the same but have"),
     ):
         rro = ReduceReturnOp(reduce_constant)
         ReduceOp((init_val,), (Region(Block([rro], arg_types=[i64, i32])),)).verify()
@@ -358,7 +359,9 @@ def test_reduce_return_op_at_end():
 
     with pytest.raises(
         VerifyException,
-        match="'scf.reduce' terminates with operation test.termop instead of scf.reduce.return",
+        match=re.escape(
+            "'scf.reduce' terminates with operation test.termop instead of scf.reduce.return"
+        ),
     ):
         ReduceOp(
             (init_val,), (Region(Block([TestTermOp.create()], arg_types=[i32, i32])),)
@@ -394,7 +397,9 @@ def test_reduce_return_type_is_operand_type():
     init_val = ConstantOp.from_int_and_width(10, i32)
     with pytest.raises(
         VerifyException,
-        match="scf.reduce.return result type at end of scf.reduce block must",
+        match=re.escape(
+            "scf.reduce.return result type at end of scf.reduce block must"
+        ),
     ):
         ReduceOp((init_val,), (Region(reduce_block),)).verify()
 

--- a/tests/dialects/test_stencil.py
+++ b/tests/dialects/test_stencil.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 
 from xdsl.builder import Builder
@@ -48,8 +50,10 @@ def test_stencilboundsattr_verify():
     with pytest.raises(
         VerifyException,
         match=(
-            "Incoherent stencil bounds: lower and upper bounds must have the same"
-            " dimensionality."
+            re.escape(
+                "Incoherent stencil bounds: lower and upper bounds must have the same"
+                " dimensionality."
+            )
         ),
     ):
         StencilBoundsAttr(IndexAttr.from_indices(1), IndexAttr.from_indices(2, 2))
@@ -57,8 +61,10 @@ def test_stencilboundsattr_verify():
     with pytest.raises(
         VerifyException,
         match=(
-            "Incoherent stencil bounds: upper bound must be strictly greater than"
-            " lower bound."
+            re.escape(
+                "Incoherent stencil bounds: upper bound must be strictly greater than"
+                " lower bound."
+            )
         ),
     ):
         StencilBoundsAttr(IndexAttr.from_indices(2, 2), IndexAttr.from_indices(2, 2))
@@ -226,7 +232,8 @@ def test_create_index_attr_from_int_list(indices: list[int]):
 
 def test_create_index_attr_from_list_edge_case():
     with pytest.raises(
-        VerifyException, match="Expected 1 to 3 indexes for stencil.index, got 4."
+        VerifyException,
+        match=re.escape("Expected 1 to 3 indexes for stencil.index, got 4."),
     ):
         IndexAttr.from_indices(*[1] * 4)
 
@@ -381,7 +388,8 @@ def test_stencil_fieldtype_constructor_empty_list(
     attr: IntegerType, bounds: list[tuple[int, int]]
 ):
     with pytest.raises(
-        VerifyException, match="Expected 1 to 3 indexes for stencil.index, got 0."
+        VerifyException,
+        match=re.escape("Expected 1 to 3 indexes for stencil.index, got 0."),
     ):
         FieldType(StencilBoundsAttr.from_bounds(bounds), attr)
 
@@ -490,7 +498,8 @@ def test_stencil_temptype_constructor_empty_list(
     attr: IntegerType, dims: list[tuple[int, int]]
 ):
     with pytest.raises(
-        VerifyException, match="Expected 1 to 3 indexes for stencil.index, got 0."
+        VerifyException,
+        match=re.escape("Expected 1 to 3 indexes for stencil.index, got 0."),
     ):
         TempType(StencilBoundsAttr.from_bounds(dims), attr)
 

--- a/tests/dialects/test_vector.py
+++ b/tests/dialects/test_vector.py
@@ -1,3 +1,4 @@
+import re
 from collections.abc import Sequence
 
 import pytest
@@ -127,7 +128,8 @@ def test_vector_load_verify_type_matching():
     load = LoadOp.build(operands=[memref_ssa_value, []], result_types=[res_vector_type])
 
     with pytest.raises(
-        Exception, match="MemRef element type should match the Vector element type."
+        Exception,
+        match=re.escape("MemRef element type should match the Vector element type."),
     ):
         load.verify()
 
@@ -137,7 +139,9 @@ def test_vector_load_verify_indexing_exception():
 
     load = LoadOp(memref_ssa_value, [], VectorType(i32, ()))
 
-    with pytest.raises(Exception, match="Expected an index for each dimension."):
+    with pytest.raises(
+        Exception, match=re.escape("Expected an index for each dimension.")
+    ):
         load.verify()
 
 
@@ -173,7 +177,8 @@ def test_vector_store_verify_type_matching():
     store = StoreOp(vector_ssa_value, memref_ssa_value, [])
 
     with pytest.raises(
-        Exception, match="MemRef element type should match the Vector element type."
+        Exception,
+        match=re.escape("MemRef element type should match the Vector element type."),
     ):
         store.verify()
 
@@ -184,7 +189,9 @@ def test_vector_store_verify_indexing_exception():
 
     store = StoreOp(vector_ssa_value, memref_ssa_value, [])
 
-    with pytest.raises(Exception, match="Expected an index for each dimension."):
+    with pytest.raises(
+        Exception, match=re.escape("Expected an index for each dimension.")
+    ):
         store.verify()
 
 
@@ -205,7 +212,9 @@ def test_vector_broadcast_verify_type_matching():
 
     with pytest.raises(
         Exception,
-        match="Source operand and result vector must have the same element type.",
+        match=re.escape(
+            "Source operand and result vector must have the same element type."
+        ),
     ):
         broadcast.verify()
 
@@ -337,7 +346,9 @@ def test_vector_masked_load_verify_indexing_exception():
         memref_ssa_value, [], mask_vector_ssa_value, passthrough_vector_ssa_value
     )
 
-    with pytest.raises(Exception, match="Expected an index for each memref dimension."):
+    with pytest.raises(
+        Exception, match=re.escape("Expected an index for each memref dimension.")
+    ):
         maskedload.verify()
 
 
@@ -404,7 +415,9 @@ def test_vector_masked_store_verify_indexing_exception():
         memref_ssa_value, [], mask_vector_ssa_value, value_to_store_vector_ssa_value
     )
 
-    with pytest.raises(Exception, match="Expected an index for each memref dimension."):
+    with pytest.raises(
+        Exception, match=re.escape("Expected an index for each memref dimension.")
+    ):
         maskedstore.verify()
 
 
@@ -443,7 +456,9 @@ def test_vector_create_mask_verify_indexing_exception():
 
     with pytest.raises(
         Exception,
-        match="Expected an operand value for each dimension of resultant mask.",
+        match=re.escape(
+            "Expected an operand value for each dimension of resultant mask."
+        ),
     ):
         create_mask.verify()
 

--- a/tests/frontend/pyast/test_frontend_op_inserter.py
+++ b/tests/frontend/pyast/test_frontend_op_inserter.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 
 from xdsl.dialects.affine import ForOp
@@ -11,7 +13,8 @@ from xdsl.ir import Block, Region
 def test_raises_exception_on_empty_stack():
     inserter = OpInserter(Block())
     with pytest.raises(
-        FrontendProgramException, match="Trying to get an operand from an empty stack."
+        FrontendProgramException,
+        match=re.escape("Trying to get an operand from an empty stack."),
     ):
         inserter.get_operand()
 
@@ -21,8 +24,10 @@ def test_raises_exception_on_op_with_no_regions():
     op_with_no_region = ConstantOp.from_int_and_width(1, i32)
     with pytest.raises(
         FrontendProgramException,
-        match="Trying to set the insertion point for operation"
-        " 'arith.constant' with no regions.",
+        match=re.escape(
+            "Trying to set the insertion point for operation"
+            " 'arith.constant' with no regions."
+        ),
     ):
         inserter.set_insertion_point_from_op(op_with_no_region)
 
@@ -32,8 +37,10 @@ def test_raises_exception_on_op_with_no_blocks():
     op_with_no_region = ForOp.from_region([], [], [], [], 0, 10, Region())
     with pytest.raises(
         FrontendProgramException,
-        match="Trying to set the insertion point for operation"
-        " 'affine.for' with no blocks in its last region.",
+        match=re.escape(
+            "Trying to set the insertion point for operation"
+            " 'affine.for' with no blocks in its last region."
+        ),
     ):
         inserter.set_insertion_point_from_op(op_with_no_region)
 
@@ -43,7 +50,9 @@ def test_raises_exception_on_op_with_no_blocks_II():
     empty_region = Region()
     with pytest.raises(
         FrontendProgramException,
-        match="Trying to set the insertion point from the region without blocks.",
+        match=re.escape(
+            "Trying to set the insertion point from the region without blocks."
+        ),
     ):
         inserter.set_insertion_point_from_region(empty_region)
 

--- a/tests/frontend/pyast/test_frontend_python_code_check.py
+++ b/tests/frontend/pyast/test_frontend_python_code_check.py
@@ -1,4 +1,5 @@
 import ast
+import re
 
 import pytest
 
@@ -70,7 +71,7 @@ a = 34
     stmts = ast.parse(src).body
     with pytest.raises(
         CodeGenerationException,
-        match="Constant 'a' is already defined and cannot be assigned to.",
+        match=re.escape("Constant 'a' is already defined and cannot be assigned to."),
     ):
         CheckAndInlineConstants.run(stmts, __file__)
 
@@ -85,7 +86,7 @@ def foo():
     stmts = ast.parse(src).body
     with pytest.raises(
         CodeGenerationException,
-        match="Constant 'x' is already defined.",
+        match=re.escape("Constant 'x' is already defined."),
     ):
         CheckAndInlineConstants.run(stmts, __file__)
 
@@ -102,7 +103,7 @@ bb0()
     stmts = ast.parse(src).body
     with pytest.raises(
         CodeGenerationException,
-        match="Constant 'y' is already defined and cannot be assigned to.",
+        match=re.escape("Constant 'y' is already defined and cannot be assigned to."),
     ):
         CheckAndInlineConstants.run(stmts, __file__)
 
@@ -120,8 +121,10 @@ def foo(x: i32):
     with pytest.raises(
         CodeGenerationException,
         match=(
-            "Constant 'z' is already defined and cannot be used as a function/block "
-            "argument name."
+            re.escape(
+                "Constant 'z' is already defined and cannot be used as a function/block "
+                "argument name."
+            )
         ),
     ):
         CheckAndInlineConstants.run(stmts, __file__)
@@ -135,7 +138,7 @@ z: Const[i32] = 2
     stmts = ast.parse(src).body
     with pytest.raises(
         CodeGenerationException,
-        match="Constant 'z' is already defined.",
+        match=re.escape("Constant 'z' is already defined."),
     ):
         CheckAndInlineConstants.run(stmts, __file__)
 
@@ -148,8 +151,10 @@ z: Const[i32] = 23 / 0
     with pytest.raises(
         CodeGenerationException,
         match=(
-            "Non-constant expression cannot be assigned to constant variable 'z' or "
-            "cannot be evaluated."
+            re.escape(
+                "Non-constant expression cannot be assigned to constant variable 'z' or "
+                "cannot be evaluated."
+            )
         ),
     ):
         CheckAndInlineConstants.run(stmts, __file__)
@@ -163,8 +168,10 @@ a: Const[i32] = x + 12
     with pytest.raises(
         CodeGenerationException,
         match=(
-            "Non-constant expression cannot be assigned to constant variable 'a' or "
-            "cannot be evaluated."
+            re.escape(
+                "Non-constant expression cannot be assigned to constant variable 'a' or "
+                "cannot be evaluated."
+            )
         ),
     ):
         CheckAndInlineConstants.run(stmts, __file__)

--- a/tests/interpreters/test_ematch_interpreter.py
+++ b/tests/interpreters/test_ematch_interpreter.py
@@ -1,3 +1,4 @@
+import re
 from dataclasses import dataclass
 from typing import Any, cast
 
@@ -426,7 +427,8 @@ def test_eclass_union_two_different_constants_fails():
     ematch_funcs.eclass_union_find.add(const_eclass2)
 
     with pytest.raises(
-        AssertionError, match="Trying to union two different constant eclasses."
+        AssertionError,
+        match=re.escape("Trying to union two different constant eclasses."),
     ):
         ematch_funcs.eclass_union(interpreter, const_eclass1, const_eclass2)
 

--- a/tests/interpreters/test_eqsat_pdl_interp_interpreter.py
+++ b/tests/interpreters/test_eqsat_pdl_interp_interpreter.py
@@ -1,3 +1,4 @@
+import re
 from collections.abc import Sequence
 from typing import Any, cast
 
@@ -94,7 +95,9 @@ def test_run_get_result_error_case():
     # Test GetResultOp should raise InterpretationError
     with pytest.raises(
         InterpretationError,
-        match="pdl_interp.get_result currently only supports operations with results that are used by a single eclass each.",
+        match=re.escape(
+            "pdl_interp.get_result currently only supports operations with results that are used by a single eclass each."
+        ),
     ):
         interpreter.run_op(
             eqsat_pdl_interp.GetResultOp(0, create_ssa_value(pdl.OperationType())),
@@ -208,7 +211,9 @@ def test_run_get_results_error_case_multiple_uses():
     # Test GetResultsOp should raise InterpretationError due to multiple uses
     with pytest.raises(
         InterpretationError,
-        match="pdl_interp.get_results only supports results that are used by a single eclass each.",
+        match=re.escape(
+            "pdl_interp.get_results only supports results that are used by a single eclass each."
+        ),
     ):
         interpreter.run_op(
             eqsat_pdl_interp.GetResultsOp(
@@ -234,7 +239,9 @@ def test_run_get_results_error_case_non_eclass_use():
     # Test GetResultsOp should raise InterpretationError due to multiple uses
     with pytest.raises(
         InterpretationError,
-        match="pdl_interp.get_results only supports results that are used by a single eclass each.",
+        match=re.escape(
+            "pdl_interp.get_results only supports results that are used by a single eclass each."
+        ),
     ):
         interpreter.run_op(
             eqsat_pdl_interp.GetResultsOp(
@@ -431,7 +438,9 @@ def test_run_get_defining_op_eclass_error_multiple_gdo():
     # Test should raise InterpretationError when using different gdo_op
     with pytest.raises(
         InterpretationError,
-        match="Case where a block contains multiple pdl_interp.get_defining_op is currently not supported",
+        match=re.escape(
+            "Case where a block contains multiple pdl_interp.get_defining_op is currently not supported"
+        ),
     ):
         interpreter.run_op(gdo_op2, (eclass_op.results[0],))
 
@@ -1243,7 +1252,9 @@ def test_run_choose_error_wrong_op():
     # Test should raise InterpretationError when using different choose_op
     with pytest.raises(
         InterpretationError,
-        match="Expected this ChooseOp to be at the top of the backtrack stack.",
+        match=re.escape(
+            "Expected this ChooseOp to be at the top of the backtrack stack."
+        ),
     ):
         interp_functions.run_choose(interpreter, choose_op2, ())
 
@@ -1276,7 +1287,8 @@ def test_eclass_union_different_constants_fails():
 
     # Should raise assertion error when trying to union different constant eclasses
     with pytest.raises(
-        AssertionError, match="Trying to union two different constant eclasses."
+        AssertionError,
+        match=re.escape("Trying to union two different constant eclasses."),
     ):
         interp_functions.eclass_union(interpreter, const_eclass1, const_eclass2)
 
@@ -1376,7 +1388,9 @@ def test_run_replace_no_uses_returns_empty():
     # Call run_replace - should raise InterpretationError since input_op has no uses
     with pytest.raises(
         InterpretationError,
-        match="Operation's result can only be used once, by an eclass operation.",
+        match=re.escape(
+            "Operation's result can only be used once, by an eclass operation."
+        ),
     ):
         interp_functions.run_eqsat_replace(
             interpreter, replace_op, (input_op, replacement_eclass.results[0])

--- a/tests/interpreters/test_linalg_interpreter.py
+++ b/tests/interpreters/test_linalg_interpreter.py
@@ -1,4 +1,5 @@
 import math
+import re
 from typing import cast
 
 import pytest
@@ -36,7 +37,7 @@ def test_unimplemented_inputs():
 
     with pytest.raises(
         NotImplementedError,
-        match="library_call not yet supported in linalg.generic interpreter",
+        match=re.escape("library_call not yet supported in linalg.generic interpreter"),
     ):
         op = linalg.ops.GenericOp(
             (),

--- a/tests/interpreters/test_rv32_interpreter.py
+++ b/tests/interpreters/test_rv32_interpreter.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 
 from xdsl.dialects import riscv, rv32
@@ -46,7 +48,7 @@ def test_riscv_interpreter():
     get_non_zero = rv32.GetRegisterOp(riscv.Registers.UNALLOCATED_INT)
     with pytest.raises(
         InterpretationError,
-        match="Cannot get value for unallocated register !riscv.reg",
+        match=re.escape("Cannot get value for unallocated register !riscv.reg"),
     ):
         interpreter.run_op(get_non_zero, ())
 

--- a/tests/interpreters/test_rv64_interpreter.py
+++ b/tests/interpreters/test_rv64_interpreter.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 
 from xdsl.dialects import riscv, rv64
@@ -46,7 +48,7 @@ def test_riscv_interpreter():
     get_non_zero = rv64.GetRegisterOp(riscv.Registers.UNALLOCATED_INT)
     with pytest.raises(
         InterpretationError,
-        match="Cannot get value for unallocated register !riscv.reg",
+        match=re.escape("Cannot get value for unallocated register !riscv.reg"),
     ):
         interpreter.run_op(get_non_zero, ())
 

--- a/tests/ir/test_op_selector.py
+++ b/tests/ir/test_op_selector.py
@@ -1,3 +1,5 @@
+import re
+
 from xdsl.dialects.builtin import ModuleOp
 from xdsl.dialects.test import TestOp
 from xdsl.utils.op_selector import OpSelector
@@ -17,14 +19,20 @@ def test_op_selector():
 
     import pytest
 
-    with pytest.raises(IndexError, match="Matching index 4 out of range."):
+    with pytest.raises(
+        IndexError,
+        match=re.escape("Matching index 4 out of range."),
+    ):
         OpSelector(4, "test.op").get_op(module)
 
     with pytest.raises(
-        ValueError, match="Unexpected op builtin.module at index 0, expected test.op."
+        ValueError,
+        match=re.escape("Unexpected op builtin.module at index 0, expected test.op."),
     ):
         OpSelector(0, "test.op").get_op(module)
+
     with pytest.raises(
-        ValueError, match="Unexpected op test.op at index 1, expected builtin.module."
+        ValueError,
+        match=re.escape("Unexpected op test.op at index 1, expected builtin.module."),
     ):
         OpSelector(1, "builtin.module").get_op(module)

--- a/tests/irdl/test_attr_constraint.py
+++ b/tests/irdl/test_attr_constraint.py
@@ -55,7 +55,7 @@ from xdsl.utils.exceptions import PyRDLError, VerifyException
 
 def test_failing_inference():
     with pytest.raises(
-        ValueError, match="Cannot infer attribute from constraint AnyAttr()"
+        ValueError, match=re.escape("Cannot infer attribute from constraint AnyAttr()")
     ):
         AnyAttr().infer(ConstraintContext())
 
@@ -265,7 +265,9 @@ def test_sized_constraint_ops():
 def test_not_sized_constraint():
     constr = SizedConstraint(AnyInt())
 
-    with pytest.raises(VerifyException, match="Expected #test.attr_a to be sized"):
+    with pytest.raises(
+        VerifyException, match=re.escape("Expected #test.attr_a to be sized")
+    ):
         constr.verify(AttrA(), ConstraintContext())
 
 
@@ -280,7 +282,9 @@ def test_attr_set_constraint():
 
     with pytest.raises(
         VerifyException,
-        match="Expected one of #test.attr_a, #test.attr_d<#test.attr_a>, #test.attr_d<#test.attr_c>, but got #test.attr_c",
+        match=re.escape(
+            "Expected one of #test.attr_a, #test.attr_d<#test.attr_a>, #test.attr_d<#test.attr_c>, but got #test.attr_c"
+        ),
     ):
         constr.verify(AttrC(), context)
 

--- a/tests/irdl/test_attribute_definition.py
+++ b/tests/irdl/test_attribute_definition.py
@@ -198,7 +198,8 @@ def test_enum_attribute():
 def test_indirect_enum_guard():
     EnumType = TypeVar("EnumType", bound=StrEnum)
     with pytest.raises(
-        TypeError, match="Only direct inheritance from EnumAttribute is allowed."
+        TypeError,
+        match=re.escape("Only direct inheritance from EnumAttribute is allowed."),
     ):
 
         class IndirectEnumData(  # pyright: ignore[reportUnusedClass]
@@ -418,7 +419,7 @@ def test_bit_enum_illegal_subclass():
 def test_typed_attribute():
     with pytest.raises(
         PyRDLAttrDefinitionError,
-        match="TypedAttribute TypedAttr should have a 'type' parameter.",
+        match=re.escape("TypedAttribute TypedAttr should have a 'type' parameter."),
     ):
 
         @irdl_attr_definition
@@ -592,7 +593,8 @@ def test_bose_constraint():
 def test_base_constraint_fail():
     """Test the verifier of a union constraint."""
     with pytest.raises(
-        VerifyException, match="#test.str<foo> should be of base attribute test.bool"
+        VerifyException,
+        match=re.escape("#test.str<foo> should be of base attribute test.bool"),
     ):
         BoolWrapperAttr(StringData("foo"))  # pyright: ignore[reportArgumentType]
 
@@ -629,7 +631,9 @@ def test_union_constraint_right():
 
 def test_union_constraint_fail():
     """Test the verifier of a union constraint."""
-    with pytest.raises(VerifyException, match="Unexpected attribute #test.str<foo>"):
+    with pytest.raises(
+        VerifyException, match=re.escape("Unexpected attribute #test.str<foo>")
+    ):
         BoolOrIntParamAttr(StringData("foo"))  # pyright: ignore[reportArgumentType]
 
 
@@ -671,7 +675,9 @@ def test_annotated_constraint():
 
 def test_annotated_constraint_fail():
     """Test that the verifier of an annotated constraint can fail."""
-    with pytest.raises(VerifyException, match="Expected positive integer, got -42."):
+    with pytest.raises(
+        VerifyException, match=re.escape("Expected positive integer, got -42.")
+    ):
         PositiveIntAttr(IntData(-42))
 
 
@@ -709,7 +715,9 @@ def test_typevar_attribute_bool():
 
 def test_typevar_attribute_fail():
     """Test that the verifier of an generic attribute can fail."""
-    with pytest.raises(VerifyException, match="Unexpected attribute #test.str<foo>"):
+    with pytest.raises(
+        VerifyException, match=re.escape("Unexpected attribute #test.str<foo>")
+    ):
         ParamWrapperAttr(StringData("foo"))  # pyright: ignore
 
 
@@ -738,7 +746,8 @@ def test_param_attr_constraint_fail():
     a parametric constraint can fail.
     """
     with pytest.raises(
-        VerifyException, match="#test.bool<True> should be of base attribute test.int"
+        VerifyException,
+        match=re.escape("#test.bool<True> should be of base attribute test.int"),
     ):
         ParamConstrAttr(ParamWrapperAttr(BoolData(True)))  # pyright: ignore
 
@@ -774,7 +783,8 @@ def test_nested_generic_constraint_fail():
     a parametric constraint can fail.
     """
     with pytest.raises(
-        VerifyException, match="#test.bool<True> should be of base attribute test.int"
+        VerifyException,
+        match=re.escape("#test.bool<True> should be of base attribute test.int"),
     ):
         NestedParamWrapperAttr(ParamWrapperAttr(BoolData(True)))  # pyright: ignore
 
@@ -804,7 +814,9 @@ def test_nested_param_attr_constraint_fail():
     """
     Test that the verifier of a nested parametric constraint can fail.
     """
-    with pytest.raises(VerifyException, match="Expected positive integer, got -42."):
+    with pytest.raises(
+        VerifyException, match=re.escape("Expected positive integer, got -42.")
+    ):
         NestedParamConstrAttr(NestedParamWrapperAttr(ParamWrapperAttr(IntData(-42))))
 
 
@@ -831,7 +843,9 @@ def test_informative_attribute():
 
     with pytest.raises(
         VerifyException,
-        match="Dear user, here's what this constraint means in your abstraction.\nUnderlying verification failure: #test.int<42> should be of base attribute none",
+        match=re.escape(
+            "Dear user, here's what this constraint means in your abstraction.\nUnderlying verification failure: #test.int<42> should be of base attribute none"
+        ),
     ):
         InformativeAttr(IntData(42))
 
@@ -843,7 +857,9 @@ def test_informative_constraint():
     constr = MessageConstraint(NoneAttr(), "User-enlightening message.")
     with pytest.raises(
         VerifyException,
-        match="User-enlightening message.\nUnderlying verification failure: Expected attribute none but got #builtin.int<1>",
+        match=re.escape(
+            "User-enlightening message.\nUnderlying verification failure: Expected attribute none but got #builtin.int<1>"
+        ),
     ):
         constr.verify(IntAttr(1), ConstraintContext())
     assert constr.can_infer(set())
@@ -1292,7 +1308,7 @@ def test_class_var_fail():
     """Test that lowercase ClassVar fields are not allowed."""
     with pytest.raises(
         PyRDLAttrDefinitionError,
-        match='Invalid ClassVar name "constant", must be uppercase.',
+        match=re.escape('Invalid ClassVar name "constant", must be uppercase.'),
     ):
 
         @irdl_attr_definition

--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import textwrap
 from collections.abc import Callable
 from io import StringIO
@@ -2404,7 +2405,9 @@ def test_multiple_optional_regions():
     """Test that a variadic region variable cannot directly follow another variadic region variable."""
     with pytest.raises(
         PyRDLOpDefinitionError,
-        match="An optional/variadic region variable cannot be followed by another region variable.",
+        match=re.escape(
+            "An optional/variadic region variable cannot be followed by another region variable."
+        ),
     ):
 
         @irdl_op_definition
@@ -2489,7 +2492,9 @@ def test_attr_dict_directly_after_optional_group_with_first_region_variable():
     """Test that regions require an 'attr-dict' directive."""
     with pytest.raises(
         PyRDLOpDefinitionError,
-        match="An optional group with a region as a first element cannot be followed by a `attr-dict' directive as it is ambiguous.",
+        match=re.escape(
+            "An optional group with a region as a first element cannot be followed by a `attr-dict' directive as it is ambiguous."
+        ),
     ):
 
         @irdl_op_definition
@@ -2913,7 +2918,7 @@ def test_non_verifying_inference():
     )
     with pytest.raises(
         VerifyException,
-        match="i32 should be of base attribute test.param_one",
+        match=re.escape("i32 should be of base attribute test.param_one"),
     ):
         parser = Parser(ctx, program)
         while (op := parser.parse_optional_operation()) is not None:
@@ -2993,7 +2998,7 @@ def test_variadic_comma_safeguard(
 ):
     with pytest.raises(
         PyRDLOpDefinitionError,
-        match="A variadic directive cannot be followed by a comma literal.",
+        match=re.escape("A variadic directive cannot be followed by a comma literal."),
     ):
 
         @irdl_op_definition
@@ -3036,7 +3041,9 @@ def test_chained_variadic_types_safeguard(
 ):
     with pytest.raises(
         PyRDLOpDefinitionError,
-        match="An optional/variadic type directive cannot be followed by another type directive.",
+        match=re.escape(
+            "An optional/variadic type directive cannot be followed by another type directive."
+        ),
     ):
 
         @irdl_op_definition
@@ -3061,7 +3068,9 @@ def test_chained_variadic_operands_safeguard(
 ):
     with pytest.raises(
         PyRDLOpDefinitionError,
-        match="An optional/variadic operand variable cannot be followed by another operand variable.",
+        match=re.escape(
+            "An optional/variadic operand variable cannot be followed by another operand variable."
+        ),
     ):
 
         @irdl_op_definition
@@ -3929,7 +3938,7 @@ def test_custom_directive_param(program: str):
 
 def test_non_upper_classvar():
     with pytest.raises(
-        PyRDLError, match='Invalid ClassVar name "bad", must be uppercase.'
+        PyRDLError, match=re.escape('Invalid ClassVar name "bad", must be uppercase.')
     ):
 
         @irdl_custom_directive
@@ -3948,7 +3957,9 @@ def test_non_upper_classvar():
 def test_bad_parameter():
     with pytest.raises(
         PyRDLError,
-        match="Custom directive BadParam has parameter int_param which is not a format directive.",
+        match=re.escape(
+            "Custom directive BadParam has parameter int_param which is not a format directive."
+        ),
     ):
 
         @irdl_custom_directive

--- a/tests/irdl/test_operation_builder.py
+++ b/tests/irdl/test_operation_builder.py
@@ -83,8 +83,10 @@ def test_opt_result_builder_two_args():
     with pytest.raises(
         ValueError,
         match=(
-            "Error in test.opt_result_op builder: optional VarIRConstruct.RESULT 0 "
-            "'res' expects a list of size at most 1 or None, but got a list of size 2"
+            re.escape(
+                "Error in test.opt_result_op builder: optional VarIRConstruct.RESULT 0 "
+                "'res' expects a list of size at most 1 or None, but got a list of size 2"
+            )
         ),
     ):
         OptResultOp.build(result_types=[[StringAttr(""), StringAttr("")]])
@@ -239,8 +241,10 @@ def test_opt_operand_builder_two_args():
     with pytest.raises(
         ValueError,
         match=(
-            "Error in test.opt_operand_op builder: optional VarIRConstruct.OPERAND 0 "
-            "'res' expects a list of size at most 1 or None, but got a list of size 2"
+            re.escape(
+                "Error in test.opt_operand_op builder: optional VarIRConstruct.OPERAND 0 "
+                "'res' expects a list of size at most 1 or None, but got a list of size 2"
+            )
         ),
     ):
         OptOperandOp.build(operands=[[op, op]])
@@ -500,8 +504,10 @@ def test_opt_region_builder_two_args():
     with pytest.raises(
         ValueError,
         match=(
-            "Error in test.opt_region_op builder: optional VarIRConstruct.REGION 0 "
-            "'reg' expects a list of size at most 1 or None, but got a list of size 2"
+            re.escape(
+                "Error in test.opt_region_op builder: optional VarIRConstruct.REGION 0 "
+                "'reg' expects a list of size at most 1 or None, but got a list of size 2"
+            )
         ),
     ):
         OptRegionOp.build(regions=[[Region(), Region()]])

--- a/tests/irdl/test_operation_definition.py
+++ b/tests/irdl/test_operation_definition.py
@@ -193,7 +193,8 @@ class AttrOp(IRDLOperation):
 def test_attr_verify():
     op = AttrOp.create(attributes={"attr": IntAttr(1)})
     with pytest.raises(
-        VerifyException, match="#builtin.int<1> should be of base attribute string"
+        VerifyException,
+        match=re.escape("#builtin.int<1> should be of base attribute string"),
     ):
         op.verify()
 
@@ -350,14 +351,18 @@ def test_range_var_fail_not_satisfy_constraint():
     op = ConstraintRangeVarOp.create(
         operands=[test_operand], result_types=[TestType("foo")]
     )
-    with pytest.raises(VerifyException, match='Unexpected attribute !test.type<"foo">'):
+    with pytest.raises(
+        VerifyException, match=re.escape('Unexpected attribute !test.type<"foo">')
+    ):
         op.verify()
 
     op = ConstraintRangeVarOp.create(
         operands=[test_operand, test_operand],
         result_types=[TestType("foo"), TestType("foo")],
     )
-    with pytest.raises(VerifyException, match='Unexpected attribute !test.type<"foo">'):
+    with pytest.raises(
+        VerifyException, match=re.escape('Unexpected attribute !test.type<"foo">')
+    ):
         op.verify()
 
 
@@ -557,7 +562,7 @@ def test_attribute_missing():
 
     with pytest.raises(
         VerifyException,
-        match="attribute 'attr' expected in operation 'test.attribute_op'",
+        match=re.escape("attribute 'attr' expected in operation 'test.attribute_op'"),
     ):
         op.verify()
 
@@ -605,7 +610,7 @@ def test_property_missing():
 
     with pytest.raises(
         VerifyException,
-        match="property 'attr' expected in operation 'test.attribute_op'",
+        match=re.escape("property 'attr' expected in operation 'test.attribute_op'"),
     ):
         op.verify()
 
@@ -634,26 +639,34 @@ def test_op_accessor_assignment():
     new_operands: SSAValues[SSAValue[Attribute]] = SSAValues((val1, val2))
     with pytest.raises(
         NotImplementedError,
-        match="Cannot write to named operands, regions, results, or successors.",
+        match=re.escape(
+            "Cannot write to named operands, regions, results, or successors."
+        ),
     ):
         op1.ops = new_operands
 
     new_results: SSAValues[OpResult[Attribute]] = SSAValues((val1, val2))
     with pytest.raises(
         NotImplementedError,
-        match="Cannot write to named operands, regions, results, or successors.",
+        match=re.escape(
+            "Cannot write to named operands, regions, results, or successors."
+        ),
     ):
         op1.res = new_results
 
     with pytest.raises(
         NotImplementedError,
-        match="Cannot write to named operands, regions, results, or successors.",
+        match=re.escape(
+            "Cannot write to named operands, regions, results, or successors."
+        ),
     ):
         op1.regs = (Region(),)
 
     with pytest.raises(
         NotImplementedError,
-        match="Cannot write to named operands, regions, results, or successors.",
+        match=re.escape(
+            "Cannot write to named operands, regions, results, or successors."
+        ),
     ):
         op1.successor = [Block(), Block()]
 
@@ -695,26 +708,34 @@ def test_op_segmented_accessor_assignment():
     new_operands: SSAValues[SSAValue[Attribute]] = SSAValues((val1, val2))
     with pytest.raises(
         NotImplementedError,
-        match="Cannot write to named operands, regions, results, or successors.",
+        match=re.escape(
+            "Cannot write to named operands, regions, results, or successors."
+        ),
     ):
         op1.operands1 = new_operands
 
     new_results: SSAValues[OpResult[Attribute]] = SSAValues((val1, val2))
     with pytest.raises(
         NotImplementedError,
-        match="Cannot write to named operands, regions, results, or successors.",
+        match=re.escape(
+            "Cannot write to named operands, regions, results, or successors."
+        ),
     ):
         op1.results1 = new_results
 
     with pytest.raises(
         NotImplementedError,
-        match="Cannot write to named operands, regions, results, or successors.",
+        match=re.escape(
+            "Cannot write to named operands, regions, results, or successors."
+        ),
     ):
         op1.regions1 = (Region(),)
 
     with pytest.raises(
         NotImplementedError,
-        match="Cannot write to named operands, regions, results, or successors.",
+        match=re.escape(
+            "Cannot write to named operands, regions, results, or successors."
+        ),
     ):
         op1.successors1 = [Block(), Block()]
 
@@ -756,7 +777,9 @@ def test_renamed_attributes_verify():
     )
     with pytest.raises(
         VerifyException,
-        match="attribute 'attr_name' expected in operation 'test.renamed_attribute_op'",
+        match=re.escape(
+            "attribute 'attr_name' expected in operation 'test.renamed_attribute_op'"
+        ),
     ):
         op.verify()
 
@@ -811,7 +834,9 @@ def test_renamed_properties_verify():
     )
     with pytest.raises(
         VerifyException,
-        match="property 'prop_name' expected in operation 'test.renamed_property_op'",
+        match=re.escape(
+            "property 'prop_name' expected in operation 'test.renamed_property_op'"
+        ),
     ):
         op.verify()
 
@@ -971,18 +996,18 @@ def test_entry_args_op():
     op = EntryArgsOp.create(regions=[Region(Block(arg_types=[i64]))])
     with pytest.raises(
         VerifyException,
-        match="""\
+        match=re.compile("""\
 Operation does not verify: Region 'body' at position 0 entry arguments do not verify:
-.*Expected attribute i32 but got i64""",
+.*Expected attribute i32 but got i64"""),
     ):
         op.verify()
 
     op = EntryArgsOp.create(regions=[Region(Block(arg_types=[i64, i32]))])
     with pytest.raises(
         VerifyException,
-        match="""\
+        match=re.compile("""\
 Operation does not verify: Region 'body' at position 0 entry arguments do not verify:
-.*Expected attribute i32 but got i64""",
+.*Expected attribute i32 but got i64"""),
     ):
         op.verify()
 
@@ -1036,9 +1061,11 @@ class OptionlessMultipleVarOp(IRDLOperation):
 def test_no_multiple_var_option():
     with pytest.raises(
         PyRDLOpDefinitionError,
-        match="Operation test.multiple_var_op defines more than two variadic operands, "
-        "but do not define any of SameVariadicOperandSize or AttrSizedOperandSegments "
-        "PyRDL options.",
+        match=re.escape(
+            "Operation test.multiple_var_op defines more than two variadic operands, "
+            "but do not define any of SameVariadicOperandSize or AttrSizedOperandSegments "
+            "PyRDL options."
+        ),
     ):
         irdl_op_definition(OptionlessMultipleVarOp)
 

--- a/tests/irdl/test_range_constraint.py
+++ b/tests/irdl/test_range_constraint.py
@@ -46,7 +46,8 @@ class AnyRangeConstraint(RangeConstraint):
 
 def test_failing_inference():
     with pytest.raises(
-        ValueError, match="Cannot infer range from constraint AnyRangeConstraint()"
+        ValueError,
+        match=re.escape("Cannot infer range from constraint AnyRangeConstraint()"),
     ):
         AnyRangeConstraint().infer(ConstraintContext(), length=None)
 

--- a/tests/test_affine_builtins.py
+++ b/tests/test_affine_builtins.py
@@ -665,7 +665,9 @@ def test_affine_expr_simplify(expr: AffineExpr, expected: AffineExpr):
 def test_affine_expr_simplify_semi_affine_raises(expr: Callable[[], AffineExpr]):
     with pytest.raises(
         NotImplementedError,
-        match="Simplification of semi-affine expressions is not implemented yet.",
+        match=re.escape(
+            "Simplification of semi-affine expressions is not implemented yet."
+        ),
     ):
         expr().simplify(num_dims=3, num_symbols=3)
     with pytest.raises(

--- a/tests/test_builtin_traits.py
+++ b/tests/test_builtin_traits.py
@@ -2,6 +2,8 @@
 Test the usage of builtin traits.
 """
 
+import re
+
 import pytest
 
 from xdsl.dialects import arith, builtin
@@ -91,7 +93,8 @@ def test_has_parent_wrong_parent():
     """
     module = ModuleOp([HasParentOp()])
     with pytest.raises(
-        VerifyException, match="'test.has_parent' expects parent op 'test.parent'"
+        VerifyException,
+        match=re.escape("'test.has_parent' expects parent op 'test.parent'"),
     ):
         module.verify()
 
@@ -392,7 +395,7 @@ def test_single_block_implicit_terminator_with_correct_construction_fail():
 
     # test single-block region op with wrong terminator
     with pytest.raises(
-        VerifyException, match="terminates with operation test.is_terminator"
+        VerifyException, match=re.escape("terminates with operation test.is_terminator")
     ):
         HasSingleBlockImplicitTerminatorOp(
             regions=[Region(Block([IsTerminatorOp.create()])), Region()]
@@ -417,7 +420,7 @@ def test_single_block_implicit_terminator_with_wrong_construction_fail():
     )
     # test single-block region op with wrong terminator
     with pytest.raises(
-        VerifyException, match="terminates with operation test.is_terminator"
+        VerifyException, match=re.escape("terminates with operation test.is_terminator")
     ):
         op1.verify()
 

--- a/tests/test_dialect_utils.py
+++ b/tests/test_dialect_utils.py
@@ -274,5 +274,7 @@ def test_split_name(name: str, expected_1: str, expected_2: str):
 
 
 def test_split_name_failure():
-    with pytest.raises(ValueError, match="Invalid operation or attribute name test."):
+    with pytest.raises(
+        ValueError, match=re.escape("Invalid operation or attribute name test.")
+    ):
         Dialect.split_name("test")

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 
 from xdsl.context import Context
@@ -127,25 +129,31 @@ def test_ops_accessor_III():
 
     with pytest.raises(
         ValueError,
-        match="'ops' property of Region class is only available for single-block regions.",
+        match=re.escape(
+            "'ops' property of Region class is only available for single-block regions."
+        ),
     ):
         region0.ops
 
     with pytest.raises(
         ValueError,
-        match="'op' property of Region class is only available for single-operation single-block regions.",
+        match=re.escape(
+            "'op' property of Region class is only available for single-operation single-block regions."
+        ),
     ):
         region0.op
 
     with pytest.raises(
         ValueError,
-        match="'op' property of Region class is only available for single-operation single-block regions.",
+        match=re.escape(
+            "'op' property of Region class is only available for single-operation single-block regions."
+        ),
     ):
         region1.op
 
     with pytest.raises(
         ValueError,
-        match="Block is not a child of the region.",
+        match=re.escape("Block is not a child of the region."),
     ):
         region1.detach_block(block0)
 
@@ -973,7 +981,9 @@ def test_region_index_fetch_region_unavailability():
     op = MultipleRegionsOp.build(regions=[[region0]])
 
     assert op.get_region_index(region0) == 0
-    with pytest.raises(ValueError, match="Region is not attached to the operation."):
+    with pytest.raises(
+        ValueError, match=re.escape("Region is not attached to the operation.")
+    ):
         op.get_region_index(region1)
 
 
@@ -997,7 +1007,9 @@ def test_detach_region():
 def test_detach_toplevel_opration():
     a = ConstantOp.from_int_and_width(1, 32)
     assert a.parent is None
-    with pytest.raises(ValueError, match="Cannot detach a toplevel operation."):
+    with pytest.raises(
+        ValueError, match=re.escape("Cannot detach a toplevel operation.")
+    ):
         a.detach()
 
 
@@ -1013,7 +1025,8 @@ def test_add_already_attached_region():
     assert region2.parent is op2
 
     with pytest.raises(
-        ValueError, match="Cannot add region that is already attached on an operation."
+        ValueError,
+        match=re.escape("Cannot add region that is already attached on an operation."),
     ):
         op1.add_region(region2)
 
@@ -1245,7 +1258,10 @@ def test_ssa_get_on_ssa():
 
     with pytest.raises(
         ValueError,
-        match="SSAValue.get: Expected <class 'xdsl.dialects.builtin.IndexType'> but got SSAValue with type i32",
+        match=re.escape(
+            "SSAValue.get: Expected <class 'xdsl.dialects.builtin.IndexType'> "
+            "but got SSAValue with type i32"
+        ),
     ):
         SSAValue.get(ssa_value, type=IndexType)
 
@@ -1258,7 +1274,9 @@ def test_ssa_get_with_typeform():
 
     with pytest.raises(
         ValueError,
-        match="SSAValue.get: Expected xdsl.dialects.builtin.Float64Type | xdsl.dialects.builtin.IndexType but got SSAValue with type i32",
+        match=re.escape(
+            "SSAValue.get: Expected xdsl.dialects.builtin.Float64Type | xdsl.dialects.builtin.IndexType but got SSAValue with type i32"
+        ),
     ):
         SSAValue.get(ssa_value, type=Float64Type | IndexType)
 
@@ -1298,13 +1316,16 @@ def test_ssa_get_on_op():
 
     with pytest.raises(
         ValueError,
-        match="SSAValue.get: Expected <class 'xdsl.dialects.builtin.IndexType'> but got SSAValue with type i32",
+        match=re.escape(
+            "SSAValue.get: Expected <class 'xdsl.dialects.builtin.IndexType'> but got SSAValue with type i32"
+        ),
     ):
         SSAValue.get(op1, type=IndexType)
 
     op2 = test.TestOp(result_types=[i32, i32])
     with pytest.raises(
-        ValueError, match="SSAValue.get: expected operation with a single result."
+        ValueError,
+        match=re.escape("SSAValue.get: expected operation with a single result."),
     ):
         SSAValue.get(op2)
 
@@ -1414,7 +1435,9 @@ def test_get_operation_index_not_child():
     """Test that get_operation_index raises ValueError for non-child op."""
     op = test.TestOp.create()
     block = Block([test.TestOp.create()])
-    with pytest.raises(ValueError, match="Operation is not a child of the block."):
+    with pytest.raises(
+        ValueError, match=re.escape("Operation is not a child of the block.")
+    ):
         block.get_operation_index(op)
 
 
@@ -1424,7 +1447,7 @@ def test_detach_op_different_block():
     Block([op])
     block2 = Block()
     with pytest.raises(
-        ValueError, match="Cannot detach operation from a different block."
+        ValueError, match=re.escape("Cannot detach operation from a different block.")
     ):
         block2.detach_op(op)
 

--- a/tests/test_op_builder.py
+++ b/tests/test_op_builder.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 
 from xdsl.builder import Builder
@@ -205,7 +207,9 @@ def test_builder_name_hint_listener():
     op.results[0].name_hint = "world"
     assert b.insert(op).results[0].name_hint == "world"
 
-    with pytest.raises(ValueError, match="Invalid SSAValue name format `1`."):
+    with pytest.raises(
+        ValueError, match=re.escape("Invalid SSAValue name format `1`.")
+    ):
         b.name_hint = "1"
 
 
@@ -341,7 +345,9 @@ def test_build_nested_implicit_region():
 def test_build_implicit_region_fail():
     with pytest.raises(
         ValueError,
-        match="Cannot insert operation explicitly when an implicit builder exists.",
+        match=re.escape(
+            "Cannot insert operation explicitly when an implicit builder exists."
+        ),
     ):
         one = IntAttr(1)
         two = IntAttr(2)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1032,7 +1032,7 @@ def test_parse_location():
     attr = Parser(ctx, "loc(fused[unknown, unknown])").parse_optional_location()
     assert attr == FusedLoc((UnknownLoc(), UnknownLoc()), NoneAttr())
 
-    with pytest.raises(ParseError, match="Unsupported location type."):
+    with pytest.raises(ParseError, match=re.escape("Unsupported location type.")):
         Parser(ctx, "loc(unexpected)").parse_optional_location()
 
     parser = Parser(ctx, "loc(#loc1)")
@@ -1054,10 +1054,10 @@ def test_parse_location():
 
     parser = Parser(ctx, "loc(#not_loc)")
     parser.attribute_aliases["#not_loc"] = IntAttr(42)
-    with pytest.raises(ParseError, match="Expected location alias."):
+    with pytest.raises(ParseError, match=re.escape("Expected location alias.")):
         parser.parse_optional_location()
 
-    with pytest.raises(ParseError, match="Unexpected location syntax."):
+    with pytest.raises(ParseError, match=re.escape("Unexpected location syntax.")):
         Parser(ctx, "loc(1)").parse_optional_location()
 
 

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from io import StringIO
 
 import pytest
@@ -1174,7 +1175,9 @@ def test_print_properties_as_attributes_safeguard():
     parsed = parser.parse_op()
     with pytest.raises(
         ValueError,
-        match="Properties sym_name would overwrite the attributes of the same names.",
+        match=re.escape(
+            "Properties sym_name would overwrite the attributes of the same names."
+        ),
     ):
         assert_print_op(parsed, retro_prog, print_properties_as_attributes=True)
 

--- a/tests/test_pyrdl.py
+++ b/tests/test_pyrdl.py
@@ -1,5 +1,6 @@
 """Unit tests for IRDL."""
 
+import re
 from collections.abc import Mapping
 from dataclasses import dataclass
 from enum import auto
@@ -408,9 +409,11 @@ def test_data_with_generic_missing_generic_data_failure():
     with pytest.raises(
         PyRDLTypeError,
         match=(
-            "Generic `Data` type 'test.missing_genericdata' cannot be converted to an "
-            "attribute constraint. Consider making it inherit from `GenericData` "
-            "instead of `Data`."
+            re.escape(
+                "Generic `Data` type 'test.missing_genericdata' cannot be converted to an "
+                "attribute constraint. Consider making it inherit from `GenericData` "
+                "instead of `Data`."
+            )
         ),
     ):
         irdl_to_attr_constraint(MissingGenericDataData[int])

--- a/tests/test_rewriter.py
+++ b/tests/test_rewriter.py
@@ -1,3 +1,4 @@
+import re
 from collections.abc import Callable
 from io import StringIO
 
@@ -666,14 +667,14 @@ def test_inline_region_at_end():
 def test_verify_inline_region():
     region = Region(Block())
 
-    with pytest.raises(ValueError, match="Cannot move region into itself."):
+    with pytest.raises(ValueError, match=re.escape("Cannot move region into itself.")):
         Rewriter.inline_region(region, BlockInsertPoint.before(region.block))
 
-    with pytest.raises(ValueError, match="Cannot move region into itself."):
+    with pytest.raises(ValueError, match=re.escape("Cannot move region into itself.")):
         Rewriter.inline_region(region, BlockInsertPoint.after(region.block))
 
-    with pytest.raises(ValueError, match="Cannot move region into itself."):
+    with pytest.raises(ValueError, match=re.escape("Cannot move region into itself.")):
         Rewriter.inline_region(region, BlockInsertPoint.at_start(region))
 
-    with pytest.raises(ValueError, match="Cannot move region into itself."):
+    with pytest.raises(ValueError, match=re.escape("Cannot move region into itself.")):
         Rewriter.inline_region(region, BlockInsertPoint.at_end(region))

--- a/tests/test_ssa_value.py
+++ b/tests/test_ssa_value.py
@@ -21,7 +21,8 @@ def test_var_mixed_builder():
     op = TwoResultOp.build(result_types=[StringAttr("0"), StringAttr("2")])
 
     with pytest.raises(
-        ValueError, match="SSAValue.get: expected operation with a single result."
+        ValueError,
+        match=re.escape("SSAValue.get: expected operation with a single result."),
     ):
         _ = SSAValue.get(op)
 

--- a/tests/test_traits.py
+++ b/tests/test_traits.py
@@ -4,6 +4,7 @@ Test the definition and usage of traits and interfaces.
 
 from __future__ import annotations
 
+import re
 from abc import ABC
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -175,7 +176,8 @@ def test_verifier():
 
     op = TestOp.create(operands=[operand64], result_types=[i32])
     with pytest.raises(
-        VerifyException, match="Operation has a bitwidth sum greater or equal to 64."
+        VerifyException,
+        match=re.escape("Operation has a bitwidth sum greater or equal to 64."),
     ):
         op.verify()
 
@@ -235,8 +237,10 @@ def test_traits_wrong_type():
     with pytest.raises(
         PyRDLOpDefinitionError,
         match=(
-            "pyrdl operation definition 'WrongTraitsType' traits field should be an "
-            "instance of'OpTraits'."
+            re.escape(
+                "pyrdl operation definition 'WrongTraitsType' traits field should be an "
+                "instance of'OpTraits'."
+            )
         ),
     ):
         irdl_op_definition(WrongTraitsType)
@@ -496,7 +500,8 @@ def test_has_ancestor():
     assert op.has_trait(HasAncestor(TestOp))
 
     with pytest.raises(
-        VerifyException, match="'test.ancestor' expects ancestor op 'test.test'"
+        VerifyException,
+        match=re.escape("'test.ancestor' expects ancestor op 'test.test'"),
     ):
         op.verify()
 
@@ -1063,7 +1068,9 @@ def test_return_like():
 
     terminator = TestReturnLikeOp(result_types=((),), successors=((),))
 
-    with pytest.raises(VerifyException, match="test.return_like is not a terminator"):
+    with pytest.raises(
+        VerifyException, match=re.escape("test.return_like is not a terminator")
+    ):
         terminator.verify()
 
     TestReturnLikeOp.traits.add_trait(IsTerminator())
@@ -1072,7 +1079,7 @@ def test_return_like():
     results = TestReturnLikeOp(result_types=((i32,),), successors=((),))
 
     with pytest.raises(
-        VerifyException, match="test.return_like does not have zero results"
+        VerifyException, match=re.escape("test.return_like does not have zero results")
     ):
         results.verify()
 
@@ -1082,6 +1089,7 @@ def test_return_like():
     a.add_op(successors)
 
     with pytest.raises(
-        VerifyException, match="test.return_like does not have zero successors"
+        VerifyException,
+        match=re.escape("test.return_like does not have zero successors"),
     ):
         successors.verify()

--- a/tests/transforms/test_convert_pdl_to_pdl_interp.py
+++ b/tests/transforms/test_convert_pdl_to_pdl_interp.py
@@ -1,3 +1,4 @@
+import re
 from typing import cast
 
 import pytest
@@ -1070,7 +1071,9 @@ def test_extract_pattern_predicates_multiple_roots():
     pattern = pdl.PatternOp(1, "pattern", body)
     builder = PredicateTreeBuilder()
 
-    with pytest.raises(ValueError, match="Multi-root patterns are not yet supported."):
+    with pytest.raises(
+        ValueError, match=re.escape("Multi-root patterns are not yet supported.")
+    ):
         builder._extract_pattern_predicates(pattern)  # pyright: ignore[reportPrivateUsage]
 
 
@@ -4006,7 +4009,8 @@ def test_generate_operation_result_type_rewriter_error_unresolvable():
 
     # Call method - should raise ValueError
     with pytest.raises(
-        ValueError, match='Unable to infer result types for pdl.operation "test.op"'
+        ValueError,
+        match=re.escape('Unable to infer result types for pdl.operation "test.op"'),
     ):
         generator._generate_operation_result_type_rewriter(  # pyright: ignore[reportPrivateUsage]
             op_to_create, map_rewrite_value, types_list, rewrite_values
@@ -4048,7 +4052,8 @@ def test_generate_operation_result_type_rewriter_strategy1_partial_resolution():
 
     # Should raise ValueError because not all types can be resolved
     with pytest.raises(
-        ValueError, match='Unable to infer result types for pdl.operation "test.op"'
+        ValueError,
+        match=re.escape('Unable to infer result types for pdl.operation "test.op"'),
     ):
         generator._generate_operation_result_type_rewriter(  # pyright: ignore[reportPrivateUsage]
             op_to_create, map_rewrite_value, types_list, rewrite_values
@@ -4092,7 +4097,8 @@ def test_generate_operation_result_type_rewriter_strategy3_operation_before_repl
 
     # Should raise ValueError because Strategy 3 skips this case
     with pytest.raises(
-        ValueError, match='Unable to infer result types for pdl.operation "new.op"'
+        ValueError,
+        match=re.escape('Unable to infer result types for pdl.operation "new.op"'),
     ):
         generator._generate_operation_result_type_rewriter(  # pyright: ignore[reportPrivateUsage]
             new_op, map_rewrite_value, types_list, rewrite_values

--- a/tests/transforms/test_linalg_tiling_helpers.py
+++ b/tests/transforms/test_linalg_tiling_helpers.py
@@ -1,3 +1,4 @@
+import re
 from collections.abc import Sequence
 from typing import Any
 
@@ -135,7 +136,7 @@ def test_tiling_plan_rejects_tensor_results():
 def test_tiling_plan_rejects_linalg_index():
     op = _generic_2d_copy_op(use_index=True)
 
-    with pytest.raises(ValueError, match="using linalg.index"):
+    with pytest.raises(ValueError, match=re.escape("using linalg.index")):
         TilingPlan.analyze_generic_op(op, (2, 0))
 
 

--- a/tests/utils/test_mlir_lexer.py
+++ b/tests/utils/test_mlir_lexer.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 
 from xdsl.utils.exceptions import ParseError
@@ -35,7 +37,7 @@ def test_invalid_escape_in_string_literal():
         0, len(input_string), Input(input_string, "test.mlir")
     )
     with pytest.raises(
-        ParseError, match="Incomplete escape sequence at end of string."
+        ParseError, match=re.escape("Incomplete escape sequence at end of string.")
     ):
         string_literal.bytes_contents
 


### PR DESCRIPTION
Towards #5927.

Enables RUF043 (`pytest-raises-ambiguous-pattern`) by removing it from `lint.ignore` and making the intent of existing `pytest.raises(..., match=...)` patterns explicit.

The existing violations were reviewed to distinguish literal exception messages from intentional regular expressions:
- literal messages use `re.escape(...)`
- the four patterns that intentionally rely on regex behavior preserve that behavior with `re.compile(...)`

The original `match=` values were also compared against `HEAD` after the changes to verify that the expected exception messages themselves were not altered.

Validation:
- `uv run --no-sync ruff check . --select RUF043`
- Ruff check and format check on all changed Python files
- Pyright on all changed Python files
- affected tests: 2693 passed, 1 skipped
- full test suite: 5232 passed, 1 skipped
- `git diff --check`
