### PR TITLE
dialects: (linalg) tile by sizes that are not known statically

### DIFF
--- a/tests/filecheck/transforms/linalg-tiling.mlir
+++ b/tests/filecheck/transforms/linalg-tiling.mlir
@@ -326,3 +326,33 @@ linalg.generic {
 // CHECK-NEXT:   }
 // CHECK-NEXT:   "test.op"(%C) : (tensor<?x4xf32>) -> ()
 // CHECK-NEXT: }
+
+// -----
+
+// A tile size that is not known until the op runs steps the loop directly.
+// It cannot be shown to divide the range either, so its tiles are clamped.
+
+%A, %B = "test.op"() : () -> (memref<8x4xf32>, memref<8x4xf32>)
+linalg.generic {
+    indexing_maps = [affine_map<(i, j) -> (i, j)>, affine_map<(i, j) -> (i, j)>],
+    iterator_types = ["parallel", "parallel"]
+} ins(%A : memref<8x4xf32>) outs(%B : memref<8x4xf32>) attrs = {test_tile_sizes = array<i32: 0, 0>, test_dynamic_tile_sizes = array<i32: 0>} {
+^bb0(%a: f32, %b: f32):
+    linalg.yield %a : f32
+}
+
+// CHECK:      builtin.module {
+// CHECK-NEXT:   %A, %B = "test.op"() : () -> (memref<8x4xf32>, memref<8x4xf32>)
+// CHECK-NEXT:   %0 = "test.op"() : () -> index
+// CHECK-NEXT:   %1 = arith.constant 0 : index
+// CHECK-NEXT:   %2 = arith.constant 8 : index
+// CHECK-NEXT:   scf.for %3 = %1 to %2 step %0 {
+// CHECK-NEXT:     %4 = "affine.min"(%0, %2, %3) <{map = affine_map<(d0, d1, d2) -> (d0, (d1 + (d2 * -1)))>}> : (index, index, index) -> index
+// CHECK-NEXT:     %5 = memref.subview %A[%3, 0] [%4, 4] [1, 1] : memref<8x4xf32> to memref<?x4xf32, strided<[4, 1], offset: ?>>
+// CHECK-NEXT:     %6 = memref.subview %B[%3, 0] [%4, 4] [1, 1] : memref<8x4xf32> to memref<?x4xf32, strided<[4, 1], offset: ?>>
+// CHECK-NEXT:     linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%5 : memref<?x4xf32, strided<[4, 1], offset: ?>>) outs(%6 : memref<?x4xf32, strided<[4, 1], offset: ?>>) {
+// CHECK-NEXT:     ^bb0(%a: f32, %b: f32):
+// CHECK-NEXT:       linalg.yield %a : f32
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT: }

--- a/tests/transforms/test_linalg_tiling_helpers.py
+++ b/tests/transforms/test_linalg_tiling_helpers.py
@@ -224,6 +224,20 @@ def test_tiling_plan_marks_a_dynamic_range_partial():
     assert plan.partial_tiled_dims == frozenset({0})
 
 
+def test_tiling_plan_tiles_a_dim_whose_tile_size_is_not_static():
+    op = _generic_2d_copy_op()
+    tile_size = create_ssa_value(IndexType())
+
+    # Tiling by zero means leaving a dimension alone, and a size that is not
+    # known until the op runs cannot be shown to be zero, so the dimension is
+    # tiled. It cannot be shown to divide the range either, so it is partial.
+    plan = TilingPlan.analyze_generic_op(op, (tile_size, 0))
+
+    assert plan.tiled_dims == (0,)
+    assert plan.partial_tiled_dims == frozenset({0})
+    assert plan.tile_sizes == (tile_size, 0)
+
+
 def test_tiling_plan_rejects_non_projected_permutation_map():
     i = AffineExpr.dimension(0)
     j = AffineExpr.dimension(1)

--- a/xdsl/dialects/linalg/transforms/tiling.py
+++ b/xdsl/dialects/linalg/transforms/tiling.py
@@ -34,6 +34,22 @@ _PARTIAL_TILE_MIN_MAP = AffineMapAttr(
 )
 
 
