### PR TITLE
documentation: fix link to SCF dialect

### DIFF
--- a/docs/notebooks/mlir_ir.py
+++ b/docs/notebooks/mlir_ir.py
@@ -256,7 +256,7 @@ def _(mo):
 
 @app.cell(hide_code=True)
 def _(mo):
-    mo.md(r"""The [`scf` dialect](https://mlir.llvm.org/docs/Dialects/Scf/) contains operations for structured control flow.""")
+    mo.md(r"""The [`scf` dialect](https://mlir.llvm.org/docs/Dialects/SCFDialect/) contains operations for structured control flow.""")
     return
 
 


### PR DESCRIPTION
This PR fixes a broken link to the SCF dialect in the [Func, Arith, and SCF Dialects](https://docs.xdsl.dev/notebooks/html/mlir_ir/) notebook.

CC: @superlopuh @alexarice