### PR TITLE
backend: (x86) record the target on the module and allocate registers for it

### DIFF
--- a/tests/backend/x86/test_register_stack.py
+++ b/tests/backend/x86/test_register_stack.py
@@ -1,8 +1,14 @@
+import re
+
 import pytest
 
 from xdsl.backend.register_stack import OutOfRegisters
+from xdsl.backend.x86 import arch
 from xdsl.backend.x86.register_stack import X86RegisterStack
 from xdsl.dialects import x86
+from xdsl.dialects.builtin import IntegerAttr, ModuleOp, StringAttr, i32
+from xdsl.dialects.x86 import registers
+from xdsl.utils.exceptions import DiagnosticException
 
 
 def test_default_reserved_registers():
@@ -67,3 +73,40 @@ def test_vector_registers_share_one_pool():
 
     with pytest.raises(OutOfRegisters):
         stack.pop(x86.registers.AVX2RegisterType)
+
+
+def test_allocatable_registers_follow_the_target():
+    """
+    xmm16-31 and ymm16-31 need EVEX, so they are only allocatable on AVX-512.
+    Handing them out on a VEX-only target produces assembly that faults with #UD
+    on hardware that does not have them.
+    """
+
+    def vector_indices(stack: X86RegisterStack) -> set[int]:
+        return stack.allocatable_registers[registers.X86_VECTOR_POOL_KEY]
+
+    assert vector_indices(X86RegisterStack.get_for_arch(arch.AVX2)) == set(range(16))
+    assert vector_indices(X86RegisterStack.get_for_arch(arch.UNKNOWN)) == set(range(16))
+    assert vector_indices(X86RegisterStack.get_for_arch(arch.AVX512)) == set(range(32))
+
+    # The default stack, used when no target is recorded, is the conservative one.
+    assert vector_indices(X86RegisterStack.get()) == set(range(16))
+
+
+def test_arch_round_trips_through_the_module():
+    module = ModuleOp([])
+    assert arch.X86Arch.from_module(module) is arch.UNKNOWN
+
+    arch.AVX512.set_on_module(module)
+    assert module.attributes[arch.ARCH_ATTR_NAME] == StringAttr("avx512")
+    assert arch.X86Arch.from_module(module).name() == "avx512"
+
+    arch.AVX2.set_on_module(module)
+    assert arch.X86Arch.from_module(module).name() == "avx2"
+
+
+def test_arch_on_module_must_be_a_string():
+    module = ModuleOp([])
+    module.attributes[arch.ARCH_ATTR_NAME] = IntegerAttr(2, i32)
+    with pytest.raises(DiagnosticException, match=re.escape("must be a string")):
+        arch.X86Arch.from_module(module)

--- a/tests/filecheck/projects/libxsmm/Makefile
+++ b/tests/filecheck/projects/libxsmm/Makefile
@@ -14,7 +14,7 @@ matmul.o: matmul.s
 	@$(CC) -c $< -o $@ -Wa,--noexecstack
 
 matmul.s: integration_test_matmul.mlir
-	 @uv run xdsl-opt $< -p test-vectorize-matmul,convert-vector-to-ptr,convert-memref-to-ptr{lower_func=true},convert-ptr-type-offsets,canonicalize,convert-func-to-x86-func,convert-vector-to-x86{arch=avx2},convert-ptr-to-x86{arch=avx2},convert-arith-to-x86,reconcile-unrealized-casts,canonicalize,x86-infer-broadcast,dce,x86-allocate-registers,canonicalize -t x86-asm > $@
+	 @uv run xdsl-opt $< -p x86-set-arch{arch=avx2},test-vectorize-matmul,convert-vector-to-ptr,convert-memref-to-ptr{lower_func=true},convert-ptr-type-offsets,canonicalize,convert-func-to-x86-func,convert-vector-to-x86{arch=avx2},convert-ptr-to-x86{arch=avx2},convert-arith-to-x86,reconcile-unrealized-casts,canonicalize,x86-infer-broadcast,dce,x86-allocate-registers,canonicalize -t x86-asm > $@
 
 clean:
 	rm -f main.o matmul.o matmul.s exe

