### PR TITLE
dialects: (linalg) tile linalg.generic ops over tensors

### DIFF
--- a/tests/filecheck/transforms/linalg-tiling-reject-unsupported.mlir
+++ b/tests/filecheck/transforms/linalg-tiling-reject-unsupported.mlir
@@ -20,20 +20,41 @@ builtin.module {
 
 builtin.module {
   %input = "test.op"() : () -> tensor<4x4xf32>
-  %output = "test.op"() : () -> tensor<4x4xf32>
-  %result = linalg.generic {
+  %out_tensor = "test.op"() : () -> tensor<4x4xf32>
+  %out_memref = "test.op"() : () -> memref<4x4xf32>
+  %result = "linalg.generic"(%input, %out_tensor, %out_memref) <{
+      indexing_maps = [
+          affine_map<(d0, d1) -> (d0, d1)>,
+          affine_map<(d0, d1) -> (d0, d1)>,
+          affine_map<(d0, d1) -> (d0, d1)>
+      ],
+      iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>],
+      operandSegmentSizes = array<i32: 1, 2>
+  }> ({
+  ^bb0(%in: f32, %a: f32, %b: f32):
+      "linalg.yield"(%in) : (f32) -> ()
+  }) {test_tile_sizes = array<i32: 2, 2>} : (tensor<4x4xf32>, tensor<4x4xf32>, memref<4x4xf32>) -> tensor<4x4xf32>
+  "test.op"(%result) : (tensor<4x4xf32>) -> ()
+}
+// CHECK: tiling linalg.generic with a mix of memref and tensor operands is not supported
+
+// -----
+
+builtin.module {
+  %input = "test.op"() : () -> tensor<4x4xf32>
+  %output = "test.op"() : () -> memref<4x4xf32>
+  linalg.generic {
       indexing_maps = [
           affine_map<(i, j) -> (i, j)>,
           affine_map<(i, j) -> (i, j)>
       ],
       iterator_types = ["parallel", "parallel"]
-  } ins(%input : tensor<4x4xf32>) outs(%output : tensor<4x4xf32>) attrs = {test_tile_sizes = array<i32: 2, 2>} {
+  } ins(%input : tensor<4x4xf32>) outs(%output : memref<4x4xf32>) attrs = {test_tile_sizes = array<i32: 2, 2>} {
   ^bb0(%in: f32, %out: f32):
-      linalg.yield %in : f32
-  } -> tensor<4x4xf32>
-  "test.op"(%result) : (tensor<4x4xf32>) -> ()
+      linalg.yield %out : f32
+  }
 }
-// CHECK: tiling linalg.generic with tensor results is not supported yet
+// CHECK: tiling linalg.generic with a mix of memref and tensor operands is not supported
 
 // -----
 
@@ -72,24 +93,6 @@ builtin.module {
   }
 }
 // CHECK: tiling of non-parallel iterator dimensions is not supported yet
-
-// -----
-
-builtin.module {
-  %input = "test.op"() : () -> tensor<4x4xf32>
-  %output = "test.op"() : () -> memref<4x4xf32>
-  linalg.generic {
-      indexing_maps = [
-          affine_map<(i, j) -> (i, j)>,
-          affine_map<(i, j) -> (i, j)>
-      ],
-      iterator_types = ["parallel", "parallel"]
-  } ins(%input : tensor<4x4xf32>) outs(%output : memref<4x4xf32>) attrs = {test_tile_sizes = array<i32: 2, 2>} {
-  ^bb0(%in: f32, %out: f32):
-      linalg.yield %out : f32
-  }
-}
-// CHECK: tiling linalg.generic with non-memref operands is not supported yet
 
 // -----
 

