### PR TITLE
dialects: (tensor) add mixed static/dynamic builders to extract_slice

### DIFF
--- a/tests/dialects/test_tensor.py
+++ b/tests/dialects/test_tensor.py
@@ -71,7 +71,7 @@ def test_extract_slice_dynamic():
     size = create_ssa_value(IndexType())
 
     result_type = ExtractSliceOp.infer_result_type(source_t, [size, 5, 6])
-    extract_slice = ExtractSliceOp.get(
+    extract_slice = ExtractSliceOp(
         source_v, [offset, 0, 0], [size, 5, 6], [1, 1, 1], result_type
     )
     extract_slice.verify()
@@ -97,7 +97,7 @@ def test_extract_slice_get_all_static():
     source_v = create_ssa_value(source_t)
 
     result_type = ExtractSliceOp.infer_result_type(source_t, [4, 5, 6])
-    extract_slice = ExtractSliceOp.get(
+    extract_slice = ExtractSliceOp(
         source_v, [1, 2, 3], [4, 5, 6], [1, 1, 1], result_type
     )
     extract_slice.verify()

--- a/tests/dialects/test_tensor.py
+++ b/tests/dialects/test_tensor.py
@@ -1,4 +1,13 @@
-from xdsl.dialects.builtin import DYNAMIC_INDEX, DenseArrayBase, TensorType, f64, i64
+import pytest
+
+from xdsl.dialects.builtin import (
+    DYNAMIC_INDEX,
+    DenseArrayBase,
+    IndexType,
+    TensorType,
+    f64,
+    i64,
+)
 from xdsl.dialects.stencil import IndexAttr
 from xdsl.dialects.tensor import ExtractSliceOp, FromElementsOp, InsertSliceOp
 from xdsl.dialects.test import TestOp
@@ -28,6 +37,72 @@ def test_extract_slice_static():
     assert extract_slice.static_offsets == DenseArrayBase.from_list(i64, [1, 2, 3])
     assert extract_slice.static_sizes == DenseArrayBase.from_list(i64, [4, 5, 6])
     assert extract_slice.static_strides == DenseArrayBase.from_list(i64, [8, 9, 10])
+    assert extract_slice.offsets == ()
+    assert extract_slice.sizes == ()
+    assert extract_slice.strides == ()
+    assert extract_slice.result.type == TensorType(f64, [4, 5, 6])
+
+
+def test_extract_slice_infer_result_type():
+    source_t = TensorType(f64, [10, 20, 30])
+    size = create_ssa_value(IndexType())
+
+    assert ExtractSliceOp.infer_result_type(source_t, [4, 5, 6]) == TensorType(
+        f64, [4, 5, 6]
+    )
+
+    # A dynamic size makes that dimension dynamic in the result type.
+    assert ExtractSliceOp.infer_result_type(source_t, [size, 5, 6]) == TensorType(
+        f64, [DYNAMIC_INDEX, 5, 6]
+    )
+
+
+def test_extract_slice_infer_result_type_rank_mismatch():
+    source_t = TensorType(f64, [10, 20, 30])
+
+    with pytest.raises(ValueError, match="sizes to match source rank"):
+        ExtractSliceOp.infer_result_type(source_t, [4, 5])
+
+
+def test_extract_slice_dynamic():
+    source_t = TensorType(f64, [10, 20, 30])
+    source_v = create_ssa_value(source_t)
+    offset = create_ssa_value(IndexType())
+    size = create_ssa_value(IndexType())
+
+    result_type = ExtractSliceOp.infer_result_type(source_t, [size, 5, 6])
+    extract_slice = ExtractSliceOp.get(
+        source_v, [offset, 0, 0], [size, 5, 6], [1, 1, 1], result_type
+    )
+    extract_slice.verify()
+
+    # Static entries keep their value; dynamic ones are marked and moved to operands.
+    assert extract_slice.static_offsets == DenseArrayBase.from_list(
+        i64, [DYNAMIC_INDEX, 0, 0]
+    )
+    assert extract_slice.static_sizes == DenseArrayBase.from_list(
+        i64, [DYNAMIC_INDEX, 5, 6]
+    )
+    assert extract_slice.static_strides == DenseArrayBase.from_list(i64, [1, 1, 1])
+
+    assert extract_slice.offsets == (offset,)
+    assert extract_slice.sizes == (size,)
+    assert extract_slice.strides == ()
+
+    assert extract_slice.result.type == TensorType(f64, [DYNAMIC_INDEX, 5, 6])
+
+
+def test_extract_slice_get_all_static():
+    source_t = TensorType(f64, [10, 20, 30])
+    source_v = create_ssa_value(source_t)
+
+    result_type = ExtractSliceOp.infer_result_type(source_t, [4, 5, 6])
+    extract_slice = ExtractSliceOp.get(
+        source_v, [1, 2, 3], [4, 5, 6], [1, 1, 1], result_type
+    )
+    extract_slice.verify()
+
+    assert extract_slice.static_offsets == DenseArrayBase.from_list(i64, [1, 2, 3])
     assert extract_slice.offsets == ()
     assert extract_slice.sizes == ()
     assert extract_slice.strides == ()

--- a/xdsl/dialects/tensor.py
+++ b/xdsl/dialects/tensor.py
@@ -565,14 +565,14 @@ class ExtractSliceOp(IRDLOperation):
 
     traits = traits_def(Pure())
 
-    @staticmethod
-    def get(
+    def __init__(
+        self,
         source: SSAValue | Operation,
         offsets: Sequence[SSAValue | int],
         sizes: Sequence[SSAValue | int],
         strides: Sequence[SSAValue | int],
         result_type: Attribute,
-    ) -> ExtractSliceOp:
+    ):
         """
         Build a tensor.extract_slice from offsets, sizes, and strides that may each
         be a static integer or a dynamic SSA value.
@@ -581,7 +581,7 @@ class ExtractSliceOp(IRDLOperation):
         static_sizes, dyn_sizes = split_dynamic_index_list(sizes, DYNAMIC_INDEX)
         static_strides, dyn_strides = split_dynamic_index_list(strides, DYNAMIC_INDEX)
 
-        return ExtractSliceOp.build(
+        super().__init__(
             operands=[source, dyn_offsets, dyn_sizes, dyn_strides],
             result_types=[result_type],
             properties={

--- a/xdsl/dialects/tensor.py
+++ b/xdsl/dialects/tensor.py
@@ -27,6 +27,7 @@ from xdsl.dialects.utils import (
     DynamicIndexList,
     parse_dynamic_index_list_without_types,
     print_dynamic_index_list,
+    split_dynamic_index_list,
 )
 from xdsl.dialects.utils.reshape_ops_utils import (
     ContiguousArrayOfIntArray,
@@ -563,6 +564,58 @@ class ExtractSliceOp(IRDLOperation):
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
     traits = traits_def(Pure())
+
+    @staticmethod
+    def get(
+        source: SSAValue | Operation,
+        offsets: Sequence[SSAValue | int],
+        sizes: Sequence[SSAValue | int],
+        strides: Sequence[SSAValue | int],
+        result_type: Attribute,
+    ) -> ExtractSliceOp:
+        """
+        Build a tensor.extract_slice from offsets, sizes, and strides that may each
+        be a static integer or a dynamic SSA value.
+        """
+        static_offsets, dyn_offsets = split_dynamic_index_list(offsets, DYNAMIC_INDEX)
+        static_sizes, dyn_sizes = split_dynamic_index_list(sizes, DYNAMIC_INDEX)
+        static_strides, dyn_strides = split_dynamic_index_list(strides, DYNAMIC_INDEX)
+
+        return ExtractSliceOp.build(
+            operands=[source, dyn_offsets, dyn_sizes, dyn_strides],
+            result_types=[result_type],
+            properties={
+                "static_offsets": DenseArrayBase.from_list(i64, static_offsets),
+                "static_sizes": DenseArrayBase.from_list(i64, static_sizes),
+                "static_strides": DenseArrayBase.from_list(i64, static_strides),
+            },
+        )
+
+    @staticmethod
+    def infer_result_type(
+        source_type: TensorType[Attribute],
+        sizes: Sequence[SSAValue | int],
+    ) -> TensorType[Attribute]:
+        """
+        Infer the result type of a tensor.extract_slice from its source type and
+        sizes. Offsets and strides do not affect the result shape.
+
+        Raises:
+            ValueError: If sizes do not match the source rank.
+        """
+        rank = source_type.get_num_dims()
+        if len(sizes) != rank:
+            raise ValueError("expected sizes to match source rank")
+
+        result_shape = tuple(
+            size if isinstance(size, int) else DYNAMIC_INDEX for size in sizes
+        )
+
+        return TensorType(
+            source_type.get_element_type(),
+            result_shape,
+            source_type.encoding,
+        )
 
     @staticmethod
     def from_static_parameters(

--- a/xdsl/transforms/csl_stencil_bufferize.py
+++ b/xdsl/transforms/csl_stencil_bufferize.py
@@ -13,17 +13,14 @@ from xdsl.dialects import (
     tensor,
 )
 from xdsl.dialects.builtin import (
-    DYNAMIC_INDEX,
     AnyDenseElement,
     AnyTensorType,
     AnyTensorTypeConstr,
-    DenseArrayBase,
     DenseIntOrFPElementsAttr,
     FunctionType,
     MemRefType,
     ModuleOp,
     TensorType,
-    i64,
 )
 from xdsl.ir import (
     Attribute,
@@ -237,17 +234,11 @@ class ApplyOpBufferize(RewritePattern):
             linalg_op,
             [
                 extract_slice_op := tensor.ExtractSliceOp(
-                    operands=[iter_arg, [op.receive_chunk.block.args[1]], [], []],
-                    result_types=[chunk_type],
-                    properties={
-                        "static_offsets": DenseArrayBase.from_list(
-                            i64, (DYNAMIC_INDEX,)
-                        ),
-                        "static_sizes": DenseArrayBase.from_list(
-                            i64, chunk_type.get_shape()
-                        ),
-                        "static_strides": DenseArrayBase.from_list(i64, (1,)),
-                    },
+                    iter_arg,
+                    (op.receive_chunk.block.args[1],),
+                    chunk_type.get_shape(),
+                    (1,),
+                    chunk_type,
                 ),
                 type(linalg_op).build(
                     operands=[linalg_op.inputs, extract_slice_op.results],
@@ -272,13 +263,11 @@ class ApplyOpBufferize(RewritePattern):
         assert isa(typ, TensorType[Attribute])
 
         return tensor.ExtractSliceOp(
-            operands=[to_tensor.tensor, [offset], [], []],
-            result_types=[TensorType(typ.get_element_type(), typ.get_shape()[1:])],
-            properties={
-                "static_offsets": DenseArrayBase.from_list(i64, (DYNAMIC_INDEX,)),
-                "static_sizes": DenseArrayBase.from_list(i64, typ.get_shape()[1:]),
-                "static_strides": DenseArrayBase.from_list(i64, (1,)),
-            },
+            to_tensor.tensor,
+            (offset,),
+            typ.get_shape()[1:],
+            (1,),
+            TensorType(typ.get_element_type(), typ.get_shape()[1:]),
         )
 
 
@@ -459,15 +448,11 @@ class InjectApplyOutsIntoLinalgOuts(RewritePattern):
             )
 
             extract_slice_op = tensor.ExtractSliceOp(
-                operands=[arg_to_tensor, [], [], []],
-                result_types=[yld_arg.op.tensor.type],
-                properties={
-                    "static_offsets": DenseArrayBase.from_list(i64, offsets),
-                    "static_sizes": DenseArrayBase.from_list(
-                        i64, yld_arg.type.get_shape()
-                    ),
-                    "static_strides": DenseArrayBase.from_list(i64, (1,)),
-                },
+                arg_to_tensor,
+                offsets,
+                yld_arg.type.get_shape(),
+                (1,),
+                yld_arg.op.tensor.type,
             )
             rewriter.insert(
                 [arg_to_tensor, extract_slice_op], InsertPoint.before(linalg_op)


### PR DESCRIPTION
First of a series working towards the tensor-based tiling checkbox on #6140. Split out of #6362 at review request.

`tensor.extract_slice` can currently only be built through `from_static_parameters`, which takes fully static offsets, sizes and strides. That cannot express a slice whose parameters are only known at runtime, such as one taken at a loop induction variable, which is what tiling needs.

This adds two static methods to `ExtractSliceOp`, mirroring the existing `memref.SubviewOp` pair:

- `get(source, offsets, sizes, strides, result_type)` takes offsets, sizes and strides that are each either a static integer or a dynamic SSA value, and uses `split_dynamic_index_list` to separate the static entries from the dynamic operands.
- `infer_result_type(source_type, sizes)` derives the result type from the source type and the sizes. Offsets and strides do not affect the result shape, and a dynamic size yields a dynamic dimension.

```python
ExtractSliceOp.infer_result_type(tensor<5x4xf32>, [2, 2])    # tensor<2x2xf32>
ExtractSliceOp.infer_result_type(tensor<5x4xf32>, [%sz, 2])  # tensor<?x2xf32>
```

`from_static_parameters` is unchanged.

### Notes

- These are static methods rather than an `__init__`, so that existing callers constructing the op with `operands=` / `result_types=` / `properties=` keep working. `xdsl/transforms/csl_stencil_bufferize.py` does this in three places.
- `infer_result_type` takes no `reduce_rank` flag, unlike the memref one, as nothing needs it yet. Happy to add it for parity if preferred.
- `ExtractSliceOp` still has no `verify_` checking that the count of dynamic index markers matches the number of operands, which `memref.SubviewOp` does have. That gap is pre-existing and left alone here, but I am glad to address it separately.
