### PR TITLE
dialects: (linalg) take the size of a tile from the tiling plan

### DIFF
--- a/tests/transforms/test_linalg_tiling_helpers.py
+++ b/tests/transforms/test_linalg_tiling_helpers.py
@@ -39,22 +39,20 @@ def test_operand_tile_info_analyze_identity_map():
     source_type = MemRefType(f32, [4, 5])
     indexing_map = AffineMap.from_callable(lambda i, j: (i, j))
 
-    info = OperandTileInfo.analyze(indexing_map, source_type, (2, 0))
+    info = OperandTileInfo.analyze(indexing_map, source_type)
 
     assert info.source_type == source_type
     assert info.loop_dims == (0, 1)
-    assert info.result_shape == (2, 5)
 
 
 def test_operand_tile_info_analyze_transpose_map():
     source_type = MemRefType(f32, [5, 4])
     indexing_map = AffineMap.from_callable(lambda i, j: (j, i))
 
-    info = OperandTileInfo.analyze(indexing_map, source_type, (2, 0))
+    info = OperandTileInfo.analyze(indexing_map, source_type)
 
     assert info.source_type == source_type
     assert info.loop_dims == (1, 0)
-    assert info.result_shape == (5, 2)
 
 
 def _generic_2d_copy_op(
@@ -111,10 +109,8 @@ def test_tiling_plan_analyze_generic_op():
     assert len(plan.operand_infos) == 2
 
     assert plan.operand_infos[0].loop_dims == (0, 1)
-    assert plan.operand_infos[0].result_shape == (2, 5)
 
     assert plan.operand_infos[1].loop_dims == (0, 1)
-    assert plan.operand_infos[1].result_shape == (2, 5)
 
 
 def test_tiling_plan_analyze_generic_op_without_tiled_dims():
@@ -148,7 +144,6 @@ def test_tiling_plan_accepts_tensor_operands():
     assert plan.loop_ranges == (4, 5)
     assert plan.tiled_dims == (0,)
     assert plan.operand_infos[0].source_type == TensorType(f32, [4, 5])
-    assert plan.operand_infos[0].result_shape == (2, 5)
 
 
 def test_tiling_plan_rejects_linalg_index():
@@ -249,9 +244,9 @@ def test_slice_parameters_compute_tiled_and_untiled_dims():
     source_type = MemRefType(f32, [4, 5])
     iv = create_ssa_value(IndexType())
     indexing_map = AffineMap.from_callable(lambda i, j: (i, j))
-    operand_info = OperandTileInfo.analyze(indexing_map, source_type, (2, 0))
+    operand_info = OperandTileInfo.analyze(indexing_map, source_type)
 
-    parameters = SliceParameters.compute(indexing_map, operand_info, {0: iv})
+    parameters = SliceParameters.compute(indexing_map, operand_info, {0: iv}, {0: 2})
 
     # Dim 0's loop is tiled, so it starts at the induction variable and spans one
     # tile; dim 1's loop is not, so it starts at zero and spans the whole operand.
@@ -263,9 +258,9 @@ def test_slice_parameters_compute_tiled_and_untiled_dims():
 def test_slice_parameters_compute_without_tiled_dims():
     source_type = MemRefType(f32, [4, 5])
     indexing_map = AffineMap.from_callable(lambda i, j: (i, j))
-    operand_info = OperandTileInfo.analyze(indexing_map, source_type, (0, 0))
+    operand_info = OperandTileInfo.analyze(indexing_map, source_type)
 
-    parameters = SliceParameters.compute(indexing_map, operand_info, {})
+    parameters = SliceParameters.compute(indexing_map, operand_info, {}, {})
 
     # Nothing is tiled, so the slice covers the whole operand.
     assert parameters.offsets == (0, 0)
@@ -278,9 +273,9 @@ def test_slice_parameters_compute_follows_indexing_map():
     source_type = MemRefType(f32, [5, 4])
     iv = create_ssa_value(IndexType())
     indexing_map = AffineMap.from_callable(lambda i, j: (j, i))
-    operand_info = OperandTileInfo.analyze(indexing_map, source_type, (2, 0))
+    operand_info = OperandTileInfo.analyze(indexing_map, source_type)
 
-    parameters = SliceParameters.compute(indexing_map, operand_info, {0: iv})
+    parameters = SliceParameters.compute(indexing_map, operand_info, {0: iv}, {0: 2})
 
     assert parameters.offsets == (0, iv)
     assert parameters.sizes == (5, 2)
@@ -295,8 +290,8 @@ def _tiled_slice_for(source_type: MemRefType[Attribute] | TensorType[Attribute])
     operand = create_ssa_value(source_type)
     iv = create_ssa_value(IndexType())
     indexing_map = AffineMap.from_callable(lambda i, j: (i, j))
-    operand_info = OperandTileInfo.analyze(indexing_map, source_type, (2, 0))
-    parameters = SliceParameters.compute(indexing_map, operand_info, {0: iv})
+    operand_info = OperandTileInfo.analyze(indexing_map, source_type)
+    parameters = SliceParameters.compute(indexing_map, operand_info, {0: iv}, {0: 2})
 
     result = _build_tiled_slice(
         rewriter, InsertPoint.before(op), operand, source_type, parameters
@@ -338,8 +333,8 @@ def _tiled_insert_for(
 
     iv = create_ssa_value(IndexType())
     indexing_map = AffineMap.from_callable(lambda i, j: (i, j))
-    operand_info = OperandTileInfo.analyze(indexing_map, destination_type, (2, 0))
-    parameters = SliceParameters.compute(indexing_map, operand_info, {0: iv})
+    operand_info = OperandTileInfo.analyze(indexing_map, destination_type)
+    parameters = SliceParameters.compute(indexing_map, operand_info, {0: iv}, {0: 2})
 
     destination = create_ssa_value(destination_type)
     tiled_value = create_ssa_value(

--- a/xdsl/dialects/linalg/transforms/tiling.py
+++ b/xdsl/dialects/linalg/transforms/tiling.py
@@ -27,34 +27,24 @@ class OperandTileInfo:
     This records how one operand should be sliced when we enter a tile.
     - `source_type` keeps the original type.
     - `loop_dims` the loop dimension that comes from each indexing-map.
-    - `result_shape` the shape that tiled slice should have.
     """
 
     source_type: MemRefType[Attribute] | TensorType[Attribute]
     loop_dims: tuple[int, ...]
-    result_shape: tuple[int, ...]
 
     @staticmethod
     def analyze(
         indexing_map: AffineMap,
         source_type: MemRefType[Attribute] | TensorType[Attribute],
-        tile_sizes: Sequence[int],
     ) -> "OperandTileInfo":
         """
         Analyze how one operand should be sliced for each tile.
         """
 
-        source_shape = source_type.get_shape()
         loop_dims = tuple(
             cast(AffineDimExpr, expr).position for expr in indexing_map.results
         )
-        result_shape = tuple(
-            tile_sizes[loop_dim]
-            if tile_sizes[loop_dim] != 0
-            else source_shape[result_index]
-            for result_index, loop_dim in enumerate(loop_dims)
-        )
-        return OperandTileInfo(source_type, loop_dims, result_shape)
+        return OperandTileInfo(source_type, loop_dims)
 
 
 @dataclass(frozen=True)
@@ -111,11 +101,7 @@ class TilingPlan:
             source_type = operand.type
             assert isa(source_type, MemRefType | TensorType)
             operand_infos_list.append(
-                OperandTileInfo.analyze(
-                    indexing_map.data,
-                    source_type,
-                    normalized_tile_sizes,
-                )
+                OperandTileInfo.analyze(indexing_map.data, source_type)
             )
         operand_infos = tuple(operand_infos_list)
 
@@ -277,14 +263,15 @@ class SliceParameters:
         indexing_map: AffineMap,
         operand_info: OperandTileInfo,
         tiled_loop_ivs: dict[int, SSAValue],
+        tile_sizes: dict[int, SSAValue | int],
     ) -> "SliceParameters":
         """
         Compute where the current tile sits within one operand.
 
         Each result of the indexing map addresses one dimension of the operand.
         A dimension whose loop is tiled starts at that loop's induction variable
-        and spans one tile, and a dimension whose loop is not tiled starts at
-        zero and spans the whole operand.
+        and spans that loop's tile, and a dimension whose loop is not tiled
+        starts at zero and spans the whole operand.
         """
 
         source_shape = operand_info.source_type.get_shape()
@@ -296,7 +283,7 @@ class SliceParameters:
             loop_dim = operand_info.loop_dims[result_index]
             if loop_dim in tiled_loop_ivs:
                 offsets.append(tiled_loop_ivs[loop_dim])
-                sizes.append(operand_info.result_shape[result_index])
+                sizes.append(tile_sizes[loop_dim])
             else:
                 offsets.append(0)
                 sizes.append(source_shape[result_index])
@@ -430,8 +417,14 @@ def tile_linalg_generic(
     )
 
     num_inputs = len(op.inputs)
+    tile_sizes_by_dim: dict[int, SSAValue | int] = {
+        dim: plan.tile_sizes[dim] for dim in plan.tiled_dims
+    }
+
     slice_parameters = tuple(
-        SliceParameters.compute(indexing_map.data, operand_info, tiled_loop_ivs)
+        SliceParameters.compute(
+            indexing_map.data, operand_info, tiled_loop_ivs, tile_sizes_by_dim
+        )
         for operand_info, indexing_map in zip(
             plan.operand_infos, op.get_indexing_maps(), strict=True
         )


### PR DESCRIPTION
Groundwork towards the partial tiles checkbox on #6140.

`OperandTileInfo` recorded a `result_shape`, the shape each tiled slice should have. Per dimension that was one of two things already known elsewhere: for a tiled dimension it was that dimension's tile size, and for an untiled one it was the operand shape the slice already reads.

This drops it, and passes the tile size of each tiled dimension to `SliceParameters.compute` instead:

```python
tile_sizes_by_dim: dict[int, SSAValue | int] = {
    dim: plan.tile_sizes[dim] for dim in plan.tiled_dims
}
```

Where a tile begins and how far it spans is then decided in one place, from the plan, rather than partly precomputed per operand and partly derived at slice time.

The map is typed `dict[int, SSAValue | int]` because a tile size need not stay a compile-time constant: a dimension whose loop range is not divisible by its tile size has a smaller tile on its last iteration, and its size becomes a value. That is the follow-up; nothing here computes such a size yet.

Generated IR is unchanged, so the existing filecheck expectations are untouched. The unit tests that asserted `result_shape` now assert the loop dimensions and the slice parameters instead, which is where that information lives.
