### PR TITLE
transformations: (convert-x86-scf-to-x86) skip unnecessary moves

### DIFF
--- a/tests/filecheck/transforms/convert-x86-scf-to-x86.mlir
+++ b/tests/filecheck/transforms/convert-x86-scf-to-x86.mlir
@@ -10,10 +10,9 @@
 //  CHECK-NEXT:    ^bb1(%offset: !x86.reg64<rcx>):
 //  CHECK-NEXT:      x86.label "scf_body_0_for"
 //  CHECK-NEXT:      "test.op"(%offset, %src, %dst) : (!x86.reg64<rcx>, !x86.reg64<rax>, !x86.reg64<rbx>) -> ()
-//  CHECK-NEXT:      %offset_1 = x86.ds.mov %offset : (!x86.reg64<rcx>) -> !x86.reg64<rcx>
-//  CHECK-NEXT:      %offset_2 = x86.rs.add %offset_1, %step : (!x86.reg64<rcx>, !x86.reg64<rdx>) -> !x86.reg64<rcx>
-//  CHECK-NEXT:      %1 = x86.ss.cmp %offset_2, %forty : (!x86.reg64<rcx>, !x86.reg64<r8>) -> !x86.rflags<rflags>
-//  CHECK-NEXT:      x86.c.jl %1 : !x86.rflags<rflags>, ^bb1(%offset_2 : !x86.reg64<rcx>), ^bb2(%offset_2 : !x86.reg64<rcx>)
+//  CHECK-NEXT:      %offset_1 = x86.rs.add %offset, %step : (!x86.reg64<rcx>, !x86.reg64<rdx>) -> !x86.reg64<rcx>
+//  CHECK-NEXT:      %1 = x86.ss.cmp %offset_1, %forty : (!x86.reg64<rcx>, !x86.reg64<r8>) -> !x86.rflags<rflags>
+//  CHECK-NEXT:      x86.c.jl %1 : !x86.rflags<rflags>, ^bb1(%offset_1 : !x86.reg64<rcx>), ^bb2(%offset_1 : !x86.reg64<rcx>)
 //  CHECK-NEXT:    ^bb2(%zero_end: !x86.reg64<rcx>):
 //  CHECK-NEXT:      x86.label "scf_body_end_0_for"
 //  CHECK-NEXT:      x86_func.ret
