### PR TITLE
transformations: (x86) fold vector loads into FMA memory operands

### DIFF
--- a/tests/filecheck/dialects/x86/x86_assembly_emission.mlir
+++ b/tests/filecheck/dialects/x86/x86_assembly_emission.mlir
@@ -408,6 +408,18 @@ x86_func.func @funcyasm() {
 %rrm_vfmadd231ps_avx512_broadcast = x86.rsm.vfmadd231ps %rrm_vfmadd231pd_avx512_broadcast, %zmm1, [%1 + 4] {broadcast} : (!x86.avx512reg<zmm0>, !x86.avx512reg<zmm1>, !x86.reg64<rdx>) -> !x86.avx512reg<zmm0>
 // CHECK: vfmadd231ps zmm0, zmm1, [rdx+4]{1to16}
 
+// The broadcast lane count follows the register bank, not the instruction:
+// AVX512VL allows EVEX broadcast on ymm and xmm operands too, where the same
+// instruction broadcasts to fewer lanes.
+%rrm_vfmadd231pd_ymm_broadcast = x86.rsm.vfmadd231pd %rrr_vfmadd231pd_avx2, %ymm1, [%1] {broadcast} : (!x86.avx2reg<ymm0>, !x86.avx2reg<ymm1>, !x86.reg64<rdx>) -> !x86.avx2reg<ymm0>
+// CHECK: vfmadd231pd ymm0, ymm1, [rdx]{1to4}
+%rrm_vfmadd231ps_ymm_broadcast = x86.rsm.vfmadd231ps %rrm_vfmadd231pd_ymm_broadcast, %ymm1, [%1] {broadcast} : (!x86.avx2reg<ymm0>, !x86.avx2reg<ymm1>, !x86.reg64<rdx>) -> !x86.avx2reg<ymm0>
+// CHECK: vfmadd231ps ymm0, ymm1, [rdx]{1to8}
+%rrm_vfmadd231pd_xmm_broadcast = x86.rsm.vfmadd231pd %rrr_vfmadd231pd_sse, %xmm1, [%1] {broadcast} : (!x86.ssereg<xmm0>, !x86.ssereg<xmm1>, !x86.reg64<rdx>) -> !x86.ssereg<xmm0>
+// CHECK: vfmadd231pd xmm0, xmm1, [rdx]{1to2}
+%rrm_vfmadd231ps_xmm_broadcast = x86.rsm.vfmadd231ps %rrm_vfmadd231pd_xmm_broadcast, %xmm1, [%1] {broadcast} : (!x86.ssereg<xmm0>, !x86.ssereg<xmm1>, !x86.reg64<rdx>) -> !x86.ssereg<xmm0>
+// CHECK: vfmadd231ps xmm0, xmm1, [rdx]{1to4}
+
 %dss_addpd_avx512 = x86.dss.addpd %zmm1, %zmm2 : (!x86.avx512reg<zmm1>, !x86.avx512reg<zmm2>) -> !x86.avx512reg<zmm0>
 // CHECK-NEXT: addpd zmm0, zmm1, zmm2
 %dss_addps_avx512 = x86.dss.addps %zmm1, %zmm2 : (!x86.avx512reg<zmm1>, !x86.avx512reg<zmm2>) -> !x86.avx512reg<zmm0>

--- a/tests/filecheck/transforms/x86-fold-memory-operands-avx512.mlir
+++ b/tests/filecheck/transforms/x86-fold-memory-operands-avx512.mlir
@@ -1,0 +1,41 @@
+// RUN: xdsl-opt -p 'x86-fold-memory-operands{arch=avx512}' %s | filecheck %s
+
+// On AVX-512 a broadcast-load folds into the FMA as an EVEX embedded
+// broadcast, removing the broadcast instruction and the vector register it
+// occupied.
+%ptr = "test.op"() : () -> !x86.reg64
+%acc = "test.op"() : () -> !x86.avx512reg
+%b = "test.op"() : () -> !x86.avx512reg
+%bcast = x86.dm.vbroadcastsd [%ptr + 16] : (!x86.reg64) -> !x86.avx512reg
+%fma = x86.rss.vfmadd231pd %acc, %b, %bcast : (!x86.avx512reg, !x86.avx512reg, !x86.avx512reg) -> !x86.avx512reg
+"test.op"(%fma) : (!x86.avx512reg) -> ()
+// CHECK:       %fma = x86.rsm.vfmadd231pd %acc, %b, [%ptr + 16] {broadcast} : (!x86.avx512reg, !x86.avx512reg, !x86.reg64) -> !x86.avx512reg
+// CHECK-NOT:   x86.dm.vbroadcastsd [%ptr + 16]
+
+// AVX512VL extends EVEX to 256-bit operands, so a ymm broadcast folds on an
+// AVX-512 target as well.
+%ptr_v = "test.op"() : () -> !x86.reg64
+%acc_v = "test.op"() : () -> !x86.avx2reg
+%b_v = "test.op"() : () -> !x86.avx2reg
+%bcast_v = x86.dm.vbroadcastsd [%ptr_v] : (!x86.reg64) -> !x86.avx2reg
+%fma_v = x86.rss.vfmadd231pd %acc_v, %b_v, %bcast_v : (!x86.avx2reg, !x86.avx2reg, !x86.avx2reg) -> !x86.avx2reg
+"test.op"(%fma_v) : (!x86.avx2reg) -> ()
+// CHECK:       %fma_v = x86.rsm.vfmadd231pd %acc_v, %b_v, [%ptr_v] {broadcast} : (!x86.avx2reg, !x86.avx2reg, !x86.reg64) -> !x86.avx2reg
+
+// Single-precision broadcasts fold to the ps form.
+%ptr_s = "test.op"() : () -> !x86.reg64
+%acc_s = "test.op"() : () -> !x86.avx512reg
+%b_s = "test.op"() : () -> !x86.avx512reg
+%bcast_s = x86.dm.vbroadcastss [%ptr_s + 4] : (!x86.reg64) -> !x86.avx512reg
+%fma_s = x86.rss.vfmadd231ps %acc_s, %b_s, %bcast_s : (!x86.avx512reg, !x86.avx512reg, !x86.avx512reg) -> !x86.avx512reg
+"test.op"(%fma_s) : (!x86.avx512reg) -> ()
+// CHECK:       %fma_s = x86.rsm.vfmadd231ps %acc_s, %b_s, [%ptr_s + 4] {broadcast} : (!x86.avx512reg, !x86.avx512reg, !x86.reg64) -> !x86.avx512reg
+
+// Plain vector loads still fold without the broadcast modifier.
+%ptr_p = "test.op"() : () -> !x86.reg64
+%acc_p = "test.op"() : () -> !x86.avx512reg
+%b_p = "test.op"() : () -> !x86.avx512reg
+%load_p = x86.dm.vmovupd [%ptr_p] : (!x86.reg64) -> !x86.avx512reg
+%fma_p = x86.rss.vfmadd231pd %acc_p, %b_p, %load_p : (!x86.avx512reg, !x86.avx512reg, !x86.avx512reg) -> !x86.avx512reg
+"test.op"(%fma_p) : (!x86.avx512reg) -> ()
+// CHECK:       %fma_p = x86.rsm.vfmadd231pd %acc_p, %b_p, [%ptr_p] : (!x86.avx512reg, !x86.avx512reg, !x86.reg64) -> !x86.avx512reg

--- a/tests/filecheck/transforms/x86-fold-memory-operands.mlir
+++ b/tests/filecheck/transforms/x86-fold-memory-operands.mlir
@@ -1,0 +1,66 @@
+// RUN: xdsl-opt -p 'x86-fold-memory-operands{arch=avx2}' %s | filecheck %s
+
+// A vector load feeding an FMA folds into the memory operand. This form is
+// VEX-encodable, so it applies at AVX2.
+%ptr = "test.op"() : () -> !x86.reg64
+%acc = "test.op"() : () -> !x86.avx2reg
+%b = "test.op"() : () -> !x86.avx2reg
+%load = x86.dm.vmovupd [%ptr + 8] : (!x86.reg64) -> !x86.avx2reg
+%fma = x86.rss.vfmadd231pd %acc, %b, %load : (!x86.avx2reg, !x86.avx2reg, !x86.avx2reg) -> !x86.avx2reg
+"test.op"(%fma) : (!x86.avx2reg) -> ()
+// CHECK:       %fma = x86.rsm.vfmadd231pd %acc, %b, [%ptr + 8] : (!x86.avx2reg, !x86.avx2reg, !x86.reg64) -> !x86.avx2reg
+// CHECK-NOT:   x86.dm.vmovupd [%ptr + 8]
+
+// Aligned loads fold too; the memory-operand form has no alignment requirement.
+%ptr_a = "test.op"() : () -> !x86.reg64
+%acc_a = "test.op"() : () -> !x86.avx2reg
+%b_a = "test.op"() : () -> !x86.avx2reg
+%load_a = x86.dm.vmovaps [%ptr_a] : (!x86.reg64) -> !x86.avx2reg
+%fma_a = x86.rss.vfmadd231ps %acc_a, %b_a, %load_a : (!x86.avx2reg, !x86.avx2reg, !x86.avx2reg) -> !x86.avx2reg
+"test.op"(%fma_a) : (!x86.avx2reg) -> ()
+// CHECK:       %fma_a = x86.rsm.vfmadd231ps %acc_a, %b_a, [%ptr_a] : (!x86.avx2reg, !x86.avx2reg, !x86.reg64) -> !x86.avx2reg
+
+// The multiply operands commute, so a load in source1 folds as well, leaving
+// the register operand in source1 of the fused instruction.
+%ptr_c = "test.op"() : () -> !x86.reg64
+%acc_c = "test.op"() : () -> !x86.avx2reg
+%b_c = "test.op"() : () -> !x86.avx2reg
+%load_c = x86.dm.vmovupd [%ptr_c] : (!x86.reg64) -> !x86.avx2reg
+%fma_c = x86.rss.vfmadd231pd %acc_c, %load_c, %b_c : (!x86.avx2reg, !x86.avx2reg, !x86.avx2reg) -> !x86.avx2reg
+"test.op"(%fma_c) : (!x86.avx2reg) -> ()
+// CHECK:       %fma_c = x86.rsm.vfmadd231pd %acc_c, %b_c, [%ptr_c] : (!x86.avx2reg, !x86.avx2reg, !x86.reg64) -> !x86.avx2reg
+
+// A broadcast-load does NOT fold at AVX2: the embedded broadcast modifier
+// requires EVEX encoding, which AVX2 does not have.
+%ptr_y = "test.op"() : () -> !x86.reg64
+%acc_y = "test.op"() : () -> !x86.avx2reg
+%b_y = "test.op"() : () -> !x86.avx2reg
+%bcast_y = x86.dm.vbroadcastsd [%ptr_y] : (!x86.reg64) -> !x86.avx2reg
+%fma_y = x86.rss.vfmadd231pd %acc_y, %b_y, %bcast_y : (!x86.avx2reg, !x86.avx2reg, !x86.avx2reg) -> !x86.avx2reg
+"test.op"(%fma_y) : (!x86.avx2reg) -> ()
+// CHECK:       %bcast_y = x86.dm.vbroadcastsd [%ptr_y] : (!x86.reg64) -> !x86.avx2reg
+// CHECK-NEXT:  %fma_y = x86.rss.vfmadd231pd %acc_y, %b_y, %bcast_y
+
+// A load with more than one use does not fold: doing so would duplicate the
+// memory access rather than remove it.
+%ptr_m = "test.op"() : () -> !x86.reg64
+%acc_m = "test.op"() : () -> !x86.avx2reg
+%b_m = "test.op"() : () -> !x86.avx2reg
+%load_m = x86.dm.vmovupd [%ptr_m] : (!x86.reg64) -> !x86.avx2reg
+%fma_m = x86.rss.vfmadd231pd %acc_m, %b_m, %load_m : (!x86.avx2reg, !x86.avx2reg, !x86.avx2reg) -> !x86.avx2reg
+"test.op"(%load_m) : (!x86.avx2reg) -> ()
+"test.op"(%fma_m) : (!x86.avx2reg) -> ()
+// CHECK:       %load_m = x86.dm.vmovupd [%ptr_m] : (!x86.reg64) -> !x86.avx2reg
+// CHECK-NEXT:  %fma_m = x86.rss.vfmadd231pd %acc_m, %b_m, %load_m
+
+// A store between the load and the FMA blocks the fold: folding would sink the
+// read past a write that may alias it.
+%ptr_s = "test.op"() : () -> !x86.reg64
+%acc_s = "test.op"() : () -> !x86.avx2reg
+%b_s = "test.op"() : () -> !x86.avx2reg
+%load_s = x86.dm.vmovupd [%ptr_s] : (!x86.reg64) -> !x86.avx2reg
+x86.ms.vmovupd %ptr_s, %b_s : (!x86.reg64, !x86.avx2reg) -> ()
+%fma_s = x86.rss.vfmadd231pd %acc_s, %b_s, %load_s : (!x86.avx2reg, !x86.avx2reg, !x86.avx2reg) -> !x86.avx2reg
+"test.op"(%fma_s) : (!x86.avx2reg) -> ()
+// CHECK:       %load_s = x86.dm.vmovupd [%ptr_s] : (!x86.reg64) -> !x86.avx2reg
+// CHECK:       %fma_s = x86.rss.vfmadd231pd %acc_s, %b_s, %load_s

--- a/xdsl/backend/x86/arch.py
+++ b/xdsl/backend/x86/arch.py
@@ -65,9 +65,13 @@ class X86Arch(Arch):
         try:
             return self.VECTOR_TYPES_BY_BITWIDTH[vector_size]
         except KeyError:
+            # `from None` keeps the raw `KeyError: 512` out of the traceback, so
+            # the reported cause is the diagnostic rather than a dict lookup.
             raise DiagnosticException(
-                f"The vector size ({vector_size} bits) and target architecture `{self.name()}` are inconsistent."
-            )
+                f"The vector size ({vector_size} bits) and target architecture "
+                f"`{self.name()}` are inconsistent. Supported vector sizes are "
+                f"{sorted(self.VECTOR_TYPES_BY_BITWIDTH)}."
+            ) from None
 
     def _scalar_type_for_type(self, value_type: Attribute) -> type[GeneralRegisterType]:
         if isinstance(value_type, FixedBitwidthType):

