### PR TITLE
dialects: (fir) i64 array sizes

### DIFF
--- a/xdsl/dialects/experimental/fir.py
+++ b/xdsl/dialects/experimental/fir.py
@@ -720,8 +720,6 @@ class SequenceType(ParametrizedAttribute, TypeAttribute):
             if shape is None:
                 shape = [1]
 
-            # MLIR upstream uses i64 by default
-            # see [MLIR source @ v22.1.2](https://github.com/llvm/llvm-project/blob/1ab49a973e210e97d61e5db6557180dcb92c3e98/flang/include/flang/Optimizer/Dialect/FIRTypes.td#L447).
             shape_array_attr = ArrayAttr(
                 [(IntegerAttr(d, 64) if isinstance(d, int) else d) for d in shape]
             )

--- a/xdsl/dialects/experimental/fir.py
+++ b/xdsl/dialects/experimental/fir.py
@@ -719,9 +719,13 @@ class SequenceType(ParametrizedAttribute, TypeAttribute):
         else:
             if shape is None:
                 shape = [1]
+
+            # MLIR upstream uses i64 by default
+            # see [MLIR source @ v22.1.2](https://github.com/llvm/llvm-project/blob/1ab49a973e210e97d61e5db6557180dcb92c3e98/flang/include/flang/Optimizer/Dialect/FIRTypes.td#L447).
             shape_array_attr = ArrayAttr(
-                [(IntegerAttr(d, 32) if isinstance(d, int) else d) for d in shape]
+                [(IntegerAttr(d, 64) if isinstance(d, int) else d) for d in shape]
             )
+
             super().__init__(
                 shape_array_attr,
                 type1,


### PR DESCRIPTION
In MLIR, `fir.array` uses an `ArrayAttr[I64]` to represent its shape type. Assuming `i32` by default limits (and can silently wrap around to `i32`) large sizes being uses in arrays.

```cpp
def fir_SequenceType : FIR_Type<"Sequence", "array"> {
  let summary = "FIR array type";

  let description = [{...}];

  let parameters = (ins
    ArrayRefParameter<"int64_t", "Sequence shape">:$shape,
    "mlir::Type":$eleTy,
    "mlir::AffineMapAttr":$layoutMap
  );
```