--- a/tests/filecheck/transforms/linalg-tiling.mlir
+++ b/tests/filecheck/transforms/linalg-tiling.mlir
@@ -105,3 +105,83 @@ linalg.generic {
 // CHECK-NEXT:     }
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
+
+// -----
+
+// Tensors are tiled by extracting each tile, computing it, and inserting the
+// result back into the tensor carried by the loops.
+
+%A, %B = "test.op"() : () -> (tensor<4x4xf32>, tensor<4x4xf32>)
+
+%C = "linalg.generic"(%A, %B) <{
+  indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>],
+  iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>],
+  operandSegmentSizes = array<i32: 1, 1>
+}> ({
+^bb0(%a: f32, %b: f32):
+  "linalg.yield"(%a) : (f32) -> ()
+}) {test_tile_sizes = array<i32: 2, 2>} : (tensor<4x4xf32>, tensor<4x4xf32>) -> tensor<4x4xf32>
+
+"test.op"(%C) : (tensor<4x4xf32>) -> ()
+
+// Each loop carries the tensor: the outer one from %B, the inner one from the
+// block argument of the outer one. The output tile is extracted from the
+// carried value, not from %B, so tiles accumulate.
+
+// CHECK:      builtin.module {
+// CHECK-NEXT:   %A, %B = "test.op"() : () -> (tensor<4x4xf32>, tensor<4x4xf32>)
+// CHECK-NEXT:   %0 = arith.constant 0 : index
+// CHECK-NEXT:   %1 = arith.constant 4 : index
+// CHECK-NEXT:   %2 = arith.constant 4 : index
+// CHECK-NEXT:   %3 = arith.constant 2 : index
+// CHECK-NEXT:   %4 = arith.constant 2 : index
+// CHECK-NEXT:   %C = scf.for %5 = %0 to %1 step %3 iter_args(%6 = %B) -> (tensor<4x4xf32>) {
+// CHECK-NEXT:     %7 = scf.for %8 = %0 to %2 step %4 iter_args(%9 = %6) -> (tensor<4x4xf32>) {
+// CHECK-NEXT:       %10 = "tensor.extract_slice"(%A, %5, %8) <{static_offsets = array<i64: -9223372036854775808, -9223372036854775808>, static_sizes = array<i64: 2, 2>, static_strides = array<i64: 1, 1>, operandSegmentSizes = array<i32: 1, 2, 0, 0>}> : (tensor<4x4xf32>, index, index) -> tensor<2x2xf32>
+// CHECK-NEXT:       %11 = "tensor.extract_slice"(%9, %5, %8) <{static_offsets = array<i64: -9223372036854775808, -9223372036854775808>, static_sizes = array<i64: 2, 2>, static_strides = array<i64: 1, 1>, operandSegmentSizes = array<i32: 1, 2, 0, 0>}> : (tensor<4x4xf32>, index, index) -> tensor<2x2xf32>
+// CHECK-NEXT:       %12 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%10 : tensor<2x2xf32>) outs(%11 : tensor<2x2xf32>) {
+// CHECK-NEXT:       ^bb0(%a: f32, %b: f32):
+// CHECK-NEXT:         linalg.yield %a : f32
+// CHECK-NEXT:       } -> tensor<2x2xf32>
+// CHECK-NEXT:       %13 = "tensor.insert_slice"(%12, %9, %5, %8) <{static_offsets = array<i64: -9223372036854775808, -9223372036854775808>, static_sizes = array<i64: 2, 2>, static_strides = array<i64: 1, 1>, operandSegmentSizes = array<i32: 1, 1, 2, 0, 0>}> : (tensor<2x2xf32>, tensor<4x4xf32>, index, index) -> tensor<4x4xf32>
+// CHECK-NEXT:       scf.yield %13 : tensor<4x4xf32>
+// CHECK-NEXT:     }
+// CHECK-NEXT:     scf.yield %7 : tensor<4x4xf32>
+// CHECK-NEXT:   }
+// CHECK-NEXT:   "test.op"(%C) : (tensor<4x4xf32>) -> ()
+// CHECK-NEXT: }
+
+// -----
+
+// An untiled tensor dimension takes its whole extent.
+
+%A, %B = "test.op"() : () -> (tensor<4x4xf32>, tensor<4x4xf32>)
+
+%C = "linalg.generic"(%A, %B) <{
+  indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>],
+  iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>],
+  operandSegmentSizes = array<i32: 1, 1>
+}> ({
+^bb0(%a: f32, %b: f32):
+  "linalg.yield"(%a) : (f32) -> ()
+}) {test_tile_sizes = array<i32: 2, 0>} : (tensor<4x4xf32>, tensor<4x4xf32>) -> tensor<4x4xf32>
+
+"test.op"(%C) : (tensor<4x4xf32>) -> ()
+
+// CHECK:      builtin.module {
+// CHECK-NEXT:   %A, %B = "test.op"() : () -> (tensor<4x4xf32>, tensor<4x4xf32>)
+// CHECK-NEXT:   %0 = arith.constant 0 : index
+// CHECK-NEXT:   %1 = arith.constant 4 : index
+// CHECK-NEXT:   %2 = arith.constant 2 : index
+// CHECK-NEXT:   %C = scf.for %3 = %0 to %1 step %2 iter_args(%4 = %B) -> (tensor<4x4xf32>) {
+// CHECK-NEXT:     %5 = "tensor.extract_slice"(%A, %3) <{static_offsets = array<i64: -9223372036854775808, 0>, static_sizes = array<i64: 2, 4>, static_strides = array<i64: 1, 1>, operandSegmentSizes = array<i32: 1, 1, 0, 0>}> : (tensor<4x4xf32>, index) -> tensor<2x4xf32>
+// CHECK-NEXT:     %6 = "tensor.extract_slice"(%4, %3) <{static_offsets = array<i64: -9223372036854775808, 0>, static_sizes = array<i64: 2, 4>, static_strides = array<i64: 1, 1>, operandSegmentSizes = array<i32: 1, 1, 0, 0>}> : (tensor<4x4xf32>, index) -> tensor<2x4xf32>
+// CHECK-NEXT:     %7 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%5 : tensor<2x4xf32>) outs(%6 : tensor<2x4xf32>) {
+// CHECK-NEXT:     ^bb0(%a: f32, %b: f32):
+// CHECK-NEXT:       linalg.yield %a : f32
+// CHECK-NEXT:     } -> tensor<2x4xf32>
+// CHECK-NEXT:     %8 = "tensor.insert_slice"(%7, %4, %3) <{static_offsets = array<i64: -9223372036854775808, 0>, static_sizes = array<i64: 2, 4>, static_strides = array<i64: 1, 1>, operandSegmentSizes = array<i32: 1, 1, 1, 0, 0>}> : (tensor<2x4xf32>, tensor<4x4xf32>, index) -> tensor<4x4xf32>
+// CHECK-NEXT:     scf.yield %8 : tensor<4x4xf32>
+// CHECK-NEXT:   }
+// CHECK-NEXT:   "test.op"(%C) : (tensor<4x4xf32>) -> ()
+// CHECK-NEXT: }