--- a/xdsl/dialects/x86/assembly.py
+++ b/xdsl/dialects/x86/assembly.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Literal, TypeAlias
+from typing import TypeAlias
 
 from xdsl.backend.assembly_printer import reg
 from xdsl.dialects.builtin import IntegerAttr, StringAttr, UnitAttr
@@ -32,9 +32,15 @@ def memory_access_str(register: SSAValue, offset: IntegerAttr) -> str:
 def broadcast_memory_access_str(
     register: SSAValue,
     offset: IntegerAttr,
-    broadcast: Literal["1to8", "1to16"],
+    broadcast: str,
 ) -> str:
-    """e.g. ``[rsi+512]{1to8}``"""
+    """
+    e.g. ``[rsi+512]{1to8}``
+
+    The lane count depends on both the element width and the width of the
+    register bank the instruction is allocated to, so it is computed by the
+    operation rather than drawn from a fixed set.
+    """
     return f"{memory_access_str(register, offset)}{{{broadcast}}}"
 
 

--- a/xdsl/dialects/x86/ops.py
+++ b/xdsl/dialects/x86/ops.py
@@ -1459,13 +1459,25 @@ class RSMB_Operation(X86Instruction, ABC, Generic[R1InvT, R2InvT, R4InvT]):
 
     @classmethod
     @abstractmethod
