### PR TITLE
backend: (cost model) skip throughput test when llvm-mca lacks the target backend

### DIFF
--- a/tests/backend/test_asm_reporter.py
+++ b/tests/backend/test_asm_reporter.py
@@ -4,19 +4,21 @@ from xdsl.backend.block_throughput_cost_model import MCABlockThroughputCostModel
 from xdsl.builder import Builder
 from xdsl.dialects import x86_func
 
-llvm_mca_available = MCABlockThroughputCostModel.is_installed()
+x86_reporter = MCABlockThroughputCostModel(
+    target="x86_64-unknown-linux-gnu", arch="skylake"
+)
 
 
-@pytest.mark.skipif(not llvm_mca_available, reason="llvm-mca is not installed")
+@pytest.mark.skipif(
+    not x86_reporter.is_available(),
+    reason="llvm-mca is not installed or cannot analyse the x86 target",
+)
 def test_mca_reporter_x86():
     @Builder.implicit_region
     def trivial_x86_func():
         x86_func.RetOp()
 
-    reporter = MCABlockThroughputCostModel(
-        target="x86_64-unknown-linux-gnu", arch="skylake"
-    )
-    estimated_cost = reporter.estimate_throughput(trivial_x86_func.block)
+    estimated_cost = x86_reporter.estimate_throughput(trivial_x86_func.block)
     assert estimated_cost is not None, (
         "MCA reporter should return a valid cost estimate"
     )

--- a/xdsl/backend/block_throughput_cost_model.py
+++ b/xdsl/backend/block_throughput_cost_model.py
@@ -91,6 +91,21 @@ class ExternalBlockThroughputCostModel(BlockThroughputCostModel):
     def is_installed(cls) -> bool:
         return which(cls.tool_name()) is not None
 
+    def is_available(self) -> bool:
+        if not self.is_installed():
+            return False
+        # Probe with a trivial instruction fed through stdin, so an unsupported
+        # target fails at target lookup while a supported one exits 0.
+        self.src_path = "-"
+        result = subprocess.run(
+            self.cmd(),
+            input="nop\n",
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+        return result.returncode == 0
+
     def estimate_throughput(self, block: Block) -> float | None:
         with NamedTemporaryFile(mode="w+", delete=False, suffix=".s") as tmp_file:
             self.src_path = tmp_file.name


### PR DESCRIPTION
## Description

`ExternalBlockThroughputCostModel.is_available()` now probes whether the tool can actually analyse the configured target (feeding a `nop` through stdin and checking the exit code), instead of only checking that the binary exists. The `llvm-mca` test skips based on this.

## Motivation

`is_installed()` only checked that `llvm-mca` was on `PATH`. On an LLVM build without the X86 backend, the binary exists but fails with `unable to get target for 'x86_64-...'`, so the x86 throughput test ran and errored out, breaking `make tests`. Probing target support makes the test skip cleanly on such builds while still running wherever the target is supported.
