### PR TITLE
dialects: (affine) custom printing for affine.for/affine.yield

### DIFF
--- a/tests/filecheck/dialects/affine/affine_ops.mlir
+++ b/tests/filecheck/dialects/affine/affine_ops.mlir
@@ -4,10 +4,8 @@
 
     // For without value being passed during iterations
 
-    "affine.for"() <{"lowerBoundMap" = affine_map<() -> (0)>, "upperBoundMap" = affine_map<() -> (256)>, "step" = 1 : index, operandSegmentSizes = array<i32: 0, 0, 0>}> ({
-    ^bb0(%i: index):
-      "affine.yield"() : () -> ()
-    }) : () -> ()
+    affine.for %i = 0 to 256 {
+    }
 
     // CHECK:      affine.for %{{.*}} = 0 to 256 {
     // CHECK-NEXT: }
@@ -15,10 +13,8 @@
 
     // For with a discardable attribute, which must survive custom syntax round-trip
 
-    "affine.for"() <{"lowerBoundMap" = affine_map<() -> (0)>, "upperBoundMap" = affine_map<() -> (4)>, "step" = 1 : index, operandSegmentSizes = array<i32: 0, 0, 0>}> ({
-    ^bb9(%i2: index):
-      "affine.yield"() : () -> ()
-    }) {"foo" = 1 : i32} : () -> ()
+    affine.for %i2 = 0 to 4 {
+    } {foo = 1 : i32}
 
     // CHECK:      affine.for %{{.*}} = 0 to 4 {
     // CHECK-NEXT: } {foo = 1 : i32}
@@ -27,21 +23,19 @@
     // For with values being passed during iterations
 
     %init_value = "test.op"() : () -> !test.type<"int">
-    %res = "affine.for"(%init_value) <{"lowerBoundMap" = affine_map<() -> (-10)>, "upperBoundMap" = affine_map<() -> (10)>, "step" = 1 : index, operandSegmentSizes = array<i32: 0, 0, 1>}> ({
-    ^bb1(%i: index, %step_value: !test.type<"int">):
+    %res = affine.for %i = -10 to 10 iter_args(%step_value = %init_value) -> (!test.type<"int">) {
       %next_value = "test.op"() : () -> !test.type<"int">
-      "affine.yield"(%next_value) : (!test.type<"int">) -> ()
-    }) : (!test.type<"int">) -> (!test.type<"int">)
+      affine.yield %next_value : !test.type<"int">
+    }
     %00 = "test.op"() : () -> index
     %N = "test.op"() : () -> index
-    %res2 = "affine.for"(%00, %N, %init_value) <{"lowerBoundMap" = affine_map<(d0) -> (d0)>, "upperBoundMap" = affine_map<()[s0] -> (s0)>, "step" = 1 : index, operandSegmentSizes = array<i32: 1, 1, 1>}> ({
-    ^bb1(%i: index, %step_value: !test.type<"int">):
+    %res2 = affine.for %i = affine_map<(d0) -> (d0)>(%00) to %N iter_args(%step_value = %init_value) -> (!test.type<"int">) {
       %next_value = "test.op"() : () -> !test.type<"int">
-      "affine.yield"(%next_value) : (!test.type<"int">) -> ()
-    }) : (index, index, !test.type<"int">) -> (!test.type<"int">)
+      affine.yield %next_value : !test.type<"int">
+    }
     "affine.parallel"(%N) <{"lowerBoundsMap" = affine_map<() -> (0)>, "lowerBoundsGroups" = dense<1> : vector<1xi32>, "upperBoundsMap" = affine_map<()[s0] -> (s0)>, "upperBoundsGroups" = dense<1> : vector<1xi32>, "steps" = [1 : i64], "reductions" = []}> ({
     ^bb1(%i: index):
-      "affine.yield"() : () -> ()
+      affine.yield
     }) : (index) -> ()
 
     // CHECK:      %res = affine.for %{{.*}} = -10 to 10 iter_args(%{{.*}} = %{{.*}}) -> (!test.type<"int">) {
@@ -91,18 +85,16 @@
     // CHECK-NEXT: %vnested = affine.vector_load %vmemref[%zero + 3, %zero * 2 + %zero * 5] : memref<2x3xf64>, vector<2xf64>
 
     func.func @empty() {
-    "affine.for"() <{"lowerBoundMap" = affine_map<() -> (0)>, "step" = 1 : index, "upperBoundMap" = affine_map<() -> (10)>, operandSegmentSizes = array<i32: 0, 0, 0>}> ({
-    ^bb2(%arg0: index):
-      "affine.yield"() : () -> ()
-    }) : () -> ()
+    affine.for %arg0 = 0 to 10 {
+    }
     "affine.if"() <{condition = affine_set<() : (0 == 0)>}> ({
-      "affine.yield"() : () -> ()
+      affine.yield
     }, {
     })  : () -> ()
     "affine.if"() <{condition = affine_set<() : (0 == 0)>}> ({
-      "affine.yield"() : () -> ()
+      affine.yield
     }, {
-      "affine.yield"() : () -> ()
+      affine.yield
     }) : () -> ()
 
     func.return
@@ -125,9 +117,9 @@
   func.func @affine_if() -> f32 {
     %0 = arith.constant 0.000000e+00 : f32
     %1 = "affine.if"() <{condition = affine_set<() : (0 == 0)>}> ({
-      "affine.yield"(%0) : (f32) -> ()
+      affine.yield %0 : f32
     }, {
-      "affine.yield"(%0) : (f32) -> ()
+      affine.yield %0 : f32
     }) : () -> f32
     func.return %1 : f32
   }

--- a/tests/filecheck/dialects/affine/affine_ops.mlir
+++ b/tests/filecheck/dialects/affine/affine_ops.mlir
@@ -162,4 +162,36 @@
   // CHECK:      affine.for %{{.*}} = max affine_map<(d0)[s0] -> (d0, s0)>(%{{.*}})[%{{.*}}] to 10 {
   // CHECK-NEXT: }
 
+  // For with a `min` prefix on the upper bound
+
+  affine.for %i6 = max affine_map<(d0)[s0] -> (d0, s0)>(%bound_d)[%bound_s] to min affine_map<(d0) -> (d0, 10)>(%bound_d) {
+  }
+
+  // CHECK:      affine.for %{{.*}} = max affine_map<(d0)[s0] -> (d0, s0)>(%{{.*}})[%{{.*}}] to min affine_map<(d0) -> (d0, 10)>(%{{.*}}) {
+  // CHECK-NEXT: }
+
+  // For with a plain (non-min/max) affine map as the upper bound
+
+  %ub_d = "test.op"() : () -> index
+  affine.for %i7 = 0 to affine_map<(d0) -> (4 * d0)>(%ub_d) {
+  }
+
+  // CHECK:      %ub_d = "test.op"() : () -> index
+  // CHECK-NEXT: affine.for %{{.*}} = 0 to affine_map<(d0) -> ((d0 * 4))>(%{{.*}}) {
+  // CHECK-NEXT: }
+
+  // For with multiple loop-carried values
+
+  %ia_init0 = "test.op"() : () -> index
+  %ia_init1 = "test.op"() : () -> index
+  %ia_res0, %ia_res1 = affine.for %i8 = 0 to 10 iter_args(%a = %ia_init0, %b = %ia_init1) -> (index, index) {
+    affine.yield %a, %b : index, index
+  }
+
+  // CHECK:      %ia_init0 = "test.op"() : () -> index
+  // CHECK-NEXT: %ia_init1 = "test.op"() : () -> index
+  // CHECK-NEXT: %ia_res0, %ia_res1 = affine.for %{{.*}} = 0 to 10 iter_args(%{{.*}} = %{{.*}}, %{{.*}} = %{{.*}}) -> (index, index) {
+  // CHECK-NEXT:   affine.yield %{{.*}}, %{{.*}} : index, index
+  // CHECK-NEXT: }
+
 }) : () -> ()

