### PR TITLE
dialects: (linalg) tile operands whose shapes are not known statically

### DIFF
--- a/tests/filecheck/transforms/linalg-tiling-reject-unsupported.mlir
+++ b/tests/filecheck/transforms/linalg-tiling-reject-unsupported.mlir
@@ -97,24 +97,6 @@ builtin.module {
 // -----
 
 builtin.module {
-  %input = "test.op"() : () -> memref<?x4xf32>
-  %output = "test.op"() : () -> memref<?x4xf32>
-  linalg.generic {
-      indexing_maps = [
-          affine_map<(i, j) -> (i, j)>,
-          affine_map<(i, j) -> (i, j)>
-      ],
-      iterator_types = ["parallel", "parallel"]
-  } ins(%input : memref<?x4xf32>) outs(%output : memref<?x4xf32>) attrs = {test_tile_sizes = array<i32: 2, 2>} {
-  ^bb0(%in: f32, %out: f32):
-      linalg.yield %in : f32
-  }
-}
-// CHECK: tiling linalg.generic with dynamic operand shapes is not supported yet
-
-// -----
-
-builtin.module {
   %input = "test.op"() : () -> memref<4x4xf32>
   %output = "test.op"() : () -> memref<4x4xf32>
   linalg.generic {

--- a/tests/filecheck/transforms/linalg-tiling.mlir
+++ b/tests/filecheck/transforms/linalg-tiling.mlir
@@ -260,3 +260,69 @@ linalg.generic {
 // CHECK-NEXT:   }
 // CHECK-NEXT:   "test.op"(%C) : (tensor<5x4xf32>) -> ()
 // CHECK-NEXT: }
+
+// -----
+
+// A loop range that is not known until the op runs is read back off an
+// operand, and its tiles are clamped like any other leftover.
+
+%A, %B = "test.op"() : () -> (memref<?x4xf32>, memref<?x4xf32>)
+linalg.generic {
+    indexing_maps = [affine_map<(i, j) -> (i, j)>, affine_map<(i, j) -> (i, j)>],
+    iterator_types = ["parallel", "parallel"]
+} ins(%A : memref<?x4xf32>) outs(%B : memref<?x4xf32>) attrs = {test_tile_sizes = array<i32: 2, 0>} {
+^bb0(%a: f32, %b: f32):
+    linalg.yield %a : f32
+}
+
+// CHECK:      builtin.module {
+// CHECK-NEXT:   %A, %B = "test.op"() : () -> (memref<?x4xf32>, memref<?x4xf32>)
+// CHECK-NEXT:   %0 = arith.constant 0 : index
+// CHECK-NEXT:   %1 = arith.constant 0 : index
+// CHECK-NEXT:   %2 = memref.dim %A, %1 : memref<?x4xf32>
+// CHECK-NEXT:   %3 = arith.constant 2 : index
+// CHECK-NEXT:   scf.for %4 = %0 to %2 step %3 {
+// CHECK-NEXT:     %5 = "affine.min"(%3, %2, %4) <{map = affine_map<(d0, d1, d2) -> (d0, (d1 + (d2 * -1)))>}> : (index, index, index) -> index
+// CHECK-NEXT:     %6 = memref.subview %A[%4, 0] [%5, 4] [1, 1] : memref<?x4xf32> to memref<?x4xf32, strided<[4, 1], offset: ?>>
+// CHECK-NEXT:     %7 = memref.subview %B[%4, 0] [%5, 4] [1, 1] : memref<?x4xf32> to memref<?x4xf32, strided<[4, 1], offset: ?>>
+// CHECK-NEXT:     linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%6 : memref<?x4xf32, strided<[4, 1], offset: ?>>) outs(%7 : memref<?x4xf32, strided<[4, 1], offset: ?>>) {
+// CHECK-NEXT:     ^bb0(%a: f32, %b: f32):
+// CHECK-NEXT:       linalg.yield %a : f32
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+
+// -----
+
+// The same for tensors, read with tensor.dim.
+
+%A, %B = "test.op"() : () -> (tensor<?x4xf32>, tensor<?x4xf32>)
+%C = "linalg.generic"(%A, %B) <{
+  indexing_maps = [affine_map<(d0,d1)->(d0,d1)>, affine_map<(d0,d1)->(d0,d1)>],
+  iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>],
+  operandSegmentSizes = array<i32: 1, 1>
+}> ({
+^bb0(%a: f32, %b: f32):
+  "linalg.yield"(%a) : (f32) -> ()
+}) {test_tile_sizes = array<i32: 2, 0>} : (tensor<?x4xf32>, tensor<?x4xf32>) -> tensor<?x4xf32>
+"test.op"(%C) : (tensor<?x4xf32>) -> ()
+
+// CHECK:      builtin.module {
+// CHECK-NEXT:   %A, %B = "test.op"() : () -> (tensor<?x4xf32>, tensor<?x4xf32>)
+// CHECK-NEXT:   %0 = arith.constant 0 : index
+// CHECK-NEXT:   %1 = arith.constant 0 : index
+// CHECK-NEXT:   %2 = tensor.dim %A, %1 : tensor<?x4xf32>
+// CHECK-NEXT:   %3 = arith.constant 2 : index
+// CHECK-NEXT:   %C = scf.for %4 = %0 to %2 step %3 iter_args(%5 = %B) -> (tensor<?x4xf32>) {
+// CHECK-NEXT:     %6 = "affine.min"(%3, %2, %4) <{map = affine_map<(d0, d1, d2) -> (d0, (d1 + (d2 * -1)))>}> : (index, index, index) -> index
+// CHECK-NEXT:     %7 = "tensor.extract_slice"(%A, %4, %6) <{static_offsets = array<i64: -9223372036854775808, 0>, static_sizes = array<i64: -9223372036854775808, 4>, static_strides = array<i64: 1, 1>, operandSegmentSizes = array<i32: 1, 1, 1, 0>}> : (tensor<?x4xf32>, index, index) -> tensor<?x4xf32>
+// CHECK-NEXT:     %8 = "tensor.extract_slice"(%5, %4, %6) <{static_offsets = array<i64: -9223372036854775808, 0>, static_sizes = array<i64: -9223372036854775808, 4>, static_strides = array<i64: 1, 1>, operandSegmentSizes = array<i32: 1, 1, 1, 0>}> : (tensor<?x4xf32>, index, index) -> tensor<?x4xf32>
+// CHECK-NEXT:     %9 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%7 : tensor<?x4xf32>) outs(%8 : tensor<?x4xf32>) {
+// CHECK-NEXT:     ^bb0(%a: f32, %b: f32):
+// CHECK-NEXT:       linalg.yield %a : f32
+// CHECK-NEXT:     } -> tensor<?x4xf32>
+// CHECK-NEXT:     %10 = "tensor.insert_slice"(%9, %5, %4, %6) <{static_offsets = array<i64: -9223372036854775808, 0>, static_sizes = array<i64: -9223372036854775808, 4>, static_strides = array<i64: 1, 1>, operandSegmentSizes = array<i32: 1, 1, 1, 1, 0>}> : (tensor<?x4xf32>, tensor<?x4xf32>, index, index) -> tensor<?x4xf32>
+// CHECK-NEXT:     scf.yield %10 : tensor<?x4xf32>
+// CHECK-NEXT:   }
+// CHECK-NEXT:   "test.op"(%C) : (tensor<?x4xf32>) -> ()
+// CHECK-NEXT: }

--- a/tests/transforms/test_linalg_tiling_helpers.py
+++ b/tests/transforms/test_linalg_tiling_helpers.py
@@ -210,11 +210,18 @@ def test_tiling_plan_rejects_mixed_memref_and_tensor_outputs():
         TilingPlan.analyze_generic_op(op, (2, 0))
 
 
-def test_tiling_plan_rejects_dynamic_operand_shape():
-    op = _generic_2d_copy_op(input_type=MemRefType(f32, [DYNAMIC_INDEX, 5]))
+def test_tiling_plan_marks_a_dynamic_range_partial():
+    # The range is not known until the op runs, so it cannot be shown to divide
+    # by the tile size and has to be treated as leaving a leftover tile.
+    op = _generic_2d_copy_op(
+        input_type=MemRefType(f32, [DYNAMIC_INDEX, 5]),
+        output_type=MemRefType(f32, [DYNAMIC_INDEX, 5]),
+    )
 
-    with pytest.raises(ValueError, match="dynamic operand shapes"):
-        TilingPlan.analyze_generic_op(op, (2, 0))
+    plan = TilingPlan.analyze_generic_op(op, (2, 0))
+
+    assert plan.tiled_dims == (0,)
+    assert plan.partial_tiled_dims == frozenset({0})
 
 
 def test_tiling_plan_rejects_non_projected_permutation_map():
@@ -404,7 +411,7 @@ def test_build_tile_loops_without_iter_args():
     rewriter = PatternRewriter(op)
 
     loops, tiled_loop_ivs, _ = _build_tile_loops(
-        rewriter, InsertPoint.before(op), (4, 5), (2, 0), (0,)
+        rewriter, InsertPoint.before(op), (4, 5), (2, 0), (0,), {}
     )
 
     (loop,) = loops
@@ -421,7 +428,7 @@ def test_build_tile_loops_threads_iter_args():
     init = create_ssa_value(TensorType(f32, [4, 5]))
 
     loops, tiled_loop_ivs, _ = _build_tile_loops(
-        rewriter, InsertPoint.before(op), (4, 5), (2, 2), (0, 1), (init,)
+        rewriter, InsertPoint.before(op), (4, 5), (2, 2), (0, 1), {}, (init,)
     )
 
     outer, inner = loops

--- a/xdsl/dialects/linalg/transforms/tiling.py
+++ b/xdsl/dialects/linalg/transforms/tiling.py
@@ -111,10 +111,13 @@ class TilingPlan:
             tiled_dims,
         )
 
+        # A range that is not known until the op runs cannot be shown to divide
+        # by its tile size, so it is treated as leaving a leftover tile.
         partial_tiled_dims = frozenset(
             dim
             for dim in tiled_dims
-            if loop_ranges[dim] % normalized_tile_sizes[dim] != 0
+            if loop_ranges[dim] < 0
+            or loop_ranges[dim] % normalized_tile_sizes[dim] != 0
         )
 
         operand_infos_list: list[OperandTileInfo] = []
@@ -185,12 +188,6 @@ def _verify_generic_is_tileable(
                 "tiling linalg.generic with operands that are neither memrefs nor "
                 "tensors is not supported yet"
             )
-        operand_type = raw_operand_type
-
-        if any(dim < 0 for dim in operand_type.get_shape()):
-            raise ValueError(
-                "tiling linalg.generic with dynamic operand shapes is not supported yet"
-            )
 
         if not indexing_map.is_projected_permutation():
             raise ValueError(
@@ -200,12 +197,64 @@ def _verify_generic_is_tileable(
     return op.get_static_loop_ranges()
 
 
+def _loop_range_sources(
+    op: linalg.ops.GenericOp, plan: TilingPlan
+) -> dict[int, tuple[SSAValue, int]]:
+    """
+    Say where the range of each tiled loop can be read from when it is not known
+    until the op runs.
+
+    A loop range comes from the operands it indexes, so a range that is not
+    static is read back off one of them, as the operand and the position within
+    it that the loop dimension addresses.
+    """
+
+    sources: dict[int, tuple[SSAValue, int]] = {}
+    for operand, operand_info in zip(op.operands, plan.operand_infos, strict=True):
+        for result_index, loop_dim in enumerate(operand_info.loop_dims):
+            if loop_dim not in plan.tiled_dims or loop_dim in sources:
+                continue
+            if plan.loop_ranges[loop_dim] < 0:
+                sources[loop_dim] = (operand, result_index)
+    return sources
+
+
+def _build_loop_range(
+    rewriter: PatternRewriter,
+    insertion_point: InsertPoint,
+    source: SSAValue,
+    position: int,
+) -> SSAValue:
+    """
+    Read one dimension of an operand, for a loop range only known at runtime.
+    """
+
+    position_op = arith.ConstantOp(IntegerAttr(position, IndexType()))
+    rewriter.insert(position_op, insertion_point)
+
+    source_type = source.type
+    assert isa(source_type, MemRefType | TensorType)
+    match source_type:
+        case MemRefType():
+            dim_op = memref.DimOp.from_source_and_index(source, position_op)
+        case TensorType():
+            dim_op = tensor.DimOp.build(
+                operands=[source, position_op], result_types=[IndexType()]
+            )
+        case _:
+            assert_never(source_type)
+
+    rewriter.insert(dim_op, insertion_point)
+    return dim_op.result
+
+
 def _build_tile_loops(
     rewriter: PatternRewriter,
     insertion_point: InsertPoint,
     loop_ranges: Sequence[int],
     tile_sizes: Sequence[int],
     tiled_dims: Sequence[int],
+    range_sources: dict[int, tuple[SSAValue, int]],
     iter_args: Sequence[SSAValue] = (),
 ) -> tuple[list[scf.ForOp], dict[int, SSAValue], InsertPoint]:
     """
@@ -226,21 +275,22 @@ def _build_tile_loops(
 
     index = IndexType()
     zero = arith.ConstantOp(IntegerAttr(0, index))
-    ub_ops = {
-        dim: arith.ConstantOp(IntegerAttr(loop_ranges[dim], index))
-        for dim in tiled_dims
-    }
+    rewriter.insert(zero, insertion_point)
+
+    ubs: dict[int, SSAValue] = {}
+    for dim in tiled_dims:
+        if loop_ranges[dim] < 0:
+            source, position = range_sources[dim]
+            ubs[dim] = _build_loop_range(rewriter, insertion_point, source, position)
+        else:
+            ub_op = arith.ConstantOp(IntegerAttr(loop_ranges[dim], index))
+            rewriter.insert(ub_op, insertion_point)
+            ubs[dim] = ub_op.result
+
     tile_ops = {
         dim: arith.ConstantOp(IntegerAttr(tile_sizes[dim], index)) for dim in tiled_dims
     }
-    rewriter.insert(
-        [
-            zero,
-            *(ub_ops[dim] for dim in tiled_dims),
-            *(tile_ops[dim] for dim in tiled_dims),
-        ],
-        insertion_point,
-    )
+    rewriter.insert([tile_ops[dim] for dim in tiled_dims], insertion_point)
 
     current_insertion_point = insertion_point
     loops: list[scf.ForOp] = []
@@ -250,7 +300,7 @@ def _build_tile_loops(
     for dim in tiled_dims:
         loop = scf.ForOp(
             zero.result,
-            ub_ops[dim].result,
+            ubs[dim],
             tile_ops[dim].result,
             carried,
             Region(Block(arg_types=(index, *carried_types))),
@@ -465,6 +515,7 @@ def tile_linalg_generic(
         plan.loop_ranges,
         plan.tile_sizes,
         plan.tiled_dims,
+        _loop_range_sources(op, plan),
         iter_args,
     )
 


### PR DESCRIPTION
Part of the dynamic shapes checkbox on #6140. Follows on from #6379.

An operand with a dynamic dimension gives a loop range that is not known until the op runs, which the pass rejected rather than tiled.

A loop range comes from the operands the loop indexes, so a range that is not static can be read back off one of them, at the position that loop dimension addresses:

```mlir
%1 = arith.constant 0 : index
%2 = memref.dim %A, %1 : memref<?x4xf32>
%3 = arith.constant 2 : index
scf.for %4 = %0 to %2 step %3 {
  %5 = "affine.min"(%3, %2, %4) ... : (index, index, index) -> index
  %6 = memref.subview %A[%4, 0] [%5, 4] [1, 1] : memref<?x4xf32> to memref<?x4xf32, strided<[4, 1], offset: ?>>
```

That bound then feeds the loop and the clamp added in #6379. A range that is not known cannot be shown to divide by its tile size, so it is treated as leaving a leftover tile, which is what that clamp already handles. Nothing new is needed to tile the last iteration.

Tensors read their range the same way, with a `tensor.dim`.

A loop whose range is static builds the same constant bound as before, so its generated IR is unchanged and the existing filecheck expectations are untouched.

### Tests

Filecheck covers a dynamic memref and a dynamic tensor. The unit test that asserted dynamic shapes were rejected now asserts that such a range is marked as leaving a leftover tile.

### Not covered

This is the shapes half of that checkbox. Tile sizes are still static: they arrive as an attribute, and which dimensions are tiled is decided by comparing them against zero, so accepting a tile size that is a value would change the shape of the pass's interface. Happy to look at that separately if it is wanted.
