### PR TITLE
dialects: (x86_scf) make for loop lower bound inout

### DIFF
--- a/tests/dialects/test_x86_scf.py
+++ b/tests/dialects/test_x86_scf.py
@@ -46,6 +46,8 @@ def test_for_rof_init(
         body,
     )
     assert op.body.block.arg_types == (x86.registers.R12, *iter_arg_types)
+    assert len(op.results) == 1 + len(iter_arg_types)
+    assert op.lb_end.type == lb.type
     with ImplicitBuilder(op.body) as (_i, *args):
         x86_scf.YieldOp(*args)
     op.verify()
@@ -87,6 +89,8 @@ def test_for_rof_bounds_and_step(
 
     assert op.ub is (ub_attr if static_ub else ub_val)
     assert op.step is (step_attr if static_step else step_val)
+    assert len(op.results) == 1
+    assert op.lb_end.type == lb.type
 
 
 @pytest.mark.parametrize("loop_cls", [x86_scf.ForOp, x86_scf.RofOp])

--- a/tests/filecheck/backend/x86/x86_allocate_registers.mlir
+++ b/tests/filecheck/backend/x86/x86_allocate_registers.mlir
@@ -49,20 +49,20 @@ x86_func.func @loops() {
 // CHECK-NEXT:      %start, %end, %step = "test.op"() : () -> (!x86.reg64<rcx>, !x86.reg64<rdx>, !x86.reg64<rax>)
   %start, %end, %step = "test.op"() : () -> (!x86.reg64, !x86.reg64, !x86.reg64)
 
-// CHECK-NEXT:      %for_result = x86_scf.for %iv : !x86.reg64<rbx>  = %start to %end step %step iter_args(%iter_val = %step) -> (!x86.reg64<rax>) {
+// CHECK-NEXT:      %start_end, %for_result = x86_scf.for %iv : !x86.reg64<rcx>  = %start to %end step %step iter_args(%iter_val = %step) -> (!x86.reg64<rax>) {
 // CHECK-NEXT:        %moved_val = x86.ds.mov %iter_val : (!x86.reg64<rax>) -> !x86.reg64<rax>
 // CHECK-NEXT:        x86_scf.yield %moved_val : !x86.reg64<rax>
 // CHECK-NEXT:      }
-  %for_result = x86_scf.for %iv : !x86.reg64 = %start to %end step %step iter_args(%iter_val = %step) -> (!x86.reg64) {
+  %start_end, %for_result = x86_scf.for %iv : !x86.reg64 = %start to %end step %step iter_args(%iter_val = %step) -> (!x86.reg64) {
     %moved_val = x86.ds.mov %iter_val : (!x86.reg64) -> !x86.reg64
     x86_scf.yield %moved_val : !x86.reg64
   }
 
-// CHECK-NEXT:      %for_static_step = x86_scf.for %iv2 : !x86.reg64<rcx>  = %start to %end step 2 : si32 iter_args(%iter_val2 = %step) -> (!x86.reg64<rax>) {
+// CHECK-NEXT:      %start_end_1, %for_static_step = x86_scf.for %iv2 : !x86.reg64<rcx>  = %start to %end step 2 : si32 iter_args(%iter_val2 = %step) -> (!x86.reg64<rax>) {
 // CHECK-NEXT:        %moved_val2 = x86.ds.mov %iter_val2 : (!x86.reg64<rax>) -> !x86.reg64<rax>
 // CHECK-NEXT:        x86_scf.yield %moved_val2 : !x86.reg64<rax>
 // CHECK-NEXT:      }
-  %for_static_step = x86_scf.for %iv2 : !x86.reg64 = %start to %end step 2 : si32 iter_args(%iter_val2 = %step) -> (!x86.reg64) {
+  %start_end_1, %for_static_step = x86_scf.for %iv2 : !x86.reg64 = %start to %end step 2 : si32 iter_args(%iter_val2 = %step) -> (!x86.reg64) {
     %moved_val2 = x86.ds.mov %iter_val2 : (!x86.reg64) -> !x86.reg64
     x86_scf.yield %moved_val2 : !x86.reg64
   }

--- a/tests/filecheck/backend/x86/x86_regalloc_verify_liveness.mlir
+++ b/tests/filecheck/backend/x86/x86_regalloc_verify_liveness.mlir
@@ -11,6 +11,18 @@ x86_func.func @inc(%ptr: !x86.reg64<rax>) {
   x86_func.ret
 }
 
+
+// -----
+
+// CHECK: lb should not be read after in/out usage
+x86_func.func @lb_live_after(%lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
+  %lb_end = x86_scf.for %i : !x86.reg64 = %lb to %ub step %step {
+    x86_scf.yield
+  }
+  "test.op"(%lb) : (!x86.reg64) -> ()
+  x86_func.ret
+}
+
 // -----
 
 // CHECK: Cannot yet verify register liveness for regions with multiple blocks.
@@ -45,10 +57,22 @@ x86_func.func @inc3(%ptr: !x86.reg64) {
 // CHECK: ptr should not be read after in/out usage
 x86_func.func @inc4(%ptr: !x86.reg64) {
   %init,%bound,%step = "test.op"(): () -> (!x86.reg64,!x86.reg64,!x86.reg64)
-  x86_scf.for %i : !x86.reg64  = %init to %bound step %step {
+  %init_1 = x86_scf.for %i : !x86.reg64  = %init to %bound step %step {
     %ptr2 = x86.r.inc %ptr : (!x86.reg64) -> !x86.reg64
     %ptr3 = x86.r.inc %ptr : (!x86.reg64) -> !x86.reg64
   }
+  x86_func.ret
+}
+
+
+// -----
+
+// CHECK: lb should not be read after in/out usage
+x86_func.func @lb_live_after(%lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
+  %lb_end = x86_scf.for %i : !x86.reg64 = %lb to %ub step %step {
+    x86_scf.yield
+  }
+  "test.op"(%lb) : (!x86.reg64) -> ()
   x86_func.ret
 }
 
@@ -60,6 +84,18 @@ x86_func.func @inc4(%ptr: !x86.reg64) {
   x86.fallthrough ^next()
 ^next:
   %ptr3 = x86.r.inc %ptr : (!x86.reg64) -> !x86.reg64
+  x86_func.ret
+}
+
+
+// -----
+
+// CHECK: lb should not be read after in/out usage
+x86_func.func @lb_live_after(%lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
+  %lb_end = x86_scf.for %i : !x86.reg64 = %lb to %ub step %step {
+    x86_scf.yield
+  }
+  "test.op"(%lb) : (!x86.reg64) -> ()
   x86_func.ret
 }
 
@@ -87,7 +123,7 @@ x86_func.func @inc6(%ptr: !x86.reg64<rax>)
 
 // CHECK: x should not be read after in/out usage
 x86_func.func @body_use_before_clobber(%x: !x86.reg64, %lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
-  x86_scf.for %i : !x86.reg64 = %lb to %ub step %step {
+  %lb_end = x86_scf.for %i : !x86.reg64 = %lb to %ub step %step {
     "test.op"(%x) : (!x86.reg64) -> ()
     %x2 = x86.r.inc %x : (!x86.reg64) -> !x86.reg64
   }
@@ -98,7 +134,7 @@ x86_func.func @body_use_before_clobber(%x: !x86.reg64, %lb: !x86.reg64, %ub: !x8
 
 // CHECK: x should not be read after in/out usage
 x86_func.func @body_only_use_is_clobber(%x: !x86.reg64, %lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
-  x86_scf.for %i : !x86.reg64 = %lb to %ub step %step {
+  %lb_end = x86_scf.for %i : !x86.reg64 = %lb to %ub step %step {
     %x2 = x86.r.inc %x : (!x86.reg64) -> !x86.reg64
   }
   x86_func.ret
@@ -108,7 +144,7 @@ x86_func.func @body_only_use_is_clobber(%x: !x86.reg64, %lb: !x86.reg64, %ub: !x
 
 // CHECK: i should not be read after in/out usage
 x86_func.func @iv_clobbered(%lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
-  x86_scf.for %i : !x86.reg64 = %lb to %ub step %step {
+  %lb_end = x86_scf.for %i : !x86.reg64 = %lb to %ub step %step {
     %i2 = x86.r.inc %i : (!x86.reg64) -> !x86.reg64
   }
   x86_func.ret
@@ -118,7 +154,7 @@ x86_func.func @iv_clobbered(%lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64)
 
 // CHECK: ub should not be read after in/out usage
 x86_func.func @ub_clobbered(%lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
-  x86_scf.for %i : !x86.reg64 = %lb to %ub step %step {
+  %lb_end = x86_scf.for %i : !x86.reg64 = %lb to %ub step %step {
     %u2 = x86.r.inc %ub : (!x86.reg64) -> !x86.reg64
   }
   x86_func.ret
@@ -129,7 +165,7 @@ x86_func.func @ub_clobbered(%lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64)
 // CHECK: x should not be read after in/out usage
 x86_func.func @clobber_before_loop(%x: !x86.reg64, %lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
   %x2 = x86.r.inc %x : (!x86.reg64) -> !x86.reg64
-  x86_scf.for %i : !x86.reg64 = %lb to %ub step %step {
+  %lb_end = x86_scf.for %i : !x86.reg64 = %lb to %ub step %step {
     "test.op"(%x) : (!x86.reg64) -> ()
   }
   x86_func.ret
@@ -139,7 +175,7 @@ x86_func.func @clobber_before_loop(%x: !x86.reg64, %lb: !x86.reg64, %ub: !x86.re
 
 // CHECK: init should not be read after in/out usage
 x86_func.func @iter_arg_live_after(%init: !x86.reg64, %lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
-  %res = x86_scf.for %i : !x86.reg64 = %lb to %ub step %step iter_args(%a = %init) -> (!x86.reg64) {
+  %lb_end, %res = x86_scf.for %i : !x86.reg64 = %lb to %ub step %step iter_args(%a = %init) -> (!x86.reg64) {
     %a2 = x86.r.inc %a : (!x86.reg64) -> !x86.reg64
     x86_scf.yield %a2 : !x86.reg64
   }
@@ -151,7 +187,7 @@ x86_func.func @iter_arg_live_after(%init: !x86.reg64, %lb: !x86.reg64, %ub: !x86
 
 // CHECK: Value %v is used by more than one in/out operand
 x86_func.func @duplicate_iter_args(%v: !x86.reg64, %lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
-  %r0, %r1 = x86_scf.for %i : !x86.reg64 = %lb to %ub step %step iter_args(%a = %v, %b = %v) -> (!x86.reg64, !x86.reg64) {
+  %lb_end, %r0, %r1 = x86_scf.for %i : !x86.reg64 = %lb to %ub step %step iter_args(%a = %v, %b = %v) -> (!x86.reg64, !x86.reg64) {
     x86_scf.yield %a, %b : !x86.reg64, !x86.reg64
   }
   x86_func.ret
@@ -162,7 +198,7 @@ x86_func.func @duplicate_iter_args(%v: !x86.reg64, %lb: !x86.reg64, %ub: !x86.re
 // CHECK: Value is used by more than one in/out operand
 x86_func.func @duplicate_iter_args(%lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
   %0 = x86.get_register : !x86.reg64
-  %r0, %r1 = x86_scf.for %i : !x86.reg64 = %lb to %ub step %step iter_args(%a = %0, %b = %0) -> (!x86.reg64, !x86.reg64) {
+  %lb_end, %r0, %r1 = x86_scf.for %i : !x86.reg64 = %lb to %ub step %step iter_args(%a = %0, %b = %0) -> (!x86.reg64, !x86.reg64) {
     x86_scf.yield %a, %b : !x86.reg64, !x86.reg64
   }
   x86_func.ret
@@ -172,8 +208,8 @@ x86_func.func @duplicate_iter_args(%lb: !x86.reg64, %ub: !x86.reg64, %step: !x86
 
 // CHECK: x should not be read after in/out usage
 x86_func.func @nested_clobber(%x: !x86.reg64, %lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
-  x86_scf.for %i : !x86.reg64 = %lb to %ub step %step {
-    x86_scf.for %j : !x86.reg64 = %lb to %ub step %step {
+  %lb_end = x86_scf.for %i : !x86.reg64 = %lb to %ub step %step {
+    %lb_end_1 = x86_scf.for %j : !x86.reg64 = %lb to %ub step %step {
       %x2 = x86.r.inc %x : (!x86.reg64) -> !x86.reg64
     }
   }
@@ -184,7 +220,7 @@ x86_func.func @nested_clobber(%x: !x86.reg64, %lb: !x86.reg64, %ub: !x86.reg64, 
 
 // CHECK-LABEL: @loop_live_in_untouched
 x86_func.func @loop_live_in_untouched(%x: !x86.reg64, %lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
-  x86_scf.for %i : !x86.reg64 = %lb to %ub step %step {
+  %lb_end = x86_scf.for %i : !x86.reg64 = %lb to %ub step %step {
     "test.op"(%x) : (!x86.reg64) -> ()
   }
   x86_func.ret
@@ -194,7 +230,7 @@ x86_func.func @loop_live_in_untouched(%x: !x86.reg64, %lb: !x86.reg64, %ub: !x86
 
 // CHECK-LABEL: @iter_arg_accumulate
 x86_func.func @iter_arg_accumulate(%init: !x86.reg64, %lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
-  %res = x86_scf.for %i : !x86.reg64 = %lb to %ub step %step iter_args(%a = %init) -> (!x86.reg64) {
+  %lb_end, %res = x86_scf.for %i : !x86.reg64 = %lb to %ub step %step iter_args(%a = %init) -> (!x86.reg64) {
     "test.op"(%a) : (!x86.reg64) -> ()
     %a2 = x86.r.inc %a : (!x86.reg64) -> !x86.reg64
     x86_scf.yield %a2 : !x86.reg64
@@ -207,7 +243,7 @@ x86_func.func @iter_arg_accumulate(%init: !x86.reg64, %lb: !x86.reg64, %ub: !x86
 
 // CHECK: a should not be read after in/out usage
 x86_func.func @iter_arg_read_after_clobber(%init: !x86.reg64, %lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
-  %res = x86_scf.for %i : !x86.reg64 = %lb to %ub step %step iter_args(%a = %init) -> (!x86.reg64) {
+  %lb_end, %res = x86_scf.for %i : !x86.reg64 = %lb to %ub step %step iter_args(%a = %init) -> (!x86.reg64) {
     %a2 = x86.r.inc %a : (!x86.reg64) -> !x86.reg64
     "test.op"(%a) : (!x86.reg64) -> ()
     x86_scf.yield %a2 : !x86.reg64
@@ -219,9 +255,21 @@ x86_func.func @iter_arg_read_after_clobber(%init: !x86.reg64, %lb: !x86.reg64, %
 
 // CHECK: x should not be read after in/out usage
 x86_func.func @rof_body_clobber(%x: !x86.reg64, %lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
-  x86_scf.rof %i : !x86.reg64 = %ub down to %lb step %step {
+  %lb_end = x86_scf.rof %i : !x86.reg64 = %ub down to %lb step %step {
     %x2 = x86.r.inc %x : (!x86.reg64) -> !x86.reg64
   }
+  x86_func.ret
+}
+
+
+// -----
+
+// CHECK: lb should not be read after in/out usage
+x86_func.func @lb_live_after(%lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
+  %lb_end = x86_scf.for %i : !x86.reg64 = %lb to %ub step %step {
+    x86_scf.yield
+  }
+  "test.op"(%lb) : (!x86.reg64) -> ()
   x86_func.ret
 }
 

--- a/tests/filecheck/dialects/x86_scf/x86_scf_invalid.mlir
+++ b/tests/filecheck/dialects/x86_scf/x86_scf_invalid.mlir
@@ -24,7 +24,7 @@
 "x86_scf.for"(%lb, %ub, %step) <{ub_attr = 10 : si32, operandSegmentSizes = array<i32: 1, 1, 1, 0>}> ({
 ^bb0(%i: !x86.reg64):
     x86_scf.yield
-}) : (!x86.reg64, !x86.reg64, !x86.reg64) -> ()
+}) : (!x86.reg64, !x86.reg64, !x86.reg64) -> (!x86.reg64)
 
 // CHECK: Operation does not verify: Exactly one of ub_attr (static) or ub_val (dynamic) must be set
 
@@ -35,7 +35,7 @@
 "x86_scf.for"(%lb, %ub, %step) <{step_attr = 1 : si32, operandSegmentSizes = array<i32: 1, 1, 1, 0>}> ({
 ^bb0(%i: !x86.reg64):
     x86_scf.yield
-}) : (!x86.reg64, !x86.reg64, !x86.reg64) -> ()
+}) : (!x86.reg64, !x86.reg64, !x86.reg64) -> (!x86.reg64)
 
 // CHECK: Operation does not verify: Exactly one of step_attr (static) or step_val (dynamic) must be set
 
@@ -88,3 +88,14 @@ x86_scf.rof %i : !x86.reg64 = %ub down to 0 : si32 step 1 : si32 {
 }
 
 // CHECK: Expected an operand.
+
+// -----
+
+%lb = "test.op"() : () -> !x86.reg64<rax>
+
+"x86_scf.for"(%lb) <{ub_attr = 10 : si32, step_attr = 1 : si32, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> ({
+^bb0(%i: !x86.reg64<rbx>):
+    x86_scf.yield
+}) : (!x86.reg64<rax>) -> (!x86.reg64<rax>)
+
+// CHECK: Operation does not verify: Expected induction var to be same type as lb

--- a/tests/filecheck/dialects/x86_scf/x86_scf_ops.mlir
+++ b/tests/filecheck/dialects/x86_scf/x86_scf_ops.mlir
@@ -4,32 +4,32 @@
 %ub = x86.di.mov 100 : () -> !x86.reg64
 %step = x86.di.mov 1 : () -> !x86.reg64
 %acc = x86.di.mov 0 : () -> !x86.reg64<rbx>
-%res_for = x86_scf.for %i : !x86.reg64 = %lb to %ub step %step iter_args(%acc_in = %acc) -> (!x86.reg64<rbx>) {
+%lb_end, %res_for = x86_scf.for %i : !x86.reg64 = %lb to %ub step %step iter_args(%acc_in = %acc) -> (!x86.reg64<rbx>) {
     %res = x86.ri.add %acc_in, 1 : (!x86.reg64<rbx>) -> !x86.reg64<rbx>
     x86_scf.yield %res : !x86.reg64<rbx>
 }
 
-%res_rof = x86_scf.rof %j : !x86.reg64 = %ub down to %lb step %step iter_args(%acc_in = %acc) -> (!x86.reg64<rbx>) {
+%lb_end_1, %res_rof = x86_scf.rof %j : !x86.reg64 = %ub down to %lb step %step iter_args(%acc_in = %acc) -> (!x86.reg64<rbx>) {
     %res = x86.ri.add %acc_in, 1 : (!x86.reg64<rbx>) -> !x86.reg64<rbx>
     x86_scf.yield %res : !x86.reg64<rbx>
 }
 
-%res_for_static_ub = x86_scf.for %k : !x86.reg64 = %lb to 100 : si32 step %step iter_args(%acc_in = %acc) -> (!x86.reg64<rbx>) {
+%lb_end_2, %res_for_static_ub = x86_scf.for %k : !x86.reg64 = %lb to 100 : si32 step %step iter_args(%acc_in = %acc) -> (!x86.reg64<rbx>) {
     %res = x86.ri.add %acc_in, 1 : (!x86.reg64<rbx>) -> !x86.reg64<rbx>
     x86_scf.yield %res : !x86.reg64<rbx>
 }
 
-%res_for_static_step = x86_scf.for %m : !x86.reg64 = %lb to %ub step 2 : si32 iter_args(%acc_in = %acc) -> (!x86.reg64<rbx>) {
+%lb_end_3, %res_for_static_step = x86_scf.for %m : !x86.reg64 = %lb to %ub step 2 : si32 iter_args(%acc_in = %acc) -> (!x86.reg64<rbx>) {
     %res = x86.ri.add %acc_in, 1 : (!x86.reg64<rbx>) -> !x86.reg64<rbx>
     x86_scf.yield %res : !x86.reg64<rbx>
 }
 
-%res_rof_static_step = x86_scf.rof %n : !x86.reg64 = %ub down to %lb step 2 : si32 iter_args(%acc_in = %acc) -> (!x86.reg64<rbx>) {
+%lb_end_4, %res_rof_static_step = x86_scf.rof %n : !x86.reg64 = %ub down to %lb step 2 : si32 iter_args(%acc_in = %acc) -> (!x86.reg64<rbx>) {
     %res = x86.ri.add %acc_in, 1 : (!x86.reg64<rbx>) -> !x86.reg64<rbx>
     x86_scf.yield %res : !x86.reg64<rbx>
 }
 
-%res_for_static_bounds = x86_scf.for %p : !x86.reg64 = %lb to 100 : si32 step 2 : si32 iter_args(%acc_in = %acc) -> (!x86.reg64<rbx>) {
+%lb_end_5, %res_for_static_bounds = x86_scf.for %p : !x86.reg64 = %lb to 100 : si32 step 2 : si32 iter_args(%acc_in = %acc) -> (!x86.reg64<rbx>) {
     %res = x86.ri.add %acc_in, 1 : (!x86.reg64<rbx>) -> !x86.reg64<rbx>
     x86_scf.yield %res : !x86.reg64<rbx>
 }
@@ -39,27 +39,27 @@
 // CHECK-NEXT:    %ub = x86.di.mov 100 : () -> !x86.reg64
 // CHECK-NEXT:    %step = x86.di.mov 1 : () -> !x86.reg64
 // CHECK-NEXT:    %acc = x86.di.mov 0 : () -> !x86.reg64<rbx>
-// CHECK-NEXT:    %res_for = x86_scf.for %i : !x86.reg64  = %lb to %ub step %step iter_args(%acc_in = %acc) -> (!x86.reg64<rbx>) {
+// CHECK-NEXT:    %lb_end, %res_for = x86_scf.for %i : !x86.reg64  = %lb to %ub step %step iter_args(%acc_in = %acc) -> (!x86.reg64<rbx>) {
 // CHECK-NEXT:      %res = x86.ri.add %acc_in, 1 : (!x86.reg64<rbx>) -> !x86.reg64<rbx>
 // CHECK-NEXT:      x86_scf.yield %res : !x86.reg64<rbx>
 // CHECK-NEXT:    }
-// CHECK-NEXT:    %res_rof = x86_scf.rof %j : !x86.reg64  = %ub down  to %lb step %step iter_args(%acc_in_1 = %acc) -> (!x86.reg64<rbx>) {
+// CHECK-NEXT:    %lb_end_1, %res_rof = x86_scf.rof %j : !x86.reg64  = %ub down  to %lb step %step iter_args(%acc_in_1 = %acc) -> (!x86.reg64<rbx>) {
 // CHECK-NEXT:      %res_1 = x86.ri.add %acc_in_1, 1 : (!x86.reg64<rbx>) -> !x86.reg64<rbx>
 // CHECK-NEXT:      x86_scf.yield %res_1 : !x86.reg64<rbx>
 // CHECK-NEXT:    }
-// CHECK-NEXT:    %res_for_static_ub = x86_scf.for %k : !x86.reg64  = %lb to 100 : si32 step %step iter_args(%acc_in_2 = %acc) -> (!x86.reg64<rbx>) {
+// CHECK-NEXT:    %lb_end_2, %res_for_static_ub = x86_scf.for %k : !x86.reg64  = %lb to 100 : si32 step %step iter_args(%acc_in_2 = %acc) -> (!x86.reg64<rbx>) {
 // CHECK-NEXT:      %res_2 = x86.ri.add %acc_in_2, 1 : (!x86.reg64<rbx>) -> !x86.reg64<rbx>
 // CHECK-NEXT:      x86_scf.yield %res_2 : !x86.reg64<rbx>
 // CHECK-NEXT:    }
-// CHECK-NEXT:    %res_for_static_step = x86_scf.for %m : !x86.reg64  = %lb to %ub step 2 : si32 iter_args(%acc_in_3 = %acc) -> (!x86.reg64<rbx>) {
+// CHECK-NEXT:    %lb_end_3, %res_for_static_step = x86_scf.for %m : !x86.reg64  = %lb to %ub step 2 : si32 iter_args(%acc_in_3 = %acc) -> (!x86.reg64<rbx>) {
 // CHECK-NEXT:      %res_3 = x86.ri.add %acc_in_3, 1 : (!x86.reg64<rbx>) -> !x86.reg64<rbx>
 // CHECK-NEXT:      x86_scf.yield %res_3 : !x86.reg64<rbx>
 // CHECK-NEXT:    }
-// CHECK-NEXT:    %res_rof_static_step = x86_scf.rof %n : !x86.reg64  = %ub down  to %lb step 2 : si32 iter_args(%acc_in_4 = %acc) -> (!x86.reg64<rbx>) {
+// CHECK-NEXT:    %lb_end_4, %res_rof_static_step = x86_scf.rof %n : !x86.reg64  = %ub down  to %lb step 2 : si32 iter_args(%acc_in_4 = %acc) -> (!x86.reg64<rbx>) {
 // CHECK-NEXT:      %res_4 = x86.ri.add %acc_in_4, 1 : (!x86.reg64<rbx>) -> !x86.reg64<rbx>
 // CHECK-NEXT:      x86_scf.yield %res_4 : !x86.reg64<rbx>
 // CHECK-NEXT:    }
-// CHECK-NEXT:    %res_for_static_bounds = x86_scf.for %p : !x86.reg64  = %lb to 100 : si32 step 2 : si32 iter_args(%acc_in_5 = %acc) -> (!x86.reg64<rbx>) {
+// CHECK-NEXT:    %lb_end_5, %res_for_static_bounds = x86_scf.for %p : !x86.reg64  = %lb to 100 : si32 step 2 : si32 iter_args(%acc_in_5 = %acc) -> (!x86.reg64<rbx>) {
 // CHECK-NEXT:      %res_5 = x86.ri.add %acc_in_5, 1 : (!x86.reg64<rbx>) -> !x86.reg64<rbx>
 // CHECK-NEXT:      x86_scf.yield %res_5 : !x86.reg64<rbx>
 // CHECK-NEXT:    }

--- a/tests/filecheck/transforms/convert-scf-to-x86-scf.mlir
+++ b/tests/filecheck/transforms/convert-scf-to-x86-scf.mlir
@@ -7,7 +7,7 @@
 //  CHECK-NEXT:      %zero_outer_1 = asm.to_reg %zero_outer : index -> !x86.reg64
 //  CHECK-NEXT:      %forty_outer_1 = asm.to_reg %forty_outer : index -> !x86.reg64
 //  CHECK-NEXT:      %step_outer_1 = asm.to_reg %step_outer : index -> !x86.reg64
-//  CHECK-NEXT:      x86_scf.for %offset_outer : !x86.reg64  = %zero_outer_1 to %forty_outer_1 step %step_outer_1 {
+//  CHECK-NEXT:      %zero_outer_end = x86_scf.for %offset_outer : !x86.reg64  = %zero_outer_1 to %forty_outer_1 step %step_outer_1 {
 //  CHECK-NEXT:        %offset_outer_1 = asm.from_reg %offset_outer : !x86.reg64 -> index
 //  CHECK-NEXT:        %zero_inner = arith.constant 0 : index
 //  CHECK-NEXT:        %step_inner = arith.constant 2 : index
@@ -15,7 +15,7 @@
 //  CHECK-NEXT:        %zero_inner_1 = asm.to_reg %zero_inner : index -> !x86.reg64
 //  CHECK-NEXT:        %forty_inner_1 = asm.to_reg %forty_inner : index -> !x86.reg64
 //  CHECK-NEXT:        %step_inner_1 = asm.to_reg %step_inner : index -> !x86.reg64
-//  CHECK-NEXT:        x86_scf.for %offset_inner : !x86.reg64  = %zero_inner_1 to %forty_inner_1 step %step_inner_1 {
+//  CHECK-NEXT:        %zero_inner_end = x86_scf.for %offset_inner : !x86.reg64  = %zero_inner_1 to %forty_inner_1 step %step_inner_1 {
 //  CHECK-NEXT:          %offset_inner_1 = asm.from_reg %offset_inner : !x86.reg64 -> index
 //  CHECK-NEXT:          "test.op"(%src, %dst, %offset_outer_1, %offset_inner_1) : (index, index, index, index) -> ()
 //  CHECK-NEXT:        }

--- a/tests/filecheck/transforms/convert-x86-scf-to-x86.mlir
+++ b/tests/filecheck/transforms/convert-x86-scf-to-x86.mlir
@@ -5,17 +5,16 @@
 //  CHECK-NEXT:      %zero = x86.di.mov 0 : () -> !x86.reg64<rcx>
 //  CHECK-NEXT:      %step = x86.di.mov 4 : () -> !x86.reg64<rdx>
 //  CHECK-NEXT:      %forty = x86.di.mov 40 : () -> !x86.reg64<r8>
-//  CHECK-NEXT:      %zero_1 = x86.ds.mov %zero : (!x86.reg64<rcx>) -> !x86.reg64<r9>
-//  CHECK-NEXT:      %0 = x86.ss.cmp %zero_1, %forty : (!x86.reg64<r9>, !x86.reg64<r8>) -> !x86.rflags<rflags>
-//  CHECK-NEXT:      x86.c.jge %0 : !x86.rflags<rflags>, ^bb2(%zero_1 : !x86.reg64<r9>), ^bb1(%zero_1 : !x86.reg64<r9>)
-//  CHECK-NEXT:    ^bb1(%offset: !x86.reg64<r9>):
+//  CHECK-NEXT:      %0 = x86.ss.cmp %zero, %forty : (!x86.reg64<rcx>, !x86.reg64<r8>) -> !x86.rflags<rflags>
+//  CHECK-NEXT:      x86.c.jge %0 : !x86.rflags<rflags>, ^bb2(%zero : !x86.reg64<rcx>), ^bb1(%zero : !x86.reg64<rcx>)
+//  CHECK-NEXT:    ^bb1(%offset: !x86.reg64<rcx>):
 //  CHECK-NEXT:      x86.label "scf_body_0_for"
-//  CHECK-NEXT:      "test.op"(%offset, %src, %dst) : (!x86.reg64<r9>, !x86.reg64<rax>, !x86.reg64<rbx>) -> ()
-//  CHECK-NEXT:      %offset_1 = x86.ds.mov %offset : (!x86.reg64<r9>) -> !x86.reg64<r9>
-//  CHECK-NEXT:      %offset_2 = x86.rs.add %offset_1, %step : (!x86.reg64<r9>, !x86.reg64<rdx>) -> !x86.reg64<r9>
-//  CHECK-NEXT:      %1 = x86.ss.cmp %offset_2, %forty : (!x86.reg64<r9>, !x86.reg64<r8>) -> !x86.rflags<rflags>
-//  CHECK-NEXT:      x86.c.jl %1 : !x86.rflags<rflags>, ^bb1(%offset_2 : !x86.reg64<r9>), ^bb2(%offset_2 : !x86.reg64<r9>)
-//  CHECK-NEXT:    ^bb2(%offset_3: !x86.reg64<r9>):
+//  CHECK-NEXT:      "test.op"(%offset, %src, %dst) : (!x86.reg64<rcx>, !x86.reg64<rax>, !x86.reg64<rbx>) -> ()
+//  CHECK-NEXT:      %offset_1 = x86.ds.mov %offset : (!x86.reg64<rcx>) -> !x86.reg64<rcx>
+//  CHECK-NEXT:      %offset_2 = x86.rs.add %offset_1, %step : (!x86.reg64<rcx>, !x86.reg64<rdx>) -> !x86.reg64<rcx>
+//  CHECK-NEXT:      %1 = x86.ss.cmp %offset_2, %forty : (!x86.reg64<rcx>, !x86.reg64<r8>) -> !x86.rflags<rflags>
+//  CHECK-NEXT:      x86.c.jl %1 : !x86.rflags<rflags>, ^bb1(%offset_2 : !x86.reg64<rcx>), ^bb2(%offset_2 : !x86.reg64<rcx>)
+//  CHECK-NEXT:    ^bb2(%zero_end: !x86.reg64<rcx>):
 //  CHECK-NEXT:      x86.label "scf_body_end_0_for"
 //  CHECK-NEXT:      x86_func.ret
 //  CHECK-NEXT:    }
@@ -23,8 +22,8 @@ x86_func.func @copy10(%src: !x86.reg64<rax>, %dst: !x86.reg64<rbx>) {
     %zero = x86.di.mov 0 : () -> !x86.reg64<rcx>
     %step = x86.di.mov 4 : () -> !x86.reg64<rdx>
     %forty = x86.di.mov 40 : () -> !x86.reg64<r8>
-    x86_scf.for %offset : !x86.reg64<r9> = %zero to %forty step %step {
-        "test.op"(%offset, %src, %dst) :  (!x86.reg64<r9>, !x86.reg64<rax>, !x86.reg64<rbx>) -> ()
+    %zero_end = x86_scf.for %offset : !x86.reg64<rcx> = %zero to %forty step %step {
+        "test.op"(%offset, %src, %dst) :  (!x86.reg64<rcx>, !x86.reg64<rax>, !x86.reg64<rbx>) -> ()
         yield
     }
     ret
@@ -36,31 +35,29 @@ x86_func.func @copy10(%src: !x86.reg64<rax>, %dst: !x86.reg64<rbx>) {
 //  CHECK-NEXT:      %zero_outer = x86.di.mov 0 : () -> !x86.reg64<rcx>
 //  CHECK-NEXT:      %step_outer = x86.di.mov 4 : () -> !x86.reg64<rdx>
 //  CHECK-NEXT:      %forty_outer = x86.di.mov 40 : () -> !x86.reg64<r8>
-//  CHECK-NEXT:      %zero_outer_1 = x86.ds.mov %zero_outer : (!x86.reg64<rcx>) -> !x86.reg64<r9>
-//  CHECK-NEXT:      %0 = x86.ss.cmp %zero_outer_1, %forty_outer : (!x86.reg64<r9>, !x86.reg64<r8>) -> !x86.rflags<rflags>
-//  CHECK-NEXT:      x86.c.jge %0 : !x86.rflags<rflags>, ^bb4(%zero_outer_1 : !x86.reg64<r9>), ^bb1(%zero_outer_1 : !x86.reg64<r9>)
-//  CHECK-NEXT:    ^bb1(%offset_outer: !x86.reg64<r9>):
+//  CHECK-NEXT:      %0 = x86.ss.cmp %zero_outer, %forty_outer : (!x86.reg64<rcx>, !x86.reg64<r8>) -> !x86.rflags<rflags>
+//  CHECK-NEXT:      x86.c.jge %0 : !x86.rflags<rflags>, ^bb4(%zero_outer : !x86.reg64<rcx>), ^bb1(%zero_outer : !x86.reg64<rcx>)
+//  CHECK-NEXT:    ^bb1(%offset_outer: !x86.reg64<rcx>):
 //  CHECK-NEXT:      x86.label "scf_body_1_for"
 //  CHECK-NEXT:      %zero_inner = x86.di.mov 0 : () -> !x86.reg64<r10>
 //  CHECK-NEXT:      %step_inner = x86.di.mov 2 : () -> !x86.reg64<r11>
 //  CHECK-NEXT:      %forty_inner = x86.di.mov 40 : () -> !x86.reg64<r12>
-//  CHECK-NEXT:      %zero_inner_1 = x86.ds.mov %zero_inner : (!x86.reg64<r10>) -> !x86.reg64<r13>
-//  CHECK-NEXT:      %1 = x86.ss.cmp %zero_inner_1, %forty_inner : (!x86.reg64<r13>, !x86.reg64<r12>) -> !x86.rflags<rflags>
-//  CHECK-NEXT:      x86.c.jge %1 : !x86.rflags<rflags>, ^bb3(%zero_inner_1 : !x86.reg64<r13>), ^bb2(%zero_inner_1 : !x86.reg64<r13>)
-//  CHECK-NEXT:    ^bb2(%offset_inner: !x86.reg64<r13>):
+//  CHECK-NEXT:      %1 = x86.ss.cmp %zero_inner, %forty_inner : (!x86.reg64<r10>, !x86.reg64<r12>) -> !x86.rflags<rflags>
+//  CHECK-NEXT:      x86.c.jge %1 : !x86.rflags<rflags>, ^bb3(%zero_inner : !x86.reg64<r10>), ^bb2(%zero_inner : !x86.reg64<r10>)
+//  CHECK-NEXT:    ^bb2(%offset_inner: !x86.reg64<r10>):
 //  CHECK-NEXT:      x86.label "scf_body_0_for"
-//  CHECK-NEXT:      "test.op"(%src, %dst, %offset_outer, %offset_inner) : (!x86.reg64<rax>, !x86.reg64<rbx>, !x86.reg64<r9>, !x86.reg64<r13>) -> ()
-//  CHECK-NEXT:      %offset_inner_1 = x86.ds.mov %offset_inner : (!x86.reg64<r13>) -> !x86.reg64<r13>
-//  CHECK-NEXT:      %offset_inner_2 = x86.rs.add %offset_inner_1, %step_inner : (!x86.reg64<r13>, !x86.reg64<r11>) -> !x86.reg64<r13>
-//  CHECK-NEXT:      %2 = x86.ss.cmp %offset_inner_2, %forty_inner : (!x86.reg64<r13>, !x86.reg64<r12>) -> !x86.rflags<rflags>
-//  CHECK-NEXT:      x86.c.jl %2 : !x86.rflags<rflags>, ^bb2(%offset_inner_2 : !x86.reg64<r13>), ^bb3(%offset_inner_2 : !x86.reg64<r13>)
-//  CHECK-NEXT:    ^bb3(%offset_inner_3: !x86.reg64<r13>):
+//  CHECK-NEXT:      "test.op"(%src, %dst, %offset_outer, %offset_inner) : (!x86.reg64<rax>, !x86.reg64<rbx>, !x86.reg64<rcx>, !x86.reg64<r10>) -> ()
+//  CHECK-NEXT:      %offset_inner_1 = x86.ds.mov %offset_inner : (!x86.reg64<r10>) -> !x86.reg64<r10>
+//  CHECK-NEXT:      %offset_inner_2 = x86.rs.add %offset_inner_1, %step_inner : (!x86.reg64<r10>, !x86.reg64<r11>) -> !x86.reg64<r10>
+//  CHECK-NEXT:      %2 = x86.ss.cmp %offset_inner_2, %forty_inner : (!x86.reg64<r10>, !x86.reg64<r12>) -> !x86.rflags<rflags>
+//  CHECK-NEXT:      x86.c.jl %2 : !x86.rflags<rflags>, ^bb2(%offset_inner_2 : !x86.reg64<r10>), ^bb3(%offset_inner_2 : !x86.reg64<r10>)
+//  CHECK-NEXT:    ^bb3(%zero_inner_end: !x86.reg64<r10>):
 //  CHECK-NEXT:      x86.label "scf_body_end_0_for"
-//  CHECK-NEXT:      %offset_outer_1 = x86.ds.mov %offset_outer : (!x86.reg64<r9>) -> !x86.reg64<r9>
-//  CHECK-NEXT:      %offset_outer_2 = x86.rs.add %offset_outer_1, %step_outer : (!x86.reg64<r9>, !x86.reg64<rdx>) -> !x86.reg64<r9>
-//  CHECK-NEXT:      %3 = x86.ss.cmp %offset_outer_2, %forty_outer : (!x86.reg64<r9>, !x86.reg64<r8>) -> !x86.rflags<rflags>
-//  CHECK-NEXT:      x86.c.jl %3 : !x86.rflags<rflags>, ^bb1(%offset_outer_2 : !x86.reg64<r9>), ^bb4(%offset_outer_2 : !x86.reg64<r9>)
-//  CHECK-NEXT:    ^bb4(%offset_outer_3: !x86.reg64<r9>):
+//  CHECK-NEXT:      %offset_outer_1 = x86.ds.mov %offset_outer : (!x86.reg64<rcx>) -> !x86.reg64<rcx>
+//  CHECK-NEXT:      %offset_outer_2 = x86.rs.add %offset_outer_1, %step_outer : (!x86.reg64<rcx>, !x86.reg64<rdx>) -> !x86.reg64<rcx>
+//  CHECK-NEXT:      %3 = x86.ss.cmp %offset_outer_2, %forty_outer : (!x86.reg64<rcx>, !x86.reg64<r8>) -> !x86.rflags<rflags>
+//  CHECK-NEXT:      x86.c.jl %3 : !x86.rflags<rflags>, ^bb1(%offset_outer_2 : !x86.reg64<rcx>), ^bb4(%offset_outer_2 : !x86.reg64<rcx>)
+//  CHECK-NEXT:    ^bb4(%zero_outer_end: !x86.reg64<rcx>):
 //  CHECK-NEXT:      x86.label "scf_body_end_1_for"
 //  CHECK-NEXT:      x86_func.ret
 //  CHECK-NEXT:    }
@@ -72,12 +69,12 @@ x86_func.func @nested(%src: !x86.reg64<rax>, %dst: !x86.reg64<rbx>) {
     %zero_outer = x86.di.mov 0 : () -> !x86.reg64<rcx>
     %step_outer = x86.di.mov 4 : () -> !x86.reg64<rdx>
     %forty_outer = x86.di.mov 40 : () -> !x86.reg64<r8>
-    x86_scf.for %offset_outer : !x86.reg64<r9> = %zero_outer to %forty_outer step %step_outer {
+    %zero_outer_end = x86_scf.for %offset_outer : !x86.reg64<rcx> = %zero_outer to %forty_outer step %step_outer {
         %zero_inner = x86.di.mov 0 : () -> !x86.reg64<r10>
         %step_inner = x86.di.mov 2 : () -> !x86.reg64<r11>
         %forty_inner = x86.di.mov 40 : () -> !x86.reg64<r12>
-        x86_scf.for %offset_inner : !x86.reg64<r13> = %zero_inner to %forty_inner step %step_inner {
-            "test.op"(%src, %dst, %offset_outer, %offset_inner) : (!x86.reg64<rax>, !x86.reg64<rbx>, !x86.reg64<r9>, !x86.reg64<r13>) -> ()
+        %zero_inner_end = x86_scf.for %offset_inner : !x86.reg64<r10> = %zero_inner to %forty_inner step %step_inner {
+            "test.op"(%src, %dst, %offset_outer, %offset_inner) : (!x86.reg64<rax>, !x86.reg64<rbx>, !x86.reg64<rcx>, !x86.reg64<r10>) -> ()
             x86_scf.yield
         }
         x86_scf.yield
@@ -90,7 +87,7 @@ x86_func.func @nested(%src: !x86.reg64<rax>, %dst: !x86.reg64<rbx>) {
 x86_func.func @static_ub_for_fails() {
     %zero = x86.di.mov 0 : () -> !x86.reg64<rcx>
     %step = x86.di.mov 1 : () -> !x86.reg64<rdx>
-    x86_scf.for %i : !x86.reg64<r9> = %zero to 10 : si32 step %step {
+    %zero_end = x86_scf.for %i : !x86.reg64<rcx> = %zero to 10 : si32 step %step {
         x86_scf.yield
     }
     ret
@@ -102,7 +99,7 @@ x86_func.func @static_ub_for_fails() {
 x86_func.func @static_ub_for_with_iter_args_fails(%init: !x86.reg64<rax>) {
     %zero = x86.di.mov 0 : () -> !x86.reg64<rcx>
     %step = x86.di.mov 1 : () -> !x86.reg64<rdx>
-    %res = x86_scf.for %i : !x86.reg64<r9> = %zero to 20 : si32 step %step iter_args(%acc = %init) -> (!x86.reg64<rax>) {
+    %zero_end, %res = x86_scf.for %i : !x86.reg64<rcx> = %zero to 20 : si32 step %step iter_args(%acc = %init) -> (!x86.reg64<rax>) {
         x86_scf.yield %acc : !x86.reg64<rax>
     }
     "test.op"(%res) : (!x86.reg64<rax>) -> ()
@@ -115,7 +112,7 @@ x86_func.func @static_ub_for_with_iter_args_fails(%init: !x86.reg64<rax>) {
 x86_func.func @static_step_for_fails() {
     %zero = x86.di.mov 0 : () -> !x86.reg64<rcx>
     %forty = x86.di.mov 40 : () -> !x86.reg64<r8>
-    x86_scf.for %i : !x86.reg64<r9> = %zero to %forty step 1 : si32 {
+    %zero_end = x86_scf.for %i : !x86.reg64<rcx> = %zero to %forty step 1 : si32 {
         x86_scf.yield
     }
     ret
@@ -127,7 +124,7 @@ x86_func.func @static_step_for_fails() {
 x86_func.func @static_step_for_with_iter_args_fails(%init: !x86.reg64<rax>) {
     %zero = x86.di.mov 0 : () -> !x86.reg64<rcx>
     %forty = x86.di.mov 40 : () -> !x86.reg64<r8>
-    %res = x86_scf.for %i : !x86.reg64<r9> = %zero to %forty step 1 : si32 iter_args(%acc = %init) -> (!x86.reg64<rax>) {
+    %zero_end, %res = x86_scf.for %i : !x86.reg64<rcx> = %zero to %forty step 1 : si32 iter_args(%acc = %init) -> (!x86.reg64<rax>) {
         x86_scf.yield %acc : !x86.reg64<rax>
     }
     "test.op"(%res) : (!x86.reg64<rax>) -> ()

--- a/tests/filecheck/transforms/x86-regalloc-legalize-verify.mlir
+++ b/tests/filecheck/transforms/x86-regalloc-legalize-verify.mlir
@@ -9,83 +9,114 @@ x86_func.func @live_inout() {
   x86_func.ret
 }
 
-// CHECK-LABEL: @live_inout
-// CHECK:         %a_1 = x86.ds.mov %a
-// CHECK:         %b = x86.rs.add %a_1, %imm
-// CHECK:         %c = x86.rs.add %a, %b
+// CHECK-LABEL: x86_func.func @live_inout() {
+// CHECK-NEXT:    %a = x86.di.mov 1 : () -> !x86.reg64
+// CHECK-NEXT:    %imm = x86.di.mov 2 : () -> !x86.reg64
+// CHECK-NEXT:    %a_1 = x86.ds.mov %a : (!x86.reg64) -> !x86.reg64
+// CHECK-NEXT:    %b = x86.rs.add %a_1, %imm : (!x86.reg64, !x86.reg64) -> !x86.reg64
+// CHECK-NEXT:    %c = x86.rs.add %a, %b : (!x86.reg64, !x86.reg64) -> !x86.reg64
+// CHECK-NEXT:    x86_func.ret
+// CHECK-NEXT:  }
 
 // -----
 
 // V1: body use before clobber.
 x86_func.func @body_use_before_clobber(%x: !x86.reg64, %lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
-  x86_scf.for %i : !x86.reg64 = %lb to %ub step %step {
+  %lb_end = x86_scf.for %i : !x86.reg64 = %lb to %ub step %step {
     "test.op"(%x) : (!x86.reg64) -> ()
     %x2 = x86.r.inc %x : (!x86.reg64) -> !x86.reg64
   }
   x86_func.ret
 }
 
-// CHECK-LABEL: @body_use_before_clobber
-// CHECK:         x86.ds.mov %x
+// CHECK-LABEL: x86_func.func @body_use_before_clobber(%x: !x86.reg64, %lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
+// CHECK-NEXT:    %lb_end = x86_scf.for %i : !x86.reg64  = %lb to %ub step %step {
+// CHECK-NEXT:      "test.op"(%x) : (!x86.reg64) -> ()
+// CHECK-NEXT:      %x_1 = x86.ds.mov %x : (!x86.reg64) -> !x86.reg64
+// CHECK-NEXT:      %x2 = x86.r.inc %x_1 : (!x86.reg64) -> !x86.reg64
+// CHECK-NEXT:    }
+// CHECK-NEXT:    x86_func.ret
+// CHECK-NEXT:  }
 
 // -----
 
 // V2: live-in only use is clobber.
 x86_func.func @body_only_use_is_clobber(%x: !x86.reg64, %lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
-  x86_scf.for %i : !x86.reg64 = %lb to %ub step %step {
+  %lb_end = x86_scf.for %i : !x86.reg64 = %lb to %ub step %step {
     %x2 = x86.r.inc %x : (!x86.reg64) -> !x86.reg64
   }
   x86_func.ret
 }
 
-// CHECK-LABEL: @body_only_use_is_clobber
-// CHECK:         x86.ds.mov %x
+// CHECK-LABEL: x86_func.func @body_only_use_is_clobber(%x: !x86.reg64, %lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
+// CHECK-NEXT:    %lb_end = x86_scf.for %i : !x86.reg64  = %lb to %ub step %step {
+// CHECK-NEXT:      %x_1 = x86.ds.mov %x : (!x86.reg64) -> !x86.reg64
+// CHECK-NEXT:      %x2 = x86.r.inc %x_1 : (!x86.reg64) -> !x86.reg64
+// CHECK-NEXT:    }
+// CHECK-NEXT:    x86_func.ret
+// CHECK-NEXT:  }
 
 // -----
 
 // V3: IV clobbered.
 x86_func.func @iv_clobbered(%lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
-  x86_scf.for %i : !x86.reg64 = %lb to %ub step %step {
+  %lb_end = x86_scf.for %i : !x86.reg64 = %lb to %ub step %step {
     %i2 = x86.r.inc %i : (!x86.reg64) -> !x86.reg64
   }
   x86_func.ret
 }
 
-// CHECK-LABEL: @iv_clobbered
-// CHECK:         x86.ds.mov %i
+// CHECK-LABEL: x86_func.func @iv_clobbered(%lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
+// CHECK-NEXT:    %lb_end = x86_scf.for %i : !x86.reg64  = %lb to %ub step %step {
+// CHECK-NEXT:      %i_1 = x86.ds.mov %i : (!x86.reg64) -> !x86.reg64
+// CHECK-NEXT:      %i2 = x86.r.inc %i_1 : (!x86.reg64) -> !x86.reg64
+// CHECK-NEXT:    }
+// CHECK-NEXT:    x86_func.ret
+// CHECK-NEXT:  }
 
 // -----
 
 // V4: ub clobbered.
 x86_func.func @ub_clobbered(%lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
-  x86_scf.for %i : !x86.reg64 = %lb to %ub step %step {
+  %lb_end = x86_scf.for %i : !x86.reg64 = %lb to %ub step %step {
     %u2 = x86.r.inc %ub : (!x86.reg64) -> !x86.reg64
   }
   x86_func.ret
 }
 
-// CHECK-LABEL: @ub_clobbered
-// CHECK:         x86.ds.mov %ub
+// CHECK-LABEL: x86_func.func @ub_clobbered(%lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
+// CHECK-NEXT:    %lb_end = x86_scf.for %i : !x86.reg64  = %lb to %ub step %step {
+// CHECK-NEXT:      %ub_1 = x86.ds.mov %ub : (!x86.reg64) -> !x86.reg64
+// CHECK-NEXT:      %u2 = x86.r.inc %ub_1 : (!x86.reg64) -> !x86.reg64
+// CHECK-NEXT:    }
+// CHECK-NEXT:    x86_func.ret
+// CHECK-NEXT:  }
 
 // -----
 
 // V5: clobber before loop.
 x86_func.func @clobber_before_loop(%x: !x86.reg64, %lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
   %x2 = x86.r.inc %x : (!x86.reg64) -> !x86.reg64
-  x86_scf.for %i : !x86.reg64 = %lb to %ub step %step {
+  %lb_end = x86_scf.for %i : !x86.reg64 = %lb to %ub step %step {
     "test.op"(%x) : (!x86.reg64) -> ()
   }
   x86_func.ret
 }
 
-// CHECK-LABEL: @clobber_before_loop
-// CHECK:         x86.ds.mov %x
+// CHECK-LABEL: x86_func.func @clobber_before_loop(%x: !x86.reg64, %lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
+// CHECK-NEXT:    %x_1 = x86.ds.mov %x : (!x86.reg64) -> !x86.reg64
+// CHECK-NEXT:    %x2 = x86.r.inc %x_1 : (!x86.reg64) -> !x86.reg64
+// CHECK-NEXT:    %lb_end = x86_scf.for %i : !x86.reg64  = %lb to %ub step %step {
+// CHECK-NEXT:      "test.op"(%x) : (!x86.reg64) -> ()
+// CHECK-NEXT:    }
+// CHECK-NEXT:    x86_func.ret
+// CHECK-NEXT:  }
 
 // -----
 
 // V6: iter_arg live after loop.
 x86_func.func @iter_arg_live_after(%init: !x86.reg64, %lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
-  %res = x86_scf.for %i : !x86.reg64 = %lb to %ub step %step iter_args(%a = %init) -> (!x86.reg64) {
+  %lb_end, %res = x86_scf.for %i : !x86.reg64 = %lb to %ub step %step iter_args(%a = %init) -> (!x86.reg64) {
     %a2 = x86.r.inc %a : (!x86.reg64) -> !x86.reg64
     x86_scf.yield %a2 : !x86.reg64
   }
@@ -93,56 +124,84 @@ x86_func.func @iter_arg_live_after(%init: !x86.reg64, %lb: !x86.reg64, %ub: !x86
   x86_func.ret
 }
 
-// CHECK-LABEL: @iter_arg_live_after
-// CHECK:         x86.ds.mov %init
+// CHECK-LABEL: x86_func.func @iter_arg_live_after(%init: !x86.reg64, %lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
+// CHECK-NEXT:    %init_1 = x86.ds.mov %init : (!x86.reg64) -> !x86.reg64
+// CHECK-NEXT:    %lb_end, %res = x86_scf.for %i : !x86.reg64  = %lb to %ub step %step iter_args(%a = %init_1) -> (!x86.reg64) {
+// CHECK-NEXT:      %a2 = x86.r.inc %a : (!x86.reg64) -> !x86.reg64
+// CHECK-NEXT:      x86_scf.yield %a2 : !x86.reg64
+// CHECK-NEXT:    }
+// CHECK-NEXT:    "test.op"(%init) : (!x86.reg64) -> ()
+// CHECK-NEXT:    x86_func.ret
+// CHECK-NEXT:  }
 
 // -----
 
 // V7: duplicate iter_args.
 x86_func.func @duplicate_iter_args(%v: !x86.reg64, %lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
-  %r0, %r1 = x86_scf.for %i : !x86.reg64 = %lb to %ub step %step iter_args(%a = %v, %b = %v) -> (!x86.reg64, !x86.reg64) {
+  %lb_end, %r0, %r1 = x86_scf.for %i : !x86.reg64 = %lb to %ub step %step iter_args(%a = %v, %b = %v) -> (!x86.reg64, !x86.reg64) {
     x86_scf.yield %a, %b : !x86.reg64, !x86.reg64
   }
   x86_func.ret
 }
 
-// CHECK-LABEL: @duplicate_iter_args
-// CHECK:         x86.ds.mov %v
+// CHECK-LABEL: x86_func.func @duplicate_iter_args(%v: !x86.reg64, %lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
+// CHECK-NEXT:    %v_1 = x86.ds.mov %v : (!x86.reg64) -> !x86.reg64
+// CHECK-NEXT:    %lb_end, %r0, %r1 = x86_scf.for %i : !x86.reg64  = %lb to %ub step %step iter_args(%a = %v_1, %b = %v) -> (!x86.reg64, !x86.reg64) {
+// CHECK-NEXT:      x86_scf.yield %a, %b : !x86.reg64, !x86.reg64
+// CHECK-NEXT:    }
+// CHECK-NEXT:    x86_func.ret
+// CHECK-NEXT:  }
 
 // -----
 
 // Duplicate iter_args, also live after the loop.
 x86_func.func @duplicate_iter_args_live_after(%v: !x86.reg64, %lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
-  %r0, %r1 = x86_scf.for %i : !x86.reg64 = %lb to %ub step %step iter_args(%a = %v, %b = %v) -> (!x86.reg64, !x86.reg64) {
+  %lb_end, %r0, %r1 = x86_scf.for %i : !x86.reg64 = %lb to %ub step %step iter_args(%a = %v, %b = %v) -> (!x86.reg64, !x86.reg64) {
     x86_scf.yield %a, %b : !x86.reg64, !x86.reg64
   }
   "test.op"(%v) : (!x86.reg64) -> ()
   x86_func.ret
 }
 
-// CHECK-LABEL: @duplicate_iter_args_live_after
-// CHECK:         iter_args(%a = %v_1, %b = %v_2)
+// CHECK-LABEL: x86_func.func @duplicate_iter_args_live_after(%v: !x86.reg64, %lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
+// CHECK-NEXT:    %v_1 = x86.ds.mov %v : (!x86.reg64) -> !x86.reg64
+// CHECK-NEXT:    %v_2 = x86.ds.mov %v : (!x86.reg64) -> !x86.reg64
+// CHECK-NEXT:    %lb_end, %r0, %r1 = x86_scf.for %i : !x86.reg64  = %lb to %ub step %step iter_args(%a = %v_1, %b = %v_2) -> (!x86.reg64, !x86.reg64) {
+// CHECK-NEXT:      x86_scf.yield %a, %b : !x86.reg64, !x86.reg64
+// CHECK-NEXT:    }
+// CHECK-NEXT:    "test.op"(%v) : (!x86.reg64) -> ()
+// CHECK-NEXT:    x86_func.ret
+// CHECK-NEXT:  }
 
 // -----
 
 // V8: nested clobber.
 x86_func.func @nested_clobber(%x: !x86.reg64, %lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
-  x86_scf.for %i : !x86.reg64 = %lb to %ub step %step {
-    x86_scf.for %j : !x86.reg64 = %lb to %ub step %step {
+  %lb_end = x86_scf.for %i : !x86.reg64 = %lb to %ub step %step {
+    %lb_end_1 = x86_scf.for %j : !x86.reg64 = %lb to %ub step %step {
       %x2 = x86.r.inc %x : (!x86.reg64) -> !x86.reg64
     }
   }
   x86_func.ret
 }
 
-// CHECK-LABEL: @nested_clobber
-// CHECK:         x86.ds.mov %x
+// CHECK-LABEL: x86_func.func @nested_clobber(%x: !x86.reg64, %lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
+// CHECK-NEXT:    %lb_1 = x86.ds.mov %lb : (!x86.reg64) -> !x86.reg64
+// CHECK-NEXT:    %lb_end = x86_scf.for %i : !x86.reg64  = %lb_1 to %ub step %step {
+// CHECK-NEXT:      %lb_2 = x86.ds.mov %lb : (!x86.reg64) -> !x86.reg64
+// CHECK-NEXT:      %lb_end_1 = x86_scf.for %j : !x86.reg64  = %lb_2 to %ub step %step {
+// CHECK-NEXT:        %x_1 = x86.ds.mov %x : (!x86.reg64) -> !x86.reg64
+// CHECK-NEXT:        %x2 = x86.r.inc %x_1 : (!x86.reg64) -> !x86.reg64
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:    x86_func.ret
+// CHECK-NEXT:  }
 
 // -----
 
 // V11: iter_arg read after clobber in body.
 x86_func.func @iter_arg_read_after_clobber(%init: !x86.reg64, %lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
-  %res = x86_scf.for %i : !x86.reg64 = %lb to %ub step %step iter_args(%a = %init) -> (!x86.reg64) {
+  %lb_end, %res = x86_scf.for %i : !x86.reg64 = %lb to %ub step %step iter_args(%a = %init) -> (!x86.reg64) {
     %a2 = x86.r.inc %a : (!x86.reg64) -> !x86.reg64
     "test.op"(%a) : (!x86.reg64) -> ()
     x86_scf.yield %a2 : !x86.reg64
@@ -150,18 +209,49 @@ x86_func.func @iter_arg_read_after_clobber(%init: !x86.reg64, %lb: !x86.reg64, %
   x86_func.ret
 }
 
-// CHECK-LABEL: @iter_arg_read_after_clobber
-// CHECK:         x86.ds.mov %a
+// CHECK-LABEL: x86_func.func @iter_arg_read_after_clobber(%init: !x86.reg64, %lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
+// CHECK-NEXT:    %lb_end, %res = x86_scf.for %i : !x86.reg64  = %lb to %ub step %step iter_args(%a = %init) -> (!x86.reg64) {
+// CHECK-NEXT:      %a_1 = x86.ds.mov %a : (!x86.reg64) -> !x86.reg64
+// CHECK-NEXT:      %a2 = x86.r.inc %a_1 : (!x86.reg64) -> !x86.reg64
+// CHECK-NEXT:      "test.op"(%a) : (!x86.reg64) -> ()
+// CHECK-NEXT:      x86_scf.yield %a2 : !x86.reg64
+// CHECK-NEXT:    }
+// CHECK-NEXT:    x86_func.ret
+// CHECK-NEXT:  }
 
 // -----
 
 // V12: rof.
 x86_func.func @rof_body_clobber(%x: !x86.reg64, %lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
-  x86_scf.rof %i : !x86.reg64 = %ub down to %lb step %step {
+  %lb_end = x86_scf.rof %i : !x86.reg64 = %ub down to %lb step %step {
     %x2 = x86.r.inc %x : (!x86.reg64) -> !x86.reg64
   }
   x86_func.ret
 }
 
-// CHECK-LABEL: @rof_body_clobber
-// CHECK:         x86.ds.mov %x
+// CHECK-LABEL: x86_func.func @rof_body_clobber(%x: !x86.reg64, %lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
+// CHECK-NEXT:    %lb_end = x86_scf.rof %i : !x86.reg64  = %ub down  to %lb step %step {
+// CHECK-NEXT:      %x_1 = x86.ds.mov %x : (!x86.reg64) -> !x86.reg64
+// CHECK-NEXT:      %x2 = x86.r.inc %x_1 : (!x86.reg64) -> !x86.reg64
+// CHECK-NEXT:    }
+// CHECK-NEXT:    x86_func.ret
+// CHECK-NEXT:  }
+
+// -----
+
+// lb live after loop.
+x86_func.func @lb_live_after(%lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
+  %lb_end = x86_scf.for %i : !x86.reg64 = %lb to %ub step %step {
+    x86_scf.yield
+  }
+  "test.op"(%lb) : (!x86.reg64) -> ()
+  x86_func.ret
+}
+
+// CHECK-LABEL: x86_func.func @lb_live_after(%lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
+// CHECK-NEXT:    %lb_1 = x86.ds.mov %lb : (!x86.reg64) -> !x86.reg64
+// CHECK-NEXT:    %lb_end = x86_scf.for %i : !x86.reg64  = %lb_1 to %ub step %step {
+// CHECK-NEXT:    }
+// CHECK-NEXT:    "test.op"(%lb) : (!x86.reg64) -> ()
+// CHECK-NEXT:    x86_func.ret
+// CHECK-NEXT:  }

--- a/tests/filecheck/transforms/x86-regalloc-legalize.mlir
+++ b/tests/filecheck/transforms/x86-regalloc-legalize.mlir
@@ -9,13 +9,14 @@ x86_func.func @live_inout() {
   x86_func.ret
 }
 
-// CHECK-LABEL: @live_inout
+// CHECK-LABEL: x86_func.func @live_inout() {
 // CHECK-NEXT:    %a = x86.di.mov 1 : () -> !x86.reg64
 // CHECK-NEXT:    %imm = x86.di.mov 2 : () -> !x86.reg64
 // CHECK-NEXT:    %a_1 = x86.ds.mov %a : (!x86.reg64) -> !x86.reg64
 // CHECK-NEXT:    %b = x86.rs.add %a_1, %imm : (!x86.reg64, !x86.reg64) -> !x86.reg64
 // CHECK-NEXT:    %c = x86.rs.add %a, %b : (!x86.reg64, !x86.reg64) -> !x86.reg64
 // CHECK-NEXT:    x86_func.ret
+// CHECK-NEXT:  }
 
 // -----
 
@@ -27,79 +28,94 @@ x86_func.func @last_use_inout() {
   x86_func.ret
 }
 
-// CHECK-LABEL: @last_use_inout
+// CHECK-LABEL: x86_func.func @last_use_inout() {
 // CHECK-NEXT:    %a = x86.di.mov 1 : () -> !x86.reg64
 // CHECK-NEXT:    %imm = x86.di.mov 2 : () -> !x86.reg64
 // CHECK-NEXT:    %b = x86.rs.add %a, %imm : (!x86.reg64, !x86.reg64) -> !x86.reg64
 // CHECK-NEXT:    x86_func.ret
+// CHECK-NEXT:  }
 
 // -----
 
 // L3: live-in whose only use is the clobber (same as V2).
 x86_func.func @for_outer_last_use_in_body(%x: !x86.reg64, %lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
-  x86_scf.for %i : !x86.reg64 = %lb to %ub step %step {
+  %lb_end = x86_scf.for %i : !x86.reg64 = %lb to %ub step %step {
     %x2 = x86.r.inc %x : (!x86.reg64) -> !x86.reg64
   }
   x86_func.ret
 }
 
-// CHECK-LABEL: @for_outer_last_use_in_body
-// CHECK:         x86_scf.for
+// CHECK-LABEL: x86_func.func @for_outer_last_use_in_body(%x: !x86.reg64, %lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
+// CHECK-NEXT:    %lb_end = x86_scf.for %i : !x86.reg64  = %lb to %ub step %step {
 // CHECK-NEXT:      %x_1 = x86.ds.mov %x : (!x86.reg64) -> !x86.reg64
 // CHECK-NEXT:      %x2 = x86.r.inc %x_1 : (!x86.reg64) -> !x86.reg64
+// CHECK-NEXT:    }
+// CHECK-NEXT:    x86_func.ret
+// CHECK-NEXT:  }
 
 // -----
 
 // L4: body use before the clobber (V1).
 x86_func.func @body_use_before_clobber(%x: !x86.reg64, %lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
-  x86_scf.for %i : !x86.reg64 = %lb to %ub step %step {
+  %lb_end = x86_scf.for %i : !x86.reg64 = %lb to %ub step %step {
     "test.op"(%x) : (!x86.reg64) -> ()
     %x2 = x86.r.inc %x : (!x86.reg64) -> !x86.reg64
   }
   x86_func.ret
 }
 
-// CHECK-LABEL: @body_use_before_clobber
-// CHECK:           "test.op"(%x)
+// CHECK-LABEL: x86_func.func @body_use_before_clobber(%x: !x86.reg64, %lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
+// CHECK-NEXT:    %lb_end = x86_scf.for %i : !x86.reg64  = %lb to %ub step %step {
+// CHECK-NEXT:      "test.op"(%x) : (!x86.reg64) -> ()
 // CHECK-NEXT:      %x_1 = x86.ds.mov %x : (!x86.reg64) -> !x86.reg64
 // CHECK-NEXT:      %x2 = x86.r.inc %x_1 : (!x86.reg64) -> !x86.reg64
+// CHECK-NEXT:    }
+// CHECK-NEXT:    x86_func.ret
+// CHECK-NEXT:  }
 
 // -----
 
 // L5: induction variable clobbered (V3).
 x86_func.func @iv_clobbered(%lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
-  x86_scf.for %i : !x86.reg64 = %lb to %ub step %step {
+  %lb_end = x86_scf.for %i : !x86.reg64 = %lb to %ub step %step {
     %i2 = x86.r.inc %i : (!x86.reg64) -> !x86.reg64
   }
   x86_func.ret
 }
 
-// CHECK-LABEL: @iv_clobbered
-// CHECK:           %i_1 = x86.ds.mov %i : (!x86.reg64) -> !x86.reg64
+// CHECK-LABEL: x86_func.func @iv_clobbered(%lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
+// CHECK-NEXT:    %lb_end = x86_scf.for %i : !x86.reg64  = %lb to %ub step %step {
+// CHECK-NEXT:      %i_1 = x86.ds.mov %i : (!x86.reg64) -> !x86.reg64
 // CHECK-NEXT:      %i2 = x86.r.inc %i_1 : (!x86.reg64) -> !x86.reg64
+// CHECK-NEXT:    }
+// CHECK-NEXT:    x86_func.ret
+// CHECK-NEXT:  }
 
 // -----
 
 // L6: clobber before the loop (V5).
 x86_func.func @clobber_before_loop(%x: !x86.reg64, %lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
   %x2 = x86.r.inc %x : (!x86.reg64) -> !x86.reg64
-  x86_scf.for %i : !x86.reg64 = %lb to %ub step %step {
+  %lb_end = x86_scf.for %i : !x86.reg64 = %lb to %ub step %step {
     "test.op"(%x) : (!x86.reg64) -> ()
   }
   x86_func.ret
 }
 
-// CHECK-LABEL: @clobber_before_loop
-// CHECK:         %x_1 = x86.ds.mov %x : (!x86.reg64) -> !x86.reg64
+// CHECK-LABEL: x86_func.func @clobber_before_loop(%x: !x86.reg64, %lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
+// CHECK-NEXT:    %x_1 = x86.ds.mov %x : (!x86.reg64) -> !x86.reg64
 // CHECK-NEXT:    %x2 = x86.r.inc %x_1 : (!x86.reg64) -> !x86.reg64
-// CHECK:         x86_scf.for
-// CHECK-NEXT:      "test.op"(%x)
+// CHECK-NEXT:    %lb_end = x86_scf.for %i : !x86.reg64  = %lb to %ub step %step {
+// CHECK-NEXT:      "test.op"(%x) : (!x86.reg64) -> ()
+// CHECK-NEXT:    }
+// CHECK-NEXT:    x86_func.ret
+// CHECK-NEXT:  }
 
 // -----
 
 // L7: iter_args operand live after the loop (V6).
 x86_func.func @iter_arg_live_after(%init: !x86.reg64, %lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
-  %res = x86_scf.for %i : !x86.reg64 = %lb to %ub step %step iter_args(%a = %init) -> (!x86.reg64) {
+  %lb_end, %res = x86_scf.for %i : !x86.reg64 = %lb to %ub step %step iter_args(%a = %init) -> (!x86.reg64) {
     %a2 = x86.r.inc %a : (!x86.reg64) -> !x86.reg64
     x86_scf.yield %a2 : !x86.reg64
   }
@@ -107,48 +123,63 @@ x86_func.func @iter_arg_live_after(%init: !x86.reg64, %lb: !x86.reg64, %ub: !x86
   x86_func.ret
 }
 
-// CHECK-LABEL: @iter_arg_live_after
-// CHECK:         %init_1 = x86.ds.mov %init : (!x86.reg64) -> !x86.reg64
-// CHECK:         iter_args(%a = %init_1)
-// CHECK:         "test.op"(%init)
+// CHECK-LABEL: x86_func.func @iter_arg_live_after(%init: !x86.reg64, %lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
+// CHECK-NEXT:    %init_1 = x86.ds.mov %init : (!x86.reg64) -> !x86.reg64
+// CHECK-NEXT:    %lb_end, %res = x86_scf.for %i : !x86.reg64  = %lb to %ub step %step iter_args(%a = %init_1) -> (!x86.reg64) {
+// CHECK-NEXT:      %a2 = x86.r.inc %a : (!x86.reg64) -> !x86.reg64
+// CHECK-NEXT:      x86_scf.yield %a2 : !x86.reg64
+// CHECK-NEXT:    }
+// CHECK-NEXT:    "test.op"(%init) : (!x86.reg64) -> ()
+// CHECK-NEXT:    x86_func.ret
+// CHECK-NEXT:  }
 
 // -----
 
 // L8: duplicate iter_args (V7).
 x86_func.func @duplicate_iter_args(%v: !x86.reg64, %lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
-  %r0, %r1 = x86_scf.for %i : !x86.reg64 = %lb to %ub step %step iter_args(%a = %v, %b = %v) -> (!x86.reg64, !x86.reg64) {
+  %lb_end, %r0, %r1 = x86_scf.for %i : !x86.reg64 = %lb to %ub step %step iter_args(%a = %v, %b = %v) -> (!x86.reg64, !x86.reg64) {
     x86_scf.yield %a, %b : !x86.reg64, !x86.reg64
   }
   x86_func.ret
 }
 
-// CHECK-LABEL: @duplicate_iter_args
-// CHECK:         %v_1 = x86.ds.mov %v : (!x86.reg64) -> !x86.reg64
-// CHECK:         iter_args(%a = %v_1, %b = %v)
+// CHECK-LABEL: x86_func.func @duplicate_iter_args(%v: !x86.reg64, %lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
+// CHECK-NEXT:    %v_1 = x86.ds.mov %v : (!x86.reg64) -> !x86.reg64
+// CHECK-NEXT:    %lb_end, %r0, %r1 = x86_scf.for %i : !x86.reg64  = %lb to %ub step %step iter_args(%a = %v_1, %b = %v) -> (!x86.reg64, !x86.reg64) {
+// CHECK-NEXT:      x86_scf.yield %a, %b : !x86.reg64, !x86.reg64
+// CHECK-NEXT:    }
+// CHECK-NEXT:    x86_func.ret
+// CHECK-NEXT:  }
 
 // -----
 
 // L9: nested loops (V8).
 x86_func.func @nested_clobber(%x: !x86.reg64, %lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
-  x86_scf.for %i : !x86.reg64 = %lb to %ub step %step {
-    x86_scf.for %j : !x86.reg64 = %lb to %ub step %step {
+  %lb_end = x86_scf.for %i : !x86.reg64 = %lb to %ub step %step {
+    %lb_end_1 = x86_scf.for %j : !x86.reg64 = %lb to %ub step %step {
       %x2 = x86.r.inc %x : (!x86.reg64) -> !x86.reg64
     }
   }
   x86_func.ret
 }
 
-// CHECK-LABEL: @nested_clobber
-// CHECK:         x86_scf.for
-// CHECK:           x86_scf.for
+// CHECK-LABEL: x86_func.func @nested_clobber(%x: !x86.reg64, %lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
+// CHECK-NEXT:    %lb_1 = x86.ds.mov %lb : (!x86.reg64) -> !x86.reg64
+// CHECK-NEXT:    %lb_end = x86_scf.for %i : !x86.reg64  = %lb_1 to %ub step %step {
+// CHECK-NEXT:      %lb_2 = x86.ds.mov %lb : (!x86.reg64) -> !x86.reg64
+// CHECK-NEXT:      %lb_end_1 = x86_scf.for %j : !x86.reg64  = %lb_2 to %ub step %step {
 // CHECK-NEXT:        %x_1 = x86.ds.mov %x : (!x86.reg64) -> !x86.reg64
 // CHECK-NEXT:        %x2 = x86.r.inc %x_1 : (!x86.reg64) -> !x86.reg64
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:    x86_func.ret
+// CHECK-NEXT:  }
 
 // -----
 
 // L10: accumulator pattern (V10) — no copy.
 x86_func.func @iter_arg_accumulate(%init: !x86.reg64, %lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
-  %res = x86_scf.for %i : !x86.reg64 = %lb to %ub step %step iter_args(%a = %init) -> (!x86.reg64) {
+  %lb_end, %res = x86_scf.for %i : !x86.reg64 = %lb to %ub step %step iter_args(%a = %init) -> (!x86.reg64) {
     "test.op"(%a) : (!x86.reg64) -> ()
     %a2 = x86.r.inc %a : (!x86.reg64) -> !x86.reg64
     x86_scf.yield %a2 : !x86.reg64
@@ -157,46 +188,96 @@ x86_func.func @iter_arg_accumulate(%init: !x86.reg64, %lb: !x86.reg64, %ub: !x86
   x86_func.ret
 }
 
-// CHECK-LABEL: @iter_arg_accumulate
-// CHECK-NOT:     x86.ds.mov
+// CHECK-LABEL: x86_func.func @iter_arg_accumulate(%init: !x86.reg64, %lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
+// CHECK-NEXT:    %lb_end, %res = x86_scf.for %i : !x86.reg64  = %lb to %ub step %step iter_args(%a = %init) -> (!x86.reg64) {
+// CHECK-NEXT:      "test.op"(%a) : (!x86.reg64) -> ()
+// CHECK-NEXT:      %a2 = x86.r.inc %a : (!x86.reg64) -> !x86.reg64
+// CHECK-NEXT:      x86_scf.yield %a2 : !x86.reg64
+// CHECK-NEXT:    }
+// CHECK-NEXT:    "test.op"(%res) : (!x86.reg64) -> ()
+// CHECK-NEXT:    x86_func.ret
+// CHECK-NEXT:  }
 
 // -----
 
 // L11: rof (V12).
 x86_func.func @rof_body_clobber(%x: !x86.reg64, %lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
-  x86_scf.rof %i : !x86.reg64 = %ub down to %lb step %step {
+  %lb_end = x86_scf.rof %i : !x86.reg64 = %ub down to %lb step %step {
     %x2 = x86.r.inc %x : (!x86.reg64) -> !x86.reg64
   }
   x86_func.ret
 }
 
-// CHECK-LABEL: @rof_body_clobber
-// CHECK:           %x_1 = x86.ds.mov %x : (!x86.reg64) -> !x86.reg64
+// CHECK-LABEL: x86_func.func @rof_body_clobber(%x: !x86.reg64, %lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
+// CHECK-NEXT:    %lb_end = x86_scf.rof %i : !x86.reg64  = %ub down  to %lb step %step {
+// CHECK-NEXT:      %x_1 = x86.ds.mov %x : (!x86.reg64) -> !x86.reg64
 // CHECK-NEXT:      %x2 = x86.r.inc %x_1 : (!x86.reg64) -> !x86.reg64
+// CHECK-NEXT:    }
+// CHECK-NEXT:    x86_func.ret
+// CHECK-NEXT:  }
 
 // -----
 
 // L12: duplicate iter_args, also live after the loop: both slots need a copy.
 x86_func.func @duplicate_iter_args_live_after(%v: !x86.reg64, %lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
-  %r0, %r1 = x86_scf.for %i : !x86.reg64 = %lb to %ub step %step iter_args(%a = %v, %b = %v) -> (!x86.reg64, !x86.reg64) {
+  %lb_end, %r0, %r1 = x86_scf.for %i : !x86.reg64 = %lb to %ub step %step iter_args(%a = %v, %b = %v) -> (!x86.reg64, !x86.reg64) {
     x86_scf.yield %a, %b : !x86.reg64, !x86.reg64
   }
   "test.op"(%v) : (!x86.reg64) -> ()
   x86_func.ret
 }
 
-// CHECK-LABEL: @duplicate_iter_args_live_after
-// CHECK:         %v_1 = x86.ds.mov %v : (!x86.reg64) -> !x86.reg64
+// CHECK-LABEL: x86_func.func @duplicate_iter_args_live_after(%v: !x86.reg64, %lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
+// CHECK-NEXT:    %v_1 = x86.ds.mov %v : (!x86.reg64) -> !x86.reg64
 // CHECK-NEXT:    %v_2 = x86.ds.mov %v : (!x86.reg64) -> !x86.reg64
-// CHECK:         iter_args(%a = %v_1, %b = %v_2)
-// CHECK:         "test.op"(%v)
+// CHECK-NEXT:    %lb_end, %r0, %r1 = x86_scf.for %i : !x86.reg64  = %lb to %ub step %step iter_args(%a = %v_1, %b = %v_2) -> (!x86.reg64, !x86.reg64) {
+// CHECK-NEXT:      x86_scf.yield %a, %b : !x86.reg64, !x86.reg64
+// CHECK-NEXT:    }
+// CHECK-NEXT:    "test.op"(%v) : (!x86.reg64) -> ()
+// CHECK-NEXT:    x86_func.ret
+// CHECK-NEXT:  }
+
+// -----
+
+// L13: lb live after the loop — copy before for; original lb still used after.
+x86_func.func @lb_live_after(%lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
+  %lb_end = x86_scf.for %i : !x86.reg64 = %lb to %ub step %step {
+    x86_scf.yield
+  }
+  "test.op"(%lb) : (!x86.reg64) -> ()
+  x86_func.ret
+}
+
+// CHECK-LABEL: x86_func.func @lb_live_after(%lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
+// CHECK-NEXT:    %lb_1 = x86.ds.mov %lb : (!x86.reg64) -> !x86.reg64
+// CHECK-NEXT:    %lb_end = x86_scf.for %i : !x86.reg64  = %lb_1 to %ub step %step {
+// CHECK-NEXT:    }
+// CHECK-NEXT:    "test.op"(%lb) : (!x86.reg64) -> ()
+// CHECK-NEXT:    x86_func.ret
+// CHECK-NEXT:  }
+
+// -----
+
+// L14: lb last use — no copy.
+x86_func.func @lb_last_use(%lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
+  %lb_end = x86_scf.for %i : !x86.reg64 = %lb to %ub step %step {
+    x86_scf.yield
+  }
+  x86_func.ret
+}
+
+// CHECK-LABEL: x86_func.func @lb_last_use(%lb: !x86.reg64, %ub: !x86.reg64, %step: !x86.reg64) {
+// CHECK-NEXT:    %lb_end = x86_scf.for %i : !x86.reg64  = %lb to %ub step %step {
+// CHECK-NEXT:    }
+// CHECK-NEXT:    x86_func.ret
+// CHECK-NEXT:  }
 
 // -----
 
 // External / empty function declaration is a no-op.
 x86_func.func @external(%ptr: !x86.reg64)
 
-// CHECK-LABEL: @external
+// CHECK-LABEL: x86_func.func @external(!x86.reg64) -> ()
 
 // -----
 

--- a/xdsl/dialects/x86_scf.py
+++ b/xdsl/dialects/x86_scf.py
@@ -31,6 +31,7 @@ from xdsl.irdl import (
     opt_operand_def,
     opt_prop_def,
     region_def,
+    result_def,
     traits_def,
     var_operand_def,
     var_result_def,
@@ -69,6 +70,9 @@ class ForRofOperation(X86HasRegisterConstraints, ABC):
     step_attr = opt_prop_def(IntegerAttr[SI32])
 
     iter_args = var_operand_def(X86RegisterType)
+
+    lb_end = result_def(GeneralRegisterType)
+    """Final value of the lower-bound / induction-variable register (inout with `lb`)."""
 
     res = var_result_def(X86RegisterType)
 
@@ -133,7 +137,7 @@ class ForRofOperation(X86HasRegisterConstraints, ABC):
         super().__init__(
             operands=[lb, ub_val, step_val, iter_args],
             properties={"ub_attr": ub_attr, "step_attr": step_attr},
-            result_types=[[SSAValue.get(a).type for a in iter_args]],
+            result_types=[lb.type, [SSAValue.get(a).type for a in iter_args]],
             regions=[body],
         )
 
@@ -159,6 +163,16 @@ class ForRofOperation(X86HasRegisterConstraints, ABC):
                 raise VerifyException(
                     f"The first block argument of the body is of type {iter_var.type}"
                     " instead of x86 GeneralRegisterType"
+                )
+            if iter_var.type != self.lb.type:
+                raise VerifyException(
+                    f"Expected induction var to be same type as lb, "
+                    f"got {iter_var.type} and {self.lb.type}"
+                )
+            if iter_var.type != self.lb_end.type:
+                raise VerifyException(
+                    f"Expected induction var to be same type as lb_end result, "
+                    f"got {iter_var.type} and {self.lb_end.type}"
                 )
         for idx, (arg, block_arg) in enumerate(
             zip(self.iter_args, self.body.block.args[1:])
@@ -186,6 +200,7 @@ class ForRofOperation(X86HasRegisterConstraints, ABC):
                     )
 
     def allocate_registers(self, allocator: BlockAllocator) -> None:
+        """Allocate loop-carried and IV registers, then the body under those reservations."""
         # Allocate values used inside the body but defined outside.
         # Their scope lasts for the whole body execution scope
         live_ins = allocator.live_ins_per_block[self.body.block]
@@ -201,14 +216,13 @@ class ForRofOperation(X86HasRegisterConstraints, ABC):
         # The loop-carried variables are trickier
         # The for op operand, block arg, and yield operand must have the same type
         for block_arg, operand, yield_operand, op_result in zip(
-            block_args[1:], self.iter_args, yield_op.operands, self.results
+            block_args[1:], self.iter_args, yield_op.operands, self.res, strict=True
         ):
             allocator.allocate_values_same_reg(
                 (block_arg, operand, yield_operand, op_result)
             )
 
-        # Induction variable
-        allocator.allocate_value(block_args[0])
+        allocator.allocate_values_same_reg((block_args[0], self.lb, self.lb_end))
 
         # ub and step are used throughout loop when dynamic
         if self.ub_val is not None:
@@ -223,18 +237,15 @@ class ForRofOperation(X86HasRegisterConstraints, ABC):
         with allocator.available_registers.reserve_registers(regs):
             allocator.allocate_block(self.body.block)
 
-        # lb is only used as an input to the loop, so free induction variable before
-        # allocating lb to it in case it's not yet allocated
-        allocator.free_value(self.body.block.args[0])
-        allocator.allocate_value(self.lb)
-
     def get_register_constraints(self) -> RegisterConstraints:
-        ins = [self.lb]
+        """`lb` and each iter_arg are inout; dynamic `ub`/`step` are in-only."""
+        ins: list[SSAValue] = []
         if self.ub_val is not None:
             ins.append(self.ub_val)
         if self.step_val is not None:
             ins.append(self.step_val)
-        return RegisterConstraints(ins, (), tuple(zip(self.iter_args, self.results)))
+        inouts = ((self.lb, self.lb_end), *zip(self.iter_args, self.res, strict=True))
+        return RegisterConstraints(ins, (), inouts)
 
     def _body_live_outs(self, live_after: AbstractSet[SSAValue]) -> set[SSAValue]:
         """

--- a/xdsl/transforms/convert_scf_to_x86_scf.py
+++ b/xdsl/transforms/convert_scf_to_x86_scf.py
@@ -56,11 +56,13 @@ class ScfForLowering(RewritePattern):
         cast_op_results(rewriter, op)
 
         new_op = rewriter.insert(x86_scf.ForOp(lb, ub, step, values, new_region))
+        if lb.name_hint is not None:
+            new_op.lb_end.name_hint = f"{lb.name_hint}_end"
         rewriter.insertion_point = InsertPoint.after(op)
 
         res_values = tuple(
             builtin.UnrealizedConversionCastOp.cast_one(res_value, res_value_type)
-            for res_value, res_value_type in zip(new_op.results, op.results.types)
+            for res_value, res_value_type in zip(new_op.res, op.results.types)
         )
 
         for res, (cast_op, result) in zip(op.results, res_values):

--- a/xdsl/transforms/convert_x86_scf_to_x86.py
+++ b/xdsl/transforms/convert_x86_scf_to_x86.py
@@ -138,28 +138,25 @@ class LowerX86ScfForPattern(RewritePattern):
 
         mv_op.destination.name_hint = iv.name_hint
         step_op.register_out.name_hint = iv.name_hint
-        end_block.args[0].name_hint = iv.name_hint
+        end_block.args[0].name_hint = op.lb_end.name_hint
 
         rewriter.inline_region(op.body, BlockInsertPoint.before(end_block))
 
-        # Move lb to new register to initialize the iv.
         # Skip for loop if condition is not satisfied at start.
+        # lb is the IV register (inout); legalization inserts a copy when needed.
         rewriter.insert(
             (
-                mv_op := x86.ops.DS_MovOp(op.lb, destination=iv_reg),
-                cmp_op := x86.ops.SS_CmpOp(mv_op.destination, ub, result=RFLAGS),
+                cmp_op := x86.ops.SS_CmpOp(op.lb, ub, result=RFLAGS),
                 x86.ops.C_JgeOp(
                     cmp_op.result,
-                    (mv_op.destination, *op.iter_args),
-                    (mv_op.destination, *op.iter_args),
+                    (op.lb, *op.iter_args),
+                    (op.lb, *op.iter_args),
                     end_block,
                     first_body_block,
                 ),
             ),
             InsertPoint.at_end(init_block),
         )
-
-        mv_op.destination.name_hint = op.lb.name_hint
 
         # Insert label at the start of the first body block.
         rewriter.insert(
@@ -171,7 +168,7 @@ class LowerX86ScfForPattern(RewritePattern):
         rewriter.replace(
             op,
             x86.ops.LabelOp(f"scf_body_end_{suffix}"),
-            end_block.args[1:],
+            end_block.args,
         )
 
 


### PR DESCRIPTION
The operation modifies the contents of the register, so we should provide a value at the end of the loop representing the contents of the register at the end. Unfortunately involves a bunch of changes that are hard to separate, notably that we don't insert a defensive move when lowering scf to x86_scf, instead requiring that clients run x86-regalloc-legalize before register allocation.