--- a/tests/filecheck/dialects/affine/affine_ops.mlir
+++ b/tests/filecheck/dialects/affine/affine_ops.mlir
@@ -2,28 +2,7 @@
 
 "builtin.module"() ({
 
-    // For without value being passed during iterations
-
-    affine.for %i = 0 to 256 {
-    }
-
-    // CHECK:      affine.for %{{.*}} = 0 to 256 {
-    // CHECK-NEXT: }
-
-    // Discardable attribute, generic
-
-    "affine.for"() <{lowerBoundMap = affine_map<() -> (0)>, upperBoundMap = affine_map<() -> (256)>, step = 1 : index, operandSegmentSizes = array<i32: 0, 0, 0>}> ({
-    ^bb0(%i: index):
-      "affine.yield"() : () -> ()
-    }) : () -> ()
-
-    // CHECK:     "affine.for"() <{lowerBoundMap = affine_map<() -> (0)>, upperBoundMap = affine_map<() -> (256)>, step = 1 : index, operandSegmentSizes = array<i32: 0, 0, 0>}> ({
-    // CHECK-NEXT: ^bb0(%{{.*}}: index):
-    // CHECK-NEXT:   "affine.yield"() : () -> ()
-    // CHECK-NEXT: }) : () -> ()
-
-
-    // For with a discardable attribute, which must survive custom syntax round-trip
+    // For without value being passed during iterations, and discardable attribute
 
     affine.for %i2 = 0 to 4 {
     } {foo = 1 : i32}

--- a/tests/filecheck/dialects/affine/affine_ops.mlir
+++ b/tests/filecheck/dialects/affine/affine_ops.mlir
@@ -9,10 +9,19 @@
       "affine.yield"() : () -> ()
     }) : () -> ()
 
-    // CHECK:      "affine.for"() <{lowerBoundMap = affine_map<() -> (0)>, upperBoundMap = affine_map<() -> (256)>, step = 1 : index, operandSegmentSizes = array<i32: 0, 0, 0>}> ({
-    // CHECK-NEXT: ^bb0(%{{.*}}: index):
-    // CHECK-NEXT:   "affine.yield"() : () -> ()
-    // CHECK-NEXT: }) : () -> ()
+    // CHECK:      affine.for %{{.*}} = 0 to 256 {
+    // CHECK-NEXT: }
+
+
+    // For with a discardable attribute, which must survive custom syntax round-trip
+
+    "affine.for"() <{"lowerBoundMap" = affine_map<() -> (0)>, "upperBoundMap" = affine_map<() -> (4)>, "step" = 1 : index, operandSegmentSizes = array<i32: 0, 0, 0>}> ({
+    ^bb9(%i2: index):
+      "affine.yield"() : () -> ()
+    }) {"foo" = 1 : i32} : () -> ()
+
+    // CHECK:      affine.for %{{.*}} = 0 to 4 {
+    // CHECK-NEXT: } {foo = 1 : i32}
 
 
     // For with values being passed during iterations
@@ -35,14 +44,17 @@
       "affine.yield"() : () -> ()
     }) : (index) -> ()
 
-    // CHECK:      %res = "affine.for"(%{{.*}}) <{lowerBoundMap = affine_map<() -> (-10)>, upperBoundMap = affine_map<() -> (10)>, step = 1 : index, operandSegmentSizes = array<i32: 0, 0, 1>}> ({
-    // CHECK-NEXT: ^bb0(%{{.*}}: index, %{{.*}}: !test.type<"int">):
+    // CHECK:      %res = affine.for %{{.*}} = -10 to 10 iter_args(%{{.*}} = %{{.*}}) -> (!test.type<"int">) {
     // CHECK-NEXT:   %{{.*}} = "test.op"() : () -> !test.type<"int">
-    // CHECK-NEXT:   "affine.yield"(%{{.*}}) : (!test.type<"int">) -> ()
-    // CHECK-NEXT: }) : (!test.type<"int">) -> !test.type<"int">
+    // CHECK-NEXT:   affine.yield %{{.*}} : !test.type<"int">
+    // CHECK-NEXT: }
+    // CHECK:      %res2 = affine.for %{{.*}} = affine_map<(d0) -> (d0)>(%{{.*}}) to %N iter_args(%{{.*}} = %{{.*}}) -> (!test.type<"int">) {
+    // CHECK-NEXT:   %{{.*}} = "test.op"() : () -> !test.type<"int">
+    // CHECK-NEXT:   affine.yield %{{.*}} : !test.type<"int">
+    // CHECK-NEXT: }
     // CHECK:      "affine.parallel"(%N) <{lowerBoundsMap = affine_map<() -> (0)>, lowerBoundsGroups = dense<1> : vector<1xi32>, upperBoundsMap = affine_map<()[s0] -> (s0)>, upperBoundsGroups = dense<1> : vector<1xi32>, steps = [1 : i64], reductions = []}> ({
     // CHECK-NEXT: ^{{.*}}(%{{.*}}: index):
-    // CHECK-NEXT:   "affine.yield"() : () -> ()
+    // CHECK-NEXT:   affine.yield
     // CHECK-NEXT: }) : (index) -> ()
 
 
@@ -96,18 +108,16 @@
     func.return
   }
 // CHECK:    func.func @empty() {
-// CHECK-NEXT:      "affine.for"() <{lowerBoundMap = affine_map<() -> (0)>, step = 1 : index, upperBoundMap = affine_map<() -> (10)>, operandSegmentSizes = array<i32: 0, 0, 0>}> ({
-// CHECK-NEXT:      ^{{.*}}(%{{.*}}: index):
-// CHECK-NEXT:        "affine.yield"() : () -> ()
-// CHECK-NEXT:      }) : () -> ()
+// CHECK-NEXT:      affine.for %{{.*}} = 0 to 10 {
+// CHECK-NEXT:      }
 // CHECK-NEXT:      "affine.if"() <{condition = affine_set<() : (0 == 0)>}> ({
-// CHECK-NEXT:        "affine.yield"() : () -> ()
+// CHECK-NEXT:        affine.yield
 // CHECK-NEXT:      }, {
 // CHECK-NEXT:      }) : () -> ()
 // CHECK-NEXT:      "affine.if"() <{condition = affine_set<() : (0 == 0)>}> ({
-// CHECK-NEXT:        "affine.yield"() : () -> ()
+// CHECK-NEXT:        affine.yield
 // CHECK-NEXT:      }, {
-// CHECK-NEXT:        "affine.yield"() : () -> ()
+// CHECK-NEXT:        affine.yield
 // CHECK-NEXT:      }) : () -> ()
 
 // CHECK-NEXT:      func.return
@@ -124,9 +134,9 @@
 // CHECK:    func.func @affine_if() -> f32 {
 // CHECK-NEXT:      %{{.*}} = arith.constant 0.000000e+00 : f32
 // CHECK-NEXT:      %{{.*}} = "affine.if"() <{condition = affine_set<() : (0 == 0)>}> ({
-// CHECK-NEXT:        "affine.yield"(%{{.*}}) : (f32) -> ()
+// CHECK-NEXT:        affine.yield %{{.*}} : f32
 // CHECK-NEXT:      }, {
-// CHECK-NEXT:        "affine.yield"(%{{.*}}) : (f32) -> ()
+// CHECK-NEXT:        affine.yield %{{.*}} : f32
 // CHECK-NEXT:      }) : () -> f32
 // CHECK-NEXT:      func.return %{{.*}} : f32
 // CHECK-NEXT:    }

