### PR TITLE
dialects: (linalg) tile reduction dimensions

### DIFF
--- a/tests/filecheck/transforms/linalg-tiling-reject-unsupported.mlir
+++ b/tests/filecheck/transforms/linalg-tiling-reject-unsupported.mlir
@@ -83,24 +83,6 @@ builtin.module {
   %output = "test.op"() : () -> memref<4x4xf32>
   linalg.generic {
       indexing_maps = [
-          affine_map<(i, j) -> (i, j)>,
-          affine_map<(i, j) -> (i, j)>
-      ],
-      iterator_types = ["parallel", "reduction"]
-  } ins(%input : memref<4x4xf32>) outs(%output : memref<4x4xf32>) attrs = {test_tile_sizes = array<i32: 2, 2>} {
-  ^bb0(%in: f32, %out: f32):
-      linalg.yield %in : f32
-  }
-}
-// CHECK: tiling of non-parallel iterator dimensions is not supported yet
-
-// -----
-
-builtin.module {
-  %input = "test.op"() : () -> memref<4x4xf32>
-  %output = "test.op"() : () -> memref<4x4xf32>
-  linalg.generic {
-      indexing_maps = [
           affine_map<(i, j) -> (i + j)>,
           affine_map<(i, j) -> (i, j)>
       ],

--- a/tests/filecheck/transforms/linalg-tiling.mlir
+++ b/tests/filecheck/transforms/linalg-tiling.mlir
@@ -356,3 +356,120 @@ linalg.generic {
 // CHECK-NEXT:     }
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
+
+// -----
+
+// A tiled reduction dimension is absent from the output indexing map, so each
+// tile takes the whole output, reads what the last tile left in it and
+// accumulates into that. Here only the reduction dimension of a matmul is tiled.
+
+%A, %B, %C = "test.op"() : () -> (tensor<4x6xf32>, tensor<6x4xf32>, tensor<4x4xf32>)
+
+%D = linalg.generic {
+  indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>],
+  iterator_types = ["parallel", "parallel", "reduction"]
+} ins(%A, %B : tensor<4x6xf32>, tensor<6x4xf32>) outs(%C : tensor<4x4xf32>) attrs = {test_tile_sizes = array<i32: 0, 0, 2>} {
+^bb0(%a: f32, %b: f32, %c: f32):
+  %m = arith.mulf %a, %b : f32
+  %s = arith.addf %c, %m : f32
+  linalg.yield %s : f32
+} -> tensor<4x4xf32>
+
+"test.op"(%D) : (tensor<4x4xf32>) -> ()
+
+// CHECK:      builtin.module {
+// CHECK-NEXT:   %A, %B, %C = "test.op"() : () -> (tensor<4x6xf32>, tensor<6x4xf32>, tensor<4x4xf32>)
+// CHECK-NEXT:   %0 = arith.constant 0 : index
+// CHECK-NEXT:   %1 = arith.constant 6 : index
+// CHECK-NEXT:   %2 = arith.constant 2 : index
+// CHECK-NEXT:   %D = scf.for %3 = %0 to %1 step %2 iter_args(%4 = %C) -> (tensor<4x4xf32>) {
+// CHECK-NEXT:     %5 = tensor.extract_slice %A[0, %3] [4, 2] [1, 1] : tensor<4x6xf32> to tensor<4x2xf32>
+// CHECK-NEXT:     %6 = tensor.extract_slice %B[%3, 0] [2, 4] [1, 1] : tensor<6x4xf32> to tensor<2x4xf32>
+// CHECK-NEXT:     %7 = tensor.extract_slice %4[0, 0] [4, 4] [1, 1] : tensor<4x4xf32> to tensor<4x4xf32>
+// CHECK-NEXT:     %8 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%5, %6 : tensor<4x2xf32>, tensor<2x4xf32>) outs(%7 : tensor<4x4xf32>) {
+// CHECK-NEXT:     ^bb0(%a: f32, %b: f32, %c: f32):
+// CHECK-NEXT:       %m = arith.mulf %a, %b : f32
+// CHECK-NEXT:       %s = arith.addf %c, %m : f32
+// CHECK-NEXT:       linalg.yield %s : f32
+// CHECK-NEXT:     } -> tensor<4x4xf32>
+// CHECK-NEXT:     %9 = tensor.insert_slice %8 into %4[0, 0] [4, 4] [1, 1] : tensor<4x4xf32> into tensor<4x4xf32>
+// CHECK-NEXT:     scf.yield %9 : tensor<4x4xf32>
+// CHECK-NEXT:   }
+// CHECK-NEXT:   "test.op"(%D) : (tensor<4x4xf32>) -> ()
+// CHECK-NEXT: }
+
+// -----
+
+// The same over memrefs, where a tile accumulates into the output through its
+// subview rather than through a carried value.
+
+%A, %B, %C = "test.op"() : () -> (memref<4x6xf32>, memref<6x4xf32>, memref<4x4xf32>)
+
+linalg.generic {
+  indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>],
+  iterator_types = ["parallel", "parallel", "reduction"]
+} ins(%A, %B : memref<4x6xf32>, memref<6x4xf32>) outs(%C : memref<4x4xf32>) attrs = {test_tile_sizes = array<i32: 0, 0, 2>} {
+^bb0(%a: f32, %b: f32, %c: f32):
+  %m = arith.mulf %a, %b : f32
+  %s = arith.addf %c, %m : f32
+  linalg.yield %s : f32
+}
+
+// CHECK:      builtin.module {
+// CHECK-NEXT:   %A, %B, %C = "test.op"() : () -> (memref<4x6xf32>, memref<6x4xf32>, memref<4x4xf32>)
+// CHECK-NEXT:   %0 = arith.constant 0 : index
+// CHECK-NEXT:   %1 = arith.constant 6 : index
+// CHECK-NEXT:   %2 = arith.constant 2 : index
+// CHECK-NEXT:   scf.for %3 = %0 to %1 step %2 {
+// CHECK-NEXT:     %4 = memref.subview %A[0, %3] [4, 2] [1, 1] : memref<4x6xf32> to memref<4x2xf32, strided<[6, 1], offset: ?>>
+// CHECK-NEXT:     %5 = memref.subview %B[%3, 0] [2, 4] [1, 1] : memref<6x4xf32> to memref<2x4xf32, strided<[4, 1], offset: ?>>
+// CHECK-NEXT:     %6 = memref.subview %C[0, 0] [4, 4] [1, 1] : memref<4x4xf32> to memref<4x4xf32, strided<[4, 1]>>
+// CHECK-NEXT:     linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%4, %5 : memref<4x2xf32, strided<[6, 1], offset: ?>>, memref<2x4xf32, strided<[4, 1], offset: ?>>) outs(%6 : memref<4x4xf32, strided<[4, 1]>>) {
+// CHECK-NEXT:     ^bb0(%a: f32, %b: f32, %c: f32):
+// CHECK-NEXT:       %m = arith.mulf %a, %b : f32
+// CHECK-NEXT:       %s = arith.addf %c, %m : f32
+// CHECK-NEXT:       linalg.yield %s : f32
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+
+// -----
+
+// A reduction dimension that the tile size does not divide, where the last tile
+// runs past the end of the dimension and is clamped like any other.
+
+%A, %B, %C = "test.op"() : () -> (tensor<4x6xf32>, tensor<6x4xf32>, tensor<4x4xf32>)
+
+%D = linalg.generic {
+  indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>],
+  iterator_types = ["parallel", "parallel", "reduction"]
+} ins(%A, %B : tensor<4x6xf32>, tensor<6x4xf32>) outs(%C : tensor<4x4xf32>) attrs = {test_tile_sizes = array<i32: 0, 0, 4>} {
+^bb0(%a: f32, %b: f32, %c: f32):
+  %m = arith.mulf %a, %b : f32
+  %s = arith.addf %c, %m : f32
+  linalg.yield %s : f32
+} -> tensor<4x4xf32>
+
+"test.op"(%D) : (tensor<4x4xf32>) -> ()
+
+// CHECK:      builtin.module {
+// CHECK-NEXT:   %A, %B, %C = "test.op"() : () -> (tensor<4x6xf32>, tensor<6x4xf32>, tensor<4x4xf32>)
+// CHECK-NEXT:   %0 = arith.constant 0 : index
+// CHECK-NEXT:   %1 = arith.constant 6 : index
+// CHECK-NEXT:   %2 = arith.constant 4 : index
+// CHECK-NEXT:   %D = scf.for %3 = %0 to %1 step %2 iter_args(%4 = %C) -> (tensor<4x4xf32>) {
+// CHECK-NEXT:     %5 = affine.min affine_map<(d0, d1, d2) -> (d0, (d1 + (d2 * -1)))> (%2, %1, %3)
+// CHECK-NEXT:     %6 = tensor.extract_slice %A[0, %3] [4, %5] [1, 1] : tensor<4x6xf32> to tensor<4x?xf32>
+// CHECK-NEXT:     %7 = tensor.extract_slice %B[%3, 0] [%5, 4] [1, 1] : tensor<6x4xf32> to tensor<?x4xf32>
+// CHECK-NEXT:     %8 = tensor.extract_slice %4[0, 0] [4, 4] [1, 1] : tensor<4x4xf32> to tensor<4x4xf32>
+// CHECK-NEXT:     %9 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%6, %7 : tensor<4x?xf32>, tensor<?x4xf32>) outs(%8 : tensor<4x4xf32>) {
+// CHECK-NEXT:     ^bb0(%a: f32, %b: f32, %c: f32):
+// CHECK-NEXT:       %m = arith.mulf %a, %b : f32
+// CHECK-NEXT:       %s = arith.addf %c, %m : f32
+// CHECK-NEXT:       linalg.yield %s : f32
+// CHECK-NEXT:     } -> tensor<4x4xf32>
+// CHECK-NEXT:     %10 = tensor.insert_slice %9 into %4[0, 0] [4, 4] [1, 1] : tensor<4x4xf32> into tensor<4x4xf32>
+// CHECK-NEXT:     scf.yield %10 : tensor<4x4xf32>
+// CHECK-NEXT:   }
+// CHECK-NEXT:   "test.op"(%D) : (tensor<4x4xf32>) -> ()
+// CHECK-NEXT: }