--- a/tests/filecheck/transforms/x86-set-arch.mlir
+++ b/tests/filecheck/transforms/x86-set-arch.mlir
@@ -1,0 +1,19 @@
+// RUN: xdsl-opt -p 'x86-set-arch{arch=avx2}' %s | filecheck %s
+// RUN: xdsl-opt -p 'x86-set-arch{arch=avx512}' %s | filecheck %s --check-prefix=AVX512
+// RUN: xdsl-opt -p 'x86-set-arch{arch=unknown}' %s | filecheck %s --check-prefix=UNKNOWN
+// RUN: xdsl-opt -p 'x86-set-arch{arch=avx2},x86-set-arch{arch=avx512}' %s | filecheck %s --check-prefix=AVX512
+
+// The target is recorded on the module, so passes downstream can read it
+// instead of each taking their own `arch` option. Setting it twice keeps the
+// last value, which is what lets a pipeline override an earlier default.
+
+builtin.module {
+  "test.op"() : () -> ()
+}
+
+// CHECK:        builtin.module attributes {x86.arch = "avx2"} {
+// CHECK-NEXT:     "test.op"() : () -> ()
+// CHECK-NEXT:   }
+
+// AVX512:       builtin.module attributes {x86.arch = "avx512"} {
+// UNKNOWN:      builtin.module attributes {x86.arch = "unknown"} {