@@ -47,16 +46,14 @@ x86_func.func @copy10(%src: !x86.reg64<rax>, %dst: !x86.reg64<rbx>) {
 //  CHECK-NEXT:    ^bb2(%offset_inner: !x86.reg64<r10>):
 //  CHECK-NEXT:      x86.label "scf_body_0_for"
 //  CHECK-NEXT:      "test.op"(%src, %dst, %offset_outer, %offset_inner) : (!x86.reg64<rax>, !x86.reg64<rbx>, !x86.reg64<rcx>, !x86.reg64<r10>) -> ()
-//  CHECK-NEXT:      %offset_inner_1 = x86.ds.mov %offset_inner : (!x86.reg64<r10>) -> !x86.reg64<r10>
-//  CHECK-NEXT:      %offset_inner_2 = x86.rs.add %offset_inner_1, %step_inner : (!x86.reg64<r10>, !x86.reg64<r11>) -> !x86.reg64<r10>
-//  CHECK-NEXT:      %2 = x86.ss.cmp %offset_inner_2, %forty_inner : (!x86.reg64<r10>, !x86.reg64<r12>) -> !x86.rflags<rflags>
-//  CHECK-NEXT:      x86.c.jl %2 : !x86.rflags<rflags>, ^bb2(%offset_inner_2 : !x86.reg64<r10>), ^bb3(%offset_inner_2 : !x86.reg64<r10>)
+//  CHECK-NEXT:      %offset_inner_1 = x86.rs.add %offset_inner, %step_inner : (!x86.reg64<r10>, !x86.reg64<r11>) -> !x86.reg64<r10>
+//  CHECK-NEXT:      %2 = x86.ss.cmp %offset_inner_1, %forty_inner : (!x86.reg64<r10>, !x86.reg64<r12>) -> !x86.rflags<rflags>
+//  CHECK-NEXT:      x86.c.jl %2 : !x86.rflags<rflags>, ^bb2(%offset_inner_1 : !x86.reg64<r10>), ^bb3(%offset_inner_1 : !x86.reg64<r10>)
 //  CHECK-NEXT:    ^bb3(%zero_inner_end: !x86.reg64<r10>):
 //  CHECK-NEXT:      x86.label "scf_body_end_0_for"
-//  CHECK-NEXT:      %offset_outer_1 = x86.ds.mov %offset_outer : (!x86.reg64<rcx>) -> !x86.reg64<rcx>
-//  CHECK-NEXT:      %offset_outer_2 = x86.rs.add %offset_outer_1, %step_outer : (!x86.reg64<rcx>, !x86.reg64<rdx>) -> !x86.reg64<rcx>
-//  CHECK-NEXT:      %3 = x86.ss.cmp %offset_outer_2, %forty_outer : (!x86.reg64<rcx>, !x86.reg64<r8>) -> !x86.rflags<rflags>
-//  CHECK-NEXT:      x86.c.jl %3 : !x86.rflags<rflags>, ^bb1(%offset_outer_2 : !x86.reg64<rcx>), ^bb4(%offset_outer_2 : !x86.reg64<rcx>)
+//  CHECK-NEXT:      %offset_outer_1 = x86.rs.add %offset_outer, %step_outer : (!x86.reg64<rcx>, !x86.reg64<rdx>) -> !x86.reg64<rcx>
+//  CHECK-NEXT:      %3 = x86.ss.cmp %offset_outer_1, %forty_outer : (!x86.reg64<rcx>, !x86.reg64<r8>) -> !x86.rflags<rflags>
+//  CHECK-NEXT:      x86.c.jl %3 : !x86.rflags<rflags>, ^bb1(%offset_outer_1 : !x86.reg64<rcx>), ^bb4(%offset_outer_1 : !x86.reg64<rcx>)
 //  CHECK-NEXT:    ^bb4(%zero_outer_end: !x86.reg64<rcx>):
 //  CHECK-NEXT:      x86.label "scf_body_end_1_for"
 //  CHECK-NEXT:      x86_func.ret

--- a/xdsl/transforms/convert_x86_scf_to_x86.py
+++ b/xdsl/transforms/convert_x86_scf_to_x86.py
@@ -98,7 +98,6 @@ class LowerX86ScfForPattern(RewritePattern):
         # Get the induction variable and its register
         iv = first_body_block.args[0]
         assert isa(iv, SSAValue[GeneralRegisterType])
-        iv_reg = iv.type
         ub = op.ub
         if not isinstance(ub, SSAValue):
             raise PassFailedException(
@@ -114,16 +113,13 @@ class LowerX86ScfForPattern(RewritePattern):
         # comparison with upper bound, and conditionally branch back into the body.
         yield_op = last_body_block.last_op
         assert isinstance(yield_op, x86_scf.YieldOp)
-
-        mv_op = x86.ops.DS_MovOp(iv, destination=iv_reg)
-        step_op = x86.ops.RS_AddOp(mv_op.destination, step)
+        step_op = x86.ops.RS_AddOp(iv, step)
         new_iv = step_op.register_out
         cmp_op = x86.ops.SS_CmpOp(new_iv, ub, result=RFLAGS)
 
         rewriter.replace(
             yield_op,
             (
-                mv_op,
                 step_op,
                 cmp_op,
                 x86.ops.C_JlOp(
@@ -136,7 +132,6 @@ class LowerX86ScfForPattern(RewritePattern):
             ),
         )
 
-        mv_op.destination.name_hint = iv.name_hint
         step_op.register_out.name_hint = iv.name_hint
         end_block.args[0].name_hint = op.lb_end.name_hint
 


### PR DESCRIPTION
I accidentally missed this move, which just moves from a register to itself, unnecessarily.