--- a/tests/transforms/test_linalg_tiling_helpers.py
+++ b/tests/transforms/test_linalg_tiling_helpers.py
@@ -153,7 +153,7 @@ def test_tiling_plan_rejects_linalg_index():
         TilingPlan.analyze_generic_op(op, (2, 0))
 
 
-def test_tiling_plan_rejects_non_parallel_tiled_iterator():
+def test_tiling_plan_tiles_a_non_parallel_iterator():
     op = _generic_2d_copy_op(
         iterator_types=[
             linalg.attrs.IteratorTypeAttr(linalg.attrs.IteratorType.PARALLEL),
@@ -161,8 +161,9 @@ def test_tiling_plan_rejects_non_parallel_tiled_iterator():
         ]
     )
 
-    with pytest.raises(ValueError, match="non-parallel iterator dimensions"):
-        TilingPlan.analyze_generic_op(op, (0, 2))
+    plan = TilingPlan.analyze_generic_op(op, (0, 2))
+
+    assert plan.tiled_dims == (1,)
 
 
 def test_tiling_plan_rejects_operand_that_is_neither_memref_nor_tensor():

--- a/xdsl/dialects/linalg/transforms/tiling.py
+++ b/xdsl/dialects/linalg/transforms/tiling.py
@@ -193,13 +193,12 @@ def _verify_generic_is_tileable(
             "tiling linalg.generic using linalg.index is not supported yet"
         )
 
