### PR TITLE
dialects: (affine) give min an init and its own syntax

### DIFF
--- a/tests/filecheck/dialects/affine/affine_ops.mlir
+++ b/tests/filecheck/dialects/affine/affine_ops.mlir
@@ -55,6 +55,7 @@
     %2 = affine.apply affine_map<(d0)[s0] -> (((d0 + (s0 * 42)) + -1))> (%zero)[%zero]
     %min = affine.min affine_map<(d0) -> ((d0 + 41), d0)> (%zero)
     %min_sym = affine.min affine_map<(d0)[s0] -> (d0, s0)> (%zero)[%zero]
+    %min_none = affine.min affine_map<() -> (0)>
     %same_value = affine.load %memref[%zero, %zero] : memref<2x3xf64>
     %nested = affine.load %memref[3 + %zero * 7 + %zero, %zero + 7] : memref<2x3xf64>
 
@@ -62,6 +63,7 @@
     // CHECK-NEXT: %{{.*}} = affine.apply affine_map<(d0)[s0] -> (((d0 + (s0 * 42)) + -1))> (%{{.*}})[%{{.*}}]
     // CHECK-NEXT: %{{.*}} = affine.min affine_map<(d0) -> ((d0 + 41), d0)> (%{{.*}})
     // CHECK-NEXT: %{{.*}} = affine.min affine_map<(d0)[s0] -> (d0, s0)> (%{{.*}})[%{{.*}}]
+    // CHECK-NEXT: %{{.*}} = affine.min affine_map<() -> (0)> ()
     // CHECK-NEXT: %same_value = affine.load %memref[%zero, %zero] : memref<2x3xf64>
     // CHECK-NEXT: %nested = affine.load %memref[%zero * 7 + 3 + %zero, %zero + 7] : memref<2x3xf64>
 

--- a/tests/filecheck/dialects/affine/affine_ops.mlir
+++ b/tests/filecheck/dialects/affine/affine_ops.mlir
@@ -53,13 +53,15 @@
 
     %zero = "test.op"() : () -> index
     %2 = affine.apply affine_map<(d0)[s0] -> (((d0 + (s0 * 42)) + -1))> (%zero)[%zero]
-    %min = "affine.min"(%zero) <{"map" = affine_map<(d0) -> ((d0 + 41), d0)>}> : (index) -> index
+    %min = affine.min affine_map<(d0) -> ((d0 + 41), d0)> (%zero)
+    %min_sym = affine.min affine_map<(d0)[s0] -> (d0, s0)> (%zero)[%zero]
     %same_value = affine.load %memref[%zero, %zero] : memref<2x3xf64>
     %nested = affine.load %memref[3 + %zero * 7 + %zero, %zero + 7] : memref<2x3xf64>
 
     // CHECK:      %zero = "test.op"() : () -> index
     // CHECK-NEXT: %{{.*}} = affine.apply affine_map<(d0)[s0] -> (((d0 + (s0 * 42)) + -1))> (%{{.*}})[%{{.*}}]
-    // CHECK-NEXT: %{{.*}} = "affine.min"(%{{.*}}) <{map = affine_map<(d0) -> ((d0 + 41), d0)>}> : (index) -> index
+    // CHECK-NEXT: %{{.*}} = affine.min affine_map<(d0) -> ((d0 + 41), d0)> (%{{.*}})
+    // CHECK-NEXT: %{{.*}} = affine.min affine_map<(d0)[s0] -> (d0, s0)> (%{{.*}})[%{{.*}}]
     // CHECK-NEXT: %same_value = affine.load %memref[%zero, %zero] : memref<2x3xf64>
     // CHECK-NEXT: %nested = affine.load %memref[%zero * 7 + 3 + %zero, %zero + 7] : memref<2x3xf64>
 