-    def broadcast_modifier(cls) -> Literal["1to8", "1to16"]:
+    def element_bitwidth(cls) -> int:
         """
-        If broadcasting, specifies whether the operation broadcasts to 8 or 16 lanes.
-        This will be determined by the bitwidth of the lanes of the vector this
-        operation operates on.
+        The bitwidth of a single lane of the vector this operation operates on.
         """
         raise NotImplementedError()
+
+    def broadcast_modifier(self) -> str:
+        """
+        The EVEX broadcast modifier for this operation, e.g. `1to8`.
+
+        The lane count is the register width divided by the element width, so it
+        depends on the register bank this operation is allocated to: vfmadd231pd
+        broadcasts `1to2` on xmm, `1to4` on ymm and `1to8` on zmm. Hardcoding the
+        widest form emits assembly that the assembler rejects on the narrower
+        banks.
+        """
+        register_type = self.register_in.type
+        assert isinstance(register_type, X86VectorRegisterType)
+        return f"1to{register_type.bitwidth() // self.element_bitwidth()}"
 
     def assembly_line_args(self) -> tuple[AssemblyInstructionArg | None, ...]:
         if self.broadcast:
@@ -3466,8 +3478,8 @@ class RSM_Vfmadd231pdOp(
     name = "x86.rsm.vfmadd231pd"
 
     @classmethod
-    def broadcast_modifier(cls) -> Literal["1to8"]:
-        return "1to8"
+    def element_bitwidth(cls) -> int:
+        return 64
 
 
 @irdl_op_definition
@@ -3498,8 +3510,8 @@ class RSM_Vfmadd231psOp(
     name = "x86.rsm.vfmadd231ps"
 
     @classmethod
-    def broadcast_modifier(cls) -> Literal["1to16"]:
-        return "1to16"
+    def element_bitwidth(cls) -> int:
+        return 32
 
 
 @irdl_op_definition

--- a/xdsl/dialects/x86/registers.py
+++ b/xdsl/dialects/x86/registers.py
@@ -335,6 +335,13 @@ class X86VectorRegisterType(X86RegisterType):
     def register_pool_key(cls) -> str:
         return X86_VECTOR_POOL_KEY
 
+    @classmethod
+    def bitwidth(cls) -> int:
+        """
+        The width of this register bank in bits.
+        """
+        raise NotImplementedError()
+
 
 SSE_INDEX_BY_NAME = {f"xmm{i}": i for i in range(32)}
 """
@@ -351,6 +358,10 @@ class SSERegisterType(X86VectorRegisterType):
     """
 
     name = "x86.ssereg"
+
+    @classmethod
+    def bitwidth(cls) -> int:
+        return 128
 
     @classmethod
     def index_by_name(cls) -> dict[str, int]:
@@ -420,6 +431,10 @@ class AVX2RegisterType(X86VectorRegisterType):
     name = "x86.avx2reg"
 
     @classmethod
+    def bitwidth(cls) -> int:
+        return 256
+
+    @classmethod
     def index_by_name(cls) -> dict[str, int]:
         return AVX2_INDEX_BY_NAME
 
@@ -485,6 +500,10 @@ class AVX512RegisterType(X86VectorRegisterType):
     """
 
     name = "x86.avx512reg"
+
+    @classmethod
+    def bitwidth(cls) -> int:
+        return 512
 
     @classmethod
     def index_by_name(cls) -> dict[str, int]:

--- a/xdsl/transforms/__init__.py
+++ b/xdsl/transforms/__init__.py
@@ -657,6 +657,11 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
 
         return x86_allocate_registers.X86AllocateRegisters
 
+    def get_x86_fold_memory_operands():
+        from xdsl.transforms import x86_fold_memory_operands
+
+        return x86_fold_memory_operands.X86FoldMemoryOperands
+
     def get_x86_infer_broadcast():
         from xdsl.transforms import x86_infer_broadcast
 
@@ -809,6 +814,7 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
         "varith-fuse-repeated-operands": get_varith_fuse_repeated_operands,
         "vector-split-load-extract": get_vector_split_load_extract,
         "x86-allocate-registers": get_x86_allocate_registers,
+        "x86-fold-memory-operands": get_x86_fold_memory_operands,
         "x86-infer-broadcast": get_x86_infer_broadcast,
         "x86-regalloc-legalize": get_x86_regalloc_legalize,
         "x86-prologue-epilogue-insertion": get_x86_prologue_epilogue_insertion,

--- a/xdsl/transforms/x86_fold_memory_operands.py
+++ b/xdsl/transforms/x86_fold_memory_operands.py
@@ -1,0 +1,207 @@
+"""
+Fold vector loads into the memory operand of FMA instructions.
+
+x86 FMA instructions can take one of their multiply operands directly from
+memory instead of from a register:
+
+    vmovupd     ymm2, [rdi]
+    vfmadd231pd ymm0, ymm1, ymm2      ->    vfmadd231pd ymm0, ymm1, [rdi]
+
+This saves an instruction and, more importantly for a register-starved kernel
+like matmul, frees the vector register that was only holding the loaded value.
+
+AVX-512 additionally supports an embedded broadcast on the memory operand, so a
+broadcast-load feeding an FMA collapses the same way:
+
+    vbroadcastsd zmm2, [rdi]
+    vfmadd231pd  zmm0, zmm1, zmm2     ->    vfmadd231pd zmm0, zmm1, [rdi]{1to8}
+
+The embedded broadcast needs EVEX encoding, so that fold is gated on an AVX-512
+target. The plain memory-operand fold is available under VEX and so applies to
+SSE and AVX2 as well.
+"""
+
+from dataclasses import dataclass
+from typing import TypeAlias, cast
+
+from xdsl.backend.x86.arch import AVX512Arch, X86Arch
+from xdsl.context import Context
+from xdsl.dialects.builtin import ModuleOp
+from xdsl.dialects.x86.ops import (
+    DM_VbroadcastsdOp,
+    DM_VbroadcastssOp,
+    DM_VmovapdOp,
+    DM_VmovapsOp,
+    DM_VmovupdOp,
+    DM_VmovupsOp,
+    RSM_Vfmadd231pdOp,
+    RSM_Vfmadd231psOp,
+    RSS_Vfmadd231pdOp,
+    RSS_Vfmadd231psOp,
+)
+from xdsl.dialects.x86.registers import X86VectorRegisterType
+from xdsl.ir import Operation, SSAValue
+from xdsl.passes import ModulePass
+from xdsl.pattern_rewriter import (
+    GreedyRewritePatternApplier,
+    PatternRewriter,
+    PatternRewriteWalker,
+    RewritePattern,
+    op_type_rewrite_pattern,
+)
+from xdsl.traits import MemoryEffectKind, get_effects
+
+FoldableLoad: TypeAlias = (
+    DM_VmovupdOp
+    | DM_VmovapdOp
+    | DM_VmovupsOp
+    | DM_VmovapsOp
+    | DM_VbroadcastsdOp
+    | DM_VbroadcastssOp
+)
+"""Loads whose result can become the memory operand of an FMA."""
+
+
+def _writes_memory(op: Operation) -> bool:
+    """
+    Conservatively report whether `op` may write to memory.
+
+    An operation with unknown effects (`get_effects` returning None) is treated
+    as writing, since we cannot prove that it does not.
+    """
+    effects = get_effects(op)
+    if effects is None:
+        return True
+    return any(e.kind == MemoryEffectKind.WRITE for e in effects)
+
+
+def _safe_to_sink(load: Operation, user: Operation) -> bool:
+    """
+    Check that `load` can be sunk to the position of `user`.
+
+    Folding the load into `user` delays the memory read until `user` executes,
+    so it is only valid if nothing in between may write to memory. Both
+    operations must live in the same block, which is the case for the
+    straight-line code the x86 backend produces after lowering.
+    """
+    block = load.parent_block()
+    if block is None or user.parent_block() is not block:
+        return False
+
+    current = load.next_op
+    while current is not None and current is not user:
+        if _writes_memory(current):
+            return False
+        current = current.next_op
+
+    # `user` must actually come after `load` in the block.
+    return current is user
+
+
+def _load_to_fold(
+    value: SSAValue,
+    allowed: tuple[type[FoldableLoad], ...],
+    user: Operation,
+) -> FoldableLoad | None:
+    """
+    Return the load defining `value` if it can be folded into `user`, else None.
+    """
+    load = value.owner
+    if not isinstance(load, allowed):
+        return None
+    # Folding would duplicate the memory access if the loaded value is read
+    # elsewhere, which is a pessimisation rather than an optimisation.
+    if not value.has_one_use():
+        return None
+    if not _safe_to_sink(load, user):
+        return None
+    return load
+
+
+@dataclass
+class FoldLoadIntoFMA(RewritePattern):
+    """
+    Fold a vector load or broadcast-load into the memory operand of an FMA.
+    """
+
+    arch: X86Arch
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(
+        self,
+        op: RSS_Vfmadd231pdOp | RSS_Vfmadd231psOp,
+        rewriter: PatternRewriter,
+    ) -> None:
+        rsm_type: type[RSM_Vfmadd231pdOp | RSM_Vfmadd231psOp]
+        direct_loads: tuple[type[FoldableLoad], ...]
+        broadcast_loads: tuple[type[FoldableLoad], ...]
+
+        if isinstance(op, RSS_Vfmadd231pdOp):
+            rsm_type = RSM_Vfmadd231pdOp
+            direct_loads = (DM_VmovupdOp, DM_VmovapdOp)
+            broadcast_loads = (DM_VbroadcastsdOp,)
+        else:
+            rsm_type = RSM_Vfmadd231psOp
+            direct_loads = (DM_VmovupsOp, DM_VmovapsOp)
+            broadcast_loads = (DM_VbroadcastssOp,)
+
+        # The embedded broadcast modifier needs EVEX encoding, which is an
+        # AVX-512 feature. AVX512VL extends EVEX to xmm and ymm operands, so
+        # this is a property of the target rather than of the vector width.
+        candidates: list[tuple[tuple[type[FoldableLoad], ...], bool]] = [
+            (direct_loads, False)
+        ]
+        if isinstance(self.arch, AVX512Arch):
+            candidates.append((broadcast_loads, True))
+
+        # `register_in += source1 * source2`. Multiplication is commutative, so
+        # either source may become the memory operand and the other stays in a
+        # register. Try source2 first, so the common case rewrites without
+        # reordering the operands.
+        for allowed, broadcast in candidates:
+            for mem_operand, reg_operand in (
+                (op.source2, op.source1),
+                (op.source1, op.source2),
+            ):
+                load = _load_to_fold(mem_operand, allowed, op)
+                if load is None:
+                    continue
+
+                folded = rsm_type(
+                    cast(SSAValue[X86VectorRegisterType], op.register_in),
+                    reg_operand,
+                    load.memory,
+                    load.memory_offset.value.data,
+                    broadcast=broadcast,
+                    comment=op.comment,
+                    register_out=op.register_out.type,
+                )
+                # The fused instruction takes the FMA's position, which sinks
+                # the memory read to that point; `_safe_to_sink` has already
+                # checked that nothing in between writes memory. The load's
+                # address operand dominated the load and so dominates here too.
+                rewriter.replace(op, [folded])
+                # The load's only use was the FMA we just replaced.
+                rewriter.erase(load)
+                return
+
+
+@dataclass(frozen=True)
+class X86FoldMemoryOperands(ModulePass):
+    """
+    Folds vector loads into the memory operands of FMA instructions.
+
+    Run before register allocation, so that the vector registers freed by the
+    fold are available to the allocator.
+    """
+
+    name = "x86-fold-memory-operands"
+
+    arch: str
+
+    def apply(self, ctx: Context, op: ModuleOp) -> None:
+        arch = X86Arch.arch_for_name(self.arch)
+        PatternRewriteWalker(
+            GreedyRewritePatternApplier([FoldLoadIntoFMA(arch)]),
+            apply_recursively=False,
+        ).rewrite_module(op)


### PR DESCRIPTION
Depends on #6359, which is the first commit here. Opening as a draft until that lands, then I will rebase so this is a clean single-commit diff.

x86 FMA instructions can take a multiply operand straight from memory, and on AVX-512 can apply an embedded broadcast to it. The `RSM` forms of `vfmadd231pd` and `vfmadd231ps` are defined and have emission tests, but nothing generates them, so every FMA currently pays for a separate load or broadcast plus the vector register to hold the result.

This adds `x86-fold-memory-operands`, which folds a single-use load or broadcast-load into the FMA that consumes it.

The fold is rejected when:

- the loaded value has more than one use, since folding would duplicate the memory access rather than remove it
- a memory write sits between the load and the FMA, since the fold sinks the read past it
- the target is not AVX-512 and the load is a broadcast, since the embedded broadcast modifier needs EVEX

Both multiply operands are considered, as multiplication commutes.

On `tests/filecheck/projects/libxsmm` at `arch=avx512` this removes all eight broadcasts:

|                        | before | after |
|------------------------|--------|-------|
| instructions           | 28     | 20    |
| broadcast instructions | 8      | 0     |

and eight fewer live vector values reach the register allocator. The generated assembly still assembles, links against the existing `main.c` and matches the naive reference, checked on hardware with avx512f, avx512vl and fma.

Run it before `x86-allocate-registers` so the freed registers are available to the allocator.

The last commit is unrelated housekeeping I hit while debugging this: raising `DiagnosticException` from inside `except KeyError` chained the dict lookup onto the traceback, so a vector too wide for the target printed `KeyError: 512` above the actual explanation. Happy to split it out if you would rather.