### PR TITLE
dialects: (linalg) write tiles back into the tensors carried by tile loops

### DIFF
--- a/tests/transforms/test_linalg_tiling_helpers.py
+++ b/tests/transforms/test_linalg_tiling_helpers.py
@@ -22,10 +22,11 @@ from xdsl.dialects.linalg.transforms.tiling import (
     SliceParameters,
     TilingPlan,
     _build_tile_loops,  # pyright: ignore[reportPrivateUsage]
+    _build_tiled_insert,  # pyright: ignore[reportPrivateUsage]
     _build_tiled_slice,  # pyright: ignore[reportPrivateUsage]
     tile_linalg_generic,
 )
-from xdsl.ir import Attribute
+from xdsl.ir import Attribute, SSAValue
 from xdsl.ir.affine import AffineExpr, AffineMap
 from xdsl.pattern_rewriter import PatternRewriter
 from xdsl.rewriter import InsertPoint
@@ -278,6 +279,59 @@ def test_build_tiled_slice_tensor_emits_extract_slice():
     assert slice_op.static_strides == DenseArrayBase.from_list(i64, [1, 1])
     assert len(slice_op.offsets) == 1
     assert slice_op.result.type == TensorType(f32, [2, 5])
+
+
+def _tiled_insert_for(
+    destination_type: TensorType[Attribute], tile_shape: Sequence[int]
+) -> tuple[tensor.InsertSliceOp, SSAValue, SSAValue]:
+    """Write a tile of dim 0 back at a loop induction variable, tile size 2."""
+    op = _generic_2d_copy_op()
+    ModuleOp([op])
+    rewriter = PatternRewriter(op)
+
+    iv = create_ssa_value(IndexType())
+    indexing_map = AffineMap.from_callable(lambda i, j: (i, j))
+    operand_info = OperandTileInfo.analyze(indexing_map, destination_type, (2, 0))
+    parameters = SliceParameters.compute(indexing_map, operand_info, {0: iv})
+
+    destination = create_ssa_value(destination_type)
+    tiled_value = create_ssa_value(
+        TensorType(destination_type.get_element_type(), tile_shape)
+    )
+
+    result = _build_tiled_insert(
+        rewriter, InsertPoint.before(op), tiled_value, destination, parameters
+    )
+    insert_op = result.owner
+    assert isinstance(insert_op, tensor.InsertSliceOp)
+    return insert_op, tiled_value, destination
+
+
+def test_build_tiled_insert_writes_tile_back_where_it_came_from():
+    insert_op, tiled_value, destination = _tiled_insert_for(
+        TensorType(f32, [4, 5]), [2, 5]
+    )
+
+    assert insert_op.source is tiled_value
+    # The tile goes back into the destination it was extracted from, which during
+    # tiling is the value carried by the enclosing loops rather than the original.
+    assert insert_op.dest is destination
+
+    # The same parameters the tile was extracted with, so it lands where it came
+    # from: dim 0 at the induction variable spanning one tile, dim 1 whole.
+    assert insert_op.static_offsets == DenseArrayBase.from_list(i64, [DYNAMIC_INDEX, 0])
+    assert insert_op.static_sizes == DenseArrayBase.from_list(i64, [2, 5])
+    assert insert_op.static_strides == DenseArrayBase.from_list(i64, [1, 1])
+    assert len(insert_op.offsets) == 1
+
+
+def test_build_tiled_insert_result_is_the_whole_updated_tensor():
+    destination_type = TensorType(f32, [4, 5])
+    insert_op, _, _ = _tiled_insert_for(destination_type, [2, 5])
+
+    # Inserting a tile yields the whole tensor updated, not the tile, which is
+    # what lets the enclosing loops carry it on to the next iteration.
+    assert insert_op.result.type == destination_type
 
 
 def test_build_tile_loops_without_iter_args():