-    iterator_types = tuple(iterator.data for iterator in op.get_iterator_types())
-    if any(
-        iterator_types[dim] != linalg.attrs.IteratorType.PARALLEL for dim in tiled_dims
-    ):
-        raise ValueError(
-            "tiling of non-parallel iterator dimensions is not supported yet"
-        )
+    # A reduction dimension is tiled like any other. It is absent from the output
+    # indexing maps, being the dimension reduced away, so the output is not sliced
+    # along it and each tile reads the value the last one left, accumulating into
+    # it. The tiles run in the order the untiled dimension did, which leaves the
+    # reduction associating as it did before, so this holds for a reduction that
+    # cannot be reassociated, such as one over floats.
 
     indexing_maps = tuple(attr.data for attr in op.get_indexing_maps())
     for operand, indexing_map in zip(op.operands, indexing_maps, strict=True):


### PR DESCRIPTION
Ticks `reduction tiling` on #6140.

Tiling rejected any dimension that was not parallel, so a matmul could be tiled over its two parallel dimensions but not over the one it reduces, which is often the dimension tiling it is worth the most.

A reduction dimension turns out to need nothing that a parallel one does not. It is absent from the output indexing maps, being the dimension reduced away, so the output is not sliced along it. Each tile takes the whole output, reads what the last tile left there, and accumulates into it: over the value the loop carries for tensors, and through the subview for memrefs.

