### PR TITLE
dialects: (linalg) tile a generic that reads its index

### DIFF
--- a/tests/filecheck/transforms/linalg-tiling-reject-unsupported.mlir
+++ b/tests/filecheck/transforms/linalg-tiling-reject-unsupported.mlir
@@ -63,26 +63,6 @@ builtin.module {
   %output = "test.op"() : () -> memref<4x4xf32>
   linalg.generic {
       indexing_maps = [
-          affine_map<(i, j) -> (i, j)>,
-          affine_map<(i, j) -> (i, j)>
-      ],
-      iterator_types = ["parallel", "parallel"]
-  } ins(%input : memref<4x4xf32>) outs(%output : memref<4x4xf32>) attrs = {test_tile_sizes = array<i32: 2, 2>} {
-  ^bb0(%in: f32, %out: f32):
-      %i = linalg.index 0 : index
-      %unused = "test.op"(%i) : (index) -> f32
-      linalg.yield %unused : f32
-  }
-}
-// CHECK: tiling linalg.generic using linalg.index is not supported yet
-
-// -----
-
-builtin.module {
-  %input = "test.op"() : () -> memref<4x4xf32>
-  %output = "test.op"() : () -> memref<4x4xf32>
-  linalg.generic {
-      indexing_maps = [
           affine_map<(i, j) -> (i + j)>,
           affine_map<(i, j) -> (i, j)>
       ],

--- a/tests/filecheck/transforms/linalg-tiling.mlir
+++ b/tests/filecheck/transforms/linalg-tiling.mlir
@@ -473,3 +473,83 @@ linalg.generic {
 // CHECK-NEXT:   }
 // CHECK-NEXT:   "test.op"(%D) : (tensor<4x4xf32>) -> ()
 // CHECK-NEXT: }
+
+// -----
+
+// A linalg.index reads the position of the iteration it runs in, which inside a
+// tile is a position within that tile, so the offset the tile starts at is added
+// back to it. Here the first dimension is tiled and the second is not, so only
+// the index of the first is offset.
+
+%A, %C = "test.op"() : () -> (memref<4x6xindex>, memref<4x6xindex>)
+
+linalg.generic {
+  indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>],
+  iterator_types = ["parallel", "parallel"]
+} ins(%A : memref<4x6xindex>) outs(%C : memref<4x6xindex>) attrs = {test_tile_sizes = array<i32: 2, 0>} {
+^bb0(%a: index, %c: index):
+  %i = linalg.index 0 : index
+  %j = linalg.index 1 : index
+  %s = arith.addi %i, %j : index
+  linalg.yield %s : index
+}
+
+// CHECK:      builtin.module {
+// CHECK-NEXT:   %A, %C = "test.op"() : () -> (memref<4x6xindex>, memref<4x6xindex>)
+// CHECK-NEXT:   %0 = arith.constant 0 : index
+// CHECK-NEXT:   %1 = arith.constant 4 : index
+// CHECK-NEXT:   %2 = arith.constant 2 : index
+// CHECK-NEXT:   scf.for %3 = %0 to %1 step %2 {
+// CHECK-NEXT:     %4 = memref.subview %A[%3, 0] [2, 6] [1, 1] : memref<4x6xindex> to memref<2x6xindex, strided<[6, 1], offset: ?>>
+// CHECK-NEXT:     %5 = memref.subview %C[%3, 0] [2, 6] [1, 1] : memref<4x6xindex> to memref<2x6xindex, strided<[6, 1], offset: ?>>
+// CHECK-NEXT:     linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%4 : memref<2x6xindex, strided<[6, 1], offset: ?>>) outs(%5 : memref<2x6xindex, strided<[6, 1], offset: ?>>) {
+// CHECK-NEXT:     ^bb0(%a: index, %c: index):
+// CHECK-NEXT:       %i = linalg.index 0 : index
+// CHECK-NEXT:       %i_1 = affine.apply affine_map<(d0, d1) -> ((d0 + d1))> (%i, %3)
+// CHECK-NEXT:       %j = linalg.index 1 : index
+// CHECK-NEXT:       %s = arith.addi %i_1, %j : index
+// CHECK-NEXT:       linalg.yield %s : index
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+
+// -----
+
+// An index read more than once takes the offset one at each of its readers, and
+// a dimension whose tile size does not divide it is offset like any other.
+
+%A, %C = "test.op"() : () -> (tensor<6xindex>, tensor<6xindex>)
+
+%D = linalg.generic {
+  indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+  iterator_types = ["parallel"]
+} ins(%A : tensor<6xindex>) outs(%C : tensor<6xindex>) attrs = {test_tile_sizes = array<i32: 4>} {
+^bb0(%a: index, %c: index):
+  %i = linalg.index 0 : index
+  %s = arith.muli %i, %i : index
+  linalg.yield %s : index
+} -> tensor<6xindex>
+
+"test.op"(%D) : (tensor<6xindex>) -> ()
+
+// CHECK:      builtin.module {
+// CHECK-NEXT:   %A, %C = "test.op"() : () -> (tensor<6xindex>, tensor<6xindex>)
+// CHECK-NEXT:   %0 = arith.constant 0 : index
+// CHECK-NEXT:   %1 = arith.constant 6 : index
+// CHECK-NEXT:   %2 = arith.constant 4 : index
+// CHECK-NEXT:   %D = scf.for %3 = %0 to %1 step %2 iter_args(%4 = %C) -> (tensor<6xindex>) {
+// CHECK-NEXT:     %5 = affine.min affine_map<(d0, d1, d2) -> (d0, (d1 + (d2 * -1)))> (%2, %1, %3)
+// CHECK-NEXT:     %6 = tensor.extract_slice %A[%3] [%5] [1] : tensor<6xindex> to tensor<?xindex>
+// CHECK-NEXT:     %7 = tensor.extract_slice %4[%3] [%5] [1] : tensor<6xindex> to tensor<?xindex>
+// CHECK-NEXT:     %8 = linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%6 : tensor<?xindex>) outs(%7 : tensor<?xindex>) {
+// CHECK-NEXT:     ^bb0(%a: index, %c: index):
+// CHECK-NEXT:       %i = linalg.index 0 : index
+// CHECK-NEXT:       %i_1 = affine.apply affine_map<(d0, d1) -> ((d0 + d1))> (%i, %3)
+// CHECK-NEXT:       %s = arith.muli %i_1, %i_1 : index
+// CHECK-NEXT:       linalg.yield %s : index
+// CHECK-NEXT:     } -> tensor<?xindex>
+// CHECK-NEXT:     %9 = tensor.insert_slice %8 into %4[%3] [%5] [1] : tensor<?xindex> into tensor<6xindex>
+// CHECK-NEXT:     scf.yield %9 : tensor<6xindex>
+// CHECK-NEXT:   }
+// CHECK-NEXT:   "test.op"(%D) : (tensor<6xindex>) -> ()
+// CHECK-NEXT: }

--- a/tests/transforms/test_linalg_tiling_helpers.py
+++ b/tests/transforms/test_linalg_tiling_helpers.py
@@ -1,4 +1,3 @@
-import re
 from collections.abc import Sequence
 from typing import Any
 
@@ -146,11 +145,12 @@ def test_tiling_plan_accepts_tensor_operands():
     assert plan.operand_infos[0].source_type == TensorType(f32, [4, 5])
 
 
-def test_tiling_plan_rejects_linalg_index():
+def test_tiling_plan_tiles_linalg_index():
     op = _generic_2d_copy_op(use_index=True)
 
-    with pytest.raises(ValueError, match=re.escape("using linalg.index")):
-        TilingPlan.analyze_generic_op(op, (2, 0))
+    plan = TilingPlan.analyze_generic_op(op, (2, 0))
+
+    assert plan.tiled_dims == (0,)
 
 
 def test_tiling_plan_tiles_a_non_parallel_iterator():

--- a/xdsl/dialects/linalg/transforms/tiling.py
+++ b/xdsl/dialects/linalg/transforms/tiling.py
@@ -21,6 +21,11 @@ from xdsl.rewriter import InsertPoint
 from xdsl.utils.exceptions import PassFailedException
 from xdsl.utils.hints import isa
 
+# iv + index, the index a tiled iteration would have had before it was tiled.
+_INDEX_OFFSET_MAP = AffineMapAttr(
+    AffineMap(2, 0, (AffineExpr.dimension(0) + AffineExpr.dimension(1),))
+)
+
 # min(tile, ub - iv), the size of a tile that may run past the end of its loop.
 _PARTIAL_TILE_MIN_MAP = AffineMapAttr(
     AffineMap(
@@ -186,11 +191,6 @@ def _verify_generic_is_tileable(
         raise ValueError(
             "tiling linalg.generic with a mix of memref and tensor operands is "
             "not supported"
-        )
-
-    if any(isa(body_op, linalg.ops.IndexOp) for body_op in op.body.walk()):
-        raise ValueError(
-            "tiling linalg.generic using linalg.index is not supported yet"
         )
 
     # A reduction dimension is tiled like any other. It is absent from the output
@@ -512,6 +512,42 @@ def _build_tiled_insert(
     return insert_op.result
 
 
+def _offset_tiled_indices(
+    rewriter: PatternRewriter,
+    tiled_op: linalg.ops.GenericOp,
+    tiled_loop_ivs: dict[int, SSAValue],
+) -> None:
+    """
+    Give each `linalg.index` in a tiled body the index it read before tiling.
+
+    A `linalg.index` reads the position of the iteration it runs in. The tiled op
+    iterates over one tile, so it reads a position within that tile, and the
+    offset the tile starts at is added back to it. A dimension that was not tiled
+    is iterated over whole, so its index is already the one it was.
+    """
+
+    # A linalg.index can only be a direct child of the op whose iteration it
+    # reads, so the block itself is enough to find every one of them. They are
+    # taken before any is offset, since offsetting inserts into that same block,
+    # and paired with the offset to give them, which a dimension that was not
+    # tiled has none of.
+    index_ops = tuple(
+        (body_op, iv)
+        for body_op in tiled_op.body.block.ops
+        if isinstance(body_op, linalg.ops.IndexOp)
+        if (iv := tiled_loop_ivs.get(body_op.dim.value.data)) is not None
+    )
+
+    for body_op, iv in index_ops:
+        offset_op = affine.ApplyOp((body_op.result, iv), _INDEX_OFFSET_MAP)
+        rewriter.insert(offset_op, InsertPoint.after(body_op))
+        # Every reader of the index takes the offset one instead, other than the
+        # op doing the offsetting, which is left reading the index itself.
+        body_op.result.replace_uses_with_if(
+            offset_op.result, lambda use: use.operation is not offset_op
+        )
+
+
 def tile_linalg_generic(
     rewriter: PatternRewriter,
     op: linalg.ops.GenericOp,
@@ -581,6 +617,7 @@ def tile_linalg_generic(
         tuple(value.type for value in tiled_outputs) if has_tensor_outputs else (),
     )
     rewriter.insert(tiled_generic, inner_ip)
+    _offset_tiled_indices(rewriter, tiled_generic, tiled_loop_ivs)
 
     # Memref outputs are written through their subview, so only tensor outputs
     # need their computed tile written back into the value being carried.


### PR DESCRIPTION
Ticks `linalg.index` handling on #6140.

Tiling rejected a `linalg.generic` whose body read a `linalg.index`, which is how an op that depends on where it is in the iteration space is written, such as one filling a tensor from its coordinates.

A `linalg.index` reads the position of the iteration it runs in. The tiled op iterates over one tile, so it reads a position within that tile rather than within the whole, and the offset the tile starts at is added back to recover the position it read before:

```mlir
%i = linalg.index 0 : index
%i_1 = affine.apply affine_map<(d0, d1) -> ((d0 + d1))> (%i, %3)
%s = arith.addi %i_1, %j : index
```

`%3` is the induction variable of the loop over that dimension. Everything that read the index reads the offset one instead, other than the `affine.apply` doing the offsetting, which is left reading the index itself.

A dimension that was not tiled is still iterated over whole, so its index is already the one it was and is left alone. That is `%j` above, whose dimension has a tile size of zero.

This is what upstream does in `offsetIndices`, down to that last part, and it is called in the same place: on the tiled op, after it is cloned, as `getTiledImplementation` does.

### Tests

Two cases: one body reading both a tiled and an untiled dimension, so that only the tiled one is offset, and one reading an index twice over a dimension whose tile size does not divide it, so that both of its readers take one offset value.

I checked these have teeth by not offsetting at all, and by offsetting dimensions that were not tiled, each of which fails them.

The case rejecting a body that reads its index goes from the rejection tests, and the unit test that asserted the rejection now asserts the plan tiles the op instead.
