### PR TITLE
transformations: (convert-x86-scf-to-x86) support static bounds

### DIFF
--- a/tests/filecheck/transforms/convert-x86-scf-to-x86.mlir
+++ b/tests/filecheck/transforms/convert-x86-scf-to-x86.mlir
@@ -80,8 +80,21 @@ x86_func.func @nested(%src: !x86.reg64<rax>, %dst: !x86.reg64<rbx>) {
 }
 
 // -----
-// Static upper bound is currently unsupported by this lowering.
-x86_func.func @static_ub_for_fails() {
+// CHECK-LABEL:    x86_func.func @static_ub_dynamic_step() {
+//  CHECK-NEXT:      %zero = x86.di.mov 0 : () -> !x86.reg64<rcx>
+//  CHECK-NEXT:      %step = x86.di.mov 1 : () -> !x86.reg64<rdx>
+//  CHECK-NEXT:      %0 = x86.si.cmp %zero, 10 : (!x86.reg64<rcx>) -> !x86.rflags<rflags>
+//  CHECK-NEXT:      x86.c.jge %0 : !x86.rflags<rflags>, ^bb2(%zero : !x86.reg64<rcx>), ^bb1(%zero : !x86.reg64<rcx>)
+//  CHECK-NEXT:    ^bb1(%i: !x86.reg64<rcx>):
+//  CHECK-NEXT:      x86.label "scf_body_0_for"
+//  CHECK-NEXT:      %i_1 = x86.rs.add %i, %step : (!x86.reg64<rcx>, !x86.reg64<rdx>) -> !x86.reg64<rcx>
+//  CHECK-NEXT:      %1 = x86.si.cmp %i_1, 10 : (!x86.reg64<rcx>) -> !x86.rflags<rflags>
+//  CHECK-NEXT:      x86.c.jl %1 : !x86.rflags<rflags>, ^bb1(%i_1 : !x86.reg64<rcx>), ^bb2(%i_1 : !x86.reg64<rcx>)
+//  CHECK-NEXT:    ^bb2(%zero_end: !x86.reg64<rcx>):
+//  CHECK-NEXT:      x86.label "scf_body_end_0_for"
+//  CHECK-NEXT:      x86_func.ret
+//  CHECK-NEXT:    }
+x86_func.func @static_ub_dynamic_step() {
     %zero = x86.di.mov 0 : () -> !x86.reg64<rcx>
     %step = x86.di.mov 1 : () -> !x86.reg64<rdx>
     %zero_end = x86_scf.for %i : !x86.reg64<rcx> = %zero to 10 : si32 step %step {
@@ -89,42 +102,49 @@ x86_func.func @static_ub_for_fails() {
     }
     ret
 }
-// CHECK: convert-x86-scf-to-x86 expects x86_scf.for upper bound to be an SSAValue
 
 // -----
-// Static upper bound remains unsupported even with iter_args.
-x86_func.func @static_ub_for_with_iter_args_fails(%init: !x86.reg64<rax>) {
+// CHECK-LABEL:    x86_func.func @dynamic_ub_static_step() {
+//  CHECK-NEXT:      %zero = x86.di.mov 0 : () -> !x86.reg64<rcx>
+//  CHECK-NEXT:      %ub = x86.di.mov 20 : () -> !x86.reg64<r8>
+//  CHECK-NEXT:      %0 = x86.ss.cmp %zero, %ub : (!x86.reg64<rcx>, !x86.reg64<r8>) -> !x86.rflags<rflags>
+//  CHECK-NEXT:      x86.c.jge %0 : !x86.rflags<rflags>, ^bb2(%zero : !x86.reg64<rcx>), ^bb1(%zero : !x86.reg64<rcx>)
+//  CHECK-NEXT:    ^bb1(%i: !x86.reg64<rcx>):
+//  CHECK-NEXT:      x86.label "scf_body_0_for"
+//  CHECK-NEXT:      %i_1 = x86.ri.add %i, 3 : (!x86.reg64<rcx>) -> !x86.reg64<rcx>
+//  CHECK-NEXT:      %1 = x86.ss.cmp %i_1, %ub : (!x86.reg64<rcx>, !x86.reg64<r8>) -> !x86.rflags<rflags>
+//  CHECK-NEXT:      x86.c.jl %1 : !x86.rflags<rflags>, ^bb1(%i_1 : !x86.reg64<rcx>), ^bb2(%i_1 : !x86.reg64<rcx>)
+//  CHECK-NEXT:    ^bb2(%zero_end: !x86.reg64<rcx>):
+//  CHECK-NEXT:      x86.label "scf_body_end_0_for"
+//  CHECK-NEXT:      x86_func.ret
+//  CHECK-NEXT:    }
+x86_func.func @dynamic_ub_static_step() {
     %zero = x86.di.mov 0 : () -> !x86.reg64<rcx>
-    %step = x86.di.mov 1 : () -> !x86.reg64<rdx>
-    %zero_end, %res = x86_scf.for %i : !x86.reg64<rcx> = %zero to 20 : si32 step %step iter_args(%acc = %init) -> (!x86.reg64<rax>) {
-        x86_scf.yield %acc : !x86.reg64<rax>
-    }
-    "test.op"(%res) : (!x86.reg64<rax>) -> ()
-    ret
-}
-// CHECK: convert-x86-scf-to-x86 expects x86_scf.for upper bound to be an SSAValue
-
-// -----
-// Static step is currently unsupported by this lowering.
-x86_func.func @static_step_for_fails() {
-    %zero = x86.di.mov 0 : () -> !x86.reg64<rcx>
-    %forty = x86.di.mov 40 : () -> !x86.reg64<r8>
-    %zero_end = x86_scf.for %i : !x86.reg64<rcx> = %zero to %forty step 1 : si32 {
+    %ub = x86.di.mov 20 : () -> !x86.reg64<r8>
+    %zero_end = x86_scf.for %i : !x86.reg64<rcx> = %zero to %ub step 3 : si32 {
         x86_scf.yield
     }
     ret
 }
-// CHECK: convert-x86-scf-to-x86 expects x86_scf.for step to be an SSAValue
 
 // -----
-// Static step remains unsupported even with iter_args.
-x86_func.func @static_step_for_with_iter_args_fails(%init: !x86.reg64<rax>) {
+// CHECK-LABEL:    x86_func.func @static_ub_static_step() {
+//  CHECK-NEXT:      %zero = x86.di.mov 0 : () -> !x86.reg64<rcx>
+//  CHECK-NEXT:      %0 = x86.si.cmp %zero, 12 : (!x86.reg64<rcx>) -> !x86.rflags<rflags>
+//  CHECK-NEXT:      x86.c.jge %0 : !x86.rflags<rflags>, ^bb2(%zero : !x86.reg64<rcx>), ^bb1(%zero : !x86.reg64<rcx>)
+//  CHECK-NEXT:    ^bb1(%i: !x86.reg64<rcx>):
+//  CHECK-NEXT:      x86.label "scf_body_0_for"
+//  CHECK-NEXT:      %i_1 = x86.ri.add %i, 1 : (!x86.reg64<rcx>) -> !x86.reg64<rcx>
+//  CHECK-NEXT:      %1 = x86.si.cmp %i_1, 12 : (!x86.reg64<rcx>) -> !x86.rflags<rflags>
+//  CHECK-NEXT:      x86.c.jl %1 : !x86.rflags<rflags>, ^bb1(%i_1 : !x86.reg64<rcx>), ^bb2(%i_1 : !x86.reg64<rcx>)
+//  CHECK-NEXT:    ^bb2(%zero_end: !x86.reg64<rcx>):
+//  CHECK-NEXT:      x86.label "scf_body_end_0_for"
+//  CHECK-NEXT:      x86_func.ret
+//  CHECK-NEXT:    }
+x86_func.func @static_ub_static_step() {
     %zero = x86.di.mov 0 : () -> !x86.reg64<rcx>
-    %forty = x86.di.mov 40 : () -> !x86.reg64<r8>
-    %zero_end, %res = x86_scf.for %i : !x86.reg64<rcx> = %zero to %forty step 1 : si32 iter_args(%acc = %init) -> (!x86.reg64<rax>) {
-        x86_scf.yield %acc : !x86.reg64<rax>
+    %zero_end = x86_scf.for %i : !x86.reg64<rcx> = %zero to 12 : si32 step 1 : si32 {
+        x86_scf.yield
     }
-    "test.op"(%res) : (!x86.reg64<rax>) -> ()
     ret
 }
-// CHECK: convert-x86-scf-to-x86 expects x86_scf.for step to be an SSAValue

--- a/xdsl/transforms/convert_x86_scf_to_x86.py
+++ b/xdsl/transforms/convert_x86_scf_to_x86.py
@@ -10,8 +10,6 @@ from xdsl.pattern_rewriter import (
     op_type_rewrite_pattern,
 )
 from xdsl.rewriter import BlockInsertPoint, InsertPoint
-from xdsl.utils.exceptions import PassFailedException
-from xdsl.utils.hints import isa
 
 
 class LowerX86ScfForPattern(RewritePattern):
@@ -96,26 +94,26 @@ class LowerX86ScfForPattern(RewritePattern):
         last_body_block = op.body.blocks[-1]
 
         # Get the induction variable and its register
-        iv = first_body_block.args[0]
-        assert isa(iv, SSAValue[GeneralRegisterType])
+        iv = SSAValue.get(first_body_block.args[0], type=GeneralRegisterType)
         ub = op.ub
-        if not isinstance(ub, SSAValue):
-            raise PassFailedException(
-                "convert-x86-scf-to-x86 expects x86_scf.for upper bound to be an SSAValue"
-            )
         step = op.step
-        if not isinstance(step, SSAValue):
-            raise PassFailedException(
-                "convert-x86-scf-to-x86 expects x86_scf.for step to be an SSAValue"
-            )
 
         # Append the induction variable stepping logic to the last body block, add
         # comparison with upper bound, and conditionally branch back into the body.
         yield_op = last_body_block.last_op
         assert isinstance(yield_op, x86_scf.YieldOp)
-        step_op = x86.ops.RS_AddOp(iv, step)
+
+        match step:
+            case SSAValue():
+                step_op = x86.ops.RS_AddOp(iv, step)
+            case builtin.IntegerAttr():
+                step_op = x86.ops.RI_AddOp(iv, step)
         new_iv = step_op.register_out
-        cmp_op = x86.ops.SS_CmpOp(new_iv, ub)
+        match ub:
+            case SSAValue():
+                cmp_op = x86.ops.SS_CmpOp(new_iv, ub)
+            case builtin.IntegerAttr():
+                cmp_op = x86.ops.SI_CmpOp(new_iv, ub)
 
         rewriter.replace(
             yield_op,
@@ -141,7 +139,11 @@ class LowerX86ScfForPattern(RewritePattern):
         # lb is the IV register (inout); legalization inserts a copy when needed.
         rewriter.insert(
             (
-                cmp_op := x86.ops.SS_CmpOp(op.lb, ub),
+                cmp_op := (
+                    x86.ops.SS_CmpOp(op.lb, ub)
+                    if isinstance(ub, SSAValue)
+                    else x86.ops.SI_CmpOp(op.lb, ub)
+                ),
                 x86.ops.C_JgeOp(
                     cmp_op.result,
                     (op.lb, *op.iter_args),


### PR DESCRIPTION
Adds support for lowering static bounds.