### PR TITLE
transformations: (convert-x86-scf-to-x86) skip jump when lowering loop that iterates at least once

### DIFF
--- a/tests/filecheck/transforms/convert-x86-scf-to-x86.mlir
+++ b/tests/filecheck/transforms/convert-x86-scf-to-x86.mlir
@@ -80,21 +80,19 @@ x86_func.func @nested(%src: !x86.reg64<rax>, %dst: !x86.reg64<rbx>) {
 }
 
 // -----
-// CHECK-LABEL:    x86_func.func @static_ub_dynamic_step() {
+// CHECK-LABEL:    x86_func.func @entry_fallthrough_static_ub_dyn_step() {
 //  CHECK-NEXT:      %zero = x86.di.mov 0 : () -> !x86.reg64<rcx>
 //  CHECK-NEXT:      %step = x86.di.mov 1 : () -> !x86.reg64<rdx>
-//  CHECK-NEXT:      %0 = x86.si.cmp %zero, 10 : (!x86.reg64<rcx>) -> !x86.rflags<rflags>
-//  CHECK-NEXT:      x86.c.jge %0 : !x86.rflags<rflags>, ^bb2(%zero : !x86.reg64<rcx>), ^bb1(%zero : !x86.reg64<rcx>)
+//  CHECK-NEXT:      x86.fallthrough ^bb1(%zero : !x86.reg64<rcx>)
 //  CHECK-NEXT:    ^bb1(%i: !x86.reg64<rcx>):
 //  CHECK-NEXT:      x86.label "scf_body_0_for"
 //  CHECK-NEXT:      %i_1 = x86.rs.add %i, %step : (!x86.reg64<rcx>, !x86.reg64<rdx>) -> !x86.reg64<rcx>
-//  CHECK-NEXT:      %1 = x86.si.cmp %i_1, 10 : (!x86.reg64<rcx>) -> !x86.rflags<rflags>
-//  CHECK-NEXT:      x86.c.jl %1 : !x86.rflags<rflags>, ^bb1(%i_1 : !x86.reg64<rcx>), ^bb2(%i_1 : !x86.reg64<rcx>)
+//  CHECK-NEXT:      %0 = x86.si.cmp %i_1, 10 : (!x86.reg64<rcx>) -> !x86.rflags<rflags>
+//  CHECK-NEXT:      x86.c.jl %0 : !x86.rflags<rflags>, ^bb1(%i_1 : !x86.reg64<rcx>), ^bb2(%i_1 : !x86.reg64<rcx>)
 //  CHECK-NEXT:    ^bb2(%zero_end: !x86.reg64<rcx>):
-//  CHECK-NEXT:      x86.label "scf_body_end_0_for"
 //  CHECK-NEXT:      x86_func.ret
 //  CHECK-NEXT:    }
