### PR TITLE
dialects: (linalg) thread loop-carried values through tile loops

### DIFF
--- a/tests/transforms/test_linalg_tiling_helpers.py
+++ b/tests/transforms/test_linalg_tiling_helpers.py
@@ -17,11 +17,13 @@ from xdsl.dialects.builtin import (
 from xdsl.dialects.linalg.transforms.tiling import (
     OperandTileInfo,
     TilingPlan,
+    _build_tile_loops,  # pyright: ignore[reportPrivateUsage]
     tile_linalg_generic,
 )
 from xdsl.ir import Attribute
 from xdsl.ir.affine import AffineExpr, AffineMap
 from xdsl.pattern_rewriter import PatternRewriter
+from xdsl.rewriter import InsertPoint
 from xdsl.utils.test_value import create_ssa_value
 
 
@@ -187,6 +189,51 @@ def test_tiling_plan_rejects_partial_tiles():
 
     with pytest.raises(ValueError, match="partial tiles"):
         TilingPlan.analyze_generic_op(op, (3, 0))
+
+
+def test_build_tile_loops_without_iter_args():
+    op = _generic_2d_copy_op()
+    ModuleOp([op])
+    rewriter = PatternRewriter(op)
+
+    loops, tiled_loop_ivs, _ = _build_tile_loops(
+        rewriter, InsertPoint.before(op), (4, 5), (2, 0), (0,)
+    )
+
+    (loop,) = loops
+    assert loop.iter_args == ()
+    assert loop.results == ()
+    assert loop.body.block.args == (tiled_loop_ivs[0],)
+
+
+def test_build_tile_loops_threads_iter_args():
+    op = _generic_2d_copy_op()
+    ModuleOp([op])
+    rewriter = PatternRewriter(op)
+
+    init = create_ssa_value(TensorType(f32, [4, 5]))
+
+    loops, tiled_loop_ivs, _ = _build_tile_loops(
+        rewriter, InsertPoint.before(op), (4, 5), (2, 2), (0, 1), (init,)
+    )
+
+    outer, inner = loops
+
+    # The outermost loop initialises the carried value from the original value,
+    # and every nested loop from the enclosing loop's block argument. Initialising
+    # a nested loop from the original would discard the surrounding iterations.
+    assert outer.iter_args == (init,)
+    assert inner.iter_args == (outer.body.block.args[1],)
+
+    # Each loop carries the value back out as a result.
+    assert outer.result_types == (init.type,)
+    assert inner.result_types == (init.type,)
+
+    # Body blocks gain one argument per carried value, after the induction variable.
+    for loop, iv in ((outer, tiled_loop_ivs[0]), (inner, tiled_loop_ivs[1])):
+        assert len(loop.body.block.args) == 2
+        assert loop.body.block.args[0] is iv
+        assert loop.body.block.args[1].type == init.type
 
 
 def test_tile_linalg_generic_returns_false_without_tiled_dims():

--- a/xdsl/dialects/linalg/transforms/tiling.py
+++ b/xdsl/dialects/linalg/transforms/tiling.py
@@ -185,12 +185,20 @@ def _build_tile_loops(
     loop_ranges: Sequence[int],
     tile_sizes: Sequence[int],
     tiled_dims: Sequence[int],
+    iter_args: Sequence[SSAValue] = (),
 ) -> tuple[list[scf.ForOp], dict[int, SSAValue], InsertPoint]:
     """
     Build the outer tiled loops.
 
+    `iter_args` are threaded through the nest as loop-carried values, as needed
+    when tiling operands with value semantics. The outermost loop initialises
+    them from `iter_args` itself, and every nested loop initialises them from the
+    enclosing loop's block arguments, so the innermost body sees the values
+    accumulated by the surrounding iterations. Tiling memrefs carries nothing,
+    which leaves the loops without block arguments or results.
+
     Return:
-        - `loops`: the outer `scf.for` ops
+        - `loops`: the outer `scf.for` ops, outermost first
         - `tiled_loop_ivs`: a map from loop dimensions to induction variables
         - `current_insertion_point`: the place to insert `tiled subview` and the `tiled generic`
     """
@@ -216,17 +224,20 @@ def _build_tile_loops(
     current_insertion_point = insertion_point
     loops: list[scf.ForOp] = []
     tiled_loop_ivs: dict[int, SSAValue] = {}
+    carried_types = tuple(value.type for value in iter_args)
+    carried: Sequence[SSAValue] = iter_args
     for dim in tiled_dims:
         loop = scf.ForOp(
             zero.result,
             ub_ops[dim].result,
             tile_ops[dim].result,
-            (),
-            Region(Block(arg_types=(index,))),
+            carried,
+            Region(Block(arg_types=(index, *carried_types))),
         )
         rewriter.insert(loop, current_insertion_point)
         loops.append(loop)
         tiled_loop_ivs[dim] = loop.body.block.args[0]
+        carried = loop.body.block.args[1:]
         current_insertion_point = InsertPoint.at_start(loop.body.block)
 
     return loops, tiled_loop_ivs, current_insertion_point


### PR DESCRIPTION
Part of the tensor-based tiling checkbox on #6140, and the second of the smaller PRs split out of #6362. Follows on from #6366.

Tiling an operand with value semantics needs the accumulated result threaded through the tile loop nest, since each tile produces a new value rather than writing through a view.

This gives `_build_tile_loops` an optional `iter_args` parameter. The outermost loop initialises the carried values from `iter_args`, and every nested loop initialises them from the enclosing loop's block arguments, so the innermost body sees the values accumulated by the surrounding iterations:

```
outer loop:   iter_args(%accI = %B)        <- the original value
  inner loop: iter_args(%accJ = %accI)     <- the enclosing loop's block argument
```

Initialising a nested loop from the original values instead would silently discard the work of the enclosing iterations, giving IR that verifies but computes the wrong thing. The added test pins that down: removing the reassignment makes it fail on the inner loop's `iter_args`.

`scf.ForOp` derives its result types from its `iter_args`, so the loops gain results automatically.

Tiling memrefs passes no `iter_args`, leaving the loops without block arguments or results, so its generated IR is unchanged. Nothing passes `iter_args` yet; that arrives with the later PRs in the series, which is why this one is not reachable from the pass and `_build_tile_loops` is tested directly.