--- a/xdsl/backend/x86/arch.py
+++ b/xdsl/backend/x86/arch.py
@@ -9,6 +9,8 @@ from xdsl.dialects import asm, ptr, x86
 from xdsl.dialects.builtin import (
     FixedBitwidthType,
     IndexType,
+    ModuleOp,
+    StringAttr,
     VectorType,
 )
 from xdsl.dialects.x86.registers import (
@@ -28,6 +30,14 @@ from xdsl.rewriter import InsertPoint
 from xdsl.utils.exceptions import DiagnosticException
 from xdsl.utils.hints import isa
 
+ARCH_ATTR_NAME = "x86.arch"
+"""
+Name of the module attribute recording the target this module is compiled for.
+
+Set once at the top of a pipeline, so that passes downstream do not each need
+their own `arch` option.
+"""
+
 
 class X86Arch(Arch):
     VECTOR_TYPES_BY_BITWIDTH: ClassVar[dict[int, type[X86VectorRegisterType]]] = {
@@ -35,6 +45,15 @@ class X86Arch(Arch):
     }
     """
     Supported vector type for a given vector size.
+    """
+
+    VECTOR_REGISTER_COUNT: ClassVar[int] = 16
+    """
+    Number of vector registers this target can encode.
+
+    VEX encoding reaches xmm0-15 and ymm0-15. The upper half of each bank needs
+    EVEX, so it is only available on AVX-512 targets. All the vector banks share
+    one allocation pool, so this is the number of indices in that pool.
     """
 
     @staticmethod
@@ -49,6 +68,37 @@ class X86Arch(Arch):
             return _ARCH_BY_NAME[name]
         except KeyError:
             raise DiagnosticException(f"Unsupported arch {name}")
+
+    @staticmethod
+    def from_module(module: ModuleOp) -> X86Arch:
+        """
+        Read the target from the module, defaulting to the conservative
+        `unknown` target when it is not recorded.
+        """
+        attr = module.attributes.get(ARCH_ATTR_NAME)
+        if attr is None:
+            return UNKNOWN
+        if not isinstance(attr, StringAttr):
+            raise DiagnosticException(
+                f"`{ARCH_ATTR_NAME}` must be a string attribute, got {attr}."
+            )
+        return X86Arch.arch_for_name(attr.data)
+
+    def set_on_module(self, module: ModuleOp) -> None:
+        """
+        Record this target on the module.
+        """
+        module.attributes[ARCH_ATTR_NAME] = StringAttr(self.name())
+
+    def allocatable_vector_registers(self) -> tuple[X86VectorRegisterType, ...]:
+        """
+        The vector registers the allocator may use on this target.
+
+        Indexed off AVX2RegisterType because every vector bank shares a single
+        allocation pool, so what matters is which indices are available rather
+        than which bank names them.
+        """
+        return AVX2RegisterType.allocatable_registers()[: self.VECTOR_REGISTER_COUNT]
 
     def _register_type_for_vector_type(
         self, value_type: VectorType
@@ -191,6 +241,8 @@ class AVX512Arch(X86Arch):
         256: AVX2RegisterType,
         512: AVX512RegisterType,
     }
+
+    VECTOR_REGISTER_COUNT = 32
 
 
 AVX512 = AVX512Arch()

--- a/xdsl/backend/x86/register_stack.py
+++ b/xdsl/backend/x86/register_stack.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from typing_extensions import override
 
 from xdsl.backend.register_stack import RegisterStack
+from xdsl.backend.x86.arch import UNKNOWN, X86Arch
 from xdsl.dialects.x86 import registers
 
 
@@ -14,11 +15,27 @@ class X86RegisterStack(RegisterStack):
 
     DEFAULT_ALLOCATABLE_REGISTERS = (
         *reversed(registers.Reg64Type.allocatable_registers()),
-        *reversed(registers.AVX2RegisterType.allocatable_registers()),
-        *reversed(registers.AVX512RegisterType.allocatable_registers()),
+        *reversed(UNKNOWN.allocatable_vector_registers()),
     )
 
     @classmethod
     @override
     def default_allocatable_registers(cls):
         return cls.DEFAULT_ALLOCATABLE_REGISTERS
+
+    @classmethod
+    def get_for_arch(cls, arch: X86Arch, *, allow_infinite: bool = False):
+        """
+        Build a stack holding the registers this target can actually encode.
+
+        The upper half of each vector bank, xmm16-31 and ymm16-31, needs EVEX,
+        so it is only allocatable on AVX-512. Handing it out on a VEX-only
+        target produces assembly that faults on that hardware.
+        """
+        return cls.get(
+            (
+                *reversed(registers.Reg64Type.allocatable_registers()),
+                *reversed(arch.allocatable_vector_registers()),
+            ),
+            allow_infinite=allow_infinite,
+        )

--- a/xdsl/transforms/__init__.py
+++ b/xdsl/transforms/__init__.py
@@ -657,6 +657,11 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
 
         return x86_allocate_registers.X86AllocateRegisters
 
+    def get_x86_set_arch():
+        from xdsl.transforms import x86_set_arch
+
+        return x86_set_arch.X86SetArch
+
     def get_x86_infer_broadcast():
         from xdsl.transforms import x86_infer_broadcast
 
@@ -810,6 +815,7 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
         "vector-split-load-extract": get_vector_split_load_extract,
         "x86-allocate-registers": get_x86_allocate_registers,
         "x86-infer-broadcast": get_x86_infer_broadcast,
+        "x86-set-arch": get_x86_set_arch,
         "x86-regalloc-legalize": get_x86_regalloc_legalize,
         "x86-prologue-epilogue-insertion": get_x86_prologue_epilogue_insertion,
         "x86-regalloc-verify-liveness": get_x86_regalloc_verify_liveness,

--- a/xdsl/transforms/x86_allocate_registers.py
+++ b/xdsl/transforms/x86_allocate_registers.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 
+from xdsl.backend.x86.arch import X86Arch
 from xdsl.backend.x86.register_allocation import X86RegisterAllocator
 from xdsl.backend.x86.register_stack import X86RegisterStack
 from xdsl.context import Context
@@ -12,13 +13,19 @@ from xdsl.passes import ModulePass
 class X86AllocateRegisters(ModulePass):
     """
     Allocates unallocated registers in the module.
+
+    The set of allocatable registers depends on the target, which is read from
+    the `x86.arch` module attribute. Without it the conservative VEX-only set is
+    used, since handing out EVEX-only registers produces assembly that faults on
+    hardware that does not have them.
     """
 
     name = "x86-allocate-registers"
 
     def apply(self, ctx: Context, op: ModuleOp) -> None:
+        arch = X86Arch.from_module(op)
         for inner_op in op.walk():
             if isinstance(inner_op, x86_func.FuncOp):
-                available_registers = X86RegisterStack.get()
+                available_registers = X86RegisterStack.get_for_arch(arch)
                 allocator = X86RegisterAllocator(available_registers)
                 allocator.allocate_func(inner_op)

--- a/xdsl/transforms/x86_set_arch.py
+++ b/xdsl/transforms/x86_set_arch.py
@@ -1,0 +1,27 @@
+"""
+Record the x86 target on the module.
+
+Passes downstream read it from there rather than each taking their own `arch`
+option, in the same spirit as an LLVM module carrying its target triple.
+"""
+
+from dataclasses import dataclass
+
+from xdsl.backend.x86.arch import X86Arch
+from xdsl.context import Context
+from xdsl.dialects.builtin import ModuleOp
+from xdsl.passes import ModulePass
+
+
+@dataclass(frozen=True)
+class X86SetArch(ModulePass):
+    """
+    Sets the `x86.arch` attribute on the module.
+    """
+
+    name = "x86-set-arch"
+
+    arch: str
+
+    def apply(self, ctx: Context, op: ModuleOp) -> None:
+        X86Arch.arch_for_name(self.arch).set_on_module(op)


### PR DESCRIPTION
Fixes #6358. Draft, since you said you would rather judge this by looking at the code than in the abstract. Happy to reshape any of it.

### What it does

Records the target on the module as `x86.arch` and derives the allocatable register set from it.

```
x86-set-arch{arch=avx2}    sets the attribute
X86Arch.from_module        reads it, defaulting to the conservative `unknown` target
VECTOR_REGISTER_COUNT      16 on VEX targets, 32 on AVX-512
```

### One thing that made this smaller than expected

All the vector banks share a single allocation pool (`X86_VECTOR_POOL_KEY`), so listing `AVX2RegisterType` and `AVX512RegisterType` separately in `DEFAULT_ALLOCATABLE_REGISTERS` was never really about banks. It just put indices 0 to 31 in the pool unconditionally. So the fix is a per-target count of available indices rather than anything to do with which bank names them, which is why `allocatable_vector_registers` slices off `AVX2RegisterType` regardless of target.

### Behaviour

| `x86.arch` | highest vector register allocated |
|---|---|
| not set | refuses to allocate past 16 |
| `avx2` | refuses to allocate past 16 |
| `avx512` | ymm31, legal via AVX512VL |

The refusals are the point. Those kernels previously compiled by using registers the target does not have.

`tests/filecheck/projects/libxsmm` still builds at avx2, peaks at ymm9, and I assembled, linked and ran it with `-march=haswell` so EVEX would have been rejected by the assembler. Result matches the naive reference in `main.c`.

### Deliberately not included

The lowering passes still take their own `arch` option. Having them read from the module and drop the option is the part you mentioned would remove a bunch of awkward plumbing, but it is a much wider diff and touches every x86 pipeline, so it seemed better to agree the shape here first. Happy to do it in this PR if you would rather see the whole thing at once.

### Known consequence

Since the allocator gives up rather than spilling, the AVX2 vector file is now genuinely too small for what `test-vectorize-matmul` emits at anything but small shapes. That was already true, it was just hidden by handing out registers that do not exist. It does mean register blocking in the vectorisation strategy stops being an optimisation and starts being a prerequisite, which is the thread that started in #6360.