### PR TITLE
backend: (x86) report unsupported vector sizes without the raw KeyError

### DIFF
--- a/tests/backend/x86/test_lowering_utils.py
+++ b/tests/backend/x86/test_lowering_utils.py
@@ -12,6 +12,7 @@ from xdsl.dialects.x86.registers import (
 )
 from xdsl.ir import Attribute, Block
 from xdsl.rewriter import InsertPoint
+from xdsl.utils.exceptions import DiagnosticException
 from xdsl.utils.test_value import create_ssa_value
 
 
@@ -93,3 +94,30 @@ def test_move_value_to_unallocated_insertion_point():
 )
 def test_register_type_for_ptr_type(arch: arch.X86Arch):
     assert arch.register_type_for_type(ptr.PtrType()) == Reg64Type
+
+
+@pytest.mark.parametrize(
+    "target, vector_type, supported",
+    [
+        (arch.AVX2, VectorType(f64, (8,)), "[128, 256]"),
+        (arch.AVX512, VectorType(f64, (16,)), "[128, 256, 512]"),
+        (arch.UNKNOWN, VectorType(f64, (4,)), "[128]"),
+    ],
+)
+def test_register_type_for_oversized_vector(
+    target: arch.X86Arch, vector_type: VectorType, supported: str
+):
+    """
+    A vector too wide for the target reports a diagnostic naming the sizes the
+    target does support, and does not surface the underlying dict lookup.
+    """
+    with pytest.raises(DiagnosticException) as exc_info:
+        target.register_type_for_type(vector_type)
+
+    message = str(exc_info.value)
+    assert "are inconsistent" in message
+    assert f"Supported vector sizes are {supported}" in message
+    # The KeyError must not be chained onto the diagnostic, otherwise the
+    # traceback leads with `KeyError: 512` instead of the explanation.
+    assert exc_info.value.__cause__ is None
+    assert exc_info.value.__suppress_context__

--- a/tests/backend/x86/test_lowering_utils.py
+++ b/tests/backend/x86/test_lowering_utils.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 
 from xdsl.backend.x86 import arch
@@ -97,27 +99,39 @@ def test_register_type_for_ptr_type(arch: arch.X86Arch):
 
 
 @pytest.mark.parametrize(
-    "target, vector_type, supported",
+    "target, vector_type, message",
     [
-        (arch.AVX2, VectorType(f64, (8,)), "[128, 256]"),
-        (arch.AVX512, VectorType(f64, (16,)), "[128, 256, 512]"),
-        (arch.UNKNOWN, VectorType(f64, (4,)), "[128]"),
+        (
+            arch.AVX2,
+            VectorType(f64, (8,)),
+            "The vector size (512 bits) and target architecture `avx2` are "
+            "inconsistent. Supported vector sizes are [128, 256].",
+        ),
+        (
+            arch.AVX512,
+            VectorType(f64, (16,)),
+            "The vector size (1024 bits) and target architecture `avx512` are "
+            "inconsistent. Supported vector sizes are [128, 256, 512].",
+        ),
+        (
+            arch.UNKNOWN,
+            VectorType(f64, (4,)),
+            "The vector size (256 bits) and target architecture `unknown` are "
+            "inconsistent. Supported vector sizes are [128].",
+        ),
     ],
 )
 def test_register_type_for_oversized_vector(
-    target: arch.X86Arch, vector_type: VectorType, supported: str
+    target: arch.X86Arch, vector_type: VectorType, message: str
 ):
     """
     A vector too wide for the target reports a diagnostic naming the sizes the
     target does support, and does not surface the underlying dict lookup.
     """
-    with pytest.raises(DiagnosticException) as exc_info:
+    with pytest.raises(DiagnosticException, match=re.escape(message)) as exc_info:
         target.register_type_for_type(vector_type)
 
-    message = str(exc_info.value)
-    assert "are inconsistent" in message
-    assert f"Supported vector sizes are {supported}" in message
     # The KeyError must not be chained onto the diagnostic, otherwise the
-    # traceback leads with `KeyError: 512` instead of the explanation.
+    # traceback leads with `KeyError: 512` instead of the explanation above.
     assert exc_info.value.__cause__ is None
     assert exc_info.value.__suppress_context__

--- a/xdsl/backend/x86/arch.py
+++ b/xdsl/backend/x86/arch.py
@@ -65,9 +65,13 @@ class X86Arch(Arch):
         try:
             return self.VECTOR_TYPES_BY_BITWIDTH[vector_size]
         except KeyError:
+            # `from None` keeps the raw `KeyError: 512` out of the traceback, so
+            # the reported cause is the diagnostic rather than a dict lookup.
             raise DiagnosticException(
-                f"The vector size ({vector_size} bits) and target architecture `{self.name()}` are inconsistent."
-            )
+                f"The vector size ({vector_size} bits) and target architecture "
+                f"`{self.name()}` are inconsistent. Supported vector sizes are "
+                f"{sorted(self.VECTOR_TYPES_BY_BITWIDTH)}."
+            ) from None
 
     def _scalar_type_for_type(self, value_type: Attribute) -> type[GeneralRegisterType]:
         if isinstance(value_type, FixedBitwidthType):


### PR DESCRIPTION
Split out of #6360 as requested, with a dedicated test.

`_register_type_for_vector_type` raises `DiagnosticException` from inside `except KeyError`, which chains the dict lookup onto the traceback. A vector too wide for the target therefore reports:

```
KeyError: 512

During handling of the above exception, another exception occurred:
...
DiagnosticException: The vector size (512 bits) and target architecture `avx2` are inconsistent.
```

The diagnostic underneath is correct, but `KeyError: 512` is the first thing you see and it points at a dict rather than at the problem.

Two changes:

- suppress the chain with `raise ... from None`
- name the sizes the target does support, since "inconsistent" alone does not tell you whether the vector is too wide, too narrow, or an odd width

```
DiagnosticException: The vector size (512 bits) and target architecture `avx2`
are inconsistent. Supported vector sizes are [128, 256].
```

The test covers all three targets and asserts the `KeyError` is not chained, via `__cause__` and `__suppress_context__`, so a future refactor that drops the `from None` fails rather than quietly regressing the message.