### PR TITLE
core: (Constraints) add AnyRange

### DIFF
--- a/tests/irdl/test_range_constraint.py
+++ b/tests/irdl/test_range_constraint.py
@@ -1,5 +1,4 @@
 import re
-from collections.abc import Mapping, Sequence
 
 import pytest
 from typing_extensions import TypeVar
@@ -9,15 +8,13 @@ from xdsl.ir import Attribute
 from xdsl.irdl import (
     AnyAttr,
     AnyInt,
-    AttrConstraint,
+    AnyRange,
     BaseAttr,
     ConstraintContext,
     EqAttrConstraint,
     EqIntConstraint,
-    IntConstraint,
     IntTypeVarConstraint,
     IntVarConstraint,
-    RangeConstraint,
     RangeLengthConstraint,
     RangeOf,
     RangeVarConstraint,
@@ -27,29 +24,12 @@ from xdsl.irdl import (
 from xdsl.utils.exceptions import VerifyException
 
 
-class AnyRangeConstraint(RangeConstraint):
-    """Constraint for testing default infer"""
-
-    def verify(
-        self, attrs: Sequence[Attribute], constraint_context: ConstraintContext
-    ) -> None:
-        return
-
-    def verify_length(self, length: int, constraint_context: ConstraintContext) -> None:
-        return
-
-    def mapping_type_vars(
-        self, type_var_mapping: Mapping[TypeVar, AttrConstraint | IntConstraint]
-    ) -> RangeConstraint:
-        return self
-
-
 def test_failing_inference():
     with pytest.raises(
         ValueError,
-        match=re.escape("Cannot infer range from constraint AnyRangeConstraint()"),
+        match=re.escape("Cannot infer range from constraint AnyRange()"),
     ):
-        AnyRangeConstraint().infer(ConstraintContext(), length=None)
+        AnyRange().infer(ConstraintContext(), length=None)
 
 
 def test_range_of_variables():
@@ -132,10 +112,10 @@ def test_of_length():
 def test_mapping_type_vars():
     _IntT = TypeVar("_IntT", bound=int, default=int)
     tv_constr = IntTypeVarConstraint(_IntT, AnyInt())
-    range_constr = RangeLengthConstraint(AnyRangeConstraint(), tv_constr)
+    range_constr = RangeLengthConstraint(AnyRange(), tv_constr)
     my_constr = EqIntConstraint(1)
     assert range_constr.mapping_type_vars({_IntT: my_constr}) == RangeLengthConstraint(
-        AnyRangeConstraint(), my_constr
+        AnyRange(), my_constr
     )
 
 
@@ -145,7 +125,7 @@ def test_init_irdl_constraint():
 
 
 def test_empty_range():
-    constr = AnyRangeConstraint().of_length(EqIntConstraint(0))
+    constr = AnyRange().of_length(EqIntConstraint(0))
 
     assert constr.can_infer(set(), length_known=False)
 
@@ -178,26 +158,26 @@ def test_range_var_constraint_verify():
         (RangeVarConstraint("R", SingleOf(EqAttrConstraint(i32))), {}, True, (i32,)),
         (RangeVarConstraint("R", RangeOf(EqAttrConstraint(i32))), {}, None, None),
         (RangeVarConstraint("R", RangeOf(EqAttrConstraint(i32))), {}, 2, (i32, i32)),
-        (RangeVarConstraint("R", AnyRangeConstraint()), {}, None, None),
+        (RangeVarConstraint("R", AnyRange()), {}, None, None),
         (
-            RangeVarConstraint("R", AnyRangeConstraint()),
+            RangeVarConstraint("R", AnyRange()),
             {"R": (i32, i32, i32)},
             None,
             (i32, i32, i32),
         ),
         (
-            RangeVarConstraint("R", AnyRangeConstraint()),
+            RangeVarConstraint("R", AnyRange()),
             {"R": (i32, i32, i32)},
             2,
             (i32, i32, i32),
         ),
         (
-            RangeVarConstraint("R", AnyRangeConstraint()),
+            RangeVarConstraint("R", AnyRange()),
             {"R": (i32, i32, i32)},
             3,
             (i32, i32, i32),
         ),
-        (RangeVarConstraint("R", AnyRangeConstraint()), {}, 3, None),
+        (RangeVarConstraint("R", AnyRange()), {}, 3, None),
     ],
 )
 def test_range_var_constraint_infer(

--- a/xdsl/irdl/constraints.py
+++ b/xdsl/irdl/constraints.py
@@ -1187,6 +1187,26 @@ class RangeConstraint(ABC, Generic[AttributeCovT]):
 
 
 @dataclass(frozen=True)
+class AnyRange(RangeConstraint):
+    """
+    A constraint allowing any range.
+    """
+
+    def verify(
+        self, attrs: Sequence[Attribute], constraint_context: ConstraintContext
+    ) -> None:
+        return
+
+    def verify_length(self, length: int, constraint_context: ConstraintContext) -> None:
+        return
+
+    def mapping_type_vars(
+        self, type_var_mapping: Mapping[TypeVar, AttrConstraint | IntConstraint]
+    ) -> RangeConstraint:
+        return self
+
+
+@dataclass(frozen=True)
 class RangeLengthConstraint(RangeConstraint[AttributeCovT]):
     """
     Constrain an attribute range with the given length.


### PR DESCRIPTION
It feels reasonable to have this instead of using `RangeOf(AnyAttr())` everywhere