--- a/tests/filecheck/dialects/affine/affine_ops.mlir
+++ b/tests/filecheck/dialects/affine/affine_ops.mlir
@@ -10,6 +10,18 @@
     // CHECK:      affine.for %{{.*}} = 0 to 256 {
     // CHECK-NEXT: }
 
+    // Discardable attribute, generic
+
+    "affine.for"() <{lowerBoundMap = affine_map<() -> (0)>, upperBoundMap = affine_map<() -> (256)>, step = 1 : index, operandSegmentSizes = array<i32: 0, 0, 0>}> ({
+    ^bb0(%i: index):
+      "affine.yield"() : () -> ()
+    }) : () -> ()
+
+    // CHECK:     "affine.for"() <{lowerBoundMap = affine_map<() -> (0)>, upperBoundMap = affine_map<() -> (256)>, step = 1 : index, operandSegmentSizes = array<i32: 0, 0, 0>}> ({
+    // CHECK-NEXT: ^bb0(%{{.*}}: index):
+    // CHECK-NEXT:   "affine.yield"() : () -> ()
+    // CHECK-NEXT: }) : () -> ()
+
 
     // For with a discardable attribute, which must survive custom syntax round-trip
 

--- a/tests/filecheck/dialects/affine/affine_ops.mlir
+++ b/tests/filecheck/dialects/affine/affine_ops.mlir
@@ -132,4 +132,34 @@
   // CHECK: %{{.*}} = arith.constant 2 : index
   // CHECK-NEXT: %{{.*}} = affine.apply affine_map<()[{{.*}}] -> (({{.*}} * 4))> ()[%{{.*}}]
 
+  // For with a non-default step
+
+  affine.for %i3 = 0 to 10 step 2 {
+  }
+
+  // CHECK: affine.for %{{.*}} = 0 to 10 step 2 {
+  // CHECK-NEXT: }
+
+  // For with a single loop-carried value's type given without parentheses
+
+  %bare_init = "test.op"() : () -> index
+  %bare_res = affine.for %i4 = 0 to 10 iter_args(%bare_iv = %bare_init) -> index {
+    affine.yield %bare_iv : index
+  }
+
+  // CHECK: %bare_res = affine.for %{{.*}} = 0 to 10 iter_args(%{{.*}} = %{{.*}}) -> (index) {
+  // CHECK-NEXT:   affine.yield %{{.*}} : index
+  // CHECK-NEXT: }
+
+  // For with a multi-result bound requiring a `max`/`min` prefix, and a bound
+  // map with both dimension and symbol operands
+
+  %bound_d = "test.op"() : () -> index
+  %bound_s = "test.op"() : () -> index
+  affine.for %i5 = max affine_map<(d0)[s0] -> (d0, s0)>(%bound_d)[%bound_s] to 10 {
+  }
+
+  // CHECK:      affine.for %{{.*}} = max affine_map<(d0)[s0] -> (d0, s0)>(%{{.*}})[%{{.*}}] to 10 {
+  // CHECK-NEXT: }
+
 }) : () -> ()

--- a/tests/filecheck/dialects/affine/examples.mlir
+++ b/tests/filecheck/dialects/affine/examples.mlir
@@ -18,12 +18,11 @@
 
 // CHECK:         func.func private @sum_vec(%{{.*}}: memref<128xi32>) -> i32 {
 // CHECK-NEXT:      %{{.*}} = arith.constant 0 : i32
-// CHECK-NEXT:      %{{.*}} = "affine.for"(%const0) <{lowerBoundMap = affine_map<() -> (0)>, upperBoundMap = affine_map<() -> (256)>, step = 1 : index, operandSegmentSizes = array<i32: 0, 0, 1>}> ({
-// CHECK-NEXT:      ^{{.*}}(%{{.*}}: index, %{{.*}}: i32):
+// CHECK-NEXT:      %{{.*}} = affine.for %{{.*}} = 0 to 256 iter_args(%{{.*}} = %{{.*}}) -> (i32) {
 // CHECK-NEXT:        %{{.*}} = memref.load %{{.*}}[%{{.*}}] : memref<128xi32>
 // CHECK-NEXT:        %{{.*}} = arith.addi %{{.*}}, %{{.*}} : i32
-// CHECK-NEXT:        "affine.yield"(%{{.*}}) : (i32) -> ()
-// CHECK-NEXT:      }) : (i32) -> i32
+// CHECK-NEXT:        affine.yield %{{.*}} : i32
+// CHECK-NEXT:      }
 // CHECK-NEXT:      func.return %{{.*}} : i32
 // CHECK-NEXT:    }
 
@@ -54,24 +53,18 @@
   }) {"sym_name" = "affine_mm", "function_type" = (memref<256x256xf32>, memref<256x256xf32>, memref<256x256xf32>) -> memref<256x256xf32>, "sym_visibility" = "private"} : () -> ()
 
 // CHECK:         func.func private @affine_mm(%{{.*}}: memref<256x256xf32>, %{{.*}}: memref<256x256xf32>, %{{.*}}: memref<256x256xf32>) -> memref<256x256xf32> {
-// CHECK-NEXT:      "affine.for"() <{lowerBoundMap = affine_map<() -> (0)>, upperBoundMap = affine_map<() -> (256)>, step = 1 : index, operandSegmentSizes = array<i32: 0, 0, 0>}> ({
-// CHECK-NEXT:      ^{{.*}}(%{{.*}}: index):
-// CHECK-NEXT:        "affine.for"() <{lowerBoundMap = affine_map<() -> (0)>, upperBoundMap = affine_map<() -> (256)>, step = 1 : index, operandSegmentSizes = array<i32: 0, 0, 0>}> ({
-// CHECK-NEXT:        ^{{.*}}(%{{.*}}: index):
-// CHECK-NEXT:          "affine.for"() <{lowerBoundMap = affine_map<() -> (0)>, upperBoundMap = affine_map<() -> (256)>, step = 1 : index, operandSegmentSizes = array<i32: 0, 0, 0>}> ({
-// CHECK-NEXT:          ^{{.*}}(%{{.*}}: index):
+// CHECK-NEXT:      affine.for %{{.*}} = 0 to 256 {
+// CHECK-NEXT:        affine.for %{{.*}} = 0 to 256 {
+// CHECK-NEXT:          affine.for %{{.*}} = 0 to 256 {
 // CHECK-NEXT:            %{{.*}} = memref.load %{{.*}}[%{{.*}}, %{{.*}}] : memref<256x256xf32>
 // CHECK-NEXT:            %{{.*}} = memref.load %{{.*}}[%{{.*}}, %{{.*}}] : memref<256x256xf32>
 // CHECK-NEXT:            %{{.*}} = memref.load %{{.*}}[%{{.*}}, %{{.*}}] : memref<256x256xf32>
 // CHECK-NEXT:            %{{.*}} = arith.mulf %{{.*}}, %{{.*}} : f32
 // CHECK-NEXT:            %{{.*}} = arith.addf %{{.*}}, %{{.*}} : f32
 // CHECK-NEXT:            memref.store %{{.*}}, %{{.*}}[%{{.*}}, %{{.*}}] : memref<256x256xf32>
-// CHECK-NEXT:            "affine.yield"() : () -> ()
-// CHECK-NEXT:          }) : () -> ()
-// CHECK-NEXT:          "affine.yield"() : () -> ()
-// CHECK-NEXT:        }) : () -> ()
-// CHECK-NEXT:        "affine.yield"() : () -> ()
-// CHECK-NEXT:      }) : () -> ()
+// CHECK-NEXT:          }
+// CHECK-NEXT:        }
+// CHECK-NEXT:      }
 // CHECK-NEXT:      func.return %{{.*}} : memref<256x256xf32>
 // CHECK-NEXT:    }
 

