### PR TITLE
dialects: (linalg) tile loop ranges that tile sizes do not divide

### DIFF
--- a/tests/filecheck/transforms/linalg-tiling-reject-unsupported.mlir
+++ b/tests/filecheck/transforms/linalg-tiling-reject-unsupported.mlir
@@ -133,24 +133,6 @@ builtin.module {
 // -----
 
 builtin.module {
-  %input = "test.op"() : () -> memref<5x4xf32>
-  %output = "test.op"() : () -> memref<5x4xf32>
-  linalg.generic {
-      indexing_maps = [
-          affine_map<(i, j) -> (i, j)>,
-          affine_map<(i, j) -> (i, j)>
-      ],
-      iterator_types = ["parallel", "parallel"]
-  } ins(%input : memref<5x4xf32>) outs(%output : memref<5x4xf32>) attrs = {test_tile_sizes = array<i32: 2, 2>} {
-  ^bb0(%in: f32, %out: f32):
-      linalg.yield %in : f32
-  }
-}
-// CHECK: partial tiles are not supported yet
-
-// -----
-
-builtin.module {
   %input = "test.op"() : () -> memref<4x4xf32, affine_map<(d0, d1) -> (d0 * 4 + d1)>>
   %output = "test.op"() : () -> memref<4x4xf32, affine_map<(d0, d1) -> (d0 * 4 + d1)>>
   linalg.generic {

--- a/tests/filecheck/transforms/linalg-tiling.mlir
+++ b/tests/filecheck/transforms/linalg-tiling.mlir
@@ -185,3 +185,78 @@ linalg.generic {
 // CHECK-NEXT:   }
 // CHECK-NEXT:   "test.op"(%C) : (tensor<4x4xf32>) -> ()
 // CHECK-NEXT: }
+
+// -----
+
+// A dimension whose range does not divide by its tile size gets a smaller
+// tile on its last iteration, sized with affine.min. The other dimension
+// divides evenly and keeps its static tile size.
+
+%A, %B = "test.op"() : () -> (memref<5x4xf32>, memref<5x4xf32>)
+linalg.generic {
+    indexing_maps = [affine_map<(i, j) -> (i, j)>, affine_map<(i, j) -> (i, j)>],
+    iterator_types = ["parallel", "parallel"]
+} ins(%A : memref<5x4xf32>) outs(%B : memref<5x4xf32>) attrs = {test_tile_sizes = array<i32: 2, 2>} {
+^bb0(%a: f32, %b: f32):
+    linalg.yield %a : f32
+}
+
+// CHECK:      builtin.module {
+// CHECK-NEXT:   %A, %B = "test.op"() : () -> (memref<5x4xf32>, memref<5x4xf32>)
+// CHECK-NEXT:   %0 = arith.constant 0 : index
+// CHECK-NEXT:   %1 = arith.constant 5 : index
+// CHECK-NEXT:   %2 = arith.constant 4 : index
+// CHECK-NEXT:   %3 = arith.constant 2 : index
+// CHECK-NEXT:   %4 = arith.constant 2 : index
+// CHECK-NEXT:   scf.for %5 = %0 to %1 step %3 {
+// CHECK-NEXT:     scf.for %6 = %0 to %2 step %4 {
+// CHECK-NEXT:       %7 = "affine.min"(%3, %1, %5) <{map = affine_map<(d0, d1, d2) -> (d0, (d1 + (d2 * -1)))>}> : (index, index, index) -> index
+// CHECK-NEXT:       %8 = memref.subview %A[%5, %6] [%7, 2] [1, 1] : memref<5x4xf32> to memref<?x2xf32, strided<[4, 1], offset: ?>>
+// CHECK-NEXT:       %9 = memref.subview %B[%5, %6] [%7, 2] [1, 1] : memref<5x4xf32> to memref<?x2xf32, strided<[4, 1], offset: ?>>
+// CHECK-NEXT:       linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%8 : memref<?x2xf32, strided<[4, 1], offset: ?>>) outs(%9 : memref<?x2xf32, strided<[4, 1], offset: ?>>) {
+// CHECK-NEXT:       ^bb0(%a: f32, %b: f32):
+// CHECK-NEXT:         linalg.yield %a : f32
+// CHECK-NEXT:       }
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+
+// -----
+
+// A leftover tile on a tensor is extracted, computed and written back at the
+// same size, since the extract and the insert share slice parameters.
+
+%A, %B = "test.op"() : () -> (tensor<5x4xf32>, tensor<5x4xf32>)
+%C = "linalg.generic"(%A, %B) <{
+  indexing_maps = [affine_map<(d0,d1)->(d0,d1)>, affine_map<(d0,d1)->(d0,d1)>],
+  iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>],
+  operandSegmentSizes = array<i32: 1, 1>
+}> ({
+^bb0(%a: f32, %b: f32):
+  "linalg.yield"(%a) : (f32) -> ()
+}) {test_tile_sizes = array<i32: 2, 2>} : (tensor<5x4xf32>, tensor<5x4xf32>) -> tensor<5x4xf32>
+"test.op"(%C) : (tensor<5x4xf32>) -> ()
+
+// CHECK:      builtin.module {
+// CHECK-NEXT:   %A, %B = "test.op"() : () -> (tensor<5x4xf32>, tensor<5x4xf32>)
+// CHECK-NEXT:   %0 = arith.constant 0 : index
+// CHECK-NEXT:   %1 = arith.constant 5 : index
+// CHECK-NEXT:   %2 = arith.constant 4 : index
+// CHECK-NEXT:   %3 = arith.constant 2 : index
+// CHECK-NEXT:   %4 = arith.constant 2 : index
+// CHECK-NEXT:   %C = scf.for %5 = %0 to %1 step %3 iter_args(%6 = %B) -> (tensor<5x4xf32>) {
+// CHECK-NEXT:     %7 = scf.for %8 = %0 to %2 step %4 iter_args(%9 = %6) -> (tensor<5x4xf32>) {
+// CHECK-NEXT:       %10 = "affine.min"(%3, %1, %5) <{map = affine_map<(d0, d1, d2) -> (d0, (d1 + (d2 * -1)))>}> : (index, index, index) -> index
+// CHECK-NEXT:       %11 = "tensor.extract_slice"(%A, %5, %8, %10) <{static_offsets = array<i64: -9223372036854775808, -9223372036854775808>, static_sizes = array<i64: -9223372036854775808, 2>, static_strides = array<i64: 1, 1>, operandSegmentSizes = array<i32: 1, 2, 1, 0>}> : (tensor<5x4xf32>, index, index, index) -> tensor<?x2xf32>
+// CHECK-NEXT:       %12 = "tensor.extract_slice"(%9, %5, %8, %10) <{static_offsets = array<i64: -9223372036854775808, -9223372036854775808>, static_sizes = array<i64: -9223372036854775808, 2>, static_strides = array<i64: 1, 1>, operandSegmentSizes = array<i32: 1, 2, 1, 0>}> : (tensor<5x4xf32>, index, index, index) -> tensor<?x2xf32>
+// CHECK-NEXT:       %13 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%11 : tensor<?x2xf32>) outs(%12 : tensor<?x2xf32>) {
+// CHECK-NEXT:       ^bb0(%a: f32, %b: f32):
+// CHECK-NEXT:         linalg.yield %a : f32
+// CHECK-NEXT:       } -> tensor<?x2xf32>
+// CHECK-NEXT:       %14 = "tensor.insert_slice"(%13, %9, %5, %8, %10) <{static_offsets = array<i64: -9223372036854775808, -9223372036854775808>, static_sizes = array<i64: -9223372036854775808, 2>, static_strides = array<i64: 1, 1>, operandSegmentSizes = array<i32: 1, 1, 2, 1, 0>}> : (tensor<?x2xf32>, tensor<5x4xf32>, index, index, index) -> tensor<5x4xf32>
+// CHECK-NEXT:       scf.yield %14 : tensor<5x4xf32>
+// CHECK-NEXT:     }
+// CHECK-NEXT:     scf.yield %7 : tensor<5x4xf32>
+// CHECK-NEXT:   }
+// CHECK-NEXT:   "test.op"(%C) : (tensor<5x4xf32>) -> ()
+// CHECK-NEXT: }

--- a/tests/transforms/test_linalg_tiling_helpers.py
+++ b/tests/transforms/test_linalg_tiling_helpers.py
@@ -233,11 +233,33 @@ def test_tiling_plan_rejects_non_projected_permutation_map():
         TilingPlan.analyze_generic_op(op, (2, 0))
 
 
-def test_tiling_plan_rejects_partial_tiles():
+def test_tiling_plan_marks_dims_with_a_leftover_tile():
     op = _generic_2d_copy_op()
 
-    with pytest.raises(ValueError, match="partial tiles"):
-        TilingPlan.analyze_generic_op(op, (3, 0))
+    # Dim 0 has range 4 and tile size 3, so its last tile holds one element.
+    plan = TilingPlan.analyze_generic_op(op, (3, 0))
+
+    assert plan.tiled_dims == (0,)
+    assert plan.partial_tiled_dims == frozenset({0})
+
+
+def test_tiling_plan_marks_no_dims_partial_when_tiles_divide():
+    op = _generic_2d_copy_op()
+
+    # Range 4 divides by tile size 2, so every tile is whole.
+    plan = TilingPlan.analyze_generic_op(op, (2, 0))
+
+    assert plan.tiled_dims == (0,)
+    assert plan.partial_tiled_dims == frozenset()
+
+
+def test_tiling_plan_marks_a_tile_larger_than_its_range_partial():
+    op = _generic_2d_copy_op()
+
+    # A tile bigger than the range gives one iteration covering the whole range.
+    plan = TilingPlan.analyze_generic_op(op, (8, 0))
+
+    assert plan.partial_tiled_dims == frozenset({0})
 
 
 def test_slice_parameters_compute_tiled_and_untiled_dims():

--- a/xdsl/dialects/linalg/transforms/tiling.py
+++ b/xdsl/dialects/linalg/transforms/tiling.py
@@ -4,9 +4,10 @@ from typing import cast
 
 from typing_extensions import assert_never
 
-from xdsl.dialects import arith, linalg, memref, scf, tensor
+from xdsl.dialects import affine, arith, linalg, memref, scf, tensor
 from xdsl.dialects.builtin import (
     DYNAMIC_INDEX,
+    AffineMapAttr,
     IndexType,
     IntegerAttr,
     MemRefType,
@@ -14,11 +15,23 @@ from xdsl.dialects.builtin import (
 )
 from xdsl.dialects.utils import split_dynamic_index_list
 from xdsl.ir import Attribute, Block, Region, SSAValue
-from xdsl.ir.affine import AffineDimExpr, AffineMap
+from xdsl.ir.affine import AffineDimExpr, AffineExpr, AffineMap
 from xdsl.pattern_rewriter import PatternRewriter
 from xdsl.rewriter import InsertPoint
 from xdsl.utils.exceptions import PassFailedException
 from xdsl.utils.hints import isa
+
+# min(tile, ub - iv), the size of a tile that may run past the end of its loop.
+_PARTIAL_TILE_MIN_MAP = AffineMapAttr(
+    AffineMap(
+        3,
+        0,
+        (
+            AffineExpr.dimension(0),
+            AffineExpr.dimension(1) - AffineExpr.dimension(2),
+        ),
+    )
+)
 
 
 @dataclass(frozen=True)
@@ -53,12 +66,15 @@ class TilingPlan:
     This stores the information needed to turn one op into tiled loop and tiled subview.
     - `loop_ranges` are original static loop ranges.
     - `tiled_dims` the dimensions that really get tiled.
+    - `partial_tiled_dims` the tiled dimensions whose loop range is not divisible
+      by the tile size, so that their last tile is smaller than the rest.
     - `operand_infos` stores one `OperandTileInfo` per operand.
     - `tile_sizes` are the normalized tile sizes, padded to match the op loop count.
     """
 
     loop_ranges: tuple[int, ...]
     tiled_dims: tuple[int, ...]
+    partial_tiled_dims: frozenset[int]
     operand_infos: tuple[OperandTileInfo, ...]
     tile_sizes: tuple[int, ...]
 
@@ -84,6 +100,7 @@ class TilingPlan:
             return TilingPlan(
                 loop_ranges=(),
                 tiled_dims=(),
+                partial_tiled_dims=frozenset(),
                 operand_infos=(),
                 tile_sizes=normalized_tile_sizes,
             )
@@ -92,6 +109,12 @@ class TilingPlan:
             op,
             normalized_tile_sizes,
             tiled_dims,
+        )
+
+        partial_tiled_dims = frozenset(
+            dim
+            for dim in tiled_dims
+            if loop_ranges[dim] % normalized_tile_sizes[dim] != 0
         )
 
         operand_infos_list: list[OperandTileInfo] = []
@@ -108,6 +131,7 @@ class TilingPlan:
         return TilingPlan(
             loop_ranges=loop_ranges,
             tiled_dims=tiled_dims,
+            partial_tiled_dims=partial_tiled_dims,
             operand_infos=operand_infos,
             tile_sizes=normalized_tile_sizes,
         )
@@ -173,11 +197,7 @@ def _verify_generic_is_tileable(
                 "tiling linalg.generic with non-projected-permutation indexing maps is not supported yet"
             )
 
-    loop_ranges = op.get_static_loop_ranges()
-    if any(loop_ranges[dim] % tile_sizes[dim] for dim in tiled_dims):
-        raise ValueError("partial tiles are not supported yet")
-
-    return loop_ranges
+    return op.get_static_loop_ranges()
 
 
 def _build_tile_loops(
@@ -244,6 +264,38 @@ def _build_tile_loops(
     return loops, tiled_loop_ivs, current_insertion_point
 
 
+def _build_effective_tile_sizes(
+    rewriter: PatternRewriter,
+    insertion_point: InsertPoint,
+    plan: TilingPlan,
+    loops: Sequence[scf.ForOp],
+) -> dict[int, SSAValue | int]:
+    """
+    Give the size of the current tile for each tiled dimension.
+
+    A dimension whose loop range divides by its tile size always gets a whole
+    tile, so its size stays the tile size. One that does not has a smaller tile
+    on its last iteration, so its size becomes `min(tile, ub - iv)`, which is
+    the tile size everywhere except at the end.
+    """
+
+    effective: dict[int, SSAValue | int] = {}
+    for dim, loop in zip(plan.tiled_dims, loops, strict=True):
+        if dim not in plan.partial_tiled_dims:
+            effective[dim] = plan.tile_sizes[dim]
+            continue
+
+        min_op = affine.MinOp(
+            operands=[[loop.step, loop.ub, loop.body.block.args[0]]],
+            properties={"map": _PARTIAL_TILE_MIN_MAP},
+            result_types=[IndexType()],
+        )
+        rewriter.insert(min_op, insertion_point)
+        effective[dim] = min_op.result
+
+    return effective
+
+
 @dataclass(frozen=True)
 class SliceParameters:
     """
@@ -263,14 +315,14 @@ class SliceParameters:
         indexing_map: AffineMap,
         operand_info: OperandTileInfo,
         tiled_loop_ivs: dict[int, SSAValue],
-        tile_sizes: dict[int, SSAValue | int],
+        effective_tile_sizes: dict[int, SSAValue | int],
     ) -> "SliceParameters":
         """
         Compute where the current tile sits within one operand.
 
         Each result of the indexing map addresses one dimension of the operand.
         A dimension whose loop is tiled starts at that loop's induction variable
-        and spans that loop's tile, and a dimension whose loop is not tiled
+        and spans the current tile, and a dimension whose loop is not tiled
         starts at zero and spans the whole operand.
         """
 
@@ -283,7 +335,7 @@ class SliceParameters:
             loop_dim = operand_info.loop_dims[result_index]
             if loop_dim in tiled_loop_ivs:
                 offsets.append(tiled_loop_ivs[loop_dim])
-                sizes.append(tile_sizes[loop_dim])
+                sizes.append(effective_tile_sizes[loop_dim])
             else:
                 offsets.append(0)
                 sizes.append(source_shape[result_index])
@@ -417,13 +469,11 @@ def tile_linalg_generic(
     )
 
     num_inputs = len(op.inputs)
-    tile_sizes_by_dim: dict[int, SSAValue | int] = {
-        dim: plan.tile_sizes[dim] for dim in plan.tiled_dims
-    }
+    effective_tile_sizes = _build_effective_tile_sizes(rewriter, inner_ip, plan, loops)
 
     slice_parameters = tuple(
         SliceParameters.compute(
-            indexing_map.data, operand_info, tiled_loop_ivs, tile_sizes_by_dim
+            indexing_map.data, operand_info, tiled_loop_ivs, effective_tile_sizes
         )
         for operand_info, indexing_map in zip(
             plan.operand_infos, op.get_indexing_maps(), strict=True


### PR DESCRIPTION
Completes the partial tiles checkbox on #6140. Follows on from #6376.

A tile size that does not divide its loop range leaves a smaller tile on the last iteration, which the pass rejected rather than tiled. That limited tile sizes to divisors of the range, so for a dimension of extent 5 the only choices were 1 and 5.

This records which tiled dimensions have such a leftover, and gives those a tile size of `min(tile, ub - iv)` rather than the static tile size:

```mlir
%7 = "affine.min"(%3, %1, %5) <{map = affine_map<(d0, d1, d2) -> (d0, (d1 + (d2 * -1)))>}> : (index, index, index) -> index
%8 = memref.subview %A[%5, %6] [%7, 2] [1, 1] : memref<5x4xf32> to memref<?x2xf32, strided<[4, 1], offset: ?>>
```

That is the tile size on every iteration except the last, where it is what remains. The size becomes an operand of the slice rather than part of its type, so that dimension of the tile becomes dynamic.

This is per dimension rather than per op. Above, dim 0 has range 5 and tile size 2 so it clamps, while dim 1 divides evenly and keeps its static size of 2 and its static type. A dimension whose range divides generates exactly the IR it did before.

### Tensors

A leftover tile on a tensor is written back at the size it was extracted with, since the extract and the write-back share the same `SliceParameters`:

```mlir
%11 = tensor.extract_slice %A[%5, %8] [%10, 2] ... -> tensor<?x2xf32>
%13 = linalg.generic ins(%11) outs(%12) ...       -> tensor<?x2xf32>
%14 = tensor.insert_slice %13 into %9[%5, %8] [%10, 2] ...
```

### Tests

Filecheck covers a leftover tile on a memref and on a tensor. Unit tests cover which dimensions are marked: one whose range does not divide, one whose range does, and a tile size larger than its range, which gives a single iteration covering the whole range.

The rejection test goes, since the case it covered now tiles.
