### PR TITLE
transformations: (convert-x86-scf-to-x86) insert increment at start if iv not used in loop

### DIFF
--- a/tests/filecheck/transforms/convert-x86-scf-to-x86.mlir
+++ b/tests/filecheck/transforms/convert-x86-scf-to-x86.mlir
@@ -30,6 +30,36 @@ x86_func.func @copy10(%src: !x86.reg64<rax>, %dst: !x86.reg64<rbx>) {
 
 // -----
 
+
+// CHECK-LABEL:    @iv_not_used
+//  CHECK-NEXT:      %zero = x86.di.mov 0 : () -> !x86.reg64<rcx>
+//  CHECK-NEXT:      %step = x86.di.mov 4 : () -> !x86.reg64<rdx>
+//  CHECK-NEXT:      %forty = x86.di.mov 40 : () -> !x86.reg64<r8>
+//  CHECK-NEXT:      %0 = x86.ss.cmp %zero, %forty : (!x86.reg64<rcx>, !x86.reg64<r8>) -> !x86.rflags<rflags>
+//  CHECK-NEXT:      x86.c.jge %0 : !x86.rflags<rflags>, ^bb2(%zero : !x86.reg64<rcx>), ^bb1(%zero : !x86.reg64<rcx>)
+//  CHECK-NEXT:    ^bb1(%offset: !x86.reg64<rcx>):
+//  CHECK-NEXT:      x86.label "scf_body_0_for"
+//  CHECK-NEXT:      %offset_1 = x86.rs.add %offset, %step : (!x86.reg64<rcx>, !x86.reg64<rdx>) -> !x86.reg64<rcx>
+//  CHECK-NEXT:      "test.op"(%src, %dst) : (!x86.reg64<rax>, !x86.reg64<rbx>) -> ()
+//  CHECK-NEXT:      %1 = x86.ss.cmp %offset_1, %forty : (!x86.reg64<rcx>, !x86.reg64<r8>) -> !x86.rflags<rflags>
+//  CHECK-NEXT:      x86.c.jl %1 : !x86.rflags<rflags>, ^bb1(%offset_1 : !x86.reg64<rcx>), ^bb2(%offset_1 : !x86.reg64<rcx>)
+//  CHECK-NEXT:    ^bb2(%offset_end: !x86.reg64<rcx>):
+//  CHECK-NEXT:      x86.label "scf_body_end_0_for"
+//  CHECK-NEXT:      x86_func.ret
+//  CHECK-NEXT:    }
+x86_func.func @iv_not_used(%src: !x86.reg64<rax>, %dst: !x86.reg64<rbx>) {
+    %zero = x86.di.mov 0 : () -> !x86.reg64<rcx>
+    %step = x86.di.mov 4 : () -> !x86.reg64<rdx>
+    %forty = x86.di.mov 40 : () -> !x86.reg64<r8>
+    %offset_end = x86_scf.for %offset : !x86.reg64<rcx> = %zero to %forty step %step {
+        "test.op"(%src, %dst) :  (!x86.reg64<rax>, !x86.reg64<rbx>) -> ()
+        yield
+    }
+    ret
+}
+
+// -----
+
 // CHECK-LABEL:    x86_func.func @nested(%src: !x86.reg64<rax>, %dst: !x86.reg64<rbx>) {
 //  CHECK-NEXT:      %zero_outer = x86.di.mov 0 : () -> !x86.reg64<rcx>
 //  CHECK-NEXT:      %step_outer = x86.di.mov 4 : () -> !x86.reg64<rdx>

--- a/xdsl/transforms/convert_x86_scf_to_x86.py
+++ b/xdsl/transforms/convert_x86_scf_to_x86.py
@@ -95,6 +95,7 @@ class LowerX86ScfForPattern(RewritePattern):
 
         # Get the induction variable and its register
         iv = SSAValue.get(first_body_block.args[0], type=GeneralRegisterType)
+        iv_used = iv.first_use is not None
         ub = op.ub
         step = op.step
 
@@ -108,17 +109,19 @@ class LowerX86ScfForPattern(RewritePattern):
                 step_op = x86.ops.RS_AddOp(iv, step)
             case builtin.IntegerAttr():
                 step_op = x86.ops.RI_AddOp(iv, step)
+        step_op.register_out.name_hint = iv.name_hint
         new_iv = step_op.register_out
+
         match ub:
             case SSAValue():
                 cmp_op = x86.ops.SS_CmpOp(new_iv, ub)
             case builtin.IntegerAttr():
                 cmp_op = x86.ops.SI_CmpOp(new_iv, ub)
 
+        # Insert comparison and jump to beginning of loop
         rewriter.replace(
             yield_op,
             (
-                step_op,
                 cmp_op,
                 x86.ops.C_JlOp(
                     cmp_op.result,
@@ -130,7 +133,16 @@ class LowerX86ScfForPattern(RewritePattern):
             ),
         )
 
-        step_op.register_out.name_hint = iv.name_hint
+        # Insert iv increment
+        # If iv was not used prior to lowering, then put it at the start of the loop as
+        # an optimisation to avoid cycles waiting for the increment.
+        rewriter.insert(
+            step_op,
+            InsertPoint.before(cmp_op)
+            if iv_used
+            else InsertPoint.at_start(first_body_block),
+        )
+
         end_block.args[0].name_hint = op.lb_end.name_hint
 
         rewriter.inline_region(op.body, BlockInsertPoint.before(end_block))


### PR DESCRIPTION
I'm not 100% happy with this being in the lowering and would like to move it out later, but I can't think of a nice API for it to actually work. It does make sense to add the increment at the beginning and not the end to avoid stalls, as incrementing the counter takes some cycles, and if it's not used in the loop then those cycles could be spent doing something useful.