--- a/tests/filecheck/dialects/affine/examples.mlir
+++ b/tests/filecheck/dialects/affine/examples.mlir
@@ -7,12 +7,11 @@
   "func.func"() ({
   ^bb0(%ref: memref<128xi32>):
     %const0 = "arith.constant"() {"value" = 0 : i32} : () -> i32
-    %r = "affine.for"(%const0) <{"lowerBoundMap" = affine_map<() -> (0)>, "upperBoundMap" = affine_map<() -> (256)>, "step" = 1 : index, operandSegmentSizes = array<i32: 0, 0, 1>}> ({
-    ^bb1(%i: index, %sum: i32):
+    %r = affine.for %i = 0 to 256 iter_args(%sum = %const0) -> (i32) {
       %val = "memref.load"(%ref, %i) : (memref<128xi32>, index) -> i32
       %res = "arith.addi"(%sum, %val) : (i32, i32) -> i32
-      "affine.yield"(%res) : (i32) -> ()
-    }) : (i32) -> i32
+      affine.yield %res : i32
+    }
     func.return %r : i32
   }) {"sym_name" = "sum_vec", "function_type" = (memref<128xi32>) -> i32, "sym_visibility" = "private"} : () -> ()
 
@@ -31,24 +30,18 @@
 
   "func.func"() ({
   ^bb2(%0: memref<256x256xf32>, %1: memref<256x256xf32>, %2: memref<256x256xf32>):
-    "affine.for"() <{"lowerBoundMap" = affine_map<() -> (0)>, "upperBoundMap" = affine_map<() -> (256)>, "step" = 1 : index, operandSegmentSizes = array<i32: 0, 0, 0>}> ({
-    ^bb3(%3: index):
-      "affine.for"() <{"lowerBoundMap" = affine_map<() -> (0)>, "upperBoundMap" = affine_map<() -> (256)>, "step" = 1 : index, operandSegmentSizes = array<i32: 0, 0, 0>}> ({
-      ^bb4(%4: index):
-        "affine.for"() <{"lowerBoundMap" = affine_map<() -> (0)>, "upperBoundMap" = affine_map<() -> (256)>, "step" = 1 : index, operandSegmentSizes = array<i32: 0, 0, 0>}> ({
-        ^bb5(%5: index):
+    affine.for %3 = 0 to 256 {
+      affine.for %4 = 0 to 256 {
+        affine.for %5 = 0 to 256 {
           %6 = "memref.load"(%0, %3, %5) : (memref<256x256xf32>, index, index) -> f32
           %7 = "memref.load"(%1, %5, %4) : (memref<256x256xf32>, index, index) -> f32
           %8 = "memref.load"(%2, %3, %4) : (memref<256x256xf32>, index, index) -> f32
           %9 = "arith.mulf"(%6, %7) : (f32, f32) -> f32
           %10 = "arith.addf"(%8, %9) : (f32, f32) -> f32
           "memref.store"(%10, %2, %3, %4) : (f32, memref<256x256xf32>, index, index) -> ()
-          "affine.yield"() : () -> ()
-        })  : () -> ()
-        "affine.yield"() : () -> ()
-      }) : () -> ()
-      "affine.yield"() : () -> ()
-    }) : () -> ()
+        }
+      }
+    }
     "func.return"(%2) : (memref<256x256xf32>) -> ()
   }) {"sym_name" = "affine_mm", "function_type" = (memref<256x256xf32>, memref<256x256xf32>, memref<256x256xf32>) -> memref<256x256xf32>, "sym_visibility" = "private"} : () -> ()
 

--- a/tests/filecheck/dialects/affine/invalid.mlir
+++ b/tests/filecheck/dialects/affine/invalid.mlir
@@ -77,3 +77,17 @@ affine.for %i = 0 to 10 step -2 {
 }
 
 // CHECK: expected step to be representable as a positive signed integer
+
+// -----
+
+affine.for %i = 0 to "foo" {
+}
+
+// CHECK: expected an affine map or an integer for loop bound
+
+// -----
+
+affine.for %i = 0 to affine_map<()[s0] -> (s0)>() {
+}
+
+// CHECK: symbol operand count and affine map symbol count must match

--- a/tests/filecheck/dialects/affine/invalid.mlir
+++ b/tests/filecheck/dialects/affine/invalid.mlir
@@ -3,7 +3,7 @@
 %N = "test.op"() : () -> index
 "affine.parallel"(%N) <{"lowerBoundsMap" = affine_map<(i) -> (i)>, "lowerBoundsGroups" = dense<1> : vector<1xi32>, "upperBoundsMap" = affine_map<()[s0] -> (s0)>, "upperBoundsGroups" = dense<1> : vector<1xi32>, "steps" = [1 : i64], "reductions" = []}> ({
 ^bb1(%i: index):
-    "affine.yield"() : () -> ()
+    affine.yield
 }) : (index) -> ()
 
 // CHECK: Expected as many operands as results, lower bound args and upper bound args.
@@ -13,7 +13,7 @@
 %N = "test.op"() : () -> index
 "affine.parallel"(%N) <{"lowerBoundsMap" = affine_map<() -> (0)>, "lowerBoundsGroups" = dense<> : vector<0xi32>, "upperBoundsMap" = affine_map<()[s0] -> (s0)>, "upperBoundsGroups" = dense<1> : vector<1xi32>, "steps" = [1 : i64], "reductions" = []}> ({
 ^bb1(%i: index):
-    "affine.yield"() : () -> ()
+    affine.yield
 }) : (index) -> ()
 
 // CHECK: Expected a lower bound group for each lower bound
@@ -23,7 +23,7 @@
 %N = "test.op"() : () -> index
 "affine.parallel"(%N, %N) <{"lowerBoundsMap" = affine_map<()[s1] -> (0, 0, -s1)>, "lowerBoundsGroups" = dense<[1, 1, 2]> : vector<3xi32>, "upperBoundsMap" = affine_map<()[s0] -> (s0)>, "upperBoundsGroups" = dense<1> : vector<1xi32>, "steps" = [1 : i64], "reductions" = []}> ({
 ^bb1(%i: index, %j: index):
-    "affine.yield"() : () -> ()
+    affine.yield
 }) : (index, index) -> ()
 
 // CHECK: Expected a lower bound group for each lower bound
@@ -34,7 +34,7 @@
 %N = "test.op"() : () -> index
 "affine.parallel"(%N) <{"lowerBoundsMap" = affine_map<() -> (0)>, "lowerBoundsGroups" = dense<1> : vector<1xi32>, "upperBoundsMap" = affine_map<()[s0] -> (s0)>, "upperBoundsGroups" = dense<> : vector<0xi32>, "steps" = [1 : i64], "reductions" = []}> ({
 ^bb1(%i: index):
-    "affine.yield"() : () -> ()
+    affine.yield
 }) : (index) -> ()
 
 // CHECK: Expected an upper bound group for each upper bound

--- a/tests/filecheck/dialects/affine/invalid.mlir
+++ b/tests/filecheck/dialects/affine/invalid.mlir
@@ -53,3 +53,27 @@ affine.store %value, %not_memref[0, 0] : tensor<2x3xf64>
 %vector = affine.vector_load %memref[0, 0] : memref<2x3xf64>, tensor<f64>
 
 // CHECK: Expected affine.vector_load to return a vector, but found: tensor<f64>