--- a/tests/transforms/test_linalg_tiling_helpers.py
+++ b/tests/transforms/test_linalg_tiling_helpers.py
@@ -14,6 +14,7 @@ from xdsl.dialects.builtin import (
     MemRefType,
     ModuleOp,
     TensorType,
+    VectorType,
     f32,
     i64,
 )
@@ -135,11 +136,19 @@ def test_tiling_plan_rejects_negative_tile_size():
         TilingPlan.analyze_generic_op(op, (-1, 0))
 
 
-def test_tiling_plan_rejects_tensor_results():
-    op = _generic_2d_copy_op(result_types=(TensorType(f32, [4, 5]),))
+def test_tiling_plan_accepts_tensor_operands():
+    op = _generic_2d_copy_op(
+        input_type=TensorType(f32, [4, 5]),
+        output_type=TensorType(f32, [4, 5]),
+        result_types=(TensorType(f32, [4, 5]),),
+    )
 
-    with pytest.raises(NotImplementedError, match="tensor results"):
-        TilingPlan.analyze_generic_op(op, (2, 0))
+    plan = TilingPlan.analyze_generic_op(op, (2, 0))
+
+    assert plan.loop_ranges == (4, 5)
+    assert plan.tiled_dims == (0,)
+    assert plan.operand_infos[0].source_type == TensorType(f32, [4, 5])
+    assert plan.operand_infos[0].result_shape == (2, 5)
 
 
 def test_tiling_plan_rejects_linalg_index():
@@ -161,10 +170,48 @@ def test_tiling_plan_rejects_non_parallel_tiled_iterator():
         TilingPlan.analyze_generic_op(op, (0, 2))
 
 
-def test_tiling_plan_rejects_non_memref_operand():
-    op = _generic_2d_copy_op(input_type=TensorType(f32, [4, 5]))
+def test_tiling_plan_rejects_operand_that_is_neither_memref_nor_tensor():
+    op = _generic_2d_copy_op(input_type=VectorType(f32, [4, 5]))
 
-    with pytest.raises(NotImplementedError, match="non-memref operands"):
+    with pytest.raises(NotImplementedError, match="neither memrefs nor tensors"):
+        TilingPlan.analyze_generic_op(op, (2, 0))
+
+
+def test_tiling_plan_rejects_mixed_memref_and_tensor_operands():
+    # A tensor input written into a memref output. MLIR does not consider this
+    # valid either, requiring pure tensor or pure buffer semantics.
+    op = _generic_2d_copy_op(
+        input_type=TensorType(f32, [4, 5]),
+        output_type=MemRefType(f32, [4, 5]),
+    )
+
+    with pytest.raises(ValueError, match="mix of memref and tensor operands"):
+        TilingPlan.analyze_generic_op(op, (2, 0))
+
+
+def test_tiling_plan_rejects_mixed_memref_and_tensor_outputs():
+    tensor_type = TensorType(f32, [4, 5])
+    lhs = create_ssa_value(tensor_type)
+    tensor_out = create_ssa_value(tensor_type)
+    memref_out = create_ssa_value(MemRefType(f32, [4, 5]))
+
+    @Builder.implicit_region((f32, f32, f32))
+    def body(args: tuple[Any, ...]):
+        linalg.ops.YieldOp(args[0])
+
+    identity = AffineMapAttr(AffineMap.from_callable(lambda i, j: (i, j)))
+    parallel = linalg.attrs.IteratorTypeAttr(linalg.attrs.IteratorType.PARALLEL)
+
+    op = linalg.ops.GenericOp(
+        [lhs],
+        [tensor_out, memref_out],
+        body,
+        [identity, identity, identity],
+        [parallel, parallel],
+        (tensor_type,),
+    )
+
+    with pytest.raises(ValueError, match="mix of memref and tensor operands"):
         TilingPlan.analyze_generic_op(op, (2, 0))
 
 