--- a/xdsl/dialects/linalg/transforms/tiling.py
+++ b/xdsl/dialects/linalg/transforms/tiling.py
@@ -475,8 +475,8 @@ def tile_linalg_generic(
         rewriter.insert(scf.YieldOp(*yielded), InsertPoint.at_end(loop.body.block))
         yielded = loop.results
 
-    if has_tensor_outputs:
-        rewriter.replace(op, [], loops[0].results)
-    else:
-        rewriter.erase(op)
+    # The outermost loop carries out the fully updated tensors. An op tiling
+    # memrefs carries nothing and has no results, so this replaces it with
+    # nothing, which is the erase that case needs.
+    rewriter.replace(op, [], loops[0].results)
     return True

--- a/xdsl/dialects/linalg/transforms/tiling.py
+++ b/xdsl/dialects/linalg/transforms/tiling.py
@@ -6,11 +6,13 @@ from typing_extensions import assert_never
 
 from xdsl.dialects import arith, linalg, memref, scf, tensor
 from xdsl.dialects.builtin import (
+    DYNAMIC_INDEX,
     IndexType,
     IntegerAttr,
     MemRefType,
     TensorType,
 )
+from xdsl.dialects.utils import split_dynamic_index_list
 from xdsl.ir import Attribute, Block, Region, SSAValue
 from xdsl.ir.affine import AffineDimExpr, AffineMap
 from xdsl.pattern_rewriter import PatternRewriter
@@ -347,6 +349,46 @@ def _build_tiled_slice(
     return slice_op.result
 
 
+def _build_tiled_insert(
+    rewriter: PatternRewriter,
+    insertion_point: InsertPoint,
+    tiled_value: SSAValue,
+    destination: SSAValue,
+    parameters: SliceParameters,
+) -> SSAValue:
+    """
+    Write one computed tile back into `destination`, giving the updated tensor.
+
+    Tensors have value semantics, so a tile cannot be written through its slice
+    the way a `memref.subview` writes through to the memory it views. The
+    parameters are the ones the tile was extracted with, so that the tile is
+    written back exactly where it came from.
+    """
+
+    static_offsets, offsets = split_dynamic_index_list(
+        parameters.offsets, DYNAMIC_INDEX
+    )
+    static_sizes, sizes = split_dynamic_index_list(parameters.sizes, DYNAMIC_INDEX)
+    static_strides, strides = split_dynamic_index_list(
+        parameters.strides, DYNAMIC_INDEX
+    )
+
+    insert_op = tensor.InsertSliceOp.get(
+        source=tiled_value,
+        dest=destination,
+        static_sizes=static_sizes,
+        static_offsets=static_offsets,
+        static_strides=static_strides,
+        offsets=offsets,
+        sizes=sizes,
+        strides=strides,
+        result_type=destination.type,
+    )
+    rewriter.insert(insert_op, insertion_point)
+
+    return insert_op.result
+
+
 def tile_linalg_generic(
     rewriter: PatternRewriter,
     op: linalg.ops.GenericOp,
@@ -363,43 +405,78 @@ def tile_linalg_generic(
     if not plan.tiled_dims:
         return False
 
+    # Outputs with value semantics are threaded through the loops, since each
+    # tile produces a new value instead of writing through a view.
+    has_tensor_outputs = bool(op.res)
+    iter_args = tuple(op.outputs) if has_tensor_outputs else ()
+
     loops, tiled_loop_ivs, inner_ip = _build_tile_loops(
         rewriter,
         InsertPoint.before(op),
         plan.loop_ranges,
         plan.tile_sizes,
         plan.tiled_dims,
+        iter_args,
     )
-    tiled_operands: list[SSAValue] = []
-
-    for operand, operand_info, indexing_map in zip(
-        op.operands, plan.operand_infos, op.get_indexing_maps(), strict=True
-    ):
-        parameters = SliceParameters.compute(
-            indexing_map.data, operand_info, tiled_loop_ivs
-        )
-        tiled_operands.append(
-            _build_tiled_slice(
-                rewriter,
-                inner_ip,
-                operand,
-                operand_info.source_type,
-                parameters,
-            )
-        )
 
     num_inputs = len(op.inputs)
+    slice_parameters = tuple(
+        SliceParameters.compute(indexing_map.data, operand_info, tiled_loop_ivs)
+        for operand_info, indexing_map in zip(
+            plan.operand_infos, op.get_indexing_maps(), strict=True
+        )
+    )
+
+    # Output tensors are sliced from the values the innermost loop carries, so
+    # that each tile builds on the tiles the surrounding iterations wrote back.
+    # Slicing the originals instead would discard their work.
+    carried = loops[-1].body.block.args[1:]
+    slice_sources = list(op.operands)
+    slice_sources[num_inputs:] = carried if has_tensor_outputs else op.outputs
+
+    tiled_operands = [
+        _build_tiled_slice(
+            rewriter, inner_ip, source, operand_info.source_type, parameters
+        )
+        for source, operand_info, parameters in zip(
+            slice_sources, plan.operand_infos, slice_parameters, strict=True
+        )
+    ]
+
+    tiled_outputs = tiled_operands[num_inputs:]
     tiled_generic = linalg.ops.GenericOp(
         tiled_operands[:num_inputs],
-        tiled_operands[num_inputs:],
+        tiled_outputs,
         op.body.clone(),
         op.get_indexing_maps(),
         op.get_iterator_types(),
+        tuple(value.type for value in tiled_outputs) if has_tensor_outputs else (),
     )
     rewriter.insert(tiled_generic, inner_ip)
 
-    for loop in reversed(loops):
-        rewriter.insert(scf.YieldOp(), InsertPoint.at_end(loop.body.block))
+    # Memref outputs are written through their subview, so only tensor outputs
+    # need their computed tile written back into the value being carried.
+    yielded: Sequence[SSAValue] = (
+        tuple(
+            _build_tiled_insert(
+                rewriter, inner_ip, tiled_result, destination, parameters
+            )
+            for tiled_result, destination, parameters in zip(
+                tiled_generic.res, carried, slice_parameters[num_inputs:], strict=True
+            )
+        )
+        if has_tensor_outputs
+        else ()
+    )
 
-    rewriter.erase(op)
+    # The innermost loop yields the updated tensors, and each enclosing loop
+    # yields the results of the loop nested inside it.
+    for loop in reversed(loops):
+        rewriter.insert(scf.YieldOp(*yielded), InsertPoint.at_end(loop.body.block))
+        yielded = loop.results
+
+    if has_tensor_outputs:
+        rewriter.replace(op, [], loops[0].results)
+    else:
+        rewriter.erase(op)
     return True


### PR DESCRIPTION
Part of the tensor-based tiling checkbox on #6140.

A tile of a memref is written through the subview that views it, but a tile of a tensor is a new value, so it has to be written back explicitly and carried out of the loops it was computed in.

This passes the outputs of an op with tensor semantics as the loop nest iteration arguments, slices those outputs from the values the innermost loop carries rather than from the originals, and writes each computed tile back with a `tensor.insert_slice`. The innermost loop yields the updated tensors and each enclosing loop yields the results of the loop nested inside it, so the outermost loop produces the fully updated tensors, which then replace the results of the original op:

```mlir
%C = scf.for %i = ... iter_args(%accI = %B) -> (tensor<4x4xf32>) {
  %r = scf.for %j = ... iter_args(%accJ = %accI) -> (tensor<4x4xf32>) {
    %in   = tensor.extract_slice %A[%i, %j] ...
    %out  = tensor.extract_slice %accJ[%i, %j] ...     // from the carried value
    %tile = linalg.generic ins(%in) outs(%out) ... -> tensor<2x2xf32>
    %upd  = tensor.insert_slice %tile into %accJ[%i, %j] ...
    scf.yield %upd : tensor<4x4xf32>
  }
  scf.yield %r : tensor<4x4xf32>
}
```

Two things here are easy to get wrong, and both give IR that verifies while dropping the work of the surrounding iterations: slicing an output from the original tensor rather than from the carried value, and erasing the op rather than replacing its results.

A tile is written back exactly where it was extracted from, so both use the same `SliceParameters`.

Tiling memrefs carries nothing, writes nothing back and yields nothing, so its generated IR is unchanged and the existing filecheck expectations are untouched.

### Tests

Unit tests cover `_build_tiled_insert`: that it writes the tile back with the parameters it was extracted with, and that its result is the whole updated tensor rather than the tile, which is what lets the enclosing loops carry it on to the next iteration.

The loop wiring that uses this — passing the outputs as iteration arguments, the operand-carrying yields, and replacing the op's results — is exercised by filecheck once tiling tensors is reachable from the pass, in the follow-up. Tiling tensors is still rejected during analysis here.