```mlir
%D = scf.for %3 = %0 to %1 step %2 iter_args(%4 = %C) -> (tensor<4x4xf32>) {
  %5 = tensor.extract_slice %A[0, %3] [4, 2] [1, 1] : tensor<4x6xf32> to tensor<4x2xf32>
  %6 = tensor.extract_slice %B[%3, 0] [2, 4] [1, 1] : tensor<6x4xf32> to tensor<2x4xf32>
  %7 = tensor.extract_slice %4[0, 0] [4, 4] [1, 1] : tensor<4x4xf32> to tensor<4x4xf32>
  ...
```

The two inputs are sliced along the reduction dimension and the output is not, taken whole from `%4`, the value the loop carries, rather than from `%C`.

The tiles also run in the order the untiled dimension did, so the reduction associates as it did before. That is what makes this sound for a reduction that cannot be reassociated, such as one over floats.

It is how upstream tiles a reduction dimension by default. Its `FullReduction` strategy, the default one, is written there as `[reduction] -> [reduction1, reduction2]`, a loop over reduction tiles around a reduction within the tile, and it is the one strategy that needs nothing merged afterwards. The other two turn part of the reduction parallel and so do reassociate it, which is what `PartialReductionOpInterface` is asked for. This does not do that.

Upstream also says where the danger in this actually lies. Tiling a non-parallel dimension is only remarked on when the loop being built is an `scf.forall`, and then only as a warning:

```cpp
if (loopType == scf::SCFTilingOptions::LoopType::ForallOp &&
    reductionStrategy == ReductionTilingStrategy::FullReduction) {
  ...
      op.emitWarning() << "tiling is not thread safe at axis #" << index;
```

There is no such check when the loop is an `scf.for`. What a reduction cannot survive is its tiles running at the same time, rather than its being tiled at all, and the loops built here are `scf.for`, which run one after another.

So the change to the pass is the guard going, and a note on why the rest already holds.

### Tests

Three cases, being the conditions the output slice is built under: a matmul tiled over its reduction dimension alone, the same over memrefs, and one whose tile size does not divide the reduction dimension so that the last tile is clamped by an `affine.min` like any other.

I checked these have teeth by putting the guard back, which fails all three.

The case rejecting a non-parallel dimension goes from the rejection tests, and the unit test that asserted the rejection now asserts the plan tiles the dimension instead.