+
+// -----
+
+%d0 = "test.op"() : () -> index
+%d1 = "test.op"() : () -> index
+affine.for %i = affine_map<(d0, d1) -> (d0, d1)>(%d0, %d1) to 10 {
+}
+
+// CHECK: loop bound affine map with multiple results requires 'max' prefix
+
+// -----
+
+%ub = "test.op"() : () -> index
+affine.for %i = 0 to affine_map<(d0, d1) -> (d0, d1)>(%ub) {
+}
+
+// CHECK: dim operand count and affine map dim count must match
+
+// -----
+
+affine.for %i = 0 to 10 step -2 {
+}
+
+// CHECK: expected step to be representable as a positive signed integer

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/affine/affine_ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/affine/affine_ops.mlir
@@ -5,10 +5,10 @@
     // For without value being passed during iterations
 
     affine.for %i = 0 to 256 {
-    }
+    } {foo = 1 : i32}
 
     // CHECK:      affine.for %{{.*}} = 0 to 256 {
-    // CHECK-NEXT: }
+    // CHECK-NEXT: } {foo = 1 : i32}
 
 
     // For with values being passed during iterations
@@ -160,6 +160,38 @@
   }
 
   // CHECK:      affine.for %{{.*}} = max affine_map<(d0)[s0] -> (d0, s0)>(%{{.*}})[%{{.*}}] to 10 {
+  // CHECK-NEXT: }
+
+  // For with a `min` prefix on the upper bound
+
+  affine.for %i6 = max affine_map<(d0)[s0] -> (d0, s0)>(%bound_d)[%bound_s] to min affine_map<(d0) -> (d0, 10)>(%bound_d) {
+  }
+
+  // CHECK:      affine.for %{{.*}} = max affine_map<(d0)[s0] -> (d0, s0)>(%{{.*}})[%{{.*}}] to min affine_map<(d0) -> (d0, 10)>(%{{.*}}) {
+  // CHECK-NEXT: }
+
+  // For with a plain (non-min/max) affine map as the upper bound
+
+  %ub_d = "test.op"() : () -> index
+  affine.for %i7 = 0 to affine_map<(d0) -> (4 * d0)>(%ub_d) {
+  }
+
+  // CHECK:      %{{.*}} = "test.op"() : () -> index
+  // CHECK-NEXT: affine.for %{{.*}} = 0 to affine_map<(d0) -> ((d0 * 4))>(%{{.*}}) {
+  // CHECK-NEXT: }
+
+  // For with multiple loop-carried values
+
+  %ia_init0 = "test.op"() : () -> index
+  %ia_init1 = "test.op"() : () -> index
+  %ia_res0, %ia_res1 = affine.for %i8 = 0 to 10 iter_args(%a = %ia_init0, %b = %ia_init1) -> (index, index) {
+    affine.yield %a, %b : index, index
+  }
+
+  // CHECK:      %{{.*}} = "test.op"() : () -> index
+  // CHECK-NEXT: %{{.*}} = "test.op"() : () -> index
+  // CHECK-NEXT: %{{.*}}, %{{.*}} = affine.for %{{.*}} = 0 to 10 iter_args(%{{.*}} = %{{.*}}, %{{.*}} = %{{.*}}) -> (index, index) {
+  // CHECK-NEXT:   affine.yield %{{.*}}, %{{.*}} : index, index
   // CHECK-NEXT: }
 
 }) : () -> ()

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/affine/affine_ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/affine/affine_ops.mlir
@@ -9,10 +9,8 @@
       "affine.yield"() : () -> ()
     }) : () -> ()
 
-    // CHECK:      "affine.for"() <{lowerBoundMap = affine_map<() -> (0)>, operandSegmentSizes = array<i32: 0, 0, 0>, step = 1 : index, upperBoundMap = affine_map<() -> (256)>}> ({
-    // CHECK-NEXT: ^bb0(%{{.*}}: index):
-    // CHECK-NEXT:   "affine.yield"() : () -> ()
-    // CHECK-NEXT: }) : () -> ()
+    // CHECK:      affine.for %{{.*}} = 0 to 256 {
+    // CHECK-NEXT: }
 
 
     // For with values being passed during iterations
@@ -35,14 +33,17 @@
       "affine.yield"() : () -> ()
     }) : (index) -> ()
 
-    // CHECK:      %{{.*}} = "affine.for"(%{{.*}}) <{lowerBoundMap = affine_map<() -> (-10)>, operandSegmentSizes = array<i32: 0, 0, 1>, step = 1 : index, upperBoundMap = affine_map<() -> (10)>}> ({
-    // CHECK-NEXT: ^bb0(%{{.*}}: index, %{{.*}}: i32):
+    // CHECK:      %{{.*}} = affine.for %{{.*}} = -10 to 10 iter_args(%{{.*}} = %{{.*}}) -> (i32) {
     // CHECK-NEXT:   %{{.*}} = "test.op"() : () -> i32
-    // CHECK-NEXT:   "affine.yield"(%{{.*}}) : (i32) -> ()
-    // CHECK-NEXT: }) : (i32) -> i32
+    // CHECK-NEXT:   affine.yield %{{.*}} : i32
+    // CHECK-NEXT: }
+    // CHECK:      %{{.*}} = affine.for %{{.*}} = affine_map<(d0) -> (d0)>(%{{.*}}) to %{{.*}} iter_args(%{{.*}} = %{{.*}}) -> (i32) {
+    // CHECK-NEXT:   %{{.*}} = "test.op"() : () -> i32
+    // CHECK-NEXT:   affine.yield %{{.*}} : i32
+    // CHECK-NEXT: }
     // CHECK:      "affine.parallel"(%{{.*}}) <{lowerBoundsGroups = dense<1> : vector<1xi32>, lowerBoundsMap = affine_map<() -> (0)>, reductions = [], steps = [1 : i64], upperBoundsGroups = dense<1> : vector<1xi32>, upperBoundsMap = affine_map<()[s0] -> (s0)>}> ({
     // CHECK-NEXT: ^{{.*}}(%{{.*}}: index):
-    // CHECK-NEXT:   "affine.yield"() : () -> ()
+    // CHECK-NEXT:   affine.yield
     // CHECK-NEXT: }) : (index) -> ()
 
 
@@ -96,18 +97,16 @@
     func.return
   }
 // CHECK:    func.func @empty() {
-// CHECK-NEXT:      "affine.for"() <{lowerBoundMap = affine_map<() -> (0)>, operandSegmentSizes = array<i32: 0, 0, 0>, step = 1 : index, upperBoundMap = affine_map<() -> (10)>}> ({
-// CHECK-NEXT:      ^{{.*}}(%{{.*}}: index):
-// CHECK-NEXT:        "affine.yield"() : () -> ()
-// CHECK-NEXT:      }) : () -> ()
+// CHECK-NEXT:      affine.for %{{.*}} = 0 to 10 {
+// CHECK-NEXT:      }
 // CHECK-NEXT:      "affine.if"() <{condition = affine_set<() : (0 == 0)>}> ({
-// CHECK-NEXT:        "affine.yield"() : () -> ()
+// CHECK-NEXT:        affine.yield
 // CHECK-NEXT:      }, {
 // CHECK-NEXT:      }) : () -> ()
 // CHECK-NEXT:      "affine.if"() <{condition = affine_set<() : (0 == 0)>}> ({
-// CHECK-NEXT:        "affine.yield"() : () -> ()
+// CHECK-NEXT:        affine.yield
 // CHECK-NEXT:      }, {
-// CHECK-NEXT:        "affine.yield"() : () -> ()
+// CHECK-NEXT:        affine.yield
 // CHECK-NEXT:      }) : () -> ()
 
 // CHECK-NEXT:      func.return
@@ -124,9 +123,9 @@
 // CHECK:    func.func @affine_if() -> f32 {
 // CHECK-NEXT:      %{{.*}} = arith.constant 0.000000e+00 : f32
 // CHECK-NEXT:      %{{.*}} = "affine.if"() <{condition = affine_set<() : (0 == 0)>}> ({