+def _is_zero(tile_size: SSAValue | int) -> bool:
+    """Whether a tile size is known to be zero, which means not tiling at all."""
+    return isinstance(tile_size, int) and tile_size == 0
+
+
+def _divides(tile_size: SSAValue | int, loop_range: int) -> bool:
+    """
+    Whether a tile size is known to divide a loop range, so that every tile of
+    that dimension is whole. Neither a size nor a range that is only known once
+    the op runs can be shown to.
+    """
+    return (
+        isinstance(tile_size, int) and loop_range >= 0 and loop_range % tile_size == 0
+    )
+
+
 @dataclass(frozen=True)
 class OperandTileInfo:
     """
@@ -69,31 +85,37 @@ class TilingPlan:
     - `partial_tiled_dims` the tiled dimensions whose loop range is not divisible
       by the tile size, so that their last tile is smaller than the rest.
     - `operand_infos` stores one `OperandTileInfo` per operand.
-    - `tile_sizes` are the normalized tile sizes, padded to match the op loop count.
+    - `tile_sizes` are the normalized tile sizes, padded to match the op loop
+      count. A tile size that is not known until the op runs is a value.
     """
 
     loop_ranges: tuple[int, ...]
     tiled_dims: tuple[int, ...]
     partial_tiled_dims: frozenset[int]
     operand_infos: tuple[OperandTileInfo, ...]
-    tile_sizes: tuple[int, ...]
+    tile_sizes: tuple[SSAValue | int, ...]
 
     @staticmethod
     def analyze_generic_op(
         op: linalg.ops.GenericOp,
-        tile_sizes: tuple[int, ...],
+        tile_sizes: Sequence[SSAValue | int],
     ) -> "TilingPlan":
         """
         Analyze one supported `linalg.generic` and return a `TilingPlan`.
         """
 
         num_loops = op.get_num_loops()
-        normalized_tile_sizes = tile_sizes[:num_loops] + (0,) * (
-            num_loops - len(tile_sizes)
-        )
+        normalized_tile_sizes: tuple[SSAValue | int, ...] = tuple(
+            tile_sizes[:num_loops]
+        ) + (0,) * (num_loops - len(tile_sizes))
 
+        # Tiling by zero means leaving a dimension alone, so a dimension is tiled
+        # unless its tile size is known to be zero. One that is not known until
+        # the op runs cannot be, so it is tiled.
         tiled_dims = tuple(
-            dim for dim, tile_size in enumerate(normalized_tile_sizes) if tile_size != 0
+            dim
+            for dim, tile_size in enumerate(normalized_tile_sizes)
+            if not _is_zero(tile_size)
         )
 
         if not tiled_dims:
@@ -116,8 +138,7 @@ class TilingPlan:
         partial_tiled_dims = frozenset(
             dim
             for dim in tiled_dims
-            if loop_ranges[dim] < 0
-            or loop_ranges[dim] % normalized_tile_sizes[dim] != 0
+            if not _divides(normalized_tile_sizes[dim], loop_ranges[dim])
         )
 
         operand_infos_list: list[OperandTileInfo] = []
@@ -142,14 +163,17 @@ class TilingPlan:
 
 def _verify_generic_is_tileable(
     op: linalg.ops.GenericOp,
-    tile_sizes: Sequence[int],
+    tile_sizes: Sequence[SSAValue | int],
     tiled_dims: Sequence[int],
 ) -> tuple[int, ...]:
     """
     Check whether a `linalg.generic` is safe to tile.
     """
 
-    if any(tile_sizes[dim] < 0 for dim in tiled_dims):
+    if any(
+        isinstance(tile_sizes[dim], int) and cast(int, tile_sizes[dim]) < 0
+        for dim in tiled_dims
+    ):
         raise ValueError("negative tile sizes are not supported")
 
     # Operands that mix the two are rejected outright rather than tiled, since
