### PR TITLE
dialects: (x86) derive the EVEX broadcast modifier from the register width

### DIFF
--- a/tests/filecheck/dialects/x86/x86_assembly_emission.mlir
+++ b/tests/filecheck/dialects/x86/x86_assembly_emission.mlir
@@ -408,6 +408,18 @@ x86_func.func @funcyasm() {
 %rrm_vfmadd231ps_avx512_broadcast = x86.rsm.vfmadd231ps %rrm_vfmadd231pd_avx512_broadcast, %zmm1, [%1 + 4] {broadcast} : (!x86.avx512reg<zmm0>, !x86.avx512reg<zmm1>, !x86.reg64<rdx>) -> !x86.avx512reg<zmm0>
 // CHECK: vfmadd231ps zmm0, zmm1, [rdx+4]{1to16}
 
+// The broadcast lane count follows the register bank, not the instruction:
+// AVX512VL allows EVEX broadcast on ymm and xmm operands too, where the same
+// instruction broadcasts to fewer lanes.
+%rrm_vfmadd231pd_ymm_broadcast = x86.rsm.vfmadd231pd %rrr_vfmadd231pd_avx2, %ymm1, [%1] {broadcast} : (!x86.avx2reg<ymm0>, !x86.avx2reg<ymm1>, !x86.reg64<rdx>) -> !x86.avx2reg<ymm0>
+// CHECK: vfmadd231pd ymm0, ymm1, [rdx]{1to4}
+%rrm_vfmadd231ps_ymm_broadcast = x86.rsm.vfmadd231ps %rrm_vfmadd231pd_ymm_broadcast, %ymm1, [%1] {broadcast} : (!x86.avx2reg<ymm0>, !x86.avx2reg<ymm1>, !x86.reg64<rdx>) -> !x86.avx2reg<ymm0>
+// CHECK: vfmadd231ps ymm0, ymm1, [rdx]{1to8}
+%rrm_vfmadd231pd_xmm_broadcast = x86.rsm.vfmadd231pd %rrr_vfmadd231pd_sse, %xmm1, [%1] {broadcast} : (!x86.ssereg<xmm0>, !x86.ssereg<xmm1>, !x86.reg64<rdx>) -> !x86.ssereg<xmm0>
+// CHECK: vfmadd231pd xmm0, xmm1, [rdx]{1to2}
+%rrm_vfmadd231ps_xmm_broadcast = x86.rsm.vfmadd231ps %rrm_vfmadd231pd_xmm_broadcast, %xmm1, [%1] {broadcast} : (!x86.ssereg<xmm0>, !x86.ssereg<xmm1>, !x86.reg64<rdx>) -> !x86.ssereg<xmm0>
+// CHECK: vfmadd231ps xmm0, xmm1, [rdx]{1to4}
+
 %dss_addpd_avx512 = x86.dss.addpd %zmm1, %zmm2 : (!x86.avx512reg<zmm1>, !x86.avx512reg<zmm2>) -> !x86.avx512reg<zmm0>
 // CHECK-NEXT: addpd zmm0, zmm1, zmm2
 %dss_addps_avx512 = x86.dss.addps %zmm1, %zmm2 : (!x86.avx512reg<zmm1>, !x86.avx512reg<zmm2>) -> !x86.avx512reg<zmm0>

--- a/xdsl/dialects/x86/assembly.py
+++ b/xdsl/dialects/x86/assembly.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Literal, TypeAlias
+from typing import TypeAlias
 
 from xdsl.backend.assembly_printer import reg
 from xdsl.dialects.builtin import IntegerAttr, StringAttr, UnitAttr
@@ -32,9 +32,15 @@ def memory_access_str(register: SSAValue, offset: IntegerAttr) -> str:
 def broadcast_memory_access_str(
     register: SSAValue,
     offset: IntegerAttr,
-    broadcast: Literal["1to8", "1to16"],
+    broadcast: str,
 ) -> str:
-    """e.g. ``[rsi+512]{1to8}``"""
+    """
+    e.g. ``[rsi+512]{1to8}``
+
+    The lane count depends on both the element width and the width of the
+    register bank the instruction is allocated to, so it is computed by the
+    operation rather than drawn from a fixed set.
+    """
     return f"{memory_access_str(register, offset)}{{{broadcast}}}"
 
 

--- a/xdsl/dialects/x86/ops.py
+++ b/xdsl/dialects/x86/ops.py
@@ -1459,13 +1459,25 @@ class RSMB_Operation(X86Instruction, ABC, Generic[R1InvT, R2InvT, R4InvT]):
 
     @classmethod
     @abstractmethod
-    def broadcast_modifier(cls) -> Literal["1to8", "1to16"]:
+    def element_bitwidth(cls) -> int:
         """
-        If broadcasting, specifies whether the operation broadcasts to 8 or 16 lanes.
-        This will be determined by the bitwidth of the lanes of the vector this
-        operation operates on.
+        The bitwidth of a single lane of the vector this operation operates on.
         """
         raise NotImplementedError()
+
+    def broadcast_modifier(self) -> str:
+        """
+        The EVEX broadcast modifier for this operation, e.g. `1to8`.
+
+        The lane count is the register width divided by the element width, so it
+        depends on the register bank this operation is allocated to: vfmadd231pd
+        broadcasts `1to2` on xmm, `1to4` on ymm and `1to8` on zmm. Hardcoding the
+        widest form emits assembly that the assembler rejects on the narrower
+        banks.
+        """
+        register_type = self.register_in.type
+        assert isinstance(register_type, X86VectorRegisterType)
+        return f"1to{register_type.bitwidth() // self.element_bitwidth()}"
 
     def assembly_line_args(self) -> tuple[AssemblyInstructionArg | None, ...]:
         if self.broadcast:
@@ -3466,8 +3478,8 @@ class RSM_Vfmadd231pdOp(
     name = "x86.rsm.vfmadd231pd"
 
     @classmethod
-    def broadcast_modifier(cls) -> Literal["1to8"]:
-        return "1to8"
+    def element_bitwidth(cls) -> int:
+        return 64
 
 
 @irdl_op_definition
@@ -3498,8 +3510,8 @@ class RSM_Vfmadd231psOp(
     name = "x86.rsm.vfmadd231ps"
 
     @classmethod
-    def broadcast_modifier(cls) -> Literal["1to16"]:
-        return "1to16"
+    def element_bitwidth(cls) -> int:
+        return 32
 
 
 @irdl_op_definition

--- a/xdsl/dialects/x86/ops.py
+++ b/xdsl/dialects/x86/ops.py
@@ -1459,7 +1459,7 @@ class RSMB_Operation(X86Instruction, ABC, Generic[R1InvT, R2InvT, R4InvT]):
 
     @classmethod
     @abstractmethod
-    def element_bitwidth(cls) -> int:
+    def lane_bitwidth(cls) -> int:
         """
         The bitwidth of a single lane of the vector this operation operates on.
         """
@@ -1469,15 +1469,13 @@ class RSMB_Operation(X86Instruction, ABC, Generic[R1InvT, R2InvT, R4InvT]):
         """
         The EVEX broadcast modifier for this operation, e.g. `1to8`.
 
-        The lane count is the register width divided by the element width, so it
+        The lane count is the register width divided by the lane width, so it
         depends on the register bank this operation is allocated to: vfmadd231pd
-        broadcasts `1to2` on xmm, `1to4` on ymm and `1to8` on zmm. Hardcoding the
-        widest form emits assembly that the assembler rejects on the narrower
-        banks.
+        broadcasts `1to2` on xmm, `1to4` on ymm and `1to8` on zmm.
         """
         register_type = self.register_in.type
         assert isinstance(register_type, X86VectorRegisterType)
-        return f"1to{register_type.bitwidth() // self.element_bitwidth()}"
+        return f"1to{register_type.bitwidth() // self.lane_bitwidth()}"
 
     def assembly_line_args(self) -> tuple[AssemblyInstructionArg | None, ...]:
         if self.broadcast:
@@ -3478,7 +3476,7 @@ class RSM_Vfmadd231pdOp(
     name = "x86.rsm.vfmadd231pd"
 
     @classmethod
-    def element_bitwidth(cls) -> int:
+    def lane_bitwidth(cls) -> int:
         return 64
 
 
@@ -3510,7 +3508,7 @@ class RSM_Vfmadd231psOp(
     name = "x86.rsm.vfmadd231ps"
 
     @classmethod
-    def element_bitwidth(cls) -> int:
+    def lane_bitwidth(cls) -> int:
         return 32
 
 

--- a/xdsl/dialects/x86/registers.py
+++ b/xdsl/dialects/x86/registers.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from abc import ABC
+from abc import ABC, abstractmethod
 
 from typing_extensions import override
 
@@ -325,7 +325,7 @@ how many names exist (e.g. 8, 16, or 32) via
 """
 
 
-class X86VectorRegisterType(X86RegisterType):
+class X86VectorRegisterType(X86RegisterType, ABC):
     """
     The abstract class for all x86 vector register types.
     """
@@ -336,11 +336,12 @@ class X86VectorRegisterType(X86RegisterType):
         return X86_VECTOR_POOL_KEY
 
     @classmethod
+    @abstractmethod
     def bitwidth(cls) -> int:
         """
         The width of this register bank in bits.
         """
-        raise NotImplementedError()
+        ...
 
 
 SSE_INDEX_BY_NAME = {f"xmm{i}": i for i in range(32)}

--- a/xdsl/dialects/x86/registers.py
+++ b/xdsl/dialects/x86/registers.py
@@ -335,6 +335,13 @@ class X86VectorRegisterType(X86RegisterType):
     def register_pool_key(cls) -> str:
         return X86_VECTOR_POOL_KEY
 
+    @classmethod
+    def bitwidth(cls) -> int:
+        """
+        The width of this register bank in bits.
+        """
+        raise NotImplementedError()
+
 
 SSE_INDEX_BY_NAME = {f"xmm{i}": i for i in range(32)}
 """
@@ -351,6 +358,10 @@ class SSERegisterType(X86VectorRegisterType):
     """
 
     name = "x86.ssereg"
+
+    @classmethod
+    def bitwidth(cls) -> int:
+        return 128
 
     @classmethod
     def index_by_name(cls) -> dict[str, int]:
@@ -420,6 +431,10 @@ class AVX2RegisterType(X86VectorRegisterType):
     name = "x86.avx2reg"
 
     @classmethod
+    def bitwidth(cls) -> int:
+        return 256
+
+    @classmethod
     def index_by_name(cls) -> dict[str, int]:
         return AVX2_INDEX_BY_NAME
 
@@ -485,6 +500,10 @@ class AVX512RegisterType(X86VectorRegisterType):
     """
 
     name = "x86.avx512reg"
+
+    @classmethod
+    def bitwidth(cls) -> int:
+        return 512
 
     @classmethod
     def index_by_name(cls) -> dict[str, int]:


### PR DESCRIPTION
`RSM_Vfmadd231pdOp` and `RSM_Vfmadd231psOp` hardcode their broadcast modifier to `1to8` and `1to16`. Those values are only correct for zmm operands.

AVX512VL allows EVEX broadcast on ymm and xmm as well, where the same instruction broadcasts to fewer lanes, so the hardcoded modifier emits assembly the assembler rejects:

```
vfmadd231pd ymm0, ymm1, [rdx]{1to8}
error: invalid operand for instruction
```

The lane count is the register width divided by the element width. This replaces `broadcast_modifier()` with an abstract `element_bitwidth()` and computes the modifier from the type of `register_in`, adding `bitwidth()` to the vector register types.

This has not bitten anyone so far because nothing in tree generates these operations, and the existing emission tests only cover zmm, where the hardcoded values happen to be right. I ran into it while writing a pass that does generate them, which I will open separately.

Verified against the assembler for all six pd/ps by xmm/ymm/zmm forms:

```
vfmadd231pd zmm0, zmm1, [rdx]{1to8}
vfmadd231pd ymm0, ymm1, [rdx]{1to4}
vfmadd231pd xmm0, xmm1, [rdx]{1to2}
vfmadd231ps zmm0, zmm1, [rdx]{1to16}
vfmadd231ps ymm0, ymm1, [rdx]{1to8}
vfmadd231ps xmm0, xmm1, [rdx]{1to4}
```

Emission tests extended to cover the ymm and xmm cases.