### PR TITLE
dialects: (x86) RFLAGSRegisterType is always RFLAGS

### DIFF
--- a/xdsl/dialects/x86/ops.py
+++ b/xdsl/dialects/x86/ops.py
@@ -115,7 +115,6 @@ from .registers import (
     AVX512RegisterType,
     GeneralRegisterType,
     Reg32Type,
-    RFLAGSRegisterType,
     X86RegisterType,
     X86VectorRegisterType,
 )
@@ -2866,7 +2865,7 @@ class SS_CmpOp(X86Instruction):
     source1 = operand_def(X86RegisterType)
     source2 = operand_def(X86RegisterType)
 
-    result = result_def(RFLAGSRegisterType)
+    result = result_def(RFLAGS)
 
     assembly_format = (
         "$source1 `,` $source2 attr-dict `:` "
@@ -2879,7 +2878,6 @@ class SS_CmpOp(X86Instruction):
         source2: Operation | SSAValue,
         *,
         comment: str | StringAttr | None = None,
-        result: RFLAGSRegisterType,
     ):
         if isinstance(comment, str):
             comment = StringAttr(comment)
@@ -2889,7 +2887,7 @@ class SS_CmpOp(X86Instruction):
             attributes={
                 "comment": comment,
             },
-            result_types=[result],
+            result_types=[RFLAGS],
         )
 
     def assembly_line_args(self) -> tuple[AssemblyInstructionArg | None, ...]:
@@ -2911,7 +2909,7 @@ class SM_CmpOp(X86Instruction):
     memory = operand_def(GeneralRegisterType)
     memory_offset = attr_def(IntegerAttr[I64], default_value=IntegerAttr(0, i64))
 
-    result = result_def(RFLAGSRegisterType)
+    result = result_def(RFLAGS)
 
     traits = traits_def(MemoryReadEffect())
 
@@ -2927,7 +2925,6 @@ class SM_CmpOp(X86Instruction):
         memory_offset: int | IntegerAttr,
         *,
         comment: str | StringAttr | None = None,
-        result: RFLAGSRegisterType,
     ):
         if isinstance(memory_offset, int):
             memory_offset = IntegerAttr(memory_offset, i64)
@@ -2940,7 +2937,7 @@ class SM_CmpOp(X86Instruction):
                 "memory_offset": memory_offset,
                 "comment": comment,
             },
-            result_types=[result],
+            result_types=[RFLAGS],
         )
 
     def assembly_line_args(self) -> tuple[AssemblyInstructionArg | None, ...]:
@@ -3008,7 +3005,7 @@ class MS_CmpOp(X86Instruction):
     memory_offset = attr_def(IntegerAttr[I64], default_value=IntegerAttr(0, i64))
     source = operand_def(GeneralRegisterType)
 
-    result = result_def(RFLAGSRegisterType)
+    result = result_def(RFLAGS)
 
     traits = traits_def(MemoryReadEffect())
 
@@ -3024,7 +3021,6 @@ class MS_CmpOp(X86Instruction):
         memory_offset: int | IntegerAttr,
         *,
         comment: str | StringAttr | None = None,
-        result: RFLAGSRegisterType,
     ):
         if isinstance(memory_offset, int):
             memory_offset = IntegerAttr(memory_offset, i64)
@@ -3037,7 +3033,7 @@ class MS_CmpOp(X86Instruction):
                 "memory_offset": memory_offset,
                 "comment": comment,
             },
-            result_types=[result],
+            result_types=[RFLAGS],
         )
 
     def assembly_line_args(self) -> tuple[AssemblyInstructionArg | None, ...]:
@@ -3060,7 +3056,7 @@ class MI_CmpOp(X86Instruction):
     memory_offset = attr_def(IntegerAttr[SI64], default_value=IntegerAttr(0, si64))
     immediate = attr_def(IntegerAttr[SI32])
 
-    result = result_def(RFLAGSRegisterType)
+    result = result_def(RFLAGS)
 
     traits = traits_def(MemoryReadEffect())
 
@@ -3076,7 +3072,6 @@ class MI_CmpOp(X86Instruction):
         immediate: int | IntegerAttr[SI32],
         *,
         comment: str | StringAttr | None = None,
-        result: RFLAGSRegisterType,
     ):
         if isinstance(immediate, int):
             immediate = IntegerAttr(immediate, si32)
@@ -3092,7 +3087,7 @@ class MI_CmpOp(X86Instruction):
                 "memory_offset": memory_offset,
                 "comment": comment,
             },
-            result_types=[result],
+            result_types=[RFLAGS],
         )
 
     def assembly_line_args(self) -> tuple[AssemblyInstructionArg | None, ...]:

--- a/xdsl/transforms/convert_x86_scf_to_x86.py
+++ b/xdsl/transforms/convert_x86_scf_to_x86.py
@@ -1,6 +1,6 @@
 from xdsl.context import Context
 from xdsl.dialects import builtin, x86, x86_scf
-from xdsl.dialects.x86.registers import RFLAGS, GeneralRegisterType
+from xdsl.dialects.x86.registers import GeneralRegisterType
 from xdsl.ir import SSAValue
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
@@ -118,7 +118,7 @@ class LowerX86ScfForPattern(RewritePattern):
         mv_op = x86.ops.DS_MovOp(iv, destination=iv_reg)
         step_op = x86.ops.RS_AddOp(mv_op.destination, step)
         new_iv = step_op.register_out
-        cmp_op = x86.ops.SS_CmpOp(new_iv, ub, result=RFLAGS)
+        cmp_op = x86.ops.SS_CmpOp(new_iv, ub)
 
         rewriter.replace(
             yield_op,
@@ -146,7 +146,7 @@ class LowerX86ScfForPattern(RewritePattern):
         # lb is the IV register (inout); legalization inserts a copy when needed.
         rewriter.insert(
             (
-                cmp_op := x86.ops.SS_CmpOp(op.lb, ub, result=RFLAGS),
+                cmp_op := x86.ops.SS_CmpOp(op.lb, ub),
                 x86.ops.C_JgeOp(
                     cmp_op.result,
                     (op.lb, *op.iter_args),


### PR DESCRIPTION
We're inconsistent here, some of the ops that deal with the register ask the user to provide the register type when initializing, some don't, but actually we never need it as there's only one rflags register.