### PR TITLE
dialects: (linalg) factor out where a tile sits within an operand

### DIFF
--- a/tests/transforms/test_linalg_tiling_helpers.py
+++ b/tests/transforms/test_linalg_tiling_helpers.py
@@ -19,6 +19,7 @@ from xdsl.dialects.builtin import (
 )
 from xdsl.dialects.linalg.transforms.tiling import (
     OperandTileInfo,
+    SliceParameters,
     TilingPlan,
     _build_tile_loops,  # pyright: ignore[reportPrivateUsage]
     _build_tiled_slice,  # pyright: ignore[reportPrivateUsage]
@@ -196,6 +197,47 @@ def test_tiling_plan_rejects_partial_tiles():
         TilingPlan.analyze_generic_op(op, (3, 0))
 
 
+def test_slice_parameters_compute_tiled_and_untiled_dims():
+    source_type = MemRefType(f32, [4, 5])
+    iv = create_ssa_value(IndexType())
+    indexing_map = AffineMap.from_callable(lambda i, j: (i, j))
+    operand_info = OperandTileInfo.analyze(indexing_map, source_type, (2, 0))
+
+    parameters = SliceParameters.compute(indexing_map, operand_info, {0: iv})
+
+    # Dim 0's loop is tiled, so it starts at the induction variable and spans one
+    # tile; dim 1's loop is not, so it starts at zero and spans the whole operand.
+    assert parameters.offsets == (iv, 0)
+    assert parameters.sizes == (2, 5)
+    assert parameters.strides == (1, 1)
+
+
+def test_slice_parameters_compute_without_tiled_dims():
+    source_type = MemRefType(f32, [4, 5])
+    indexing_map = AffineMap.from_callable(lambda i, j: (i, j))
+    operand_info = OperandTileInfo.analyze(indexing_map, source_type, (0, 0))
+
+    parameters = SliceParameters.compute(indexing_map, operand_info, {})
+
+    # Nothing is tiled, so the slice covers the whole operand.
+    assert parameters.offsets == (0, 0)
+    assert parameters.sizes == (4, 5)
+
+
+def test_slice_parameters_compute_follows_indexing_map():
+    # The operand is indexed transposed, so loop dim 0 addresses the operand's
+    # second dimension. The induction variable has to land there, not first.
+    source_type = MemRefType(f32, [5, 4])
+    iv = create_ssa_value(IndexType())
+    indexing_map = AffineMap.from_callable(lambda i, j: (j, i))
+    operand_info = OperandTileInfo.analyze(indexing_map, source_type, (2, 0))
+
+    parameters = SliceParameters.compute(indexing_map, operand_info, {0: iv})
+
+    assert parameters.offsets == (0, iv)
+    assert parameters.sizes == (5, 2)
+
+
 def _tiled_slice_for(source_type: MemRefType[Attribute] | TensorType[Attribute]):
     """Slice dim 0 of a 2d operand at a loop induction variable, tile size 2."""
     op = _generic_2d_copy_op()
@@ -206,9 +248,10 @@ def _tiled_slice_for(source_type: MemRefType[Attribute] | TensorType[Attribute])
     iv = create_ssa_value(IndexType())
     indexing_map = AffineMap.from_callable(lambda i, j: (i, j))
     operand_info = OperandTileInfo.analyze(indexing_map, source_type, (2, 0))
+    parameters = SliceParameters.compute(indexing_map, operand_info, {0: iv})
 
     result = _build_tiled_slice(
-        rewriter, InsertPoint.before(op), operand, indexing_map, operand_info, {0: iv}
+        rewriter, InsertPoint.before(op), operand, source_type, parameters
     )
     return result.owner
 

--- a/xdsl/dialects/linalg/transforms/tiling.py
+++ b/xdsl/dialects/linalg/transforms/tiling.py
@@ -246,43 +246,74 @@ def _build_tile_loops(
     return loops, tiled_loop_ivs, current_insertion_point
 
 
+@dataclass(frozen=True)
+class SliceParameters:
+    """
+    Where one operand's tile sits within that operand.
+
+    This is the geometry of the tile, which is the same whether the operand is a
+    memref or a tensor, and so does not depend on which op ends up materializing
+    the slice.
+    """
+
+    offsets: tuple[SSAValue | int, ...]
+    sizes: tuple[SSAValue | int, ...]
+    strides: tuple[SSAValue | int, ...]
+
+    @staticmethod
+    def compute(
+        indexing_map: AffineMap,
+        operand_info: OperandTileInfo,
+        tiled_loop_ivs: dict[int, SSAValue],
+    ) -> "SliceParameters":
+        """
+        Compute where the current tile sits within one operand.
+
+        Each result of the indexing map addresses one dimension of the operand.
+        A dimension whose loop is tiled starts at that loop's induction variable
+        and spans one tile, and a dimension whose loop is not tiled starts at
+        zero and spans the whole operand.
+        """
+
+        source_shape = operand_info.source_type.get_shape()
+
+        offsets: list[SSAValue | int] = []
+        sizes: list[SSAValue | int] = []
+        for result_index, expr in enumerate(indexing_map.results):
+            assert isinstance(expr, AffineDimExpr)
+            loop_dim = operand_info.loop_dims[result_index]
+            if loop_dim in tiled_loop_ivs:
+                offsets.append(tiled_loop_ivs[loop_dim])
+                sizes.append(operand_info.result_shape[result_index])
+            else:
+                offsets.append(0)
+                sizes.append(source_shape[result_index])
+
+        return SliceParameters(tuple(offsets), tuple(sizes), (1,) * len(source_shape))
+
+
 def _build_tiled_slice(
     rewriter: PatternRewriter,
     insertion_point: InsertPoint,
     operand: SSAValue,
-    indexing_map: AffineMap,
-    operand_info: OperandTileInfo,
-    tiled_loop_ivs: dict[int, SSAValue],
+    source_type: MemRefType[Attribute] | TensorType[Attribute],
+    parameters: SliceParameters,
 ) -> SSAValue:
     """
     Build the slice of `operand` at the current tile position.
 
     Memrefs are sliced with a `memref.subview`, which views the source memory,
-    and tensors with a `tensor.extract_slice`, which produces a new value. The
-    offsets, sizes and strides are the same either way, so only the op that
-    materializes the slice differs.
+    and tensors with a `tensor.extract_slice`, which produces a new value. Only
+    the op that materializes the slice differs.
 
     `operand` is the value to slice, which is not always the operand the tile
     info was analyzed from: an output tensor is sliced from the value carried by
     the enclosing loops rather than from the original.
     """
 
-    source_shape = operand_info.source_type.get_shape()
-
-    offsets: list[SSAValue | int] = []
-    sizes: list[int] = []
-    for result_index, expr in enumerate(indexing_map.results):
-        assert isinstance(expr, AffineDimExpr)
-        loop_dim = operand_info.loop_dims[result_index]
-        if loop_dim in tiled_loop_ivs:
-            offsets.append(tiled_loop_ivs[loop_dim])
-            sizes.append(operand_info.result_shape[result_index])
-        else:
-            offsets.append(0)
-            sizes.append(source_shape[result_index])
-
-    strides = (1,) * len(source_shape)
-    source_type = operand_info.source_type
+    offsets = parameters.offsets
+    sizes = parameters.sizes
+    strides = parameters.strides
     try:
         match source_type:
             case MemRefType():
@@ -344,14 +375,16 @@ def tile_linalg_generic(
     for operand, operand_info, indexing_map in zip(
         op.operands, plan.operand_infos, op.get_indexing_maps(), strict=True
     ):
+        parameters = SliceParameters.compute(
+            indexing_map.data, operand_info, tiled_loop_ivs
+        )
         tiled_operands.append(
             _build_tiled_slice(
                 rewriter,
                 inner_ip,
                 operand,
-                indexing_map.data,
-                operand_info,
-                tiled_loop_ivs,
+                operand_info.source_type,
+                parameters,
             )
         )
 


### PR DESCRIPTION
Part of the tensor-based tiling checkbox on #6140.

Building the slice of an operand does two things: works out where the tile sits within that operand, and materializes it. Those are separate concerns — the geometry is the same whether the operand is a memref or a tensor, while the op that materializes the slice is not.

This moves that computation into `SliceParameters.compute`, and has `_build_tiled_slice` take the result along with the type it is slicing:

```python
parameters = SliceParameters.compute(indexing_map.data, operand_info, tiled_loop_ivs)
tiled_operands.append(
    _build_tiled_slice(rewriter, inner_ip, operand, operand_info.source_type, parameters)
)
```

This mirrors how upstream separates `computeSliceParameters`, which works on any `ShapedType`, from `materializeTiledShape`, which switches on the concrete type only when creating the op.

Generated IR is unchanged, so the existing filecheck expectations are untouched.

### Tests

Three unit tests for `compute`, covering a tiled dimension (offset is the induction variable, size is the tile size), an untiled one (offset zero, size the whole extent), and an operand indexed by a transposed map.

The transposed case is worth having on its own: `compute` reads `operand_info.loop_dims[result_index]` to get from a result position to a loop dimension, and with an identity map those two indices coincide, so nothing else exercises the indirection. Replacing that lookup with `result_index` fails only that test.
