### PR TITLE
dialects: (linalg) slice tensor operands with tensor.extract_slice

### DIFF
--- a/tests/transforms/test_linalg_tiling_helpers.py
+++ b/tests/transforms/test_linalg_tiling_helpers.py
@@ -5,25 +5,30 @@ from typing import Any
 import pytest
 
 from xdsl.builder import Builder
-from xdsl.dialects import linalg
+from xdsl.dialects import linalg, memref, tensor
 from xdsl.dialects.builtin import (
     DYNAMIC_INDEX,
     AffineMapAttr,
+    DenseArrayBase,
+    IndexType,
     MemRefType,
     ModuleOp,
     TensorType,
     f32,
+    i64,
 )
 from xdsl.dialects.linalg.transforms.tiling import (
     OperandTileInfo,
     TilingPlan,
     _build_tile_loops,  # pyright: ignore[reportPrivateUsage]
+    _build_tiled_slice,  # pyright: ignore[reportPrivateUsage]
     tile_linalg_generic,
 )
 from xdsl.ir import Attribute
 from xdsl.ir.affine import AffineExpr, AffineMap
 from xdsl.pattern_rewriter import PatternRewriter
 from xdsl.rewriter import InsertPoint
+from xdsl.utils.hints import isa
 from xdsl.utils.test_value import create_ssa_value
 
 
@@ -189,6 +194,47 @@ def test_tiling_plan_rejects_partial_tiles():
 
     with pytest.raises(ValueError, match="partial tiles"):
         TilingPlan.analyze_generic_op(op, (3, 0))
+
+
+def _tiled_slice_for(source_type: MemRefType[Attribute] | TensorType[Attribute]):
+    """Slice dim 0 of a 2d operand at a loop induction variable, tile size 2."""
+    op = _generic_2d_copy_op()
+    ModuleOp([op])
+    rewriter = PatternRewriter(op)
+
+    operand = create_ssa_value(source_type)
+    iv = create_ssa_value(IndexType())
+    indexing_map = AffineMap.from_callable(lambda i, j: (i, j))
+    operand_info = OperandTileInfo.analyze(indexing_map, source_type, (2, 0))
+
+    result = _build_tiled_slice(
+        rewriter, InsertPoint.before(op), operand, indexing_map, operand_info, {0: iv}
+    )
+    return result.owner
+
+
+def test_build_tiled_slice_memref_emits_subview():
+    slice_op = _tiled_slice_for(MemRefType(f32, [4, 5]))
+
+    assert isinstance(slice_op, memref.SubviewOp)
+    assert slice_op.static_offsets == DenseArrayBase.from_list(i64, [DYNAMIC_INDEX, 0])
+    assert slice_op.static_sizes == DenseArrayBase.from_list(i64, [2, 5])
+    assert len(slice_op.offsets) == 1
+    assert isa(slice_op.result.type, MemRefType)
+    assert slice_op.result.type.get_shape() == (2, 5)
+
+
+def test_build_tiled_slice_tensor_emits_extract_slice():
+    slice_op = _tiled_slice_for(TensorType(f32, [4, 5]))
+
+    assert isinstance(slice_op, tensor.ExtractSliceOp)
+    # Dim 0 is tiled, so its offset is the induction variable and its size the
+    # tile size; dim 1 is untiled, so it takes the whole extent at offset 0.
+    assert slice_op.static_offsets == DenseArrayBase.from_list(i64, [DYNAMIC_INDEX, 0])
+    assert slice_op.static_sizes == DenseArrayBase.from_list(i64, [2, 5])
+    assert slice_op.static_strides == DenseArrayBase.from_list(i64, [1, 1])
+    assert len(slice_op.offsets) == 1
+    assert slice_op.result.type == TensorType(f32, [2, 5])
 
 
 def test_build_tile_loops_without_iter_args():

--- a/xdsl/dialects/linalg/transforms/tiling.py
+++ b/xdsl/dialects/linalg/transforms/tiling.py
@@ -2,11 +2,12 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import cast
 
