### PR TITLE
transformations: (convert-linalg-to-loops) don't use current_operation

### DIFF
--- a/xdsl/transforms/convert_linalg_to_loops.py
+++ b/xdsl/transforms/convert_linalg_to_loops.py
@@ -138,6 +138,7 @@ class LowerLinalgStructuredOpPattern(RewritePattern):
         insertion_point = InsertPoint.before(op)
         rewrite_linalg_structured_to_loops(
             rewriter,
+            op,
             insertion_point,
             create_loop_bounds(rewriter, insertion_point, op),
             op.get_indexing_maps().data,

--- a/xdsl/transforms/convert_memref_stream_to_loops.py
+++ b/xdsl/transforms/convert_memref_stream_to_loops.py
@@ -178,6 +178,7 @@ class LowerGenericOpPattern(RewritePattern):
             # Imperfectly nested
             rewrite_generic_to_imperfect_loops(
                 rewriter,
+                op,
                 InsertPoint.before(op),
                 outer_ubs,
                 inner_ubs,
@@ -202,6 +203,7 @@ class LowerGenericOpPattern(RewritePattern):
 
             rewrite_linalg_structured_to_loops(
                 rewriter,
+                op,
                 insertion_point,
                 bound_values,
                 op.indexing_maps.data,

--- a/xdsl/transforms/loop_nest_lowering_utils.py
+++ b/xdsl/transforms/loop_nest_lowering_utils.py
@@ -214,6 +214,7 @@ def _insert_store_ops(
 
 def rewrite_linalg_structured_to_loops(
     rewriter: PatternRewriter,
+    op: Operation,
     insertion_point: InsertPoint,
     ubs: Sequence[SSAValue],
     load_indexing_maps: Sequence[AffineMapAttr],
@@ -288,12 +289,12 @@ def rewrite_linalg_structured_to_loops(
         (),
         make_body,
     )
-
-    rewriter.erase(rewriter.current_operation)
+    rewriter.erase(op)
 
 
 def rewrite_generic_to_imperfect_loops(
     rewriter: PatternRewriter,
+    op: Operation,
     insertion_point: InsertPoint,
     outer_ubs: Sequence[int],
     inner_ubs: Sequence[int],
@@ -426,4 +427,4 @@ def rewrite_generic_to_imperfect_loops(
         outer_make_body,
     )
 
-    rewriter.erase(rewriter.current_operation)
+    rewriter.erase(op)


### PR DESCRIPTION
We're planning on deprecating it, so pass the op directly to the helpers instead.
