### PR TITLE
dialects: (tensor) give extract_slice its own syntax

### DIFF
--- a/tests/filecheck/dialects/csl/csl-stencil-ops.mlir
+++ b/tests/filecheck/dialects/csl/csl-stencil-ops.mlir
@@ -11,8 +11,8 @@ builtin.module {
       %6 = csl_stencil.access %3[-1, 0] : tensor<4x510xf32>
       %7 = csl_stencil.access %2[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
       %8 = csl_stencil.access %2[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
-      %9 = "tensor.extract_slice"(%7) <{"static_offsets" = array<i64: 1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
-      %10 = "tensor.extract_slice"(%8) <{"static_offsets" = array<i64: -1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+      %9 = tensor.extract_slice %7[1] [510] [1] : tensor<512xf32> to tensor<510xf32>
+      %10 = tensor.extract_slice %8[-1] [510] [1] : tensor<512xf32> to tensor<510xf32>
       %11 = csl_stencil.access %3[0, 1] : tensor<4x510xf32>
       %12 = csl_stencil.access %3[0, -1] : tensor<4x510xf32>
       %13 = arith.addf %12, %11 : tensor<510xf32>
@@ -40,8 +40,8 @@ builtin.module {
 // CHECK-NEXT:       %6 = csl_stencil.access %3[-1, 0] : tensor<4x510xf32>
 // CHECK-NEXT:       %7 = csl_stencil.access %2[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
 // CHECK-NEXT:       %8 = csl_stencil.access %2[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
-// CHECK-NEXT:       %9 = "tensor.extract_slice"(%7) <{static_offsets = array<i64: 1>, static_sizes = array<i64: 510>, static_strides = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
-// CHECK-NEXT:       %10 = "tensor.extract_slice"(%8) <{static_offsets = array<i64: -1>, static_sizes = array<i64: 510>, static_strides = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+// CHECK-NEXT:       %9 = tensor.extract_slice %7[1] [510] [1] : tensor<512xf32> to tensor<510xf32>
+// CHECK-NEXT:       %10 = tensor.extract_slice %8[-1] [510] [1] : tensor<512xf32> to tensor<510xf32>
 // CHECK-NEXT:       %11 = csl_stencil.access %3[0, 1] : tensor<4x510xf32>
 // CHECK-NEXT:       %12 = csl_stencil.access %3[0, -1] : tensor<4x510xf32>
 // CHECK-NEXT:       %13 = arith.addf %12, %11 : tensor<510xf32>
@@ -119,8 +119,8 @@ builtin.module {
         // takes combined chunks and applies further compute (communicate_cb)
         %12 = csl_stencil.access %3[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
         %13 = csl_stencil.access %3[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
-        %14 = "tensor.extract_slice"(%12) <{"static_offsets" = array<i64: 1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
-        %15 = "tensor.extract_slice"(%13) <{"static_offsets" = array<i64: -1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+        %14 = tensor.extract_slice %12[1] [510] [1] : tensor<512xf32> to tensor<510xf32>
+        %15 = tensor.extract_slice %13[-1] [510] [1] : tensor<512xf32> to tensor<510xf32>
 
         %16 = arith.addf %rcv, %14 : tensor<510xf32>
         %17 = arith.addf %16, %15 : tensor<510xf32>
@@ -157,8 +157,8 @@ builtin.module {
 // CHECK-NEXT:     ^bb0(%11: !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %rcv: tensor<510xf32>):
 // CHECK-NEXT:       %12 = csl_stencil.access %11[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
 // CHECK-NEXT:       %13 = csl_stencil.access %11[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
-// CHECK-NEXT:       %14 = "tensor.extract_slice"(%12) <{static_offsets = array<i64: 1>, static_sizes = array<i64: 510>, static_strides = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
-// CHECK-NEXT:       %15 = "tensor.extract_slice"(%13) <{static_offsets = array<i64: -1>, static_sizes = array<i64: 510>, static_strides = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+// CHECK-NEXT:       %14 = tensor.extract_slice %12[1] [510] [1] : tensor<512xf32> to tensor<510xf32>
+// CHECK-NEXT:       %15 = tensor.extract_slice %13[-1] [510] [1] : tensor<512xf32> to tensor<510xf32>
 // CHECK-NEXT:       %16 = arith.addf %rcv, %14 : tensor<510xf32>
 // CHECK-NEXT:       %17 = arith.addf %16, %15 : tensor<510xf32>
 // CHECK-NEXT:       %18 = arith.constant 1.666600e-01 : f32
@@ -231,8 +231,8 @@ builtin.module {
     ^bb1(%12: !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>, %13: tensor<510xf32>):
       %14 = csl_stencil.access %12[0, 0] : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>
       %15 = arith.constant dense<1.666600e-01> : tensor<510xf32>
-      %16 = "tensor.extract_slice"(%14) <{"static_offsets" = array<i64: 2>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
-      %17 = "tensor.extract_slice"(%14) <{"static_offsets" = array<i64: 0>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+      %16 = tensor.extract_slice %14[2] [510] [1] : tensor<512xf32> to tensor<510xf32>
+      %17 = tensor.extract_slice %14[0] [510] [1] : tensor<512xf32> to tensor<510xf32>
       %18 = arith.addf %13, %17 : tensor<510xf32>
       %19 = arith.addf %18, %16 : tensor<510xf32>
       %20 = arith.mulf %19, %15 : tensor<510xf32>
@@ -260,8 +260,8 @@ builtin.module {
 //CHECK-NEXT:     ^bb0(%12: !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>, %13: tensor<510xf32>):
 //CHECK-NEXT:       %14 = csl_stencil.access %12[0, 0] : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>
 //CHECK-NEXT:       %15 = arith.constant dense<1.666600e-01> : tensor<510xf32>
-//CHECK-NEXT:       %16 = "tensor.extract_slice"(%14) <{static_offsets = array<i64: 2>, static_sizes = array<i64: 510>, static_strides = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
-//CHECK-NEXT:       %17 = "tensor.extract_slice"(%14) <{static_offsets = array<i64: 0>, static_sizes = array<i64: 510>, static_strides = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+//CHECK-NEXT:       %16 = tensor.extract_slice %14[2] [510] [1] : tensor<512xf32> to tensor<510xf32>
+//CHECK-NEXT:       %17 = tensor.extract_slice %14[0] [510] [1] : tensor<512xf32> to tensor<510xf32>
 //CHECK-NEXT:       %18 = arith.addf %13, %17 : tensor<510xf32>
 //CHECK-NEXT:       %19 = arith.addf %18, %16 : tensor<510xf32>
 //CHECK-NEXT:       %20 = arith.mulf %19, %15 : tensor<510xf32>

--- a/tests/filecheck/dialects/tensor/invalid_ops.mlir
+++ b/tests/filecheck/dialects/tensor/invalid_ops.mlir
@@ -181,3 +181,18 @@ builtin.module {
 %tensor1, %tensor2, %tensor3 = "test.op"() : () -> (tensor<1x2xf32>, tensor<1x2xf32>, tensor<2x1xf32>) 
 // CHECK: static concatenation size mismatch along non-concatenated dimension 1
 %res = tensor.concat dim(0) %tensor1, %tensor2, %tensor3 : (tensor<1x2xf32>, tensor<1x2xf32>, tensor<2x1xf32>) ->  tensor<4x2xf32>
+
+// -----
+%t, %i = "test.op"() : () -> (tensor<8x16xf32>, index)
+// CHECK: The number of dynamic positions passed as values (1) does not match the number of dynamic position markers (0) in the offset arguments.
+%res = "tensor.extract_slice"(%t, %i) <{static_offsets = array<i64: 0, 0>, static_sizes = array<i64: 4, 4>, static_strides = array<i64: 1, 1>, operandSegmentSizes = array<i32: 1, 1, 0, 0>}> : (tensor<8x16xf32>, index) -> tensor<4x4xf32>
+
+// -----
+%t, %i = "test.op"() : () -> (tensor<8x16xf32>, index)
+// CHECK: The number of dynamic positions passed as values (1) does not match the number of dynamic position markers (0) in the size arguments.
+%res = "tensor.extract_slice"(%t, %i) <{static_offsets = array<i64: 0, 0>, static_sizes = array<i64: 4, 4>, static_strides = array<i64: 1, 1>, operandSegmentSizes = array<i32: 1, 0, 1, 0>}> : (tensor<8x16xf32>, index) -> tensor<4x4xf32>
+
+// -----
+%t, %i = "test.op"() : () -> (tensor<8x16xf32>, index)
+// CHECK: The number of dynamic positions passed as values (1) does not match the number of dynamic position markers (0) in the stride arguments.
+%res = "tensor.extract_slice"(%t, %i) <{static_offsets = array<i64: 0, 0>, static_sizes = array<i64: 4, 4>, static_strides = array<i64: 1, 1>, operandSegmentSizes = array<i32: 1, 0, 0, 1>}> : (tensor<8x16xf32>, index) -> tensor<4x4xf32>

--- a/tests/filecheck/dialects/tensor/ops.mlir
+++ b/tests/filecheck/dialects/tensor/ops.mlir
@@ -9,6 +9,9 @@
 %extract1 = tensor.extract %tensor[%index, %index1] : tensor<?x?xf32>
 %insert1 = tensor.insert %extract1 into %tensor[%index, %index1] : tensor<?x?xf32>
 %fromelements = tensor.from_elements %index, %index1 : tensor<2xindex>
+%extract_slice1 = tensor.extract_slice %cast1[0, 1] [2, 2] [1, 1] : tensor<4x4xf32> to tensor<2x2xf32>
+%extract_slice2 = tensor.extract_slice %cast1[%index, 1] [2, %index1] [1, 1] : tensor<4x4xf32> to tensor<2x?xf32>
+%extract_slice3 = tensor.extract_slice %cast1[0, 1] [2, 2] [1, 1] {hello = "world"} : tensor<4x4xf32> to tensor<2x2xf32>
 %res_collapse1 = tensor.collapse_shape %tensor [ [0, 1], [2] ] : tensor<?x?xf32> into tensor<4x1xf32>
 
 %expanded1 = tensor.expand_shape %tensor [[0, 1, 2], [3]] output_shape [%dim1, 1, 1, %dim2] : tensor<?x?xf32> into tensor<?x1x1x?xf32>
@@ -44,6 +47,9 @@
 // CHECK-NEXT:   %extract1 = tensor.extract %tensor[%index, %index1] : tensor<?x?xf32>
 // CHECK-NEXT:   %insert1 = tensor.insert %extract1 into %tensor[%index, %index1] : tensor<?x?xf32>
 // CHECK-NEXT:   %fromelements = tensor.from_elements %index, %index1 : tensor<2xindex>
+// CHECK-NEXT:   %extract_slice1 = tensor.extract_slice %cast1[0, 1] [2, 2] [1, 1] : tensor<4x4xf32> to tensor<2x2xf32>
+// CHECK-NEXT:   %extract_slice2 = tensor.extract_slice %cast1[%index, 1] [2, %index1] [1, 1] : tensor<4x4xf32> to tensor<2x?xf32>
+// CHECK-NEXT:   %extract_slice3 = tensor.extract_slice %cast1[0, 1] [2, 2] [1, 1] {hello = "world"} : tensor<4x4xf32> to tensor<2x2xf32>
 // CHECK-NEXT:   %res_collapse1 = tensor.collapse_shape %tensor [[0 : i64, 1 : i64], [2 : i64]] : tensor<?x?xf32> into tensor<4x1xf32>
 // CHECK-NEXT:   %expanded1 = tensor.expand_shape %tensor [[0 : i64, 1 : i64, 2 : i64], [3 : i64]] output_shape [%dim1, 1, 1, %dim2] : tensor<?x?xf32> into tensor<?x1x1x?xf32>
 // CHECK-NEXT:   %expanded_with_attr_dict = tensor.expand_shape %tensor [[0 : i64, 1 : i64, 2 : i64], [3 : i64]] output_shape [%dim1, 1, 1, %dim2] {test_attr = 42 : i8} : tensor<?x?xf32> into tensor<?x1x1x?xf32>
@@ -75,6 +81,9 @@
 // CHECK-GENERIC-NEXT:   %extract1 = "tensor.extract"(%tensor, %index, %index1) : (tensor<?x?xf32>, index, index) -> f32
 // CHECK-GENERIC-NEXT:   %insert1 = "tensor.insert"(%extract1, %tensor, %index, %index1) : (f32, tensor<?x?xf32>, index, index) -> tensor<?x?xf32>
 // CHECK-GENERIC-NEXT:   %fromelements = "tensor.from_elements"(%index, %index1) : (index, index) -> tensor<2xindex>
+// CHECK-GENERIC-NEXT:   %extract_slice1 = "tensor.extract_slice"(%cast1) <{static_offsets = array<i64: 0, 1>, static_sizes = array<i64: 2, 2>, static_strides = array<i64: 1, 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<4x4xf32>) -> tensor<2x2xf32>
+// CHECK-GENERIC-NEXT:   %extract_slice2 = "tensor.extract_slice"(%cast1, %index, %index1) <{static_offsets = array<i64: -9223372036854775808, 1>, static_sizes = array<i64: 2, -9223372036854775808>, static_strides = array<i64: 1, 1>, operandSegmentSizes = array<i32: 1, 1, 1, 0>}> : (tensor<4x4xf32>, index, index) -> tensor<2x?xf32>
+// CHECK-GENERIC-NEXT:   %extract_slice3 = "tensor.extract_slice"(%cast1) <{static_offsets = array<i64: 0, 1>, static_sizes = array<i64: 2, 2>, static_strides = array<i64: 1, 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> {hello = "world"} : (tensor<4x4xf32>) -> tensor<2x2xf32>
 // CHECK-GENERIC-NEXT:   %res_collapse1 = "tensor.collapse_shape"(%tensor) <{reassociation = [[0 : i64, 1 : i64], [2 : i64]]}> : (tensor<?x?xf32>) -> tensor<4x1xf32>
 // CHECK-GENERIC-NEXT:   %expanded1 = "tensor.expand_shape"(%tensor, %dim1, %dim2) <{reassociation = [[0 : i64, 1 : i64, 2 : i64], [3 : i64]], static_output_shape = array<i64: -9223372036854775808, 1, 1, -9223372036854775808>}> : (tensor<?x?xf32>, index, index) -> tensor<?x1x1x?xf32>
 // CHECK-GENERIC-NEXT:   %expanded_with_attr_dict = "tensor.expand_shape"(%tensor, %dim1, %dim2) <{reassociation = [[0 : i64, 1 : i64, 2 : i64], [3 : i64]], static_output_shape = array<i64: -9223372036854775808, 1, 1, -9223372036854775808>}> {test_attr = 42 : i8} : (tensor<?x?xf32>, index, index) -> tensor<?x1x1x?xf32>

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/tensor/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/tensor/ops.mlir
@@ -8,7 +8,7 @@
 %shape = "test.op"() : () -> (tensor<1xi32>)
 %t4 = tensor.reshape %src(%shape) : (tensor<4x1xf32>, tensor<1xi32>) -> tensor<4xf32>
 %inserted_slice = "tensor.insert_slice"(%t2, %t1) <{"static_offsets" = array<i64: 0, 1>, "static_sizes" = array<i64: 1, 2>, "static_strides" = array<i64: 1, 1>, operandSegmentSizes = array<i32: 1, 1, 0, 0, 0>}> : (tensor<2xf32>, tensor<2x3xf32>) -> tensor<2x3xf32>
-%extracted_slice = "tensor.extract_slice"(%t1) <{"static_offsets" = array<i64: 0, 1>, "static_sizes" = array<i64: 1, 2>, "static_strides" = array<i64: 1, 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<2x3xf32>) -> tensor<2xf32>
+%extracted_slice = tensor.extract_slice %t1[0, 1] [1, 2] [1, 1] : tensor<2x3xf32> to tensor<2xf32>
 %dim1 = "tensor.dim"(%t1, %i1): (tensor<2x3xf32>, index) -> index
 %dim2 = "tensor.dim"(%t1, %i1) {"hello" = "world"}: (tensor<2x3xf32>, index) -> index
 %cast1 = "tensor.cast"(%t1) : (tensor<2x3xf32>) -> tensor<?x?xf32>

--- a/tests/filecheck/transforms/convert-stencil-to-csl-stencil.mlir
+++ b/tests/filecheck/transforms/convert-stencil-to-csl-stencil.mlir
@@ -9,17 +9,17 @@ builtin.module {
     %1 = stencil.apply(%2 = %24 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>) -> (!stencil.temp<[0,1]x[0,1]xtensor<510xf32>>) {
       %3 = arith.constant 1.666600e-01 : f32
       %4 = stencil.access %2[1, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
-      %5 = "tensor.extract_slice"(%4) <{"static_offsets" = array<i64: 1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+      %5 = tensor.extract_slice %4[1] [510] [1] : tensor<512xf32> to tensor<510xf32>
       %6 = stencil.access %2[-1, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
-      %7 = "tensor.extract_slice"(%6) <{"static_offsets" = array<i64: 1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+      %7 = tensor.extract_slice %6[1] [510] [1] : tensor<512xf32> to tensor<510xf32>
       %8 = stencil.access %2[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
-      %9 = "tensor.extract_slice"(%8) <{"static_offsets" = array<i64: 2>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+      %9 = tensor.extract_slice %8[2] [510] [1] : tensor<512xf32> to tensor<510xf32>
       %10 = stencil.access %2[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
-      %11 = "tensor.extract_slice"(%10) <{"static_offsets" = array<i64: 0>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+      %11 = tensor.extract_slice %10[0] [510] [1] : tensor<512xf32> to tensor<510xf32>
       %12 = stencil.access %2[0, 1] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
-      %13 = "tensor.extract_slice"(%12) <{"static_offsets" = array<i64: 1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+      %13 = tensor.extract_slice %12[1] [510] [1] : tensor<512xf32> to tensor<510xf32>
       %14 = stencil.access %2[0, -1] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
-      %15 = "tensor.extract_slice"(%14) <{"static_offsets" = array<i64: 1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+      %15 = tensor.extract_slice %14[1] [510] [1] : tensor<512xf32> to tensor<510xf32>
       %16 = arith.addf %15, %13 : tensor<510xf32>
       %17 = arith.addf %16, %11 : tensor<510xf32>
       %18 = arith.addf %17, %9 : tensor<510xf32>
@@ -52,9 +52,9 @@ builtin.module {
 // CHECK-NEXT:     ^bb0(%14: !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %15: tensor<510xf32>):
 // CHECK-NEXT:       %16 = arith.constant 1.666600e-01 : f32
 // CHECK-NEXT:       %17 = csl_stencil.access %14[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
-// CHECK-NEXT:       %18 = "tensor.extract_slice"(%17) <{static_offsets = array<i64: 2>, static_sizes = array<i64: 510>, static_strides = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+// CHECK-NEXT:       %18 = tensor.extract_slice %17[2] [510] [1] : tensor<512xf32> to tensor<510xf32>
 // CHECK-NEXT:       %19 = csl_stencil.access %14[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
-// CHECK-NEXT:       %20 = "tensor.extract_slice"(%19) <{static_offsets = array<i64: 0>, static_sizes = array<i64: 510>, static_strides = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+// CHECK-NEXT:       %20 = tensor.extract_slice %19[0] [510] [1] : tensor<512xf32> to tensor<510xf32>
 // CHECK-NEXT:       %21 = arith.addf %15, %20 : tensor<510xf32>
 // CHECK-NEXT:       %22 = arith.addf %21, %18 : tensor<510xf32>
 // CHECK-NEXT:       %23 = tensor.empty() : tensor<510xf32>
@@ -72,11 +72,11 @@ builtin.module {
     %0 = stencil.apply(%1 = %a : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>) -> (!stencil.temp<[0,1]x[0,1]xtensor<510xf32>>) {
       %2 = arith.constant dense<1.666600e-01> : tensor<510xf32>
       %3 = stencil.access %1[1, 0] : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>
-      %4 = "tensor.extract_slice"(%3) <{"static_offsets" = array<i64: 1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+      %4 = tensor.extract_slice %3[1] [510] [1] : tensor<512xf32> to tensor<510xf32>
       %5 = stencil.access %1[0, 0] : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>
-      %6 = "tensor.extract_slice"(%5) <{"static_offsets" = array<i64: 2>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+      %6 = tensor.extract_slice %5[2] [510] [1] : tensor<512xf32> to tensor<510xf32>
       %7 = stencil.access %1[0, -1] : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>
-      %8 = "tensor.extract_slice"(%7) <{"static_offsets" = array<i64: 1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+      %8 = tensor.extract_slice %7[1] [510] [1] : tensor<512xf32> to tensor<510xf32>
       %9 = arith.addf %8, %6 : tensor<510xf32>
       %10 = arith.addf %9, %4 : tensor<510xf32>
       %11 = arith.mulf %10, %2 : tensor<510xf32>
@@ -99,7 +99,7 @@ builtin.module {
 // CHECK-NEXT:   ^bb0(%9: !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>, %10: tensor<510xf32>):
 // CHECK-NEXT:     %11 = arith.constant dense<1.666600e-01> : tensor<510xf32>
 // CHECK-NEXT:     %12 = csl_stencil.access %9[0, 0] : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>
-// CHECK-NEXT:     %13 = "tensor.extract_slice"(%12) <{static_offsets = array<i64: 2>, static_sizes = array<i64: 510>, static_strides = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+// CHECK-NEXT:     %13 = tensor.extract_slice %12[2] [510] [1] : tensor<512xf32> to tensor<510xf32>
 // CHECK-NEXT:     %14 = arith.addf %10, %13 : tensor<510xf32>
 // CHECK-NEXT:     %15 = arith.mulf %14, %11 : tensor<510xf32>
 // CHECK-NEXT:     csl_stencil.yield %15 : tensor<510xf32>
@@ -115,11 +115,11 @@ builtin.module {
       %3 = arith.constant dense<2.345678e-01> : tensor<510xf32>
       %4 = arith.constant dense<3.141500e-01> : tensor<510xf32>
       %5 = stencil.access %1[1, 0] : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>
-      %6 = "tensor.extract_slice"(%5) <{"static_offsets" = array<i64: 1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+      %6 = tensor.extract_slice %5[1] [510] [1] : tensor<512xf32> to tensor<510xf32>
       %7 = stencil.access %1[0, 0] : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>
-      %8 = "tensor.extract_slice"(%7) <{"static_offsets" = array<i64: 2>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+      %8 = tensor.extract_slice %7[2] [510] [1] : tensor<512xf32> to tensor<510xf32>
       %9 = stencil.access %1[0, -1] : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>
-      %10 = "tensor.extract_slice"(%9) <{"static_offsets" = array<i64: 1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+      %10 = tensor.extract_slice %9[1] [510] [1] : tensor<512xf32> to tensor<510xf32>
       %11 = arith.mulf %6, %3 : tensor<510xf32>
       %12 = arith.mulf %10, %4 : tensor<510xf32>
       %13 = arith.addf %12, %8 : tensor<510xf32>
@@ -144,7 +144,7 @@ builtin.module {
 // CHECK-NEXT:   ^bb0(%9: !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>, %10: tensor<510xf32>):
 // CHECK-NEXT:     %11 = arith.constant dense<1.234500e-01> : tensor<510xf32>
 // CHECK-NEXT:     %12 = csl_stencil.access %9[0, 0] : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>
-// CHECK-NEXT:     %13 = "tensor.extract_slice"(%12) <{static_offsets = array<i64: 2>, static_sizes = array<i64: 510>, static_strides = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+// CHECK-NEXT:     %13 = tensor.extract_slice %12[2] [510] [1] : tensor<512xf32> to tensor<510xf32>
 // CHECK-NEXT:     %14 = arith.addf %10, %13 : tensor<510xf32>
 // CHECK-NEXT:     %15 = arith.mulf %14, %11 : tensor<510xf32>
 // CHECK-NEXT:     csl_stencil.yield %15 : tensor<510xf32>
@@ -163,13 +163,13 @@ builtin.module {
       %5 = arith.constant dense<1.287158e+09> : tensor<600xf32>
       %6 = arith.constant dense<1.196003e+05> : tensor<600xf32>
       %7 = stencil.access %arg5[0, 0] : !stencil.field<[-2,3]x[-2,3]xtensor<604xf32>>
-      %8 = "tensor.extract_slice"(%7) <{"static_offsets" = array<i64: 2>, "static_sizes" = array<i64: 600>, "static_strides" = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<604xf32>) -> tensor<600xf32>
+      %8 = tensor.extract_slice %7[2] [600] [1] : tensor<604xf32> to tensor<600xf32>
       %9 = arith.mulf %8, %5 : tensor<600xf32>
       %10 = stencil.access %arg5[-1, 0] : !stencil.field<[-2,3]x[-2,3]xtensor<604xf32>>
-      %11 = "tensor.extract_slice"(%10) <{"static_offsets" = array<i64: 2>, "static_sizes" = array<i64: 600>, "static_strides" = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<604xf32>) -> tensor<600xf32>
+      %11 = tensor.extract_slice %10[2] [600] [1] : tensor<604xf32> to tensor<600xf32>
       %12 = arith.mulf %11, %6 : tensor<600xf32>
       %13 = stencil.access %arg5[1, 0] : !stencil.field<[-2,3]x[-2,3]xtensor<604xf32>>
-      %14 = "tensor.extract_slice"(%13) <{"static_offsets" = array<i64: 2>, "static_sizes" = array<i64: 600>, "static_strides" = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<604xf32>) -> tensor<600xf32>
+      %14 = tensor.extract_slice %13[2] [600] [1] : tensor<604xf32> to tensor<600xf32>
       %15 = arith.mulf %14, %6 : tensor<600xf32>
       %16 = arith.addf %12, %9 : tensor<600xf32>
       %17 = arith.addf %16, %15 : tensor<600xf32>
@@ -197,7 +197,7 @@ builtin.module {
 // CHECK-NEXT:     ^bb0(%13: !stencil.field<[-2,3]x[-2,3]xtensor<604xf32>>, %14: tensor<600xf32>):
 // CHECK-NEXT:       %15 = arith.constant dense<1.28715802e+09> : tensor<600xf32>
 // CHECK-NEXT:       %16 = csl_stencil.access %13[0, 0] : !stencil.field<[-2,3]x[-2,3]xtensor<604xf32>>
-// CHECK-NEXT:       %17 = "tensor.extract_slice"(%16) <{static_offsets = array<i64: 2>, static_sizes = array<i64: 600>, static_strides = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<604xf32>) -> tensor<600xf32>
+// CHECK-NEXT:       %17 = tensor.extract_slice %16[2] [600] [1] : tensor<604xf32> to tensor<600xf32>
 // CHECK-NEXT:       %18 = arith.mulf %17, %15 : tensor<600xf32>
 // CHECK-NEXT:       %19 = arith.addf %14, %18 : tensor<600xf32>
 // CHECK-NEXT:       csl_stencil.yield %19 : tensor<600xf32>
@@ -212,13 +212,13 @@ builtin.module {
     "dmp.swap"(%arg1) {"strategy" = #dmp.grid_slice_2d<#dmp.topo<64x64>, false>, "swaps" = [#dmp.exchange<at [-1, 0, 0] size [1, 1, 64] source offset [1, 0, 0] to [-1, 0, 0]>]} : (!stencil.field<[-1,1]x[-1,1]xtensor<64xf32>>) -> ()
     stencil.apply(%arg6 = %arg0 : !stencil.field<[-1,1]x[-1,1]xtensor<64xf32>>, %arg7 = %arg1 : !stencil.field<[-1,1]x[-1,1]xtensor<64xf32>>) outs (%arg4 : !stencil.field<[-1,1]x[-1,1]xtensor<64xf32>>) {
       %0 = stencil.access %arg7[-1, 0] : !stencil.field<[-1,1]x[-1,1]xtensor<64xf32>>
-      %1 = "tensor.extract_slice"(%0) <{"static_offsets" = array<i64: 0>, "static_sizes" = array<i64: 64>, "static_strides" = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<64xf32>) -> tensor<64xf32>
+      %1 = tensor.extract_slice %0[0] [64] [1] : tensor<64xf32> to tensor<64xf32>
       %2 = stencil.access %arg7[0, 0] : !stencil.field<[-1,1]x[-1,1]xtensor<64xf32>>
-      %3 = "tensor.extract_slice"(%2) <{"static_offsets" = array<i64: 0>, "static_sizes" = array<i64: 64>, "static_strides" = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<64xf32>) -> tensor<64xf32>
+      %3 = tensor.extract_slice %2[0] [64] [1] : tensor<64xf32> to tensor<64xf32>
       %4 = stencil.access %arg6[0, -1] : !stencil.field<[-1,1]x[-1,1]xtensor<64xf32>>
-      %5 = "tensor.extract_slice"(%4) <{"static_offsets" = array<i64: 0>, "static_sizes" = array<i64: 64>, "static_strides" = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<64xf32>) -> tensor<64xf32>
+      %5 = tensor.extract_slice %4[0] [64] [1] : tensor<64xf32> to tensor<64xf32>
       %6 = stencil.access %arg6[0, 0] : !stencil.field<[-1,1]x[-1,1]xtensor<64xf32>>
-      %7 = "tensor.extract_slice"(%6) <{"static_offsets" = array<i64: 0>, "static_sizes" = array<i64: 64>, "static_strides" = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<64xf32>) -> tensor<64xf32>
+      %7 = tensor.extract_slice %6[0] [64] [1] : tensor<64xf32> to tensor<64xf32>
       %8 = arith.addf %1, %3 : tensor<64xf32>
       %9 = arith.addf %8, %5 : tensor<64xf32>
       %10 = arith.addf %9, %7 : tensor<64xf32>

--- a/tests/filecheck/transforms/csl-stencil-to-csl-wrapper.mlir
+++ b/tests/filecheck/transforms/csl-stencil-to-csl-wrapper.mlir
@@ -20,8 +20,8 @@ func.func @gauss_seidel(%a: !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>, 
     %16 = csl_stencil.access %14[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
     %17 = csl_stencil.access %14[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
     %18 = arith.constant 1.666600e-01 : f32
-    %19 = "tensor.extract_slice"(%16) <{"static_offsets" = array<i64: 1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
-    %20 = "tensor.extract_slice"(%17) <{"static_offsets" = array<i64: -1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+    %19 = tensor.extract_slice %16[1] [510] [1] : tensor<512xf32> to tensor<510xf32>
+    %20 = tensor.extract_slice %17[-1] [510] [1] : tensor<512xf32> to tensor<510xf32>
     %21 = arith.addf %15, %20 : tensor<510xf32>
     %22 = arith.addf %21, %19 : tensor<510xf32>
     %23 = tensor.empty() : tensor<510xf32>
@@ -87,8 +87,8 @@ func.func @gauss_seidel(%a: !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>, 
 // CHECK-NEXT:       %56 = csl_stencil.access %54[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
 // CHECK-NEXT:       %57 = csl_stencil.access %54[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
 // CHECK-NEXT:       %58 = arith.constant 1.666600e-01 : f32
-// CHECK-NEXT:       %59 = "tensor.extract_slice"(%56) <{static_offsets = array<i64: 1>, static_sizes = array<i64: 510>, static_strides = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
-// CHECK-NEXT:       %60 = "tensor.extract_slice"(%57) <{static_offsets = array<i64: -1>, static_sizes = array<i64: 510>, static_strides = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+// CHECK-NEXT:       %59 = tensor.extract_slice %56[1] [510] [1] : tensor<512xf32> to tensor<510xf32>
+// CHECK-NEXT:       %60 = tensor.extract_slice %57[-1] [510] [1] : tensor<512xf32> to tensor<510xf32>
 // CHECK-NEXT:       %61 = arith.addf %55, %60 : tensor<510xf32>
 // CHECK-NEXT:       %62 = arith.addf %61, %59 : tensor<510xf32>
 // CHECK-NEXT:       %63 = tensor.empty() : tensor<510xf32>

--- a/tests/filecheck/transforms/csl_stencil_bufferize.mlir
+++ b/tests/filecheck/transforms/csl_stencil_bufferize.mlir
@@ -18,8 +18,8 @@ builtin.module {
     ^bb1(%12: !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>, %13: tensor<510xf32>):
       %14 = csl_stencil.access %12[0, 0] : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>
       %15 = arith.constant dense<1.666600e-01> : tensor<510xf32>
-      %16 = "tensor.extract_slice"(%14) <{"static_offsets" = array<i64: 2>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
-      %17 = "tensor.extract_slice"(%14) <{"static_offsets" = array<i64: 0>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+      %16 = tensor.extract_slice %14[2] [510] [1] : tensor<512xf32> to tensor<510xf32>
+      %17 = tensor.extract_slice %14[0] [510] [1] : tensor<512xf32> to tensor<510xf32>
       %18 = linalg.add ins(%13, %17 : tensor<510xf32>, tensor<510xf32>) outs(%17 : tensor<510xf32>) -> tensor<510xf32>
       %19 = linalg.add ins(%18, %16 : tensor<510xf32>, tensor<510xf32>) outs(%16 : tensor<510xf32>) -> tensor<510xf32>
       %20 = linalg.mul ins(%19, %15 : tensor<510xf32>, tensor<510xf32>) outs(%15 : tensor<510xf32>) -> tensor<510xf32>
@@ -45,7 +45,7 @@ builtin.module {
 // CHECK-NEXT:       %11 = bufferization.to_tensor %10 restrict : memref<255xf32>
 // CHECK-NEXT:       %12 = csl_stencil.access %2[0, -1] : memref<4x255xf32>
 // CHECK-NEXT:       %13 = bufferization.to_tensor %12 restrict : memref<255xf32>
-// CHECK-NEXT:       %14 = "tensor.extract_slice"(%5, %3) <{static_offsets = array<i64: -9223372036854775808>, static_sizes = array<i64: 255>, static_strides = array<i64: 1>, operandSegmentSizes = array<i32: 1, 1, 0, 0>}> : (tensor<510xf32>, index) -> tensor<255xf32>
+// CHECK-NEXT:       %14 = tensor.extract_slice %5[%3] [255] [1] : tensor<510xf32> to tensor<255xf32>
 // CHECK-NEXT:       %15 = linalg.add ins(%13, %11 : tensor<255xf32>, tensor<255xf32>) outs(%14 : tensor<255xf32>) -> tensor<255xf32>
 // CHECK-NEXT:       %16 = linalg.add ins(%15, %9 : tensor<255xf32>, tensor<255xf32>) outs(%15 : tensor<255xf32>) -> tensor<255xf32>
 // CHECK-NEXT:       %17 = linalg.add ins(%16, %7 : tensor<255xf32>, tensor<255xf32>) outs(%16 : tensor<255xf32>) -> tensor<255xf32>
@@ -58,12 +58,12 @@ builtin.module {
 // CHECK-NEXT:       %24 = bufferization.to_tensor %20 restrict : memref<512xf32>
 // CHECK-NEXT:       %25 = arith.constant dense<1.666600e-01> : memref<510xf32>
 // CHECK-NEXT:       %26 = bufferization.to_tensor %25 restrict : memref<510xf32>
-// CHECK-NEXT:       %27 = "tensor.extract_slice"(%24) <{static_offsets = array<i64: 2>, static_sizes = array<i64: 510>, static_strides = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
-// CHECK-NEXT:       %28 = "tensor.extract_slice"(%24) <{static_offsets = array<i64: 0>, static_sizes = array<i64: 510>, static_strides = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+// CHECK-NEXT:       %27 = tensor.extract_slice %24[2] [510] [1] : tensor<512xf32> to tensor<510xf32>
+// CHECK-NEXT:       %28 = tensor.extract_slice %24[0] [510] [1] : tensor<512xf32> to tensor<510xf32>
 // CHECK-NEXT:       %29 = linalg.add ins(%23, %28 : tensor<510xf32>, tensor<510xf32>) outs(%23 : tensor<510xf32>) -> tensor<510xf32>
 // CHECK-NEXT:       %30 = linalg.add ins(%29, %27 : tensor<510xf32>, tensor<510xf32>) outs(%29 : tensor<510xf32>) -> tensor<510xf32>
 // CHECK-NEXT:       %31 = bufferization.to_tensor %22 restrict writable : memref<512xf32>
-// CHECK-NEXT:       %32 = "tensor.extract_slice"(%31) <{static_offsets = array<i64: 1>, static_sizes = array<i64: 510>, static_strides = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+// CHECK-NEXT:       %32 = tensor.extract_slice %31[1] [510] [1] : tensor<512xf32> to tensor<510xf32>
 // CHECK-NEXT:       %33 = linalg.mul ins(%30, %26 : tensor<510xf32>, tensor<510xf32>) outs(%32 : tensor<510xf32>) -> tensor<510xf32>
 // CHECK-NEXT:       csl_stencil.yield
 // CHECK-NEXT:     }) to <[0, 0], [1, 1]>

--- a/tests/filecheck/transforms/linalg-tiling.mlir
+++ b/tests/filecheck/transforms/linalg-tiling.mlir
@@ -137,8 +137,8 @@ linalg.generic {
 // CHECK-NEXT:   %4 = arith.constant 2 : index
 // CHECK-NEXT:   %C = scf.for %5 = %0 to %1 step %3 iter_args(%6 = %B) -> (tensor<4x4xf32>) {
 // CHECK-NEXT:     %7 = scf.for %8 = %0 to %2 step %4 iter_args(%9 = %6) -> (tensor<4x4xf32>) {
-// CHECK-NEXT:       %10 = "tensor.extract_slice"(%A, %5, %8) <{static_offsets = array<i64: -9223372036854775808, -9223372036854775808>, static_sizes = array<i64: 2, 2>, static_strides = array<i64: 1, 1>, operandSegmentSizes = array<i32: 1, 2, 0, 0>}> : (tensor<4x4xf32>, index, index) -> tensor<2x2xf32>
-// CHECK-NEXT:       %11 = "tensor.extract_slice"(%9, %5, %8) <{static_offsets = array<i64: -9223372036854775808, -9223372036854775808>, static_sizes = array<i64: 2, 2>, static_strides = array<i64: 1, 1>, operandSegmentSizes = array<i32: 1, 2, 0, 0>}> : (tensor<4x4xf32>, index, index) -> tensor<2x2xf32>
+// CHECK-NEXT:       %10 = tensor.extract_slice %A[%5, %8] [2, 2] [1, 1] : tensor<4x4xf32> to tensor<2x2xf32>
+// CHECK-NEXT:       %11 = tensor.extract_slice %9[%5, %8] [2, 2] [1, 1] : tensor<4x4xf32> to tensor<2x2xf32>
 // CHECK-NEXT:       %12 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%10 : tensor<2x2xf32>) outs(%11 : tensor<2x2xf32>) {
 // CHECK-NEXT:       ^bb0(%a: f32, %b: f32):
 // CHECK-NEXT:         linalg.yield %a : f32
@@ -174,8 +174,8 @@ linalg.generic {
 // CHECK-NEXT:   %1 = arith.constant 4 : index
 // CHECK-NEXT:   %2 = arith.constant 2 : index
 // CHECK-NEXT:   %C = scf.for %3 = %0 to %1 step %2 iter_args(%4 = %B) -> (tensor<4x4xf32>) {
-// CHECK-NEXT:     %5 = "tensor.extract_slice"(%A, %3) <{static_offsets = array<i64: -9223372036854775808, 0>, static_sizes = array<i64: 2, 4>, static_strides = array<i64: 1, 1>, operandSegmentSizes = array<i32: 1, 1, 0, 0>}> : (tensor<4x4xf32>, index) -> tensor<2x4xf32>
-// CHECK-NEXT:     %6 = "tensor.extract_slice"(%4, %3) <{static_offsets = array<i64: -9223372036854775808, 0>, static_sizes = array<i64: 2, 4>, static_strides = array<i64: 1, 1>, operandSegmentSizes = array<i32: 1, 1, 0, 0>}> : (tensor<4x4xf32>, index) -> tensor<2x4xf32>
+// CHECK-NEXT:     %5 = tensor.extract_slice %A[%3, 0] [2, 4] [1, 1] : tensor<4x4xf32> to tensor<2x4xf32>
+// CHECK-NEXT:     %6 = tensor.extract_slice %4[%3, 0] [2, 4] [1, 1] : tensor<4x4xf32> to tensor<2x4xf32>
 // CHECK-NEXT:     %7 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%5 : tensor<2x4xf32>) outs(%6 : tensor<2x4xf32>) {
 // CHECK-NEXT:     ^bb0(%a: f32, %b: f32):
 // CHECK-NEXT:       linalg.yield %a : f32
@@ -247,8 +247,8 @@ linalg.generic {
 // CHECK-NEXT:   %C = scf.for %5 = %0 to %1 step %3 iter_args(%6 = %B) -> (tensor<5x4xf32>) {
 // CHECK-NEXT:     %7 = scf.for %8 = %0 to %2 step %4 iter_args(%9 = %6) -> (tensor<5x4xf32>) {
 // CHECK-NEXT:       %10 = affine.min affine_map<(d0, d1, d2) -> (d0, (d1 + (d2 * -1)))> (%3, %1, %5)
-// CHECK-NEXT:       %11 = "tensor.extract_slice"(%A, %5, %8, %10) <{static_offsets = array<i64: -9223372036854775808, -9223372036854775808>, static_sizes = array<i64: -9223372036854775808, 2>, static_strides = array<i64: 1, 1>, operandSegmentSizes = array<i32: 1, 2, 1, 0>}> : (tensor<5x4xf32>, index, index, index) -> tensor<?x2xf32>
-// CHECK-NEXT:       %12 = "tensor.extract_slice"(%9, %5, %8, %10) <{static_offsets = array<i64: -9223372036854775808, -9223372036854775808>, static_sizes = array<i64: -9223372036854775808, 2>, static_strides = array<i64: 1, 1>, operandSegmentSizes = array<i32: 1, 2, 1, 0>}> : (tensor<5x4xf32>, index, index, index) -> tensor<?x2xf32>
+// CHECK-NEXT:       %11 = tensor.extract_slice %A[%5, %8] [%10, 2] [1, 1] : tensor<5x4xf32> to tensor<?x2xf32>
+// CHECK-NEXT:       %12 = tensor.extract_slice %9[%5, %8] [%10, 2] [1, 1] : tensor<5x4xf32> to tensor<?x2xf32>
 // CHECK-NEXT:       %13 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%11 : tensor<?x2xf32>) outs(%12 : tensor<?x2xf32>) {
 // CHECK-NEXT:       ^bb0(%a: f32, %b: f32):
 // CHECK-NEXT:         linalg.yield %a : f32
@@ -315,8 +315,8 @@ linalg.generic {
 // CHECK-NEXT:   %3 = arith.constant 2 : index
 // CHECK-NEXT:   %C = scf.for %4 = %0 to %2 step %3 iter_args(%5 = %B) -> (tensor<?x4xf32>) {
 // CHECK-NEXT:     %6 = affine.min affine_map<(d0, d1, d2) -> (d0, (d1 + (d2 * -1)))> (%3, %2, %4)
-// CHECK-NEXT:     %7 = "tensor.extract_slice"(%A, %4, %6) <{static_offsets = array<i64: -9223372036854775808, 0>, static_sizes = array<i64: -9223372036854775808, 4>, static_strides = array<i64: 1, 1>, operandSegmentSizes = array<i32: 1, 1, 1, 0>}> : (tensor<?x4xf32>, index, index) -> tensor<?x4xf32>
-// CHECK-NEXT:     %8 = "tensor.extract_slice"(%5, %4, %6) <{static_offsets = array<i64: -9223372036854775808, 0>, static_sizes = array<i64: -9223372036854775808, 4>, static_strides = array<i64: 1, 1>, operandSegmentSizes = array<i32: 1, 1, 1, 0>}> : (tensor<?x4xf32>, index, index) -> tensor<?x4xf32>
+// CHECK-NEXT:     %7 = tensor.extract_slice %A[%4, 0] [%6, 4] [1, 1] : tensor<?x4xf32> to tensor<?x4xf32>
+// CHECK-NEXT:     %8 = tensor.extract_slice %5[%4, 0] [%6, 4] [1, 1] : tensor<?x4xf32> to tensor<?x4xf32>
 // CHECK-NEXT:     %9 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%7 : tensor<?x4xf32>) outs(%8 : tensor<?x4xf32>) {
 // CHECK-NEXT:     ^bb0(%a: f32, %b: f32):
 // CHECK-NEXT:       linalg.yield %a : f32

--- a/tests/filecheck/transforms/stencil-bufferize.mlir
+++ b/tests/filecheck/transforms/stencil-bufferize.mlir
@@ -497,7 +497,7 @@ func.func @gauss_seidel_func(%a: !stencil.field<[-1,1023]x[-1,511]xtensor<512xf3
   %2 = stencil.apply(%3 = %1 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>) -> (!stencil.temp<[0,1]x[0,1]xtensor<510xf32>>) {
     %4 = arith.constant dense<1.666600e-01> : tensor<510xf32>
     %5 = stencil.access %3[1, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
-    %6 = "tensor.extract_slice"(%5) <{"static_offsets" = array<i64: 1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+    %6 = tensor.extract_slice %5[1] [510] [1] : tensor<512xf32> to tensor<510xf32>
     %7 = arith.addf %4, %6 : tensor<510xf32>
     stencil.return %7 : tensor<510xf32>
   }
@@ -510,7 +510,7 @@ func.func @gauss_seidel_func(%a: !stencil.field<[-1,1023]x[-1,511]xtensor<512xf3
 // CHECK-NEXT:   stencil.apply(%0 = %a : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>) outs (%b : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>) {
 // CHECK-NEXT:     %1 = arith.constant dense<1.666600e-01> : tensor<510xf32>
 // CHECK-NEXT:     %2 = stencil.access %0[1, 0] : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>
-// CHECK-NEXT:     %3 = "tensor.extract_slice"(%2) <{static_offsets = array<i64: 1>, static_sizes = array<i64: 510>, static_strides = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+// CHECK-NEXT:     %3 = tensor.extract_slice %2[1] [510] [1] : tensor<512xf32> to tensor<510xf32>
 // CHECK-NEXT:     %4 = arith.addf %1, %3 : tensor<510xf32>
 // CHECK-NEXT:     stencil.return %4 : tensor<510xf32>
 // CHECK-NEXT:   } to <[0, 0], [1, 1]>

--- a/tests/filecheck/transforms/stencil-tensorize-z-dimension.mlir
+++ b/tests/filecheck/transforms/stencil-tensorize-z-dimension.mlir
@@ -35,17 +35,17 @@ builtin.module {
 // CHECK-NEXT:        %3 = stencil.apply(%4 = %1 : !stencil.temp<[-1,1023]x[-1,511]xtensor<512xf32>>) -> (!stencil.temp<[0,1022]x[0,510]xtensor<510xf32>>) {
 // CHECK-NEXT:          %5 = arith.constant dense<1.666600e-01> : tensor<510xf32>
 // CHECK-NEXT:          %6 = stencil.access %4[1, 0] : !stencil.temp<[-1,1023]x[-1,511]xtensor<512xf32>>
-// CHECK-NEXT:          %7 = "tensor.extract_slice"(%6) <{static_offsets = array<i64: 1>, static_sizes = array<i64: 510>, static_strides = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+// CHECK-NEXT:          %7 = tensor.extract_slice %6[1] [510] [1] : tensor<512xf32> to tensor<510xf32>
 // CHECK-NEXT:          %8 = stencil.access %4[-1, 0] : !stencil.temp<[-1,1023]x[-1,511]xtensor<512xf32>>
-// CHECK-NEXT:          %9 = "tensor.extract_slice"(%8) <{static_offsets = array<i64: 1>, static_sizes = array<i64: 510>, static_strides = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+// CHECK-NEXT:          %9 = tensor.extract_slice %8[1] [510] [1] : tensor<512xf32> to tensor<510xf32>
 // CHECK-NEXT:          %10 = stencil.access %4[0, 0] : !stencil.temp<[-1,1023]x[-1,511]xtensor<512xf32>>
-// CHECK-NEXT:          %11 = "tensor.extract_slice"(%10) <{static_offsets = array<i64: 2>, static_sizes = array<i64: 510>, static_strides = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+// CHECK-NEXT:          %11 = tensor.extract_slice %10[2] [510] [1] : tensor<512xf32> to tensor<510xf32>
 // CHECK-NEXT:          %12 = stencil.access %4[0, 0] : !stencil.temp<[-1,1023]x[-1,511]xtensor<512xf32>>
-// CHECK-NEXT:          %13 = "tensor.extract_slice"(%12) <{static_offsets = array<i64: 0>, static_sizes = array<i64: 510>, static_strides = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+// CHECK-NEXT:          %13 = tensor.extract_slice %12[0] [510] [1] : tensor<512xf32> to tensor<510xf32>
 // CHECK-NEXT:          %14 = stencil.access %4[0, 1] : !stencil.temp<[-1,1023]x[-1,511]xtensor<512xf32>>
-// CHECK-NEXT:          %15 = "tensor.extract_slice"(%14) <{static_offsets = array<i64: 1>, static_sizes = array<i64: 510>, static_strides = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+// CHECK-NEXT:          %15 = tensor.extract_slice %14[1] [510] [1] : tensor<512xf32> to tensor<510xf32>
 // CHECK-NEXT:          %16 = stencil.access %4[0, -1] : !stencil.temp<[-1,1023]x[-1,511]xtensor<512xf32>>
-// CHECK-NEXT:          %17 = "tensor.extract_slice"(%16) <{static_offsets = array<i64: 1>, static_sizes = array<i64: 510>, static_strides = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+// CHECK-NEXT:          %17 = tensor.extract_slice %16[1] [510] [1] : tensor<512xf32> to tensor<510xf32>
 // CHECK-NEXT:          %18 = arith.addf %17, %15 : tensor<510xf32>
 // CHECK-NEXT:          %19 = arith.addf %18, %13 : tensor<510xf32>
 // CHECK-NEXT:          %20 = arith.addf %19, %11 : tensor<510xf32>
@@ -86,17 +86,17 @@ builtin.module {
 // CHECK-NEXT:       %1 = stencil.apply(%2 = %0 : !stencil.temp<[-1,1023]x[-1,511]xtensor<512xf32>>) -> (!stencil.temp<[0,1022]x[0,510]xtensor<510xf32>>) {
 // CHECK-NEXT:         %3 = arith.constant dense<1.666600e-01> : tensor<510xf32>
 // CHECK-NEXT:         %4 = stencil.access %2[1, 0] : !stencil.temp<[-1,1023]x[-1,511]xtensor<512xf32>>
-// CHECK-NEXT:         %5 = "tensor.extract_slice"(%4) <{static_offsets = array<i64: 1>, static_sizes = array<i64: 510>, static_strides = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+// CHECK-NEXT:         %5 = tensor.extract_slice %4[1] [510] [1] : tensor<512xf32> to tensor<510xf32>
 // CHECK-NEXT:         %6 = stencil.access %2[-1, 0] : !stencil.temp<[-1,1023]x[-1,511]xtensor<512xf32>>
-// CHECK-NEXT:         %7 = "tensor.extract_slice"(%6) <{static_offsets = array<i64: 1>, static_sizes = array<i64: 510>, static_strides = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+// CHECK-NEXT:         %7 = tensor.extract_slice %6[1] [510] [1] : tensor<512xf32> to tensor<510xf32>
 // CHECK-NEXT:         %8 = stencil.access %2[0, 0] : !stencil.temp<[-1,1023]x[-1,511]xtensor<512xf32>>
-// CHECK-NEXT:         %9 = "tensor.extract_slice"(%8) <{static_offsets = array<i64: 2>, static_sizes = array<i64: 510>, static_strides = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+// CHECK-NEXT:         %9 = tensor.extract_slice %8[2] [510] [1] : tensor<512xf32> to tensor<510xf32>
 // CHECK-NEXT:         %10 = stencil.access %2[0, 0] : !stencil.temp<[-1,1023]x[-1,511]xtensor<512xf32>>
-// CHECK-NEXT:         %11 = "tensor.extract_slice"(%10) <{static_offsets = array<i64: 0>, static_sizes = array<i64: 510>, static_strides = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+// CHECK-NEXT:         %11 = tensor.extract_slice %10[0] [510] [1] : tensor<512xf32> to tensor<510xf32>
 // CHECK-NEXT:         %12 = stencil.access %2[0, 1] : !stencil.temp<[-1,1023]x[-1,511]xtensor<512xf32>>
-// CHECK-NEXT:         %13 = "tensor.extract_slice"(%12) <{static_offsets = array<i64: 1>, static_sizes = array<i64: 510>, static_strides = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+// CHECK-NEXT:         %13 = tensor.extract_slice %12[1] [510] [1] : tensor<512xf32> to tensor<510xf32>
 // CHECK-NEXT:         %14 = stencil.access %2[0, -1] : !stencil.temp<[-1,1023]x[-1,511]xtensor<512xf32>>
-// CHECK-NEXT:         %15 = "tensor.extract_slice"(%14) <{static_offsets = array<i64: 1>, static_sizes = array<i64: 510>, static_strides = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+// CHECK-NEXT:         %15 = tensor.extract_slice %14[1] [510] [1] : tensor<512xf32> to tensor<510xf32>
 // CHECK-NEXT:         %16 = arith.addf %15, %13 : tensor<510xf32>
 // CHECK-NEXT:         %17 = arith.addf %16, %11 : tensor<510xf32>
 // CHECK-NEXT:         %18 = arith.addf %17, %9 : tensor<510xf32>
@@ -163,17 +163,17 @@ builtin.module {
 // CHECK-NEXT:      %2 = stencil.apply(%3 = %1 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>) -> (!stencil.temp<[0,1]x[0,1]xtensor<510xf32>>) {
 // CHECK-NEXT:        %4 = arith.constant dense<1.666600e-01> : tensor<510xf32>
 // CHECK-NEXT:        %5 = stencil.access %3[1, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
-// CHECK-NEXT:        %6 = "tensor.extract_slice"(%5) <{static_offsets = array<i64: 1>, static_sizes = array<i64: 510>, static_strides = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+// CHECK-NEXT:        %6 = tensor.extract_slice %5[1] [510] [1] : tensor<512xf32> to tensor<510xf32>
 // CHECK-NEXT:        %7 = stencil.access %3[-1, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
-// CHECK-NEXT:        %8 = "tensor.extract_slice"(%7) <{static_offsets = array<i64: 1>, static_sizes = array<i64: 510>, static_strides = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+// CHECK-NEXT:        %8 = tensor.extract_slice %7[1] [510] [1] : tensor<512xf32> to tensor<510xf32>
 // CHECK-NEXT:        %9 = stencil.access %3[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
-// CHECK-NEXT:        %10 = "tensor.extract_slice"(%9) <{static_offsets = array<i64: 2>, static_sizes = array<i64: 510>, static_strides = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+// CHECK-NEXT:        %10 = tensor.extract_slice %9[2] [510] [1] : tensor<512xf32> to tensor<510xf32>
 // CHECK-NEXT:        %11 = stencil.access %3[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
-// CHECK-NEXT:        %12 = "tensor.extract_slice"(%11) <{static_offsets = array<i64: 0>, static_sizes = array<i64: 510>, static_strides = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+// CHECK-NEXT:        %12 = tensor.extract_slice %11[0] [510] [1] : tensor<512xf32> to tensor<510xf32>
 // CHECK-NEXT:        %13 = stencil.access %3[0, 1] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
-// CHECK-NEXT:        %14 = "tensor.extract_slice"(%13) <{static_offsets = array<i64: 1>, static_sizes = array<i64: 510>, static_strides = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+// CHECK-NEXT:        %14 = tensor.extract_slice %13[1] [510] [1] : tensor<512xf32> to tensor<510xf32>
 // CHECK-NEXT:        %15 = stencil.access %3[0, -1] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
-// CHECK-NEXT:        %16 = "tensor.extract_slice"(%15) <{static_offsets = array<i64: 1>, static_sizes = array<i64: 510>, static_strides = array<i64: 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+// CHECK-NEXT:        %16 = tensor.extract_slice %15[1] [510] [1] : tensor<512xf32> to tensor<510xf32>
 // CHECK-NEXT:        %17 = arith.addf %16, %14 : tensor<510xf32>
 // CHECK-NEXT:        %18 = arith.addf %17, %12 : tensor<510xf32>
 // CHECK-NEXT:        %19 = arith.addf %18, %10 : tensor<510xf32>

--- a/xdsl/dialects/tensor.py
+++ b/xdsl/dialects/tensor.py
@@ -28,6 +28,7 @@ from xdsl.dialects.utils import (
     parse_dynamic_index_list_without_types,
     print_dynamic_index_list,
     split_dynamic_index_list,
+    verify_dynamic_index_list,
 )
 from xdsl.dialects.utils.reshape_ops_utils import (
     ContiguousArrayOfIntArray,
@@ -564,6 +565,36 @@ class ExtractSliceOp(IRDLOperation):
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
     traits = traits_def(Pure())
+
+    assembly_format = (
+        "$source ``"
+        "custom<DynamicIndexList>($offsets, $static_offsets)"
+        "custom<DynamicIndexList>($sizes, $static_sizes)"
+        "custom<DynamicIndexList>($strides, $static_strides)"
+        "attr-dict `:` type($source) `to` type($result)"
+    )
+
+    custom_directives = (DynamicIndexList,)
+
+    def verify_(self) -> None:
+        verify_dynamic_index_list(
+            self.static_offsets.get_values(),
+            self.offsets,
+            DYNAMIC_INDEX,
+            " in the offset arguments",
+        )
+        verify_dynamic_index_list(
+            self.static_sizes.get_values(),
+            self.sizes,
+            DYNAMIC_INDEX,
+            " in the size arguments",
+        )
+        verify_dynamic_index_list(
+            self.static_strides.get_values(),
+            self.strides,
+            DYNAMIC_INDEX,
+            " in the stride arguments",
+        )
 
     def __init__(
         self,


### PR DESCRIPTION
`tensor.extract_slice` had no syntax of its own, so it was written as a generic op, with the dynamic offsets, sizes and strides listed as operands and the static ones as three arrays. Which operand belonged to which group, and where in that group it went, was left to the reader to work out from `operandSegmentSizes` and the position of each `-9223372036854775808` marker:

```mlir
%b = "tensor.extract_slice"(%t, %i) <{static_offsets = array<i64: -9223372036854775808, 0>, static_sizes = array<i64: 4, 4>, static_strides = array<i64: 1, 1>, operandSegmentSizes = array<i32: 1, 1, 0, 0>}> : (tensor<8x16xf32>, index) -> tensor<4x4xf32>
```

It takes the syntax MLIR gives it now, which interleaves each group into one bracketed list, so an operand is read where its value is used:

```mlir
%b = tensor.extract_slice %t[%i, 0] [4, 4] [1, 1] : tensor<8x16xf32> to tensor<4x4xf32>
```

The format and the `custom<DynamicIndexList>` directives are those of `memref.subview`, which is the same op over memory and already reads this way. A subview also verifies that each group passes as many operands as it has dynamic markers, which an extract_slice now does too, so that a mismatch is reported rather than quietly read as a shorter list.

### Tests

Nothing round-tripped the op through the dialect test, so three cases are added there: one entirely static, one mixing a dynamic offset with a dynamic size so that the interleaving is read per group rather than all at once, and one carrying an attribute dictionary. Both the custom and the generic round trip run over them.

The verifier is given a case per group, so a mismatch in the offsets, in the sizes and in the strides are each reported.

The remaining changes are the printed form of the op in the tests that already covered the passes producing it.