-from xdsl.dialects import arith, linalg, memref, scf
+from xdsl.dialects import arith, linalg, memref, scf, tensor
 from xdsl.dialects.builtin import (
     IndexType,
     IntegerAttr,
     MemRefType,
+    TensorType,
 )
 from xdsl.ir import Attribute, Block, Region, SSAValue
 from xdsl.ir.affine import AffineDimExpr, AffineMap
@@ -22,17 +23,17 @@ class OperandTileInfo:
     This records how one operand should be sliced when we enter a tile.
     - `source_type` keeps the original type.
     - `loop_dims` the loop dimension that comes from each indexing-map.
-    - `result_shape` the shape that tiled subview should have.
+    - `result_shape` the shape that tiled slice should have.
     """
 
-    source_type: MemRefType[Attribute]
+    source_type: MemRefType[Attribute] | TensorType[Attribute]
     loop_dims: tuple[int, ...]
     result_shape: tuple[int, ...]
 
     @staticmethod
     def analyze(
         indexing_map: AffineMap,
-        source_type: MemRefType[Attribute],
+        source_type: MemRefType[Attribute] | TensorType[Attribute],
         tile_sizes: Sequence[int],
     ) -> "OperandTileInfo":
         """
@@ -104,7 +105,7 @@ class TilingPlan:
             op.operands, op.get_indexing_maps(), strict=True
         ):
             source_type = operand.type