-// CHECK-NEXT:        "affine.yield"(%{{.*}}) : (f32) -> ()
+// CHECK-NEXT:        affine.yield %{{.*}} : f32
 // CHECK-NEXT:      }, {
-// CHECK-NEXT:        "affine.yield"(%{{.*}}) : (f32) -> ()
+// CHECK-NEXT:        affine.yield %{{.*}} : f32
 // CHECK-NEXT:      }) : () -> f32
 // CHECK-NEXT:      func.return %{{.*}} : f32
 // CHECK-NEXT:    }

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/affine/affine_ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/affine/affine_ops.mlir
@@ -132,4 +132,34 @@
   // CHECK: %{{.*}} = arith.constant 2 : index
   // CHECK-NEXT: %{{.*}} = affine.apply affine_map<()[{{.*}}] -> (({{.*}} * 4))> ()[%{{.*}}]
 
+  // For with a non-default step
+
+  affine.for %i3 = 0 to 10 step 2 {
+  }
+
+  // CHECK: affine.for %{{.*}} = 0 to 10 step 2 {
+  // CHECK-NEXT: }
+
+  // For with a single loop-carried value's type given without parentheses
+
+  %bare_init = "test.op"() : () -> index
+  %bare_res = affine.for %i4 = 0 to 10 iter_args(%bare_iv = %bare_init) -> index {
+    affine.yield %bare_iv : index
+  }
+
+  // CHECK: %{{.*}} = affine.for %{{.*}} = 0 to 10 iter_args(%{{.*}} = %{{.*}}) -> (index) {
+  // CHECK-NEXT:   affine.yield %{{.*}} : index
+  // CHECK-NEXT: }
+
+  // For with a multi-result bound requiring a `max`/`min` prefix, and a bound
+  // map with both dimension and symbol operands
+
+  %bound_d = "test.op"() : () -> index
+  %bound_s = "test.op"() : () -> index
+  affine.for %i5 = max affine_map<(d0)[s0] -> (d0, s0)>(%bound_d)[%bound_s] to 10 {
+  }
+
+  // CHECK:      affine.for %{{.*}} = max affine_map<(d0)[s0] -> (d0, s0)>(%{{.*}})[%{{.*}}] to 10 {
+  // CHECK-NEXT: }
+
 }) : () -> ()

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/affine/affine_ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/affine/affine_ops.mlir
@@ -4,10 +4,8 @@
 
     // For without value being passed during iterations
 
-    "affine.for"() <{"lowerBoundMap" = affine_map<() -> (0)>, "upperBoundMap" = affine_map<() -> (256)>, "step" = 1 : index, operandSegmentSizes = array<i32: 0, 0, 0>}> ({
-    ^bb0(%i: index):
-      "affine.yield"() : () -> ()
-    }) : () -> ()
+    affine.for %i = 0 to 256 {
+    }
 
     // CHECK:      affine.for %{{.*}} = 0 to 256 {
     // CHECK-NEXT: }
@@ -16,21 +14,19 @@
     // For with values being passed during iterations
 
     %init_value = "test.op"() : () -> i32
-    %res = "affine.for"(%init_value) <{"lowerBoundMap" = affine_map<() -> (-10)>, "upperBoundMap" = affine_map<() -> (10)>, "step" = 1 : index, operandSegmentSizes = array<i32: 0, 0, 1>}> ({
-    ^bb1(%i: index, %step_value: i32):
+    %res = affine.for %i = -10 to 10 iter_args(%step_value = %init_value) -> (i32) {
       %next_value = "test.op"() : () -> i32
-      "affine.yield"(%next_value) : (i32) -> ()
-    }) : (i32) -> (i32)
+      affine.yield %next_value : i32
+    }
     %00 = "test.op"() : () -> index
     %N = "test.op"() : () -> index
-    %res2 = "affine.for"(%00, %N, %init_value) <{"lowerBoundMap" = affine_map<(d0) -> (d0)>, "upperBoundMap" = affine_map<()[s0] -> (s0)>, "step" = 1 : index, operandSegmentSizes = array<i32: 1, 1, 1>}> ({
-    ^bb1(%i: index, %step_value: i32):
+    %res2 = affine.for %i = affine_map<(d0) -> (d0)>(%00) to %N iter_args(%step_value = %init_value) -> (i32) {
       %next_value = "test.op"() : () -> i32
-      "affine.yield"(%next_value) : (i32) -> ()
-    }) : (index, index, i32) -> (i32)
+      affine.yield %next_value : i32
+    }
     "affine.parallel"(%N) <{"lowerBoundsMap" = affine_map<() -> (0)>, "lowerBoundsGroups" = dense<1> : vector<1xi32>, "upperBoundsMap" = affine_map<()[s0] -> (s0)>, "upperBoundsGroups" = dense<1> : vector<1xi32>, "steps" = [1 : i64], "reductions" = []}> ({
     ^bb1(%i: index):
-      "affine.yield"() : () -> ()
+      affine.yield
     }) : (index) -> ()
 
     // CHECK:      %{{.*}} = affine.for %{{.*}} = -10 to 10 iter_args(%{{.*}} = %{{.*}}) -> (i32) {