--- a/tests/filecheck/dialects/affine/invalid.mlir
+++ b/tests/filecheck/dialects/affine/invalid.mlir
@@ -91,3 +91,17 @@ affine.for %i = 0 to affine_map<()[s0] -> (s0)>() {
 }
 
 // CHECK: symbol operand count and affine map symbol count must match
+
+// -----
+
+%zero = "test.op"() : () -> index
+%min = "affine.min"(%zero) <{map = affine_map<(d0, d1) -> (d0, d1)>}> : (index) -> index
+
+// CHECK: affine.min expects 2 operands, but got 1. The number of map operands must match the sum of the dimensions and symbols of its map.
+
+// -----
+
+%zero = "test.op"() : () -> index
+%min = affine.min 42 : i32 (%zero)
+
+// CHECK: Expected affine map attr

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/affine/affine_ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/affine/affine_ops.mlir
@@ -58,7 +58,7 @@
 
     // CHECK:      %{{.*}} = "test.op"() : () -> index
     // CHECK-NEXT: %{{.*}} = affine.apply affine_map<(d0)[s0] -> (((d0 + (s0 * 42)) + -1))> (%{{.*}})[%{{.*}}]
-    // CHECK-NEXT: %{{.*}} = "affine.min"(%{{.*}}) <{map = affine_map<(d0) -> ((d0 + 41), d0)>}> : (index) -> index
+    // CHECK-NEXT: %{{.*}} = affine.min affine_map<(d0) -> ((d0 + 41), d0)> (%{{.*}})
     // CHECK-NEXT: %{{.*}} = affine.load %{{.*}}[%{{.*}}, %{{.*}}] : memref<2x3xf64>
 
     %vmemref = "test.op"() : () -> memref<2x3xf64>