-x86_func.func @static_ub_dynamic_step() {
+x86_func.func @entry_fallthrough_static_ub_dyn_step() {
     %zero = x86.di.mov 0 : () -> !x86.reg64<rcx>
     %step = x86.di.mov 1 : () -> !x86.reg64<rdx>
     %zero_end = x86_scf.for %i : !x86.reg64<rcx> = %zero to 10 : si32 step %step {
@@ -104,7 +102,69 @@ x86_func.func @static_ub_dynamic_step() {
 }
 
 // -----
-// CHECK-LABEL:    x86_func.func @dynamic_ub_static_step() {
+// CHECK-LABEL:    x86_func.func @entry_fallthrough_static_bounds() {
+//  CHECK-NEXT:      %zero = x86.di.mov 0 : () -> !x86.reg64<rcx>
+//  CHECK-NEXT:      x86.fallthrough ^bb1(%zero : !x86.reg64<rcx>)
+//  CHECK-NEXT:    ^bb1(%i: !x86.reg64<rcx>):
+//  CHECK-NEXT:      x86.label "scf_body_0_for"
+//  CHECK-NEXT:      %i_1 = x86.ri.add %i, 1 : (!x86.reg64<rcx>) -> !x86.reg64<rcx>
+//  CHECK-NEXT:      %0 = x86.si.cmp %i_1, 12 : (!x86.reg64<rcx>) -> !x86.rflags<rflags>
+//  CHECK-NEXT:      x86.c.jl %0 : !x86.rflags<rflags>, ^bb1(%i_1 : !x86.reg64<rcx>), ^bb2(%i_1 : !x86.reg64<rcx>)
+//  CHECK-NEXT:    ^bb2(%zero_end: !x86.reg64<rcx>):
+//  CHECK-NEXT:      x86_func.ret
+//  CHECK-NEXT:    }
+x86_func.func @entry_fallthrough_static_bounds() {
+    %zero = x86.di.mov 0 : () -> !x86.reg64<rcx>
+    %zero_end = x86_scf.for %i : !x86.reg64<rcx> = %zero to 12 : si32 step 1 : si32 {
+        x86_scf.yield
+    }
+    ret
+}
+
+// -----
+// CHECK-LABEL:    x86_func.func @dyn_lb_static_ub(%lb: !x86.reg64<rcx>) {
+//  CHECK-NEXT:      %step = x86.di.mov 2 : () -> !x86.reg64<rdx>
+//  CHECK-NEXT:      %0 = x86.si.cmp %lb, 10 : (!x86.reg64<rcx>) -> !x86.rflags<rflags>
+//  CHECK-NEXT:      x86.c.jge %0 : !x86.rflags<rflags>, ^bb2(%lb : !x86.reg64<rcx>), ^bb1(%lb : !x86.reg64<rcx>)
+//  CHECK-NEXT:    ^bb1(%i: !x86.reg64<rcx>):
+//  CHECK-NEXT:      x86.label "scf_body_0_for"
+//  CHECK-NEXT:      %i_1 = x86.rs.add %i, %step : (!x86.reg64<rcx>, !x86.reg64<rdx>) -> !x86.reg64<rcx>
+//  CHECK-NEXT:      %1 = x86.si.cmp %i_1, 10 : (!x86.reg64<rcx>) -> !x86.rflags<rflags>
+//  CHECK-NEXT:      x86.c.jl %1 : !x86.rflags<rflags>, ^bb1(%i_1 : !x86.reg64<rcx>), ^bb2(%i_1 : !x86.reg64<rcx>)
+//  CHECK-NEXT:    ^bb2(%lb_end: !x86.reg64<rcx>):
+//  CHECK-NEXT:      x86.label "scf_body_end_0_for"
+//  CHECK-NEXT:      x86_func.ret
+//  CHECK-NEXT:    }
+x86_func.func @dyn_lb_static_ub(%lb: !x86.reg64<rcx>) {
+    %step = x86.di.mov 2 : () -> !x86.reg64<rdx>
+    %lb_end = x86_scf.for %i : !x86.reg64<rcx> = %lb to 10 : si32 step %step {
+        x86_scf.yield
+    }
+    ret
+}
+
+// -----
+// CHECK-LABEL:    x86_func.func @dyn_lb_static_bounds(%lb: !x86.reg64<rcx>) {
+//  CHECK-NEXT:      %0 = x86.si.cmp %lb, 12 : (!x86.reg64<rcx>) -> !x86.rflags<rflags>
+//  CHECK-NEXT:      x86.c.jge %0 : !x86.rflags<rflags>, ^bb2(%lb : !x86.reg64<rcx>), ^bb1(%lb : !x86.reg64<rcx>)
+//  CHECK-NEXT:    ^bb1(%i: !x86.reg64<rcx>):
+//  CHECK-NEXT:      x86.label "scf_body_0_for"
+//  CHECK-NEXT:      %i_1 = x86.ri.add %i, 1 : (!x86.reg64<rcx>) -> !x86.reg64<rcx>
+//  CHECK-NEXT:      %1 = x86.si.cmp %i_1, 12 : (!x86.reg64<rcx>) -> !x86.rflags<rflags>
+//  CHECK-NEXT:      x86.c.jl %1 : !x86.rflags<rflags>, ^bb1(%i_1 : !x86.reg64<rcx>), ^bb2(%i_1 : !x86.reg64<rcx>)
+//  CHECK-NEXT:    ^bb2(%lb_end: !x86.reg64<rcx>):
+//  CHECK-NEXT:      x86.label "scf_body_end_0_for"
+//  CHECK-NEXT:      x86_func.ret
+//  CHECK-NEXT:    }
+x86_func.func @dyn_lb_static_bounds(%lb: !x86.reg64<rcx>) {
+    %lb_end = x86_scf.for %i : !x86.reg64<rcx> = %lb to 12 : si32 step 1 : si32 {
+        x86_scf.yield
+    }
+    ret
+}
+
+// -----
+// CHECK-LABEL:    x86_func.func @dyn_ub_static_step() {
 //  CHECK-NEXT:      %zero = x86.di.mov 0 : () -> !x86.reg64<rcx>
 //  CHECK-NEXT:      %ub = x86.di.mov 20 : () -> !x86.reg64<r8>
 //  CHECK-NEXT:      %0 = x86.ss.cmp %zero, %ub : (!x86.reg64<rcx>, !x86.reg64<r8>) -> !x86.rflags<rflags>
@@ -118,7 +178,7 @@ x86_func.func @static_ub_dynamic_step() {
 //  CHECK-NEXT:      x86.label "scf_body_end_0_for"
 //  CHECK-NEXT:      x86_func.ret
 //  CHECK-NEXT:    }
-x86_func.func @dynamic_ub_static_step() {
+x86_func.func @dyn_ub_static_step() {
     %zero = x86.di.mov 0 : () -> !x86.reg64<rcx>
     %ub = x86.di.mov 20 : () -> !x86.reg64<r8>
     %zero_end = x86_scf.for %i : !x86.reg64<rcx> = %zero to %ub step 3 : si32 {
@@ -128,22 +188,22 @@ x86_func.func @dynamic_ub_static_step() {
 }
 
 // -----
-// CHECK-LABEL:    x86_func.func @static_ub_static_step() {
-//  CHECK-NEXT:      %zero = x86.di.mov 0 : () -> !x86.reg64<rcx>
-//  CHECK-NEXT:      %0 = x86.si.cmp %zero, 12 : (!x86.reg64<rcx>) -> !x86.rflags<rflags>
-//  CHECK-NEXT:      x86.c.jge %0 : !x86.rflags<rflags>, ^bb2(%zero : !x86.reg64<rcx>), ^bb1(%zero : !x86.reg64<rcx>)
+// CHECK-LABEL:    x86_func.func @known_empty() {
+//  CHECK-NEXT:      %ten = x86.di.mov 10 : () -> !x86.reg64<rcx>
+//  CHECK-NEXT:      %0 = x86.si.cmp %ten, 10 : (!x86.reg64<rcx>) -> !x86.rflags<rflags>
+//  CHECK-NEXT:      x86.c.jge %0 : !x86.rflags<rflags>, ^bb2(%ten : !x86.reg64<rcx>), ^bb1(%ten : !x86.reg64<rcx>)
 //  CHECK-NEXT:    ^bb1(%i: !x86.reg64<rcx>):
 //  CHECK-NEXT:      x86.label "scf_body_0_for"
 //  CHECK-NEXT:      %i_1 = x86.ri.add %i, 1 : (!x86.reg64<rcx>) -> !x86.reg64<rcx>
-//  CHECK-NEXT:      %1 = x86.si.cmp %i_1, 12 : (!x86.reg64<rcx>) -> !x86.rflags<rflags>
+//  CHECK-NEXT:      %1 = x86.si.cmp %i_1, 10 : (!x86.reg64<rcx>) -> !x86.rflags<rflags>
 //  CHECK-NEXT:      x86.c.jl %1 : !x86.rflags<rflags>, ^bb1(%i_1 : !x86.reg64<rcx>), ^bb2(%i_1 : !x86.reg64<rcx>)
-//  CHECK-NEXT:    ^bb2(%zero_end: !x86.reg64<rcx>):
+//  CHECK-NEXT:    ^bb2(%ten_end: !x86.reg64<rcx>):
 //  CHECK-NEXT:      x86.label "scf_body_end_0_for"
 //  CHECK-NEXT:      x86_func.ret
 //  CHECK-NEXT:    }
-x86_func.func @static_ub_static_step() {
-    %zero = x86.di.mov 0 : () -> !x86.reg64<rcx>
-    %zero_end = x86_scf.for %i : !x86.reg64<rcx> = %zero to 12 : si32 step 1 : si32 {
+x86_func.func @known_empty() {
+    %ten = x86.di.mov 10 : () -> !x86.reg64<rcx>
+    %ten_end = x86_scf.for %i : !x86.reg64<rcx> = %ten to 10 : si32 step 1 : si32 {
         x86_scf.yield
     }
     ret

--- a/xdsl/transforms/convert_x86_scf_to_x86.py
+++ b/xdsl/transforms/convert_x86_scf_to_x86.py
@@ -135,37 +135,60 @@ class LowerX86ScfForPattern(RewritePattern):
 
         rewriter.inline_region(op.body, BlockInsertPoint.before(end_block))
 
-        # Skip for loop if condition is not satisfied at start.
-        # lb is the IV register (inout); legalization inserts a copy when needed.
-        rewriter.insert(
-            (
-                cmp_op := (
-                    x86.ops.SS_CmpOp(op.lb, ub)
-                    if isinstance(ub, SSAValue)
-                    else x86.ops.SI_CmpOp(op.lb, ub)
+        if (
+            isinstance(lb_owner := op.lb.owner, x86.DI_MovOp)
+            and isinstance(ub, builtin.IntegerAttr)
+            and lb_owner.immediate.value.data < ub.value.data
+        ):
+            # Loop executes at least once, fallthrough directly into it without runtime checks
+            rewriter.insert(
+                (
+                    x86.ops.FallthroughOp(
+                        (op.lb, *op.iter_args),
+                        first_body_block,
+                    ),
                 ),
-                x86.ops.C_JgeOp(
-                    cmp_op.result,
-                    (op.lb, *op.iter_args),
-                    (op.lb, *op.iter_args),
-                    end_block,
-                    first_body_block,
+                InsertPoint.at_end(init_block),
+            )
+
+            # Replace operation by arguments to the newly added end block.
+            rewriter.replace(
+                op,
+                (),
+                end_block.args,
+            )
+        else:
+            # Skip for loop if condition is not satisfied at start.
+            # lb is the IV register (inout); legalization inserts a copy when needed.
+            rewriter.insert(
+                (
+                    cmp_op := (
+                        x86.ops.SS_CmpOp(op.lb, ub)
+                        if isinstance(ub, SSAValue)
+                        else x86.ops.SI_CmpOp(op.lb, ub)
+                    ),
+                    x86.ops.C_JgeOp(
+                        cmp_op.result,
+                        (op.lb, *op.iter_args),
+                        (op.lb, *op.iter_args),
+                        end_block,
+                        first_body_block,
+                    ),
                 ),
-            ),
-            InsertPoint.at_end(init_block),
-        )
+                InsertPoint.at_end(init_block),
+            )
+
+            # Replace operation by arguments to the newly added end block.
+            rewriter.replace(
+                op,
+                x86.ops.LabelOp(f"scf_body_end_{suffix}"),
+                end_block.args,
+            )
 
         # Insert label at the start of the first body block.
         rewriter.insert(
             x86.ops.LabelOp(f"scf_body_{suffix}"),
             InsertPoint.at_start(first_body_block),
-        )
-
-        # Replace operation by arguments to the newly end block.
-        rewriter.replace(
-            op,
-            x86.ops.LabelOp(f"scf_body_end_{suffix}"),
-            end_block.args,
         )
 
 


### PR DESCRIPTION
This is the case in our matmul generation, as we know the bounds at compile-time.