-            assert isa(source_type, MemRefType)
+            assert isa(source_type, MemRefType) or isa(source_type, TensorType)
             operand_infos_list.append(
                 OperandTileInfo.analyze(
                     indexing_map.data,
@@ -243,16 +244,25 @@ def _build_tile_loops(
     return loops, tiled_loop_ivs, current_insertion_point
 
 
-def _build_tiled_subview(
+def _build_tiled_slice(
     rewriter: PatternRewriter,
     insertion_point: InsertPoint,
     operand: SSAValue,
     indexing_map: AffineMap,
     operand_info: OperandTileInfo,
     tiled_loop_ivs: dict[int, SSAValue],
-) -> memref.SubviewOp:
+) -> SSAValue:
     """
-    Build `the subview` for one operand at the current tile position.
+    Build the slice of `operand` at the current tile position.
+
+    Memrefs are sliced with a `memref.subview`, which views the source memory,
+    and tensors with a `tensor.extract_slice`, which produces a new value. The
+    offsets, sizes and strides are the same either way, so only the op that
+    materializes the slice differs.
+
+    `operand` is the value to slice, which is not always the operand the tile
+    info was analyzed from: an output tensor is sliced from the value carried by
+    the enclosing loops rather than from the original.
     """
 
     source_shape = operand_info.source_type.get_shape()
@@ -270,27 +280,37 @@ def _build_tiled_subview(
             sizes.append(source_shape[result_index])
 
     strides = (1,) * len(source_shape)
+    source_type = operand_info.source_type
     try:
-        result_type = memref.SubviewOp.infer_result_type(
-            operand_info.source_type,
-            offsets,
-            sizes,
-            strides,
-        )
+        if isa(source_type, MemRefType):
+            slice_op = memref.SubviewOp.get(
+                operand,
+                offsets,
+                sizes,
+                strides,
+                memref.SubviewOp.infer_result_type(
+                    source_type,
+                    offsets,
+                    sizes,
+                    strides,
+                ),
+            )
+        elif isa(source_type, TensorType):
+            slice_op = tensor.ExtractSliceOp(
+                operand,
+                offsets,
+                sizes,
+                strides,
+                tensor.ExtractSliceOp.infer_result_type(source_type, sizes),
+            )
+        else:
+            raise ValueError(f"cannot tile an operand of type {source_type}")
     except ValueError as e:
         raise PassFailedException(str(e)) from e
 
-    subview = memref.SubviewOp.get(
-        operand,
-        offsets,
-        sizes,
-        strides,
-        result_type,
-    )
+    rewriter.insert(slice_op, insertion_point)
 
-    rewriter.insert(subview, insertion_point)
-
-    return subview
+    return slice_op.result
 
 
 def tile_linalg_generic(
@@ -321,10 +341,16 @@ def tile_linalg_generic(
     for operand, operand_info, indexing_map in zip(
         op.operands, plan.operand_infos, op.get_indexing_maps(), strict=True
     ):
-        subview = _build_tiled_subview(
-            rewriter, inner_ip, operand, indexing_map.data, operand_info, tiled_loop_ivs
+        tiled_operands.append(
+            _build_tiled_slice(
+                rewriter,
+                inner_ip,
+                operand,
+                indexing_map.data,
+                operand_info,
+                tiled_loop_ivs,
+            )
         )
-        tiled_operands.append(subview.result)
 
     num_inputs = len(op.inputs)
     tiled_generic = linalg.ops.GenericOp(

--- a/xdsl/dialects/linalg/transforms/tiling.py
+++ b/xdsl/dialects/linalg/transforms/tiling.py
@@ -105,7 +105,7 @@ class TilingPlan:
             op.operands, op.get_indexing_maps(), strict=True
         ):
             source_type = operand.type
-            assert isa(source_type, MemRefType) or isa(source_type, TensorType)
+            assert isa(source_type, MemRefType | TensorType)
             operand_infos_list.append(
                 OperandTileInfo.analyze(
                     indexing_map.data,

--- a/xdsl/dialects/linalg/transforms/tiling.py
+++ b/xdsl/dialects/linalg/transforms/tiling.py
@@ -2,6 +2,8 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import cast
 
+from typing_extensions import assert_never
+
 from xdsl.dialects import arith, linalg, memref, scf, tensor
 from xdsl.dialects.builtin import (
     IndexType,
@@ -282,29 +284,30 @@ def _build_tiled_slice(
     strides = (1,) * len(source_shape)
     source_type = operand_info.source_type
     try:
-        if isa(source_type, MemRefType):
-            slice_op = memref.SubviewOp.get(
-                operand,
-                offsets,
-                sizes,
-                strides,
-                memref.SubviewOp.infer_result_type(
-                    source_type,
+        match source_type:
+            case MemRefType():
+                slice_op = memref.SubviewOp.get(
+                    operand,
                     offsets,
                     sizes,
                     strides,
-                ),
-            )
-        elif isa(source_type, TensorType):
-            slice_op = tensor.ExtractSliceOp(
-                operand,
-                offsets,
-                sizes,
-                strides,
-                tensor.ExtractSliceOp.infer_result_type(source_type, sizes),
-            )
-        else:
-            raise ValueError(f"cannot tile an operand of type {source_type}")
+                    memref.SubviewOp.infer_result_type(
+                        source_type,
+                        offsets,
+                        sizes,
+                        strides,
+                    ),
+                )
+            case TensorType():
+                slice_op = tensor.ExtractSliceOp(
+                    operand,
+                    offsets,
+                    sizes,
+                    strides,
+                    tensor.ExtractSliceOp.infer_result_type(source_type, sizes),
+                )
+            case _:
+                assert_never(source_type)
     except ValueError as e:
         raise PassFailedException(str(e)) from e
 


### PR DESCRIPTION
Part of the tensor-based tiling checkbox on #6140, and the third of the smaller PRs split out of #6362. Follows on from #6366 and #6368.

Tiling slices each operand at the current tile position. Memrefs are sliced with a `memref.subview`, which views the source memory, but tensors have value semantics and need a `tensor.extract_slice`, which produces a new value.

This widens `OperandTileInfo.source_type` to accept a tensor type and picks the op that materializes the slice based on that type. The offsets, sizes and strides are computed the same way for both, so only the final construction differs:

```python
if isa(source_type, MemRefType):
    slice_op = memref.SubviewOp.get(...)
elif isa(source_type, TensorType):
    slice_op = tensor.ExtractSliceOp(...)
```

This mirrors how upstream separates `computeSliceParameters`, which works on any `ShapedType`, from `materializeTiledShape`, which switches on the concrete type only when creating the op. The memref path is unchanged.

`_build_tiled_subview` becomes `_build_tiled_slice` and returns the sliced value rather than the subview op, since the caller only ever wanted the result and the op type now varies.

The type widening and the type switch are one commit because widening on its own leaves `memref.SubviewOp.infer_result_type` receiving a union it cannot accept, so the two do not compile apart.

Tiling tensors is still rejected during analysis, so this is not yet reachable from the pass; `_build_tiled_slice` is covered directly by tests for both operand types.