--- a/tests/filecheck/transforms/linalg-tiling.mlir
+++ b/tests/filecheck/transforms/linalg-tiling.mlir
@@ -210,7 +210,7 @@ linalg.generic {
 // CHECK-NEXT:   %4 = arith.constant 2 : index
 // CHECK-NEXT:   scf.for %5 = %0 to %1 step %3 {
 // CHECK-NEXT:     scf.for %6 = %0 to %2 step %4 {
-// CHECK-NEXT:       %7 = "affine.min"(%3, %1, %5) <{map = affine_map<(d0, d1, d2) -> (d0, (d1 + (d2 * -1)))>}> : (index, index, index) -> index
+// CHECK-NEXT:       %7 = affine.min affine_map<(d0, d1, d2) -> (d0, (d1 + (d2 * -1)))> (%3, %1, %5)
 // CHECK-NEXT:       %8 = memref.subview %A[%5, %6] [%7, 2] [1, 1] : memref<5x4xf32> to memref<?x2xf32, strided<[4, 1], offset: ?>>
 // CHECK-NEXT:       %9 = memref.subview %B[%5, %6] [%7, 2] [1, 1] : memref<5x4xf32> to memref<?x2xf32, strided<[4, 1], offset: ?>>
 // CHECK-NEXT:       linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%8 : memref<?x2xf32, strided<[4, 1], offset: ?>>) outs(%9 : memref<?x2xf32, strided<[4, 1], offset: ?>>) {
@@ -246,7 +246,7 @@ linalg.generic {
 // CHECK-NEXT:   %4 = arith.constant 2 : index
 // CHECK-NEXT:   %C = scf.for %5 = %0 to %1 step %3 iter_args(%6 = %B) -> (tensor<5x4xf32>) {
 // CHECK-NEXT:     %7 = scf.for %8 = %0 to %2 step %4 iter_args(%9 = %6) -> (tensor<5x4xf32>) {
-// CHECK-NEXT:       %10 = "affine.min"(%3, %1, %5) <{map = affine_map<(d0, d1, d2) -> (d0, (d1 + (d2 * -1)))>}> : (index, index, index) -> index
+// CHECK-NEXT:       %10 = affine.min affine_map<(d0, d1, d2) -> (d0, (d1 + (d2 * -1)))> (%3, %1, %5)
 // CHECK-NEXT:       %11 = "tensor.extract_slice"(%A, %5, %8, %10) <{static_offsets = array<i64: -9223372036854775808, -9223372036854775808>, static_sizes = array<i64: -9223372036854775808, 2>, static_strides = array<i64: 1, 1>, operandSegmentSizes = array<i32: 1, 2, 1, 0>}> : (tensor<5x4xf32>, index, index, index) -> tensor<?x2xf32>
 // CHECK-NEXT:       %12 = "tensor.extract_slice"(%9, %5, %8, %10) <{static_offsets = array<i64: -9223372036854775808, -9223372036854775808>, static_sizes = array<i64: -9223372036854775808, 2>, static_strides = array<i64: 1, 1>, operandSegmentSizes = array<i32: 1, 2, 1, 0>}> : (tensor<5x4xf32>, index, index, index) -> tensor<?x2xf32>
 // CHECK-NEXT:       %13 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%11 : tensor<?x2xf32>) outs(%12 : tensor<?x2xf32>) {
@@ -282,7 +282,7 @@ linalg.generic {
 // CHECK-NEXT:   %2 = memref.dim %A, %1 : memref<?x4xf32>
 // CHECK-NEXT:   %3 = arith.constant 2 : index
 // CHECK-NEXT:   scf.for %4 = %0 to %2 step %3 {
-// CHECK-NEXT:     %5 = "affine.min"(%3, %2, %4) <{map = affine_map<(d0, d1, d2) -> (d0, (d1 + (d2 * -1)))>}> : (index, index, index) -> index
+// CHECK-NEXT:     %5 = affine.min affine_map<(d0, d1, d2) -> (d0, (d1 + (d2 * -1)))> (%3, %2, %4)
 // CHECK-NEXT:     %6 = memref.subview %A[%4, 0] [%5, 4] [1, 1] : memref<?x4xf32> to memref<?x4xf32, strided<[4, 1], offset: ?>>
 // CHECK-NEXT:     %7 = memref.subview %B[%4, 0] [%5, 4] [1, 1] : memref<?x4xf32> to memref<?x4xf32, strided<[4, 1], offset: ?>>
 // CHECK-NEXT:     linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%6 : memref<?x4xf32, strided<[4, 1], offset: ?>>) outs(%7 : memref<?x4xf32, strided<[4, 1], offset: ?>>) {
@@ -314,7 +314,7 @@ linalg.generic {
 // CHECK-NEXT:   %2 = tensor.dim %A, %1 : tensor<?x4xf32>
 // CHECK-NEXT:   %3 = arith.constant 2 : index
 // CHECK-NEXT:   %C = scf.for %4 = %0 to %2 step %3 iter_args(%5 = %B) -> (tensor<?x4xf32>) {
-// CHECK-NEXT:     %6 = "affine.min"(%3, %2, %4) <{map = affine_map<(d0, d1, d2) -> (d0, (d1 + (d2 * -1)))>}> : (index, index, index) -> index
+// CHECK-NEXT:     %6 = affine.min affine_map<(d0, d1, d2) -> (d0, (d1 + (d2 * -1)))> (%3, %2, %4)
 // CHECK-NEXT:     %7 = "tensor.extract_slice"(%A, %4, %6) <{static_offsets = array<i64: -9223372036854775808, 0>, static_sizes = array<i64: -9223372036854775808, 4>, static_strides = array<i64: 1, 1>, operandSegmentSizes = array<i32: 1, 1, 1, 0>}> : (tensor<?x4xf32>, index, index) -> tensor<?x4xf32>
 // CHECK-NEXT:     %8 = "tensor.extract_slice"(%5, %4, %6) <{static_offsets = array<i64: -9223372036854775808, 0>, static_sizes = array<i64: -9223372036854775808, 4>, static_strides = array<i64: 1, 1>, operandSegmentSizes = array<i32: 1, 1, 1, 0>}> : (tensor<?x4xf32>, index, index) -> tensor<?x4xf32>
 // CHECK-NEXT:     %9 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%7 : tensor<?x4xf32>) outs(%8 : tensor<?x4xf32>) {
@@ -347,7 +347,7 @@ linalg.generic {
 // CHECK-NEXT:   %1 = arith.constant 0 : index
 // CHECK-NEXT:   %2 = arith.constant 8 : index
 // CHECK-NEXT:   scf.for %3 = %1 to %2 step %0 {
-// CHECK-NEXT:     %4 = "affine.min"(%0, %2, %3) <{map = affine_map<(d0, d1, d2) -> (d0, (d1 + (d2 * -1)))>}> : (index, index, index) -> index
+// CHECK-NEXT:     %4 = affine.min affine_map<(d0, d1, d2) -> (d0, (d1 + (d2 * -1)))> (%0, %2, %3)
 // CHECK-NEXT:     %5 = memref.subview %A[%3, 0] [%4, 4] [1, 1] : memref<8x4xf32> to memref<?x4xf32, strided<[4, 1], offset: ?>>
 // CHECK-NEXT:     %6 = memref.subview %B[%3, 0] [%4, 4] [1, 1] : memref<8x4xf32> to memref<?x4xf32, strided<[4, 1], offset: ?>>
 // CHECK-NEXT:     linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%5 : memref<?x4xf32, strided<[4, 1], offset: ?>>) outs(%6 : memref<?x4xf32, strided<[4, 1], offset: ?>>) {

--- a/tests/filecheck/transforms/scf-parallel-loop-tiling-partial.mlir
+++ b/tests/filecheck/transforms/scf-parallel-loop-tiling-partial.mlir
@@ -25,8 +25,8 @@ func.func @tile_partial() {
 // CHECK-NEXT:   %{{.*}} = arith.muli %{{.*}}, %{{.*}} : index
 // CHECK-NEXT:   "scf.parallel"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) <{operandSegmentSizes = array<i32: 2, 2, 2, 0>}> ({
 // CHECK-NEXT:   ^{{.*}}(%{{.*}}: index, %{{.*}}: index):
-// CHECK-NEXT:     %{{.*}} = "affine.min"(%{{.*}}, %{{.*}}, %{{.*}}) <{map = affine_map<(d0, d1, d2) -> (d0, (d1 + (d2 * -1)))>}> : (index, index, index) -> index
-// CHECK-NEXT:     %{{.*}} = "affine.min"(%{{.*}}, %{{.*}}, %{{.*}}) <{map = affine_map<(d0, d1, d2) -> (d0, (d1 + (d2 * -1)))>}> : (index, index, index) -> index
+// CHECK-NEXT:     %{{.*}} = affine.min affine_map<(d0, d1, d2) -> (d0, (d1 + (d2 * -1)))> (%{{.*}}, %{{.*}}, %{{.*}})
+// CHECK-NEXT:     %{{.*}} = affine.min affine_map<(d0, d1, d2) -> (d0, (d1 + (d2 * -1)))> (%{{.*}}, %{{.*}}, %{{.*}})
 // CHECK-NEXT:     "scf.parallel"(%{{.*}}, %zero, %{{.*}}, %{{.*}}, %size, %{{.*}}, %{{.*}}, %one, %{{.*}}) <{operandSegmentSizes = array<i32: 3, 3, 3, 0>}> ({
 // CHECK-NEXT:     ^{{.*}}(%{{.*}}: index, %{{.*}}: index, %{{.*}}: index):
 // CHECK-NEXT:       %{{.*}} = arith.addi %{{.*}}, %{{.*}} : index
@@ -50,8 +50,8 @@ func.func @tile_partial() {
 // CHECK-FIRST-NEXT:   %{{.*}} = arith.muli %{{.*}}, %{{.*}} : index
 // CHECK-FIRST-NEXT:   "scf.parallel"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) <{operandSegmentSizes = array<i32: 2, 2, 2, 0>}> ({
 // CHECK-FIRST-NEXT:   ^{{.*}}(%{{.*}}: index, %{{.*}}: index):
-// CHECK-FIRST-NEXT:     %{{.*}} = "affine.min"(%{{.*}}, %{{.*}}, %{{.*}}) <{map = affine_map<(d0, d1, d2) -> (d0, (d1 + (d2 * -1)))>}> : (index, index, index) -> index
-// CHECK-FIRST-NEXT:     %{{.*}} = "affine.min"(%{{.*}}, %{{.*}}, %{{.*}}) <{map = affine_map<(d0, d1, d2) -> (d0, (d1 + (d2 * -1)))>}> : (index, index, index) -> index
+// CHECK-FIRST-NEXT:     %{{.*}} = affine.min affine_map<(d0, d1, d2) -> (d0, (d1 + (d2 * -1)))> (%{{.*}}, %{{.*}}, %{{.*}})
+// CHECK-FIRST-NEXT:     %{{.*}} = affine.min affine_map<(d0, d1, d2) -> (d0, (d1 + (d2 * -1)))> (%{{.*}}, %{{.*}}, %{{.*}})
 // CHECK-FIRST-NEXT:     "scf.parallel"(%zero, %{{.*}}, %{{.*}}, %size, %{{.*}}, %{{.*}}, %one, %{{.*}}, %{{.*}}) <{operandSegmentSizes = array<i32: 3, 3, 3, 0>}> ({
 // CHECK-FIRST-NEXT:     ^{{.*}}(%{{.*}}: index, %{{.*}}: index, %{{.*}}: index):
 // CHECK-FIRST-NEXT:       %{{.*}} = arith.addi %{{.*}}, %{{.*}} : index
@@ -75,8 +75,8 @@ func.func @tile_partial() {
 // CHECK-LAST-NEXT:   %{{.*}} = arith.muli %{{.*}}, %{{.*}} : index
 // CHECK-LAST-NEXT:   "scf.parallel"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) <{operandSegmentSizes = array<i32: 2, 2, 2, 0>}> ({
 // CHECK-LAST-NEXT:   ^{{.*}}(%{{.*}}: index, %{{.*}}: index):
-// CHECK-LAST-NEXT:     %{{.*}} = "affine.min"(%{{.*}}, %{{.*}}, %{{.*}}) <{map = affine_map<(d0, d1, d2) -> (d0, (d1 + (d2 * -1)))>}> : (index, index, index) -> index
-// CHECK-LAST-NEXT:     %{{.*}} = "affine.min"(%{{.*}}, %{{.*}}, %{{.*}}) <{map = affine_map<(d0, d1, d2) -> (d0, (d1 + (d2 * -1)))>}> : (index, index, index) -> index
+// CHECK-LAST-NEXT:     %{{.*}} = affine.min affine_map<(d0, d1, d2) -> (d0, (d1 + (d2 * -1)))> (%{{.*}}, %{{.*}}, %{{.*}})
+// CHECK-LAST-NEXT:     %{{.*}} = affine.min affine_map<(d0, d1, d2) -> (d0, (d1 + (d2 * -1)))> (%{{.*}}, %{{.*}}, %{{.*}})
 // CHECK-LAST-NEXT:     "scf.parallel"(%{{.*}}, %{{.*}}, %zero, %{{.*}}, %{{.*}}, %size, %{{.*}}, %{{.*}}, %one) <{operandSegmentSizes = array<i32: 3, 3, 3, 0>}> ({
 // CHECK-LAST-NEXT:     ^{{.*}}(%{{.*}}: index, %{{.*}}: index, %{{.*}}: index):
 // CHECK-LAST-NEXT:       %{{.*}} = arith.addi %{{.*}}, %{{.*}} : index
@@ -110,7 +110,7 @@ func.func @tile_partial_1d() {
 // CHECK-NEXT:      %2 = arith.muli %one, %1 : index
 // CHECK-NEXT:      "scf.parallel"(%zero, %size, %2) <{operandSegmentSizes = array<i32: 1, 1, 1, 0>}> ({
 // CHECK-NEXT:      ^bb0(%3: index):
-// CHECK-NEXT:        %4 = "affine.min"(%1, %size, %3) <{map = affine_map<(d0, d1, d2) -> (d0, (d1 + (d2 * -1)))>}> : (index, index, index) -> index
+// CHECK-NEXT:        %4 = affine.min affine_map<(d0, d1, d2) -> (d0, (d1 + (d2 * -1)))> (%1, %size, %3)
 // CHECK-NEXT:        "scf.parallel"(%0, %4, %one) <{operandSegmentSizes = array<i32: 1, 1, 1, 0>}> ({
 // CHECK-NEXT:        ^bb0(%arg1: index):
 // CHECK-NEXT:          %5 = arith.addi %3, %arg1 : index
@@ -145,7 +145,7 @@ func.func @tile_partial_1d() {
 // CHECK-LAST-NEXT:      %2 = arith.muli %one, %1 : index
 // CHECK-LAST-NEXT:      "scf.parallel"(%zero, %size, %2) <{operandSegmentSizes = array<i32: 1, 1, 1, 0>}> ({
 // CHECK-LAST-NEXT:      ^bb0(%3: index):
-// CHECK-LAST-NEXT:        %4 = "affine.min"(%1, %size, %3) <{map = affine_map<(d0, d1, d2) -> (d0, (d1 + (d2 * -1)))>}> : (index, index, index) -> index
+// CHECK-LAST-NEXT:        %4 = affine.min affine_map<(d0, d1, d2) -> (d0, (d1 + (d2 * -1)))> (%1, %size, %3)
 // CHECK-LAST-NEXT:        "scf.parallel"(%0, %4, %one) <{operandSegmentSizes = array<i32: 1, 1, 1, 0>}> ({
 // CHECK-LAST-NEXT:        ^bb0(%arg1: index):
 // CHECK-LAST-NEXT:          %5 = arith.addi %3, %arg1 : index

--- a/tests/filecheck/transforms/scf-parallel-loop-tiling.mlir
+++ b/tests/filecheck/transforms/scf-parallel-loop-tiling.mlir
@@ -21,8 +21,8 @@ func.func @parallel_loop(%arg0: index, %arg1: index, %arg2: index, %arg3: index,
 // CHECK:           %{{.*}} = arith.muli %{{.*}}, %{{.*}} : index
 // CHECK:           "scf.parallel"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) <{operandSegmentSizes = array<i32: 2, 2, 2, 0>}> ({
 // CHECK:           ^{{.*}}({{%.*}}: index, {{%.*}}: index):
-// CHECK:             %{{.*}} = "affine.min"(%{{.*}}, %{{.*}}, %{{.*}}) <{map = affine_map<(d0, d1, d2) -> (d0, (d1 + (d2 * -1)))>}> : (index, index, index) -> index
-// CHECK:             %{{.*}} = "affine.min"(%{{.*}}, %{{.*}}, %{{.*}}) <{map = affine_map<(d0, d1, d2) -> (d0, (d1 + (d2 * -1)))>}> : (index, index, index) -> index
+// CHECK:             %{{.*}} = affine.min affine_map<(d0, d1, d2) -> (d0, (d1 + (d2 * -1)))> (%{{.*}}, %{{.*}}, %{{.*}})
+// CHECK:             %{{.*}} = affine.min affine_map<(d0, d1, d2) -> (d0, (d1 + (d2 * -1)))> (%{{.*}}, %{{.*}}, %{{.*}})
 // CHECK:             "scf.parallel"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) <{operandSegmentSizes = array<i32: 2, 2, 2, 0>}> ({
 // CHECK:             ^{{.*}}({{%.*}}: index, {{%.*}}: index):
 // CHECK:               %{{.*}} = arith.addi %{{.*}}, %{{.*}} : index
@@ -104,7 +104,7 @@ func.func @tile_nested_innermost() {
 // CHECK:             %{{.*}} = arith.muli %{{.*}}, %{{.*}} : index
 // CHECK:             %{{.*}} = arith.muli %{{.*}}, %{{.*}} : index
 // CHECK:             "scf.parallel"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) <{operandSegmentSizes = array<i32: 2, 2, 2, 0>}> ({
-// CHECK:               %{{.*}} = "affine.min"(%{{.*}}, %{{.*}}, %{{.*}}) <{map = affine_map<(d0, d1, d2) -> (d0, (d1 + (d2 * -1)))>}> : (index, index, index) -> index
+// CHECK:               %{{.*}} = affine.min affine_map<(d0, d1, d2) -> (d0, (d1 + (d2 * -1)))> (%{{.*}}, %{{.*}}, %{{.*}})
 // CHECK:               "scf.parallel"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) <{operandSegmentSizes = array<i32: 2, 2, 2, 0>}> ({
 // CHECK:                 = arith.addi %{{.*}}, %{{.*}} : index
 // CHECK:                 = arith.addi %{{.*}}, %{{.*}} : index
@@ -118,7 +118,7 @@ func.func @tile_nested_innermost() {
 // CHECK:           %{{.*}} = arith.muli %{{.*}}, %{{.*}} : index
 // CHECK:           %{{.*}} = arith.muli %{{.*}}, %{{.*}} : index
 // CHECK:           "scf.parallel"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) <{operandSegmentSizes = array<i32: 2, 2, 2, 0>}> ({
-// CHECK:             %{{.*}} = "affine.min"(%{{.*}}, %{{.*}}, %{{.*}}) <{map = affine_map<(d0, d1, d2) -> (d0, (d1 + (d2 * -1)))>}> : (index, index, index) -> index
+// CHECK:             %{{.*}} = affine.min affine_map<(d0, d1, d2) -> (d0, (d1 + (d2 * -1)))> (%{{.*}}, %{{.*}}, %{{.*}})
 // CHECK:             "scf.parallel"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) <{operandSegmentSizes = array<i32: 2, 2, 2, 0>}> ({
 // CHECK:               = arith.addi %{{.*}}, %{{.*}} : index
 // CHECK:               = arith.addi %{{.*}}, %{{.*}} : index

--- a/xdsl/dialects/affine.py
+++ b/xdsl/dialects/affine.py
@@ -729,14 +729,63 @@ class MinOp(IRDLOperation):
 
     map = prop_def(AffineMapAttr)
 
+    def __init__(
+        self,
+        map_operands: Sequence[SSAValue | Operation],
+        affine_map: AffineMapAttr,
+    ):
+        super().__init__(
+            operands=[map_operands],
+            properties={"map": affine_map},
+            result_types=[IndexType()],
+        )
+
     def verify_(self) -> None:
         if len(self.operands) != self.map.data.num_dims + self.map.data.num_symbols:
             raise VerifyException(
                 f"{self.name} expects "
                 f"{self.map.data.num_dims + self.map.data.num_symbols} "
-                "operands, but got {len(self.operands)}. The number of map operands "
+                f"operands, but got {len(self.operands)}. The number of map operands "
                 "must match the sum of the dimensions and symbols of its map."
             )
+
+    @classmethod
+    def parse(cls, parser: Parser) -> MinOp:
+        pos = parser.pos
+        m = parser.parse_attribute()
+        if not isinstance(m, AffineMapAttr):
+            parser.raise_error("Expected affine map attr", at_position=pos)
+        dims = parser.parse_optional_comma_separated_list(
+            parser.Delimiter.PAREN, lambda: parser.parse_operand()
+        )
+        if dims is None:
+            dims = []
+        syms = parser.parse_optional_comma_separated_list(
+            parser.Delimiter.SQUARE, lambda: parser.parse_operand()
+        )
+        if syms is None:
+            syms = []
+        return MinOp(dims + syms, m)
+
+    def print(self, printer: Printer):
+        m = self.map.data
+        operands = tuple(self.arguments)
+        assert len(operands) == m.num_dims + m.num_symbols, f"{len(operands)} {m}"
+        printer.print_string(" ")
+        printer.print_attribute(self.map)
+        printer.print_string(" (")
+        if m.num_dims:
+            printer.print_list(
+                operands[: m.num_dims], lambda el: printer.print_operand(el)
+            )
+        printer.print_string(")")
+
+        if m.num_symbols:
+            printer.print_string("[")
+            printer.print_list(
+                operands[m.num_dims :], lambda el: printer.print_operand(el)
+            )
+            printer.print_string("]")
 
 
 @irdl_op_definition

--- a/xdsl/dialects/linalg/transforms/tiling.py
+++ b/xdsl/dialects/linalg/transforms/tiling.py
@@ -363,9 +363,7 @@ def _build_effective_tile_sizes(
             continue
 
         min_op = affine.MinOp(
-            operands=[[loop.step, loop.ub, loop.body.block.args[0]]],
-            properties={"map": _PARTIAL_TILE_MIN_MAP},
-            result_types=[IndexType()],
+            (loop.step, loop.ub, loop.body.block.args[0]), _PARTIAL_TILE_MIN_MAP
         )
         rewriter.insert(min_op, insertion_point)
         effective[dim] = min_op.result

--- a/xdsl/transforms/scf_parallel_loop_tiling.py
+++ b/xdsl/transforms/scf_parallel_loop_tiling.py
@@ -97,15 +97,12 @@ class ScfParallelLoopTilingPattern(RewritePattern):
 
                 arg_index = tiled_dims.index(i)
                 minop = affine.MinOp(
-                    operands=[
-                        [
-                            tile_sizes[i],
-                            outter_upper[arg_index],
-                            outter_loop.body.block.args[arg_index],
-                        ]
-                    ],
-                    properties={"map": minmap},
-                    result_types=[IndexType()],
+                    (
+                        tile_sizes[i],
+                        outter_upper[arg_index],
+                        outter_loop.body.block.args[arg_index],
+                    ),
+                    minmap,
                 )
                 minops.append(minop)
                 inner_upper.append(minop)


### PR DESCRIPTION
Second of the init and format cleanups asked for in #6379 and #6380, after #6384.

`affine.min` had neither a way to build it nor a syntax of its own, so it was built by listing operands and properties, and read back as a generic op:

```mlir
%7 = "affine.min"(%3, %1, %5) <{map = affine_map<(d0, d1, d2) -> (d0, (d1 + (d2 * -1)))>}> : (index, index, index) -> index
```

It takes its operands and its map in an init now, and prints its map ahead of its dimensions and symbols, the way `affine.apply` next to it already does:

```mlir
%7 = affine.min affine_map<(d0, d1, d2) -> (d0, (d1 + (d2 * -1)))> (%3, %1, %5)
```

The init, the parsing and the printing all follow `affine.apply`, which has the same shape: a run of index operands, a map, and an index result. The two now read alike, and the linalg tiling and scf parallel loop tiling passes that build a min are shorter for it.

The message the verifier raises interpolated only part of what it meant to report, printing the braces around the operand count rather than the count, which is fixed here as well.

### Tests

The dialect test wrote its `affine.min` as a generic op, so nothing read the new syntax back. It is written in the new syntax now, alongside one with symbols, so that both the dimensions and the symbols are parsed and printed.

### Note

This changes `tests/filecheck/mlir-conversion/with-mlir/dialects/affine/affine_ops.mlir`, which round-trips through `mlir-opt`. I cannot run that locally, so CI is the first check of it. The syntax matches MLIR's own for `affine.min`, and the `affine.apply` in that same file already prints this way.
