### PR TITLE
backend: (x86) apply the KeyError fix from #6361 to arch_for_name too

### DIFF
--- a/tests/backend/x86/test_lowering_utils.py
+++ b/tests/backend/x86/test_lowering_utils.py
@@ -135,3 +135,20 @@ def test_register_type_for_oversized_vector(
     # traceback leads with `KeyError: 512` instead of the explanation above.
     assert exc_info.value.__cause__ is None
     assert exc_info.value.__suppress_context__
+
+
+def test_unsupported_arch_name():
+    """
+    The same chaining problem as above, one function up: a bad arch name should
+    report the name and the alternatives, not a dict lookup.
+    """
+    with pytest.raises(
+        DiagnosticException,
+        match=re.escape(
+            "Unsupported arch sse9. Supported arches are ['avx2', 'avx512', 'unknown']."
+        ),
+    ) as exc_info:
+        arch.X86Arch.arch_for_name("sse9")
+
+    assert exc_info.value.__cause__ is None
+    assert exc_info.value.__suppress_context__

--- a/xdsl/backend/x86/arch.py
+++ b/xdsl/backend/x86/arch.py
@@ -48,7 +48,12 @@ class X86Arch(Arch):
         try:
             return _ARCH_BY_NAME[name]
         except KeyError:
-            raise DiagnosticException(f"Unsupported arch {name}")
+            # Same reason as below: without `from None` the traceback leads with
+            # `KeyError: 'sse9'` rather than with the diagnostic.
+            raise DiagnosticException(
+                f"Unsupported arch {name}. Supported arches are "
+                f"{sorted(_ARCH_BY_NAME)}."
+            ) from None
 
     def _register_type_for_vector_type(
         self, value_type: VectorType


### PR DESCRIPTION
Follow-up to #6361, which fixed this in `_register_type_for_vector_type`. `arch_for_name` has the same problem one function up, and I only noticed it after #6361 had merged.

Passing an arch name that does not exist currently reports:

```
KeyError: 'sse9'

During handling of the above exception, another exception occurred:
...
DiagnosticException: Unsupported arch sse9
```

Same cause: `raise DiagnosticException(...)` from inside `except KeyError` with no `from None`, so the dict lookup leads the traceback.

Also lists the arches that do exist, on the grounds that the useful thing when you have mistyped an arch name is the spelling of the right one:

```
DiagnosticException: Unsupported arch sse9. Supported arches are ['avx2', 'avx512', 'unknown'].
```

Test follows the same shape as the one in #6361, `match=` on the full message plus assertions that the `KeyError` is not chained, so dropping the `from None` in a future refactor fails rather than quietly regressing the message.

Found while writing a filecheck test for `x86-set-arch` in #6363, after codecov pointed out the pass body was uncovered.