@@ -252,7 +276,7 @@ def _build_tile_loops(
     rewriter: PatternRewriter,
     insertion_point: InsertPoint,
     loop_ranges: Sequence[int],
-    tile_sizes: Sequence[int],
+    tile_sizes: Sequence[SSAValue | int],
     tiled_dims: Sequence[int],
     range_sources: dict[int, tuple[SSAValue, int]],
     iter_args: Sequence[SSAValue] = (),
@@ -287,10 +311,15 @@ def _build_tile_loops(
             rewriter.insert(ub_op, insertion_point)
             ubs[dim] = ub_op.result
 
-    tile_ops = {
-        dim: arith.ConstantOp(IntegerAttr(tile_sizes[dim], index)) for dim in tiled_dims
-    }
-    rewriter.insert([tile_ops[dim] for dim in tiled_dims], insertion_point)
+    steps: dict[int, SSAValue] = {}
+    for dim in tiled_dims:
+        tile_size = tile_sizes[dim]
+        if isinstance(tile_size, SSAValue):
+            steps[dim] = tile_size
+        else:
+            tile_op = arith.ConstantOp(IntegerAttr(tile_size, index))
+            rewriter.insert(tile_op, insertion_point)
+            steps[dim] = tile_op.result
 
     current_insertion_point = insertion_point
     loops: list[scf.ForOp] = []
@@ -301,7 +330,7 @@ def _build_tile_loops(
         loop = scf.ForOp(
             zero.result,
             ubs[dim],
-            tile_ops[dim].result,
+            steps[dim],
             carried,
             Region(Block(arg_types=(index, *carried_types))),
         )
@@ -491,7 +520,7 @@ def _build_tiled_insert(
 def tile_linalg_generic(
     rewriter: PatternRewriter,
     op: linalg.ops.GenericOp,
-    tile_sizes: tuple[int, ...],
+    tile_sizes: Sequence[SSAValue | int],
 ) -> bool:
     """
     Rewrite supported `linalg.generic` ops into tiled formed.

--- a/xdsl/transforms/test_linalg_tiling.py
+++ b/xdsl/transforms/test_linalg_tiling.py
@@ -1,9 +1,15 @@
 from dataclasses import dataclass
 
 from xdsl.context import Context
-from xdsl.dialects import linalg
-from xdsl.dialects.builtin import DenseArrayBase, IntegerType, ModuleOp
+from xdsl.dialects import linalg, test
+from xdsl.dialects.builtin import (
+    DenseArrayBase,
+    IndexType,
+    IntegerType,
+    ModuleOp,
+)
 from xdsl.dialects.linalg.transforms.tiling import tile_linalg_generic
+from xdsl.ir import SSAValue
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
     PatternRewriter,
@@ -11,12 +17,19 @@ from xdsl.pattern_rewriter import (
     RewritePattern,
     op_type_rewrite_pattern,
 )
+from xdsl.rewriter import InsertPoint
 from xdsl.utils.hints import isa
 
 
 class TileLinalgGenericFromAttributePattern(RewritePattern):
     """
-    Rewrite supported `linalg.generic` ops annotated with `test_tile_sizes` into tiled form.
+    Rewrite supported `linalg.generic` ops annotated with `test_tile_sizes` into
+    tiled form.
+
+    A tile size is normally taken straight from that attribute. Dimensions named
+    by `test_dynamic_tile_sizes` instead take a tile size that is not known until
+    the op runs, which the pass has no way of writing in an attribute, so one is
+    produced by a `test.op` for the tiling to consume.
     """
 
     @op_type_rewrite_pattern
@@ -29,7 +42,16 @@ class TileLinalgGenericFromAttributePattern(RewritePattern):
             return
 
         assert isa(tile_sizes_attr, DenseArrayBase[IntegerType])
-        tile_sizes = tuple(tile_sizes_attr.get_values())
+        tile_sizes: list[SSAValue | int] = list(tile_sizes_attr.get_values())
+
+        dynamic_dims_attr = op.attributes.get("test_dynamic_tile_sizes")
+        if dynamic_dims_attr is not None:
+            assert isa(dynamic_dims_attr, DenseArrayBase[IntegerType])
+            for dim in dynamic_dims_attr.get_values():
+                tile_size_op = test.TestOp(result_types=[IndexType()])
+                rewriter.insert(tile_size_op, InsertPoint.before(op))
+                tile_sizes[dim] = tile_size_op.res[0]
+
         tile_linalg_generic(rewriter, op, tile_sizes)
 
 


### PR DESCRIPTION
Completes the dynamic shapes and tile sizes checkbox on #6140. Follows on from #6380, which covered the shapes.

A tile size arrived as a number, so it could not be one worked out while the program runs.

Tile sizes are now taken as either a number or a value, following upstream, which takes them as `ArrayRef<OpFoldResult>`. The two questions asked of a tile size follow upstream's answers too, and are the same shape as the rest of the pass, in that what cannot be shown is assumed:

```python
def _is_zero(tile_size):  # tiling by zero means leaving a dimension alone
    return isinstance(tile_size, int) and tile_size == 0
```

A size that is not known cannot be shown to be zero, so its dimension is tiled. Upstream does the same, tiling unless `isConstantIntValue(givenTileSize, 0)`. It cannot be shown to divide the loop range either, so its last tile is clamped the way any other leftover already is, which #6379 added. The loop steps by the value itself:

```mlir
%0 = "test.op"() : () -> index
scf.for %3 = %1 to %2 step %0 {
  %4 = "affine.min"(%0, %2, %3) ... : (index, index, index) -> index
  %5 = memref.subview %A[%3, 0] [%4, 4] [1, 1] : memref<8x4xf32> to memref<?x4xf32, strided<[4, 1], offset: ?>>
```

An op tiled by numbers alone is unaffected and generates the same IR, so the existing filecheck expectations are untouched.

### Naming such a tile size in a test

A value cannot be written in an attribute, and upstream sidesteps this by driving tiling through the transform dialect rather than an attribute. So the test pass keeps taking `test_tile_sizes` as it did, and reads a second attribute naming the dimensions whose tile size should instead be a value, producing one with a `test.op` for the tiling to consume:

```mlir
attrs = {test_tile_sizes = array<i32: 0, 0>, test_dynamic_tile_sizes = array<i32: 0>}
```

That is a device for writing the test rather than part of the pass, and I am happy to take another approach to it.
