### PR TITLE
dialects: (tensor) give insert_slice its own syntax

### DIFF
--- a/tests/filecheck/dialects/csl/csl-stencil-canonicalize.mlir
+++ b/tests/filecheck/dialects/csl/csl-stencil-canonicalize.mlir
@@ -9,7 +9,7 @@ builtin.module {
     %2 = csl_stencil.apply(%0 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %1 : tensor<510xf32>) -> (!stencil.temp<[0,1]x[0,1]xtensor<510xf32>>) <{"num_chunks" = 2, "topo" = #dmp.topo<1022x510>, "swaps" = [#csl_stencil.exchange<to [1, 0]>, #csl_stencil.exchange<to [-1, 0]>, #csl_stencil.exchange<to [0, 1]>, #csl_stencil.exchange<to [0, -1]>], operandSegmentSizes = array<i32: 1, 1, 0, 0, 0>}> ({
       ^bb0(%3: tensor<4x255xf32>, %4: index, %5: tensor<510xf32>):
         %6 = csl_stencil.access %3[1, 0] : tensor<4x255xf32>
-        %7 = "tensor.insert_slice"(%6, %5, %4) <{"static_offsets" = array<i64: 0>, "static_sizes" = array<i64: 255>, "static_strides" = array<i64: 1>, operandSegmentSizes = array<i32: 1, 1, 1, 0, 0>}> : (tensor<255xf32>, tensor<510xf32>, index) -> tensor<510xf32>
+        %7 = tensor.insert_slice %6 into %5[%4] [255] [1] : tensor<255xf32> into tensor<510xf32>
         csl_stencil.yield %7 : tensor<510xf32>
       }, {
       ^bb0(%8: !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %9: tensor<510xf32>):
@@ -21,7 +21,7 @@ builtin.module {
     %11 = csl_stencil.apply(%0 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %10 : tensor<510xf32>) -> (!stencil.temp<[0,1]x[0,1]xtensor<510xf32>>) <{"num_chunks" = 2, "topo" = #dmp.topo<1022x510>, "swaps" = [#csl_stencil.exchange<to [1, 0]>, #csl_stencil.exchange<to [-1, 0]>, #csl_stencil.exchange<to [0, 1]>, #csl_stencil.exchange<to [0, -1]>], operandSegmentSizes = array<i32: 1, 1, 0, 0, 0>}> ({
       ^bb0(%12: tensor<4x255xf32>, %13: index, %14: tensor<510xf32>):
         %15 = csl_stencil.access %12[1, 0] : tensor<4x255xf32>
-        %16 = "tensor.insert_slice"(%15, %14, %13) <{"static_offsets" = array<i64: 0>, "static_sizes" = array<i64: 255>, "static_strides" = array<i64: 1>, operandSegmentSizes = array<i32: 1, 1, 1, 0, 0>}> : (tensor<255xf32>, tensor<510xf32>, index) -> tensor<510xf32>
+        %16 = tensor.insert_slice %15 into %14[%13] [255] [1] : tensor<255xf32> into tensor<510xf32>
         csl_stencil.yield %16 : tensor<510xf32>
       }, {
       ^bb0(%17: !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %18: tensor<510xf32>):
@@ -33,7 +33,7 @@ builtin.module {
     %20 = csl_stencil.apply(%0 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %19 : tensor<510xf32>) -> (!stencil.temp<[0,1]x[0,1]xtensor<510xf32>>) <{"num_chunks" = 2, "topo" = #dmp.topo<1022x510>, "swaps" = [#csl_stencil.exchange<to [1, 0]>, #csl_stencil.exchange<to [-1, 0]>, #csl_stencil.exchange<to [0, 1]>, #csl_stencil.exchange<to [0, -1]>], operandSegmentSizes = array<i32: 1, 1, 0, 0, 0>}> ({
       ^bb0(%21: tensor<4x255xf32>, %22: index, %23: tensor<510xf32>):
         %24 = csl_stencil.access %21[1, 0] : tensor<4x255xf32>
-        %25 = "tensor.insert_slice"(%24, %23, %22) <{"static_offsets" = array<i64: 0>, "static_sizes" = array<i64: 255>, "static_strides" = array<i64: 1>, operandSegmentSizes = array<i32: 1, 1, 1, 0, 0>}> : (tensor<255xf32>, tensor<510xf32>, index) -> tensor<510xf32>
+        %25 = tensor.insert_slice %24 into %23[%22] [255] [1] : tensor<255xf32> into tensor<510xf32>
         csl_stencil.yield %25 : tensor<510xf32>
       }, {
       ^bb0(%26: !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %27: tensor<510xf32>):
@@ -52,7 +52,7 @@ builtin.module {
 // CHECK-NEXT:     %2 = csl_stencil.apply(%0 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %1 : tensor<510xf32>) -> (!stencil.temp<[0,1]x[0,1]xtensor<510xf32>>) <{num_chunks = 2 : i64, topo = #dmp.topo<1022x510>, swaps = [#csl_stencil.exchange<to [1, 0]>, #csl_stencil.exchange<to [-1, 0]>, #csl_stencil.exchange<to [0, 1]>, #csl_stencil.exchange<to [0, -1]>], operandSegmentSizes = array<i32: 1, 1, 0, 0, 0>}> ({
 // CHECK-NEXT:     ^bb0(%3: tensor<4x255xf32>, %4: index, %5: tensor<510xf32>):
 // CHECK-NEXT:       %6 = csl_stencil.access %3[1, 0] : tensor<4x255xf32>
-// CHECK-NEXT:       %7 = "tensor.insert_slice"(%6, %5, %4) <{static_offsets = array<i64: 0>, static_sizes = array<i64: 255>, static_strides = array<i64: 1>, operandSegmentSizes = array<i32: 1, 1, 1, 0, 0>}> : (tensor<255xf32>, tensor<510xf32>, index) -> tensor<510xf32>
+// CHECK-NEXT:       %7 = tensor.insert_slice %6 into %5[%4] [255] [1] : tensor<255xf32> into tensor<510xf32>
 // CHECK-NEXT:       csl_stencil.yield %7 : tensor<510xf32>
 // CHECK-NEXT:     }, {
 // CHECK-NEXT:     ^bb0(%8: !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %9: tensor<510xf32>):
@@ -62,7 +62,7 @@ builtin.module {
 // CHECK-NEXT:     %3 = csl_stencil.apply(%0 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %1 : tensor<510xf32>) -> (!stencil.temp<[0,1]x[0,1]xtensor<510xf32>>) <{num_chunks = 2 : i64, topo = #dmp.topo<1022x510>, swaps = [#csl_stencil.exchange<to [1, 0]>, #csl_stencil.exchange<to [-1, 0]>, #csl_stencil.exchange<to [0, 1]>, #csl_stencil.exchange<to [0, -1]>], operandSegmentSizes = array<i32: 1, 1, 0, 0, 0>}> ({
 // CHECK-NEXT:     ^bb0(%4: tensor<4x255xf32>, %5: index, %6: tensor<510xf32>):
 // CHECK-NEXT:       %7 = csl_stencil.access %4[1, 0] : tensor<4x255xf32>
-// CHECK-NEXT:       %8 = "tensor.insert_slice"(%7, %6, %5) <{static_offsets = array<i64: 0>, static_sizes = array<i64: 255>, static_strides = array<i64: 1>, operandSegmentSizes = array<i32: 1, 1, 1, 0, 0>}> : (tensor<255xf32>, tensor<510xf32>, index) -> tensor<510xf32>
+// CHECK-NEXT:       %8 = tensor.insert_slice %7 into %6[%5] [255] [1] : tensor<255xf32> into tensor<510xf32>
 // CHECK-NEXT:       csl_stencil.yield %8 : tensor<510xf32>
 // CHECK-NEXT:     }, {
 // CHECK-NEXT:     ^bb0(%9: !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %10: tensor<510xf32>):
@@ -72,7 +72,7 @@ builtin.module {
 // CHECK-NEXT:     %4 = csl_stencil.apply(%0 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %1 : tensor<510xf32>) -> (!stencil.temp<[0,1]x[0,1]xtensor<510xf32>>) <{num_chunks = 2 : i64, topo = #dmp.topo<1022x510>, swaps = [#csl_stencil.exchange<to [1, 0]>, #csl_stencil.exchange<to [-1, 0]>, #csl_stencil.exchange<to [0, 1]>, #csl_stencil.exchange<to [0, -1]>], operandSegmentSizes = array<i32: 1, 1, 0, 0, 0>}> ({
 // CHECK-NEXT:     ^bb0(%5: tensor<4x255xf32>, %6: index, %7: tensor<510xf32>):
 // CHECK-NEXT:       %8 = csl_stencil.access %5[1, 0] : tensor<4x255xf32>
-// CHECK-NEXT:       %9 = "tensor.insert_slice"(%8, %7, %6) <{static_offsets = array<i64: 0>, static_sizes = array<i64: 255>, static_strides = array<i64: 1>, operandSegmentSizes = array<i32: 1, 1, 1, 0, 0>}> : (tensor<255xf32>, tensor<510xf32>, index) -> tensor<510xf32>
+// CHECK-NEXT:       %9 = tensor.insert_slice %8 into %7[%6] [255] [1] : tensor<255xf32> into tensor<510xf32>
 // CHECK-NEXT:       csl_stencil.yield %9 : tensor<510xf32>
 // CHECK-NEXT:     }, {
 // CHECK-NEXT:     ^bb0(%10: !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %11: tensor<510xf32>):

--- a/tests/filecheck/dialects/csl/csl-stencil-ops.mlir
+++ b/tests/filecheck/dialects/csl/csl-stencil-ops.mlir
@@ -112,7 +112,7 @@ builtin.module {
         %9 = arith.addf %8, %6 : tensor<255xf32>
         %10 = arith.addf %9, %7 : tensor<255xf32>
 
-        %11 = "tensor.insert_slice"(%10, %iter_arg, %offset) <{"static_offsets" = array<i64: 0>, "static_sizes" = array<i64: 255>, "static_strides" = array<i64: 1>, operandSegmentSizes = array<i32: 1, 1, 1, 0, 0>}> : (tensor<255xf32>, tensor<510xf32>, index) -> tensor<510xf32>
+        %11 = tensor.insert_slice %10 into %iter_arg[%offset] [255] [1] : tensor<255xf32> into tensor<510xf32>
         csl_stencil.yield %11 : tensor<510xf32>
       }, {
       ^bb0(%3: !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %rcv: tensor<510xf32>):
@@ -151,7 +151,7 @@ builtin.module {
 // CHECK-NEXT:       %7 = arith.addf %3, %4 : tensor<255xf32>
 // CHECK-NEXT:       %8 = arith.addf %7, %5 : tensor<255xf32>
 // CHECK-NEXT:       %9 = arith.addf %8, %6 : tensor<255xf32>
-// CHECK-NEXT:       %10 = "tensor.insert_slice"(%9, %iter_arg, %offset) <{static_offsets = array<i64: 0>, static_sizes = array<i64: 255>, static_strides = array<i64: 1>, operandSegmentSizes = array<i32: 1, 1, 1, 0, 0>}> : (tensor<255xf32>, tensor<510xf32>, index) -> tensor<510xf32>
+// CHECK-NEXT:       %10 = tensor.insert_slice %9 into %iter_arg[%offset] [255] [1] : tensor<255xf32> into tensor<510xf32>
 // CHECK-NEXT:       csl_stencil.yield %10 : tensor<510xf32>
 // CHECK-NEXT:     }, {
 // CHECK-NEXT:     ^bb0(%11: !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %rcv: tensor<510xf32>):
@@ -186,7 +186,7 @@ builtin.module {
 // CHECK-GENERIC-NEXT:       %7 = "arith.addf"(%3, %4) <{fastmath = #arith.fastmath<none>}> : (tensor<255xf32>, tensor<255xf32>) -> tensor<255xf32>
 // CHECK-GENERIC-NEXT:       %8 = "arith.addf"(%7, %5) <{fastmath = #arith.fastmath<none>}> : (tensor<255xf32>, tensor<255xf32>) -> tensor<255xf32>
 // CHECK-GENERIC-NEXT:       %9 = "arith.addf"(%8, %6) <{fastmath = #arith.fastmath<none>}> : (tensor<255xf32>, tensor<255xf32>) -> tensor<255xf32>
-// CHECK-GENERIC-NEXT:       %10 = "tensor.insert_slice"(%9, %iter_arg, %offset) <{static_offsets = array<i64: 0>, static_sizes = array<i64: 255>, static_strides = array<i64: 1>, operandSegmentSizes = array<i32: 1, 1, 1, 0, 0>}> : (tensor<255xf32>, tensor<510xf32>, index) -> tensor<510xf32>
+// CHECK-GENERIC-NEXT:       %10 = "tensor.insert_slice"(%9, %iter_arg, %offset) <{static_offsets = array<i64: -9223372036854775808>, static_sizes = array<i64: 255>, static_strides = array<i64: 1>, operandSegmentSizes = array<i32: 1, 1, 1, 0, 0>}> : (tensor<255xf32>, tensor<510xf32>, index) -> tensor<510xf32>
 // CHECK-GENERIC-NEXT:       "csl_stencil.yield"(%10) : (tensor<510xf32>) -> ()
 // CHECK-GENERIC-NEXT:     }, {
 // CHECK-GENERIC-NEXT:     ^bb0(%11: !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %rcv: tensor<510xf32>):
@@ -225,7 +225,7 @@ builtin.module {
       %8 = arith.addf %7, %6 : tensor<255xf32>
       %9 = arith.addf %8, %5 : tensor<255xf32>
       %10 = arith.addf %9, %4 : tensor<255xf32>
-      %11 = "tensor.insert_slice"(%10, %3, %2) <{"static_offsets" = array<i64: -9223372036854775808>, "static_sizes" = array<i64: 255>, "static_strides" = array<i64: 1>, operandSegmentSizes = array<i32: 1, 1, 1, 0, 0>}> : (tensor<255xf32>, tensor<510xf32>, index) -> tensor<510xf32>
+      %11 = tensor.insert_slice %10 into %3[%2] [255] [1] : tensor<255xf32> into tensor<510xf32>
       csl_stencil.yield %11 : tensor<510xf32>
     }, {
     ^bb1(%12: !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>, %13: tensor<510xf32>):
@@ -254,7 +254,7 @@ builtin.module {
 //CHECK-NEXT:       %8 = arith.addf %7, %6 : tensor<255xf32>
 //CHECK-NEXT:       %9 = arith.addf %8, %5 : tensor<255xf32>
 //CHECK-NEXT:       %10 = arith.addf %9, %4 : tensor<255xf32>
-//CHECK-NEXT:       %11 = "tensor.insert_slice"(%10, %3, %2) <{static_offsets = array<i64: -9223372036854775808>, static_sizes = array<i64: 255>, static_strides = array<i64: 1>, operandSegmentSizes = array<i32: 1, 1, 1, 0, 0>}> : (tensor<255xf32>, tensor<510xf32>, index) -> tensor<510xf32>
+//CHECK-NEXT:       %11 = tensor.insert_slice %10 into %3[%2] [255] [1] : tensor<255xf32> into tensor<510xf32>
 //CHECK-NEXT:       csl_stencil.yield %11 : tensor<510xf32>
 //CHECK-NEXT:     }, {
 //CHECK-NEXT:     ^bb0(%12: !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>, %13: tensor<510xf32>):

--- a/tests/filecheck/dialects/tensor/invalid_ops.mlir
+++ b/tests/filecheck/dialects/tensor/invalid_ops.mlir
@@ -196,3 +196,18 @@ builtin.module {
 %t, %i = "test.op"() : () -> (tensor<8x16xf32>, index)
 // CHECK: The number of dynamic positions passed as values (1) does not match the number of dynamic position markers (0) in the stride arguments.
 %res = "tensor.extract_slice"(%t, %i) <{static_offsets = array<i64: 0, 0>, static_sizes = array<i64: 4, 4>, static_strides = array<i64: 1, 1>, operandSegmentSizes = array<i32: 1, 0, 0, 1>}> : (tensor<8x16xf32>, index) -> tensor<4x4xf32>
+
+// -----
+%s, %d, %i = "test.op"() : () -> (tensor<4x4xf32>, tensor<8x16xf32>, index)
+// CHECK: The number of dynamic positions passed as values (1) does not match the number of dynamic position markers (0) in the offset arguments.
+%res = "tensor.insert_slice"(%s, %d, %i) <{static_offsets = array<i64: 0, 0>, static_sizes = array<i64: 4, 4>, static_strides = array<i64: 1, 1>, operandSegmentSizes = array<i32: 1, 1, 1, 0, 0>}> : (tensor<4x4xf32>, tensor<8x16xf32>, index) -> tensor<8x16xf32>
+
+// -----
+%s, %d, %i = "test.op"() : () -> (tensor<4x4xf32>, tensor<8x16xf32>, index)
+// CHECK: The number of dynamic positions passed as values (1) does not match the number of dynamic position markers (0) in the size arguments.
+%res = "tensor.insert_slice"(%s, %d, %i) <{static_offsets = array<i64: 0, 0>, static_sizes = array<i64: 4, 4>, static_strides = array<i64: 1, 1>, operandSegmentSizes = array<i32: 1, 1, 0, 1, 0>}> : (tensor<4x4xf32>, tensor<8x16xf32>, index) -> tensor<8x16xf32>
+
+// -----
+%s, %d, %i = "test.op"() : () -> (tensor<4x4xf32>, tensor<8x16xf32>, index)
+// CHECK: The number of dynamic positions passed as values (1) does not match the number of dynamic position markers (0) in the stride arguments.
+%res = "tensor.insert_slice"(%s, %d, %i) <{static_offsets = array<i64: 0, 0>, static_sizes = array<i64: 4, 4>, static_strides = array<i64: 1, 1>, operandSegmentSizes = array<i32: 1, 1, 0, 0, 1>}> : (tensor<4x4xf32>, tensor<8x16xf32>, index) -> tensor<8x16xf32>

--- a/tests/filecheck/dialects/tensor/ops.mlir
+++ b/tests/filecheck/dialects/tensor/ops.mlir
@@ -12,6 +12,9 @@
 %extract_slice1 = tensor.extract_slice %cast1[0, 1] [2, 2] [1, 1] : tensor<4x4xf32> to tensor<2x2xf32>
 %extract_slice2 = tensor.extract_slice %cast1[%index, 1] [2, %index1] [1, 1] : tensor<4x4xf32> to tensor<2x?xf32>
 %extract_slice3 = tensor.extract_slice %cast1[0, 1] [2, 2] [1, 1] {hello = "world"} : tensor<4x4xf32> to tensor<2x2xf32>
+%insert_slice1 = tensor.insert_slice %extract_slice1 into %cast1[0, 1] [2, 2] [1, 1] : tensor<2x2xf32> into tensor<4x4xf32>
+%insert_slice2 = tensor.insert_slice %extract_slice1 into %cast1[%index, 1] [2, %index1] [1, 1] : tensor<2x2xf32> into tensor<4x4xf32>
+%insert_slice3 = tensor.insert_slice %extract_slice1 into %cast1[0, 1] [2, 2] [1, 1] {hello = "world"} : tensor<2x2xf32> into tensor<4x4xf32>
 %res_collapse1 = tensor.collapse_shape %tensor [ [0, 1], [2] ] : tensor<?x?xf32> into tensor<4x1xf32>
 
 %expanded1 = tensor.expand_shape %tensor [[0, 1, 2], [3]] output_shape [%dim1, 1, 1, %dim2] : tensor<?x?xf32> into tensor<?x1x1x?xf32>
@@ -50,6 +53,9 @@
 // CHECK-NEXT:   %extract_slice1 = tensor.extract_slice %cast1[0, 1] [2, 2] [1, 1] : tensor<4x4xf32> to tensor<2x2xf32>
 // CHECK-NEXT:   %extract_slice2 = tensor.extract_slice %cast1[%index, 1] [2, %index1] [1, 1] : tensor<4x4xf32> to tensor<2x?xf32>
 // CHECK-NEXT:   %extract_slice3 = tensor.extract_slice %cast1[0, 1] [2, 2] [1, 1] {hello = "world"} : tensor<4x4xf32> to tensor<2x2xf32>
+// CHECK-NEXT:   %insert_slice1 = tensor.insert_slice %extract_slice1 into %cast1[0, 1] [2, 2] [1, 1] : tensor<2x2xf32> into tensor<4x4xf32>
+// CHECK-NEXT:   %insert_slice2 = tensor.insert_slice %extract_slice1 into %cast1[%index, 1] [2, %index1] [1, 1] : tensor<2x2xf32> into tensor<4x4xf32>
+// CHECK-NEXT:   %insert_slice3 = tensor.insert_slice %extract_slice1 into %cast1[0, 1] [2, 2] [1, 1] {hello = "world"} : tensor<2x2xf32> into tensor<4x4xf32>
 // CHECK-NEXT:   %res_collapse1 = tensor.collapse_shape %tensor [[0 : i64, 1 : i64], [2 : i64]] : tensor<?x?xf32> into tensor<4x1xf32>
 // CHECK-NEXT:   %expanded1 = tensor.expand_shape %tensor [[0 : i64, 1 : i64, 2 : i64], [3 : i64]] output_shape [%dim1, 1, 1, %dim2] : tensor<?x?xf32> into tensor<?x1x1x?xf32>
 // CHECK-NEXT:   %expanded_with_attr_dict = tensor.expand_shape %tensor [[0 : i64, 1 : i64, 2 : i64], [3 : i64]] output_shape [%dim1, 1, 1, %dim2] {test_attr = 42 : i8} : tensor<?x?xf32> into tensor<?x1x1x?xf32>
@@ -84,6 +90,9 @@
 // CHECK-GENERIC-NEXT:   %extract_slice1 = "tensor.extract_slice"(%cast1) <{static_offsets = array<i64: 0, 1>, static_sizes = array<i64: 2, 2>, static_strides = array<i64: 1, 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> : (tensor<4x4xf32>) -> tensor<2x2xf32>
 // CHECK-GENERIC-NEXT:   %extract_slice2 = "tensor.extract_slice"(%cast1, %index, %index1) <{static_offsets = array<i64: -9223372036854775808, 1>, static_sizes = array<i64: 2, -9223372036854775808>, static_strides = array<i64: 1, 1>, operandSegmentSizes = array<i32: 1, 1, 1, 0>}> : (tensor<4x4xf32>, index, index) -> tensor<2x?xf32>
 // CHECK-GENERIC-NEXT:   %extract_slice3 = "tensor.extract_slice"(%cast1) <{static_offsets = array<i64: 0, 1>, static_sizes = array<i64: 2, 2>, static_strides = array<i64: 1, 1>, operandSegmentSizes = array<i32: 1, 0, 0, 0>}> {hello = "world"} : (tensor<4x4xf32>) -> tensor<2x2xf32>
+// CHECK-GENERIC-NEXT:   %insert_slice1 = "tensor.insert_slice"(%extract_slice1, %cast1) <{static_offsets = array<i64: 0, 1>, static_sizes = array<i64: 2, 2>, static_strides = array<i64: 1, 1>, operandSegmentSizes = array<i32: 1, 1, 0, 0, 0>}> : (tensor<2x2xf32>, tensor<4x4xf32>) -> tensor<4x4xf32>
+// CHECK-GENERIC-NEXT:   %insert_slice2 = "tensor.insert_slice"(%extract_slice1, %cast1, %index, %index1) <{static_offsets = array<i64: -9223372036854775808, 1>, static_sizes = array<i64: 2, -9223372036854775808>, static_strides = array<i64: 1, 1>, operandSegmentSizes = array<i32: 1, 1, 1, 1, 0>}> : (tensor<2x2xf32>, tensor<4x4xf32>, index, index) -> tensor<4x4xf32>
+// CHECK-GENERIC-NEXT:   %insert_slice3 = "tensor.insert_slice"(%extract_slice1, %cast1) <{static_offsets = array<i64: 0, 1>, static_sizes = array<i64: 2, 2>, static_strides = array<i64: 1, 1>, operandSegmentSizes = array<i32: 1, 1, 0, 0, 0>}> {hello = "world"} : (tensor<2x2xf32>, tensor<4x4xf32>) -> tensor<4x4xf32>
 // CHECK-GENERIC-NEXT:   %res_collapse1 = "tensor.collapse_shape"(%tensor) <{reassociation = [[0 : i64, 1 : i64], [2 : i64]]}> : (tensor<?x?xf32>) -> tensor<4x1xf32>
 // CHECK-GENERIC-NEXT:   %expanded1 = "tensor.expand_shape"(%tensor, %dim1, %dim2) <{reassociation = [[0 : i64, 1 : i64, 2 : i64], [3 : i64]], static_output_shape = array<i64: -9223372036854775808, 1, 1, -9223372036854775808>}> : (tensor<?x?xf32>, index, index) -> tensor<?x1x1x?xf32>
 // CHECK-GENERIC-NEXT:   %expanded_with_attr_dict = "tensor.expand_shape"(%tensor, %dim1, %dim2) <{reassociation = [[0 : i64, 1 : i64, 2 : i64], [3 : i64]], static_output_shape = array<i64: -9223372036854775808, 1, 1, -9223372036854775808>}> {test_attr = 42 : i8} : (tensor<?x?xf32>, index, index) -> tensor<?x1x1x?xf32>

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/tensor/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/tensor/ops.mlir
@@ -7,7 +7,7 @@
 %src = "test.op"() {"value" = dense<1.000000e-01> : tensor<4x1xf32>} : () -> tensor<4x1xf32>
 %shape = "test.op"() : () -> (tensor<1xi32>)
 %t4 = tensor.reshape %src(%shape) : (tensor<4x1xf32>, tensor<1xi32>) -> tensor<4xf32>
-%inserted_slice = "tensor.insert_slice"(%t2, %t1) <{"static_offsets" = array<i64: 0, 1>, "static_sizes" = array<i64: 1, 2>, "static_strides" = array<i64: 1, 1>, operandSegmentSizes = array<i32: 1, 1, 0, 0, 0>}> : (tensor<2xf32>, tensor<2x3xf32>) -> tensor<2x3xf32>
+%inserted_slice = tensor.insert_slice %t2 into %t1[0, 1] [1, 2] [1, 1] : tensor<2xf32> into tensor<2x3xf32>
 %extracted_slice = tensor.extract_slice %t1[0, 1] [1, 2] [1, 1] : tensor<2x3xf32> to tensor<2xf32>
 %dim1 = "tensor.dim"(%t1, %i1): (tensor<2x3xf32>, index) -> index
 %dim2 = "tensor.dim"(%t1, %i1) {"hello" = "world"}: (tensor<2x3xf32>, index) -> index

--- a/tests/filecheck/transforms/convert-stencil-to-csl-stencil.mlir
+++ b/tests/filecheck/transforms/convert-stencil-to-csl-stencil.mlir
@@ -46,7 +46,7 @@ builtin.module {
 // CHECK-NEXT:       %10 = arith.addf %9, %8 : tensor<255xf32>
 // CHECK-NEXT:       %11 = arith.addf %10, %7 : tensor<255xf32>
 // CHECK-NEXT:       %12 = arith.addf %11, %6 : tensor<255xf32>
-// CHECK-NEXT:       %13 = "tensor.insert_slice"(%12, %5, %4) <{static_offsets = array<i64: -9223372036854775808>, static_sizes = array<i64: 255>, static_strides = array<i64: 1>, operandSegmentSizes = array<i32: 1, 1, 1, 0, 0>}> : (tensor<255xf32>, tensor<510xf32>, index) -> tensor<510xf32>
+// CHECK-NEXT:       %13 = tensor.insert_slice %12 into %5[%4] [255] [1] : tensor<255xf32> into tensor<510xf32>
 // CHECK-NEXT:       csl_stencil.yield %13 : tensor<510xf32>
 // CHECK-NEXT:     }, {
 // CHECK-NEXT:     ^bb0(%14: !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %15: tensor<510xf32>):
@@ -93,7 +93,7 @@ builtin.module {
 // CHECK-NEXT:     %5 = csl_stencil.access %2[1, 0] : tensor<4x255xf32>
 // CHECK-NEXT:     %6 = csl_stencil.access %2[0, -1] : tensor<4x255xf32>
 // CHECK-NEXT:     %7 = arith.addf %6, %5 : tensor<255xf32>
-// CHECK-NEXT:     %8 = "tensor.insert_slice"(%7, %4, %3) <{static_offsets = array<i64: -9223372036854775808>, static_sizes = array<i64: 255>, static_strides = array<i64: 1>, operandSegmentSizes = array<i32: 1, 1, 1, 0, 0>}> : (tensor<255xf32>, tensor<510xf32>, index) -> tensor<510xf32>
+// CHECK-NEXT:     %8 = tensor.insert_slice %7 into %4[%3] [255] [1] : tensor<255xf32> into tensor<510xf32>
 // CHECK-NEXT:     csl_stencil.yield %8 : tensor<510xf32>
 // CHECK-NEXT:   }, {
 // CHECK-NEXT:   ^bb0(%9: !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>, %10: tensor<510xf32>):
@@ -138,7 +138,7 @@ builtin.module {
 // CHECK-NEXT:     %5 = csl_stencil.access %2[1, 0] : tensor<4x255xf32>
 // CHECK-NEXT:     %6 = csl_stencil.access %2[0, -1] : tensor<4x255xf32>
 // CHECK-NEXT:     %7 = arith.addf %6, %5 : tensor<255xf32>
-// CHECK-NEXT:     %8 = "tensor.insert_slice"(%7, %4, %3) <{static_offsets = array<i64: -9223372036854775808>, static_sizes = array<i64: 255>, static_strides = array<i64: 1>, operandSegmentSizes = array<i32: 1, 1, 1, 0, 0>}> : (tensor<255xf32>, tensor<510xf32>, index) -> tensor<510xf32>
+// CHECK-NEXT:     %8 = tensor.insert_slice %7 into %4[%3] [255] [1] : tensor<255xf32> into tensor<510xf32>
 // CHECK-NEXT:     csl_stencil.yield %8 : tensor<510xf32>
 // CHECK-NEXT:   }, {
 // CHECK-NEXT:   ^bb0(%9: !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>, %10: tensor<510xf32>):
@@ -191,7 +191,7 @@ builtin.module {
 // CHECK-NEXT:       %9 = csl_stencil.access %6[-1, 0] : tensor<8x300xf32>
 // CHECK-NEXT:       %10 = csl_stencil.access %6[1, 0] : tensor<8x300xf32>
 // CHECK-NEXT:       %11 = arith.addf %9, %10 : tensor<300xf32>
-// CHECK-NEXT:       %12 = "tensor.insert_slice"(%11, %8, %7) <{static_offsets = array<i64: -9223372036854775808>, static_sizes = array<i64: 300>, static_strides = array<i64: 1>, operandSegmentSizes = array<i32: 1, 1, 1, 0, 0>}> : (tensor<300xf32>, tensor<600xf32>, index) -> tensor<600xf32>
+// CHECK-NEXT:       %12 = tensor.insert_slice %11 into %8[%7] [300] [1] : tensor<300xf32> into tensor<600xf32>
 // CHECK-NEXT:       csl_stencil.yield %12 : tensor<600xf32>
 // CHECK-NEXT:     }, {
 // CHECK-NEXT:     ^bb0(%13: !stencil.field<[-2,3]x[-2,3]xtensor<604xf32>>, %14: tensor<600xf32>):
@@ -232,7 +232,7 @@ builtin.module {
 // CHECK-NEXT:   csl_stencil.apply(%arg1 : !stencil.field<[-1,1]x[-1,1]xtensor<64xf32>>, %0 : tensor<1x64xf32>) -> () <{swaps = [#csl_stencil.exchange<to [-1, 0]>], topo = #dmp.topo<64x64>, num_chunks = 2 : i64, operandSegmentSizes = array<i32: 1, 1, 0, 0, 0>}> ({
 // CHECK-NEXT:   ^bb0(%1: tensor<1x32xf32>, %2: index, %3: tensor<1x64xf32>):
 // CHECK-NEXT:     %4 = csl_stencil.access %1[-1, 0] : tensor<1x32xf32>
-// CHECK-NEXT:     %5 = "tensor.insert_slice"(%4, %3, %2) <{static_offsets = array<i64: 0, -9223372036854775808>, static_sizes = array<i64: 1, 32>, static_strides = array<i64: 1, 1>, operandSegmentSizes = array<i32: 1, 1, 1, 0, 0>}> : (tensor<32xf32>, tensor<1x64xf32>, index) -> tensor<1x64xf32>
+// CHECK-NEXT:     %5 = tensor.insert_slice %4 into %3[0, %2] [1, 32] [1, 1] : tensor<32xf32> into tensor<1x64xf32>
 // CHECK-NEXT:     csl_stencil.yield %5 : tensor<1x64xf32>
 // CHECK-NEXT:   }, {
 // CHECK-NEXT:   ^bb0(%6: !stencil.field<[-1,1]x[-1,1]xtensor<64xf32>>, %7: tensor<1x64xf32>):
@@ -242,7 +242,7 @@ builtin.module {
 // CHECK-NEXT:   csl_stencil.apply(%arg0 : !stencil.field<[-1,1]x[-1,1]xtensor<64xf32>>, %1 : tensor<64xf32>, %arg1 : !stencil.field<[-1,1]x[-1,1]xtensor<64xf32>>, %0 : tensor<1x64xf32>) outs (%arg4 : !stencil.field<[-1,1]x[-1,1]xtensor<64xf32>>) <{swaps = [#csl_stencil.exchange<to [0, -1]>], topo = #dmp.topo<64x64>, num_chunks = 2 : i64, bounds = #stencil.bounds<[0, 0], [1, 1]>, operandSegmentSizes = array<i32: 1, 1, 0, 2, 1>}> ({
 // CHECK-NEXT:   ^bb0(%2: tensor<1x32xf32>, %3: index, %4: tensor<64xf32>):
 // CHECK-NEXT:     %5 = csl_stencil.access %2[0, -1] : tensor<1x32xf32>
-// CHECK-NEXT:     %6 = "tensor.insert_slice"(%5, %4, %3) <{static_offsets = array<i64: -9223372036854775808>, static_sizes = array<i64: 32>, static_strides = array<i64: 1>, operandSegmentSizes = array<i32: 1, 1, 1, 0, 0>}> : (tensor<32xf32>, tensor<64xf32>, index) -> tensor<64xf32>
+// CHECK-NEXT:     %6 = tensor.insert_slice %5 into %4[%3] [32] [1] : tensor<32xf32> into tensor<64xf32>
 // CHECK-NEXT:     csl_stencil.yield %6 : tensor<64xf32>
 // CHECK-NEXT:   }, {
 // CHECK-NEXT:   ^bb0(%7: !stencil.field<[-1,1]x[-1,1]xtensor<64xf32>>, %8: tensor<64xf32>, %9: !stencil.field<[-1,1]x[-1,1]xtensor<64xf32>>, %10: tensor<1x64xf32>):

--- a/tests/filecheck/transforms/csl-stencil-to-csl-wrapper.mlir
+++ b/tests/filecheck/transforms/csl-stencil-to-csl-wrapper.mlir
@@ -13,7 +13,7 @@ func.func @gauss_seidel(%a: !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>, 
     %10 = arith.addf %9, %8 : tensor<255xf32>
     %11 = arith.addf %10, %7 : tensor<255xf32>
     %12 = arith.addf %11, %6 : tensor<255xf32>
-    %13 = "tensor.insert_slice"(%12, %5, %4) <{"static_offsets" = array<i64: 0>, "static_sizes" = array<i64: 255>, "static_strides" = array<i64: 1>, operandSegmentSizes = array<i32: 1, 1, 1, 0, 0>}> : (tensor<255xf32>, tensor<510xf32>, index) -> tensor<510xf32>
+    %13 = tensor.insert_slice %12 into %5[%4] [255] [1] : tensor<255xf32> into tensor<510xf32>
     csl_stencil.yield %13 : tensor<510xf32>
   }, {
   ^bb1(%14: !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %15: tensor<510xf32>):
@@ -80,7 +80,7 @@ func.func @gauss_seidel(%a: !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>, 
 // CHECK-NEXT:       %50 = arith.addf %48, %47 : tensor<255xf32>
 // CHECK-NEXT:       %51 = arith.addf %50, %46 : tensor<255xf32>
 // CHECK-NEXT:       %52 = arith.addf %51, %45 : tensor<255xf32>
-// CHECK-NEXT:       %53 = "tensor.insert_slice"(%52, %43, %42) <{static_offsets = array<i64: 0>, static_sizes = array<i64: 255>, static_strides = array<i64: 1>, operandSegmentSizes = array<i32: 1, 1, 1, 0, 0>}> : (tensor<255xf32>, tensor<510xf32>, index) -> tensor<510xf32>
+// CHECK-NEXT:       %53 = tensor.insert_slice %52 into %43[%42] [255] [1] : tensor<255xf32> into tensor<510xf32>
 // CHECK-NEXT:       csl_stencil.yield %53 : tensor<510xf32>
 // CHECK-NEXT:     }, {
 // CHECK-NEXT:     ^bb0(%54: !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %55: tensor<510xf32>):

--- a/tests/filecheck/transforms/csl_stencil_bufferize.mlir
+++ b/tests/filecheck/transforms/csl_stencil_bufferize.mlir
@@ -12,7 +12,7 @@ builtin.module {
       %8 = linalg.add ins(%7, %6 : tensor<255xf32>, tensor<255xf32>) outs(%7 : tensor<255xf32>) -> tensor<255xf32>
       %9 = linalg.add ins(%8, %5 : tensor<255xf32>, tensor<255xf32>) outs(%8 : tensor<255xf32>) -> tensor<255xf32>
       %10 = linalg.add ins(%9, %4 : tensor<255xf32>, tensor<255xf32>) outs(%9 : tensor<255xf32>) -> tensor<255xf32>
-      %11 = "tensor.insert_slice"(%10, %3, %2) <{"static_offsets" = array<i64: -9223372036854775808>, "static_sizes" = array<i64: 255>, "static_strides" = array<i64: 1>, operandSegmentSizes = array<i32: 1, 1, 1, 0, 0>}> : (tensor<255xf32>, tensor<510xf32>, index) -> tensor<510xf32>
+      %11 = tensor.insert_slice %10 into %3[%2] [255] [1] : tensor<255xf32> into tensor<510xf32>
       csl_stencil.yield %11 : tensor<510xf32>
     }, {
     ^bb1(%12: !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>, %13: tensor<510xf32>):
@@ -49,7 +49,7 @@ builtin.module {
 // CHECK-NEXT:       %15 = linalg.add ins(%13, %11 : tensor<255xf32>, tensor<255xf32>) outs(%14 : tensor<255xf32>) -> tensor<255xf32>
 // CHECK-NEXT:       %16 = linalg.add ins(%15, %9 : tensor<255xf32>, tensor<255xf32>) outs(%15 : tensor<255xf32>) -> tensor<255xf32>
 // CHECK-NEXT:       %17 = linalg.add ins(%16, %7 : tensor<255xf32>, tensor<255xf32>) outs(%16 : tensor<255xf32>) -> tensor<255xf32>
-// CHECK-NEXT:       %18 = "tensor.insert_slice"(%17, %5, %3) <{static_offsets = array<i64: -9223372036854775808>, static_sizes = array<i64: 255>, static_strides = array<i64: 1>, operandSegmentSizes = array<i32: 1, 1, 1, 0, 0>}> : (tensor<255xf32>, tensor<510xf32>, index) -> tensor<510xf32>
+// CHECK-NEXT:       %18 = tensor.insert_slice %17 into %5[%3] [255] [1] : tensor<255xf32> into tensor<510xf32>
 // CHECK-NEXT:       %19 = bufferization.to_buffer %18 : tensor<510xf32> to memref<510xf32>
 // CHECK-NEXT:       csl_stencil.yield %19 : memref<510xf32>
 // CHECK-NEXT:     }, {

--- a/tests/filecheck/transforms/linalg-tiling.mlir
+++ b/tests/filecheck/transforms/linalg-tiling.mlir
@@ -143,7 +143,7 @@ linalg.generic {
 // CHECK-NEXT:       ^bb0(%a: f32, %b: f32):
 // CHECK-NEXT:         linalg.yield %a : f32
 // CHECK-NEXT:       } -> tensor<2x2xf32>
-// CHECK-NEXT:       %13 = "tensor.insert_slice"(%12, %9, %5, %8) <{static_offsets = array<i64: -9223372036854775808, -9223372036854775808>, static_sizes = array<i64: 2, 2>, static_strides = array<i64: 1, 1>, operandSegmentSizes = array<i32: 1, 1, 2, 0, 0>}> : (tensor<2x2xf32>, tensor<4x4xf32>, index, index) -> tensor<4x4xf32>
+// CHECK-NEXT:       %13 = tensor.insert_slice %12 into %9[%5, %8] [2, 2] [1, 1] : tensor<2x2xf32> into tensor<4x4xf32>
 // CHECK-NEXT:       scf.yield %13 : tensor<4x4xf32>
 // CHECK-NEXT:     }
 // CHECK-NEXT:     scf.yield %7 : tensor<4x4xf32>
@@ -180,7 +180,7 @@ linalg.generic {
 // CHECK-NEXT:     ^bb0(%a: f32, %b: f32):
 // CHECK-NEXT:       linalg.yield %a : f32
 // CHECK-NEXT:     } -> tensor<2x4xf32>
-// CHECK-NEXT:     %8 = "tensor.insert_slice"(%7, %4, %3) <{static_offsets = array<i64: -9223372036854775808, 0>, static_sizes = array<i64: 2, 4>, static_strides = array<i64: 1, 1>, operandSegmentSizes = array<i32: 1, 1, 1, 0, 0>}> : (tensor<2x4xf32>, tensor<4x4xf32>, index) -> tensor<4x4xf32>
+// CHECK-NEXT:     %8 = tensor.insert_slice %7 into %4[%3, 0] [2, 4] [1, 1] : tensor<2x4xf32> into tensor<4x4xf32>
 // CHECK-NEXT:     scf.yield %8 : tensor<4x4xf32>
 // CHECK-NEXT:   }
 // CHECK-NEXT:   "test.op"(%C) : (tensor<4x4xf32>) -> ()
@@ -253,7 +253,7 @@ linalg.generic {
 // CHECK-NEXT:       ^bb0(%a: f32, %b: f32):
 // CHECK-NEXT:         linalg.yield %a : f32
 // CHECK-NEXT:       } -> tensor<?x2xf32>
-// CHECK-NEXT:       %14 = "tensor.insert_slice"(%13, %9, %5, %8, %10) <{static_offsets = array<i64: -9223372036854775808, -9223372036854775808>, static_sizes = array<i64: -9223372036854775808, 2>, static_strides = array<i64: 1, 1>, operandSegmentSizes = array<i32: 1, 1, 2, 1, 0>}> : (tensor<?x2xf32>, tensor<5x4xf32>, index, index, index) -> tensor<5x4xf32>
+// CHECK-NEXT:       %14 = tensor.insert_slice %13 into %9[%5, %8] [%10, 2] [1, 1] : tensor<?x2xf32> into tensor<5x4xf32>
 // CHECK-NEXT:       scf.yield %14 : tensor<5x4xf32>
 // CHECK-NEXT:     }
 // CHECK-NEXT:     scf.yield %7 : tensor<5x4xf32>
@@ -321,7 +321,7 @@ linalg.generic {
 // CHECK-NEXT:     ^bb0(%a: f32, %b: f32):
 // CHECK-NEXT:       linalg.yield %a : f32
 // CHECK-NEXT:     } -> tensor<?x4xf32>
-// CHECK-NEXT:     %10 = "tensor.insert_slice"(%9, %5, %4, %6) <{static_offsets = array<i64: -9223372036854775808, 0>, static_sizes = array<i64: -9223372036854775808, 4>, static_strides = array<i64: 1, 1>, operandSegmentSizes = array<i32: 1, 1, 1, 1, 0>}> : (tensor<?x4xf32>, tensor<?x4xf32>, index, index) -> tensor<?x4xf32>
+// CHECK-NEXT:     %10 = tensor.insert_slice %9 into %5[%4, 0] [%6, 4] [1, 1] : tensor<?x4xf32> into tensor<?x4xf32>
 // CHECK-NEXT:     scf.yield %10 : tensor<?x4xf32>
 // CHECK-NEXT:   }
 // CHECK-NEXT:   "test.op"(%C) : (tensor<?x4xf32>) -> ()

--- a/xdsl/dialects/tensor.py
+++ b/xdsl/dialects/tensor.py
@@ -693,19 +693,53 @@ class InsertSliceOp(IRDLOperation):
 
     name = "tensor.insert_slice"
 
+    # An insert_slice returns a copy of its destination, so the two share a type.
+    # The syntax leaves the result type off, and takes it from the destination.
+    DEST_TYPE: ClassVar = VarConstraint("DEST_TYPE", base(TensorType))
+
     source = operand_def(TensorType)
-    dest = operand_def(TensorType)
+    dest = operand_def(DEST_TYPE)
     offsets = var_operand_def(IndexType)
     sizes = var_operand_def(IndexType)
     strides = var_operand_def(IndexType)
     static_offsets = prop_def(DenseArrayBase.constr(i64))
     static_sizes = prop_def(DenseArrayBase.constr(i64))
     static_strides = prop_def(DenseArrayBase.constr(i64))
-    result = result_def(TensorType)
+    result = result_def(DEST_TYPE)
 
     irdl_options = (AttrSizedOperandSegments(as_property=True),)
 
     traits = traits_def(Pure())
+
+    assembly_format = (
+        "$source `into` $dest ``"
+        "custom<DynamicIndexList>($offsets, $static_offsets)"
+        "custom<DynamicIndexList>($sizes, $static_sizes)"
+        "custom<DynamicIndexList>($strides, $static_strides)"
+        "attr-dict `:` type($source) `into` type($dest)"
+    )
+
+    custom_directives = (DynamicIndexList,)
+
+    def verify_(self) -> None:
+        verify_dynamic_index_list(
+            self.static_offsets.get_values(),
+            self.offsets,
+            DYNAMIC_INDEX,
+            " in the offset arguments",
+        )
+        verify_dynamic_index_list(
+            self.static_sizes.get_values(),
+            self.sizes,
+            DYNAMIC_INDEX,
+            " in the size arguments",
+        )
+        verify_dynamic_index_list(
+            self.static_strides.get_values(),
+            self.strides,
+            DYNAMIC_INDEX,
+            " in the stride arguments",
+        )
 
     @staticmethod
     def get(


### PR DESCRIPTION
One of the init and format cleanups asked for in #6379 and #6380, after #6384, #6385 and #6386.

`tensor.insert_slice` had no syntax of its own, so it was written as a generic op, with the dynamic offsets, sizes and strides listed as operands and the static ones as three arrays. It takes the syntax MLIR gives it now, which interleaves each group into one bracketed list, the way `tensor.extract_slice` above it does since #6386:

```mlir
%a = tensor.insert_slice %s into %d[%i, 0] [4, 4] [1, 1] : tensor<4x4xf32> into tensor<8x16xf32>
```

An insert_slice returns a copy of its destination, so the two share a type, which the syntax relies on by leaving the result type off and taking it from the destination. That is written down here as a constraint they both carry, rather than left to each builder to keep. No caller passed a result type that differed from the destination.

It also verifies that each group lists as many operands as it has dynamic markers, as extract_slice and `memref.subview` do.

### The tests this found

Eleven insert_slices across the csl stencil tests passed an offset operand while declaring the offset static:

```mlir
"tensor.insert_slice"(%10, %iter_arg, %offset) <{"static_offsets" = array<i64: 0>, ...
```

Nothing consumes `%offset` there, so each of those slices went in at zero rather than at the offset it was handed. The block argument being passed is the offset the received chunk belongs at, `^bb0(%recv, %offset, %iter_arg)`, and the same files spell that correctly a few lines away with a dynamic marker, so they are given the dynamic offset they meant.

The new verifier rejects them as they were, so this is a change in what the pass accepts rather than only in how it prints. I checked whether a pass emits them, since that would want fixing instead: it does not. `InsertSliceOp.get` fills in the marker itself when handed offsets, and the test covering the pass that builds these is not among the eleven.

The new syntax is what makes this visible, `%iter_arg[%offset]` against `%iter_arg[0]` with an operand trailing behind.

### Tests

Three round-trip cases are added to the dialect test, through both the custom and the generic round trip: one entirely static, one mixing a dynamic offset with a dynamic size so the interleaving is read per group, and one carrying an attribute dictionary. The verifier is given a case per group.

The remaining changes are the printed form of the op in the tests that already covered the passes producing it.