@@ -80,18 +76,16 @@
     // CHECK-NEXT: %{{.*}} = affine.vector_load %{{.*}}[%{{.*}} + 3, %{{.*}} * 2 + %{{.*}} * 5] : memref<2x3xf64>, vector<2xf64>
 
     func.func @empty() {
-    "affine.for"() <{"lowerBoundMap" = affine_map<() -> (0)>, "step" = 1 : index, "upperBoundMap" = affine_map<() -> (10)>, operandSegmentSizes = array<i32: 0, 0, 0>}> ({
-    ^bb2(%arg0: index):
-      "affine.yield"() : () -> ()
-    }) : () -> ()
+    affine.for %arg0 = 0 to 10 {
+    }
     "affine.if"() <{"condition" = affine_set<() : (0 == 0)>}> ({
-      "affine.yield"() : () -> ()
+      affine.yield
     }, {
     })  : () -> ()
     "affine.if"() <{"condition" = affine_set<() : (0 == 0)>}> ({
-      "affine.yield"() : () -> ()
+      affine.yield
     }, {
-      "affine.yield"() : () -> ()
+      affine.yield
     })  : () -> ()
 
     func.return
@@ -114,9 +108,9 @@
   func.func @affine_if() -> f32 {
     %0 = arith.constant 0.000000e+00 : f32
     %1 = "affine.if"() <{"condition" = affine_set<() : (0 == 0)>}> ({
-      "affine.yield"(%0) : (f32) -> ()
+      affine.yield %0 : f32
     }, {
-      "affine.yield"(%0) : (f32) -> ()
+      affine.yield %0 : f32
     }) : () -> f32
     func.return %1 : f32
   }

--- a/tests/filecheck/transforms/cse.mlir
+++ b/tests/filecheck/transforms/cse.mlir
@@ -127,11 +127,9 @@ func.func @different_ops() -> (i32, i32) {
   }
 
 // CHECK:      %0 = arith.constant 1 : i32
-// CHECK-NEXT:      "affine.for"() <{lowerBoundMap = affine_map<() -> (0)>, operandSegmentSizes = array<i32: 0, 0, 0>, step = 1 : index, upperBoundMap = affine_map<() -> (4)>}> ({
-// CHECK-NEXT:      ^bb0(%arg0: index):
+// CHECK-NEXT:      affine.for %arg0 = 0 to 4 {
 // CHECK-NEXT:        "foo"(%0, %0) : (i32, i32) -> ()
-// CHECK-NEXT:        "affine.yield"() : () -> ()
-// CHECK-NEXT:      }) : () -> ()
+// CHECK-NEXT:      }
 // CHECK-NEXT:      func.return
 // CHECK-NEXT:    }
 
@@ -176,12 +174,10 @@ func.func @down_propagate() -> i32 {
     func.return %32 : i32
   }
 
-// CHECK:      "affine.for"() <{lowerBoundMap = affine_map<() -> (0)>, operandSegmentSizes = array<i32: 0, 0, 0>, step = 1 : index, upperBoundMap = affine_map<() -> (4)>}> ({
-// CHECK-NEXT:      ^bb0(%arg0: index):
+// CHECK:      affine.for %arg0 = 0 to 4 {
 // CHECK-NEXT:        %0 = arith.constant 1 : i32
 // CHECK-NEXT:        "foo"(%0) : (i32) -> ()
-// CHECK-NEXT:        "affine.yield"() : () -> ()
-// CHECK-NEXT:      }) : () -> ()
+// CHECK-NEXT:      }
 // CHECK-NEXT:      %1 = arith.constant 1 : i32
 // CHECK-NEXT:      func.return %1 : i32
 // CHECK-NEXT:    }

--- a/tests/filecheck/transforms/cse.mlir
+++ b/tests/filecheck/transforms/cse.mlir
@@ -117,12 +117,10 @@ func.func @different_ops() -> (i32, i32) {
 // CHECK-LABEL: @down_propagate_for
   func.func @down_propagate_for() {
     %25 = arith.constant 1 : i32
-    "affine.for"() <{"lowerBoundMap" = affine_map<() -> (0)>, operandSegmentSizes = array<i32: 0, 0, 0>, "step" = 1 : index, "upperBoundMap" = affine_map<() -> (4)>}> ({
-    ^bb0(%arg0_3: index):
+    affine.for %arg0_3 = 0 to 4 {
       %26 = arith.constant 1 : i32
       "foo"(%25, %26) : (i32, i32) -> ()
-      "affine.yield"() : () -> ()
-    }) : () -> ()
+    }
     func.return
   }
 
@@ -164,12 +162,10 @@ func.func @down_propagate() -> i32 {
 /// Check that operation definitions are NOT propagated up the dominance tree.
 // CHECK-LABEL: @up_propagate_for
  func.func @up_propagate_for() -> i32 {
-    "affine.for"() <{"lowerBoundMap" = affine_map<() -> (0)>, operandSegmentSizes = array<i32: 0, 0, 0>, "step" = 1 : index, "upperBoundMap" = affine_map<() -> (4)>}> ({
-    ^bb3(%arg0_4: index):
+    affine.for %arg0_4 = 0 to 4 {
       %31 = arith.constant 1 : i32
       "foo"(%31) : (i32) -> ()
-      "affine.yield"() : () -> ()
-    }) : () -> ()
+    }
     %32 = arith.constant 1 : i32
     func.return %32 : i32
   }

--- a/tests/filecheck/transforms/lower_affine.mlir
+++ b/tests/filecheck/transforms/lower_affine.mlir
@@ -19,15 +19,13 @@
 // CHECK-NEXT:    %{{.*}} = arith.constant 2 : index
 // CHECK-NEXT:    %{{.*}} = arith.constant 1 : index
 // CHECK-NEXT:    %v2 = scf.for %r = %{{.*}} to %{{.*}} step %{{.*}} iter_args(%acc0 = %v1) -> (f32) {
-%v2 = "affine.for"(%v1) <{"lowerBoundMap" = affine_map<() -> (0)>, "upperBoundMap" = affine_map<() -> (2)>, "step" = 1 : index, operandSegmentSizes = array<i32: 0, 0, 1>}> ({
-^bb0(%r: index, %acc0: f32):
+%v2 = affine.for %r = 0 to 2 iter_args(%acc0 = %v1) -> (f32) {
 
 // CHECK-NEXT:      %{{.*}} = arith.constant 0 : index
 // CHECK-NEXT:      %{{.*}} = arith.constant 3 : index
 // CHECK-NEXT:      %{{.*}} = arith.constant 1 : index
 // CHECK-NEXT:      %v3 = scf.for %c = %{{.*}} to %{{.*}} step %{{.*}} iter_args(%acc1 = %acc0) -> (f32) {
-  %v3 = "affine.for"(%acc0) <{"lowerBoundMap" = affine_map<() -> (0)>, "upperBoundMap" = affine_map<() -> (3)>, "step" = 1 : index, operandSegmentSizes = array<i32: 0, 0, 1>}> ({
-  ^bb1(%c: index, %acc1: f32):
+  %v3 = affine.for %c = 0 to 3 iter_args(%acc1 = %acc0) -> (f32) {
 
 // CHECK-NEXT:        %v4 = memref.load %m[%r, %c] : memref<2x3xf32>
     %v4 = "affine.load"(%m, %r, %c) <{"map" = affine_map<(d0, d1) -> (d0, d1)>}> : (memref<2x3xf32>, index, index) -> f32
@@ -36,16 +34,16 @@
     %acc_new = "test.op"(%acc1, %v4) : (f32, f32) -> f32
 
 // CHECK-NEXT:        scf.yield %acc_new : f32
-    "affine.yield"(%acc_new) : (f32) -> ()
+    affine.yield %acc_new : f32
 
 // CHECK-NEXT:      }
-  }) : (f32) -> f32
+  }
 
 // CHECK-NEXT:      scf.yield %v3 : f32
-  "affine.yield"(%v3) : (f32) -> ()
+  affine.yield %v3 : f32
 
 // CHECK-NEXT:    }
-}) : (f32) -> f32
+}
 
 // CHECK-NEXT:    %apply_dim, %apply_sym = "test.op"() : () -> (index, index)
 // CHECK-NEXT:    %apply_res = arith.constant 42 : index

--- a/xdsl/dialects/affine.py
+++ b/xdsl/dialects/affine.py
@@ -4,6 +4,8 @@ from collections.abc import Sequence
 from contextlib import nullcontext
 from typing import ClassVar, cast
 
+from typing_extensions import Self
+
 from xdsl.dialects.builtin import (
     AffineMapAttr,
     AffineSetAttr,
@@ -18,6 +20,7 @@ from xdsl.dialects.builtin import (
     VectorType,
 )
 from xdsl.dialects.memref import MemRefType
+from xdsl.dialects.utils import print_assignment
 from xdsl.ir import (
     Attribute,
     Block,
@@ -128,6 +131,109 @@ class ApplyOp(IRDLOperation):
             printer.print_string("]")
 
 
+def _parse_affine_for_bound(
+    parser: Parser, keyword: str
+) -> tuple[AffineMapAttr, Sequence[SSAValue]]:
+    """
+    Parses one `affine.for` loop bound:
+    ```
+    affine-for-bound ::= `max`|`min`)? affine-map `(` ssa-use-list `)`
+                          (`[` ssa-use-list `]`)?
+                        | ssa-id
+                        | integer-literal
+    ```
+    The `max`/`min` keyword is mandatory only when the map has multiple results,
+    since it otherwise has no effect on a single-result map.
+
+    Mirrors MLIR's [`parseBound`](https://github.com/llvm/llvm-project/blob/99f7018958ed3daf2abf8d49178c24fbf1eb1010/mlir/lib/Dialect/Affine/IR/AffineOps.cpp#L2255).
+    """
+    used_min_max = parser.parse_optional_keyword(keyword) is not None
+
+    if (operand := parser.parse_optional_operand()) is not None:
+        # A bare SSA value is sugar for a single-symbol identity map.
+        return (
+            AffineMapAttr(AffineMap(0, 1, (AffineExpr.symbol(0),))),
+            (operand,),
+        )
+
+    pos = parser.pos
+    if (value := parser.parse_optional_integer()) is not None:
+        return AffineMapAttr(AffineMap.constant_map(value)), ()
+
+    map_attr = parser.parse_attribute()
+    if not isinstance(map_attr, AffineMapAttr):
+        parser.raise_error("expected an affine map or an integer for loop bound", pos)
+    m = map_attr.data
+
+    dims = parser.parse_comma_separated_list(
+        Parser.Delimiter.PAREN, parser.parse_operand
+    )
+    syms = parser.parse_optional_comma_separated_list(
+        Parser.Delimiter.SQUARE, parser.parse_operand
+    )
+    if syms is None:
+        syms = []
+
+    if len(dims) != m.num_dims:
+        parser.raise_error("dim operand count and affine map dim count must match", pos)
+    if len(syms) != m.num_symbols:
+        parser.raise_error(
+            "symbol operand count and affine map symbol count must match", pos
+        )
+    if len(m.results) > 1 and not used_min_max:
+        parser.raise_error(
+            f"loop bound affine map with multiple results requires '{keyword}' prefix",
+            pos,
+        )
+
+    return map_attr, (*dims, *syms)
+
+
+def _print_affine_for_bound(
+    printer: Printer,
+    bound_map: AffineMapAttr,
+    bound_operands: Sequence[SSAValue],
+    prefix: str,
+) -> None:
+    """
+    Prints one `affine.for` loop bound. Bounds that are a single constant,
+    or a single-symbol identity map, are printed in their short forms,
+    everything else falls back to the full affine map + operand list,
+    with a `max`/`min` prefix when the map has multiple results.
+
+    Mirror's MLIR's [`printBound`](https://github.com/llvm/llvm-project/blob/99f7018958ed3daf2abf8d49178c24fbf1eb1010/mlir/lib/Dialect/Affine/IR/AffineOps.cpp#L2430).
+    """
+    m = bound_map.data
+
+    if len(m.results) == 1:
+        expr = m.results[0]
+
+        no_dims = m.num_dims == 0
+        no_syms = m.num_symbols == 0
+
+        # just a constant
+        if no_dims and no_syms and isinstance(expr, AffineConstantExpr):
+            printer.print_string(str(expr.value))
+            return
+
+        # just a symbol
+        if no_dims and m.num_symbols == 1 and isinstance(expr, AffineSymExpr):
+            printer.print_ssa_value(bound_operands[0])
+            return
+
+    else:
+        printer.print_string(f"{prefix} ")
+
+    printer.print_attribute(bound_map)
+
+    with printer.in_parens():
+        printer.print_list(bound_operands[: m.num_dims], printer.print_ssa_value)
+
+    if m.num_symbols:
+        with printer.in_square_brackets():
+            printer.print_list(bound_operands[m.num_dims :], printer.print_ssa_value)
+
+
 @irdl_op_definition
 class ForOp(IRDLOperation):
     name = "affine.for"
@@ -209,6 +315,129 @@ class ForOp(IRDLOperation):
             properties=properties,
             regions=[region],
         )
+
+    @classmethod
+    def parse(cls, parser: Parser) -> Self:
+        unresolved_indvar = parser.parse_argument(expect_type=False)
+        parser.parse_characters("=")
+
+        lower_bound_map, lower_bound_operands = _parse_affine_for_bound(parser, "max")
+        parser.parse_characters("to")
+        upper_bound_map, upper_bound_operands = _parse_affine_for_bound(parser, "min")
+
+        if parser.parse_optional_characters("step") is not None:
+            step_pos = parser.pos
+            step = parser.parse_integer(allow_boolean=False)
+            if step < 0:
+                parser.raise_error(
+                    "expected step to be representable as a positive signed integer",
+                    step_pos,
+                )
+        else:
+            step = 1
+
+        unresolved_iter_args: Sequence[Parser.UnresolvedArgument] = ()
+        iter_arg_operands: Sequence[SSAValue] = ()
+        iter_arg_types: Sequence[Attribute] = ()
+
+        if parser.parse_optional_characters("iter_args") is not None:
+
+            def parse_iter_arg() -> tuple[Parser.UnresolvedArgument, SSAValue]:
+                arg = parser.parse_argument(expect_type=False)
+                parser.parse_characters("=")
+                return arg, parser.parse_operand()
+
+            pairs = parser.parse_comma_separated_list(
+                Parser.Delimiter.PAREN, parse_iter_arg
+            )
+            unresolved_iter_args = tuple(arg for arg, _ in pairs)
+            iter_arg_operands = tuple(val for _, val in pairs)
+            parser.parse_characters("->")
+
+            # MLIR's `parseArrowTypeList` also accepts a single bare type
+            # (no parens) when there is only one loop-carried value.
+            if parser.parse_optional_punctuation("(") is not None:
+                iter_arg_types = parser.parse_comma_separated_list(
+                    Parser.Delimiter.NONE, parser.parse_type
+                )
+                parser.parse_punctuation(")")
+            else:
+                iter_arg_types = (parser.parse_type(),)
+
+        iter_args = tuple(
+            u_arg.resolve(t) for u_arg, t in zip(unresolved_iter_args, iter_arg_types)
+        )
+        indvar = unresolved_indvar.resolve(IndexType())
+        body = parser.parse_region((indvar, *iter_args))
+
+        # affine.for has no implicit-terminator trait (see TODO above), so the
+        # terminator omitted from the printed form when there are no iter_args
+        # must be re-inserted by hand here, mirroring `ensureTerminator`
+        block = body.block
+        if block.last_op is None or not isinstance(block.last_op, YieldOp):
+            block.add_op(YieldOp.get())
+
+        attributes = parser.parse_optional_attr_dict()
+
+        for_op = cast(
+            Self,
+            cls.from_region(
+                lower_bound_operands,
+                upper_bound_operands,
+                iter_arg_operands,
+                iter_arg_types,
+                lower_bound_map,
+                upper_bound_map,
+                body,
+                step,
+            ),
+        )
+        for_op.attributes |= attributes
+        return for_op
+
+    def print(self, printer: Printer):
+        printer.print_string(" ")
+        indvar, *block_iter_args = self.body.block.args
+        printer.print_block_argument(indvar, print_type=False)
+        printer.print_string(" = ")
+
+        _print_affine_for_bound(
+            printer, self.lowerBoundMap, self.lowerBoundOperands, "max"
+        )
+        printer.print_string(" to ")
+        _print_affine_for_bound(
+            printer, self.upperBoundMap, self.upperBoundOperands, "min"
+        )
+
+        if self.step.value.data != 1:
+            printer.print_string(f" step {self.step.value.data}")
+
+        print_block_terminators = False
+
+        if self.inits:
+            printer.print_string(" iter_args")
+
+            with printer.in_parens():
+                printer.print_list(
+                    zip(block_iter_args, self.inits),
+                    lambda pair: print_assignment(printer, *pair),
+                )
+
+            printer.print_string(" -> ")
+
+            with printer.in_parens():
+                printer.print_list(self.result_types, printer.print_attribute)
+
+            print_block_terminators = True
+
+        printer.print_string(" ")
+        printer.print_region(
+            self.body,
+            print_entry_block_args=False,
+            print_empty_block=False,
+            print_block_terminators=print_block_terminators,
+        )
+        printer.print_op_attributes(self.attributes)
 
 
 @irdl_op_definition
@@ -516,6 +745,8 @@ class YieldOp(IRDLOperation):
     arguments = var_operand_def()
 
     traits = traits_def(IsTerminator(), Pure())
+
+    assembly_format = "attr-dict ($arguments^ `:` type($arguments))?"
 
     @staticmethod
     def get(*operands: SSAValue | Operation) -> YieldOp:


### PR DESCRIPTION
The generic printing is really ugly. There's a decent chunk of printing/parsing code, happy to iterate and try clean it up a bit, it's largely a complex print.

Notably includes:
- updates all references of these ops to custom syntax across test cases
- introduces some negative test cases for new parsing logic