--- a/xdsl/dialects/linalg/transforms/tiling.py
+++ b/xdsl/dialects/linalg/transforms/tiling.py
@@ -139,9 +139,16 @@ def _verify_generic_is_tileable(
     if any(tile_sizes[dim] < 0 for dim in tiled_dims):
         raise ValueError("negative tile sizes are not supported")
 
-    if op.res:
-        raise NotImplementedError(
-            "tiling linalg.generic with tensor results is not supported yet"
+    # Operands that mix the two are rejected outright rather than tiled, since
+    # each kind is written back a different way. MLIR does not consider such an
+    # op valid either, requiring pure tensor or pure buffer semantics.
+    operand_types = tuple(operand.type for operand in op.operands)
+    if any(isa(operand_type, MemRefType) for operand_type in operand_types) and any(
+        isa(operand_type, TensorType) for operand_type in operand_types
+    ):
+        raise ValueError(
+            "tiling linalg.generic with a mix of memref and tensor operands is "
+            "not supported"
         )
 
     if any(isa(body_op, linalg.ops.IndexOp) for body_op in op.body.walk()):
@@ -161,9 +168,12 @@ def _verify_generic_is_tileable(
     for operand, indexing_map in zip(op.operands, indexing_maps, strict=True):
         raw_operand_type = operand.type
 
-        if not isa(raw_operand_type, MemRefType):
+        if not isa(raw_operand_type, MemRefType) and not isa(
+            raw_operand_type, TensorType
+        ):
             raise NotImplementedError(
-                "tiling linalg.generic with non-memref operands is not supported yet"
+                "tiling linalg.generic with operands that are neither memrefs nor "
+                "tensors is not supported yet"
             )
         operand_type = raw_operand_type
 


### PR DESCRIPTION
Completes the tensor-based tiling checkbox on #6140.

Everything needed to tile an op with tensor operands is now in place, so this stops rejecting them during analysis. Tiling a `linalg.generic` over tensors now gives:

```mlir
%C = scf.for %i = %c0 to %c4 step %c2 iter_args(%accI = %B) -> (tensor<4x4xf32>) {
  %r = scf.for %j = %c0 to %c4 step %c2 iter_args(%accJ = %accI) -> (tensor<4x4xf32>) {
    %in   = tensor.extract_slice %A[%i, %j] [2, 2] [1, 1] ...
    %out  = tensor.extract_slice %accJ[%i, %j] [2, 2] [1, 1] ...
    %tile = linalg.generic ins(%in) outs(%out) ... -> tensor<2x2xf32>
    %upd  = tensor.insert_slice %tile into %accJ[%i, %j] [2, 2] [1, 1] ...
    scf.yield %upd : tensor<4x4xf32>
  }
  scf.yield %r : tensor<4x4xf32>
}
```

Only `scf.for` is generated. xDSL has no `scf.forall`, so the parallel form upstream also supports is out of scope here.

### The operand check

It becomes a positive one: memrefs and tensors are both tileable, and anything else is still rejected.

An op whose operands mix the two is rejected as well. Each kind is written back a different way, and MLIR does not consider such an op valid either — `verifyStructuredOpInterface` requires pure tensor or pure buffer semantics:

```cpp
// Mixed tensor/buffer operands are not allowed.
if (!linalgOp.hasPureTensorSemantics() &&
    !linalgOp.hasPureBufferSemantics() && op->getNumOperands() > 0)
  return op->emitOpError("expected to have pure tensor or buffer semantics");
```

That covers all operands, so it rejects a tensor input written into a memref output as well as mixed outputs.

Worth noting separately: xDSL's `linalg.generic` verifier does not enforce this, so those ops currently parse and verify fine. Rejecting them here keeps the pass honest, but the check arguably belongs in the verifier so every pass benefits. Happy to open that as a follow-up if it seems worth having.

### Behaviour that is unchanged

Tiling memrefs carries nothing, writes nothing back and yields nothing, so its generated IR is unchanged and the existing filecheck expectations are untouched.

### Tests

Filecheck now covers tiling tensors with both dimensions tiled and with one dimension tiled. These are the first tests to exercise the loop-carried values, the write-back and the result replacement through the pass itself, rather than through their helpers.

Rejection tests cover both mixed-operand shapes, and the unit tests that previously asserted tensor operands were rejected now assert they are accepted.

Partial tiles are still rejected, for tensors as for memrefs, so tile sizes have to divide the loop ranges.
