### PR TITLE
dialects: (linalg) tile named ops as themselves

### DIFF
--- a/tests/filecheck/transforms/linalg-tiling-reject-unsupported.mlir
+++ b/tests/filecheck/transforms/linalg-tiling-reject-unsupported.mlir
@@ -36,7 +36,7 @@ builtin.module {
   }) {test_tile_sizes = array<i32: 2, 2>} : (tensor<4x4xf32>, tensor<4x4xf32>, memref<4x4xf32>) -> tensor<4x4xf32>
   "test.op"(%result) : (tensor<4x4xf32>) -> ()
 }
-// CHECK: tiling linalg.generic with a mix of memref and tensor operands is not supported
+// CHECK: tiling a linalg op with a mix of memref and tensor operands is not supported
 
 // -----
 
@@ -54,7 +54,7 @@ builtin.module {
       linalg.yield %out : f32
   }
 }
-// CHECK: tiling linalg.generic with a mix of memref and tensor operands is not supported
+// CHECK: tiling a linalg op with a mix of memref and tensor operands is not supported
 
 // -----
 
@@ -72,7 +72,7 @@ builtin.module {
       linalg.yield %in : f32
   }
 }
-// CHECK: tiling linalg.generic with non-projected-permutation indexing maps is not supported yet
+// CHECK: tiling a linalg op with non-projected-permutation indexing maps is not supported yet
 
 // -----
 

--- a/tests/filecheck/transforms/linalg-tiling.mlir
+++ b/tests/filecheck/transforms/linalg-tiling.mlir
@@ -553,3 +553,57 @@ linalg.generic {
 // CHECK-NEXT:   }
 // CHECK-NEXT:   "test.op"(%D) : (tensor<6xindex>) -> ()
 // CHECK-NEXT: }
+
+// -----
+
+// A named op is tiled into the same named op over the slices, rather than into
+// a generic. What a linalg.matmul computes is which op it is, which tiling has
+// no reason to take away from it.
+
+%A, %B, %C = "test.op"() : () -> (memref<4x6xf32>, memref<6x4xf32>, memref<4x4xf32>)
+
+linalg.matmul {test_tile_sizes = array<i32: 2, 2, 0>} ins(%A, %B : memref<4x6xf32>, memref<6x4xf32>) outs(%C : memref<4x4xf32>)
+
+// CHECK:      builtin.module {
+// CHECK-NEXT:   %A, %B, %C = "test.op"() : () -> (memref<4x6xf32>, memref<6x4xf32>, memref<4x4xf32>)
+// CHECK-NEXT:   %0 = arith.constant 0 : index
+// CHECK-NEXT:   %1 = arith.constant 4 : index
+// CHECK-NEXT:   %2 = arith.constant 4 : index
+// CHECK-NEXT:   %3 = arith.constant 2 : index
+// CHECK-NEXT:   %4 = arith.constant 2 : index
+// CHECK-NEXT:   scf.for %5 = %0 to %1 step %3 {
+// CHECK-NEXT:     scf.for %6 = %0 to %2 step %4 {
+// CHECK-NEXT:       %7 = memref.subview %A[%5, 0] [2, 6] [1, 1] : memref<4x6xf32> to memref<2x6xf32, strided<[6, 1], offset: ?>>
+// CHECK-NEXT:       %8 = memref.subview %B[0, %6] [6, 2] [1, 1] : memref<6x4xf32> to memref<6x2xf32, strided<[4, 1], offset: ?>>
+// CHECK-NEXT:       %9 = memref.subview %C[%5, %6] [2, 2] [1, 1] : memref<4x4xf32> to memref<2x2xf32, strided<[4, 1], offset: ?>>
+// CHECK-NEXT:       linalg.matmul ins(%7, %8 : memref<2x6xf32, strided<[6, 1], offset: ?>>, memref<6x2xf32, strided<[4, 1], offset: ?>>) outs(%9 : memref<2x2xf32, strided<[4, 1], offset: ?>>)
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+
+// -----
+
+// The same over tensors, tiled over the dimension the matmul reduces, so that
+// the tiles accumulate into the value the loop carries.
+
+%A, %B, %C = "test.op"() : () -> (tensor<4x6xf32>, tensor<6x4xf32>, tensor<4x4xf32>)
+
+%D = linalg.matmul {test_tile_sizes = array<i32: 0, 0, 2>} ins(%A, %B : tensor<4x6xf32>, tensor<6x4xf32>) outs(%C : tensor<4x4xf32>) -> tensor<4x4xf32>
+
+"test.op"(%D) : (tensor<4x4xf32>) -> ()
+
+// CHECK:      builtin.module {
+// CHECK-NEXT:   %A, %B, %C = "test.op"() : () -> (tensor<4x6xf32>, tensor<6x4xf32>, tensor<4x4xf32>)
+// CHECK-NEXT:   %0 = arith.constant 0 : index
+// CHECK-NEXT:   %1 = arith.constant 6 : index
+// CHECK-NEXT:   %2 = arith.constant 2 : index
+// CHECK-NEXT:   %D = scf.for %3 = %0 to %1 step %2 iter_args(%4 = %C) -> (tensor<4x4xf32>) {
+// CHECK-NEXT:     %5 = tensor.extract_slice %A[0, %3] [4, 2] [1, 1] : tensor<4x6xf32> to tensor<4x2xf32>
+// CHECK-NEXT:     %6 = tensor.extract_slice %B[%3, 0] [2, 4] [1, 1] : tensor<6x4xf32> to tensor<2x4xf32>
+// CHECK-NEXT:     %7 = tensor.extract_slice %4[0, 0] [4, 4] [1, 1] : tensor<4x4xf32> to tensor<4x4xf32>
+// CHECK-NEXT:     %8 = linalg.matmul ins(%5, %6 : tensor<4x2xf32>, tensor<2x4xf32>) outs(%7 : tensor<4x4xf32>) -> tensor<4x4xf32>
+// CHECK-NEXT:     %9 = tensor.insert_slice %8 into %4[0, 0] [4, 4] [1, 1] : tensor<4x4xf32> into tensor<4x4xf32>
+// CHECK-NEXT:     scf.yield %9 : tensor<4x4xf32>
+// CHECK-NEXT:   }
+// CHECK-NEXT:   "test.op"(%D) : (tensor<4x4xf32>) -> ()
+// CHECK-NEXT: }

--- a/tests/transforms/test_linalg_tiling_helpers.py
+++ b/tests/transforms/test_linalg_tiling_helpers.py
@@ -24,7 +24,7 @@ from xdsl.dialects.linalg.transforms.tiling import (
     _build_tile_loops,  # pyright: ignore[reportPrivateUsage]
     _build_tiled_insert,  # pyright: ignore[reportPrivateUsage]
     _build_tiled_slice,  # pyright: ignore[reportPrivateUsage]
-    tile_linalg_generic,
+    tile_structured_op,
 )
 from xdsl.ir import Attribute, SSAValue
 from xdsl.ir.affine import AffineExpr, AffineMap
@@ -96,10 +96,10 @@ def _generic_2d_copy_op(
     )
 
 
-def test_tiling_plan_analyze_generic_op():
+def test_tiling_plan_analyze():
     op = _generic_2d_copy_op()
 
-    plan = TilingPlan.analyze_generic_op(op, (2, 0))
+    plan = TilingPlan.analyze(op, (2, 0))
 
     assert plan.loop_ranges == (4, 5)
     assert plan.tiled_dims == (0,)
@@ -112,10 +112,10 @@ def test_tiling_plan_analyze_generic_op():
     assert plan.operand_infos[1].loop_dims == (0, 1)
 
 
-def test_tiling_plan_analyze_generic_op_without_tiled_dims():
+def test_tiling_plan_analyze_without_tiled_dims():
     op = _generic_2d_copy_op()
 
-    plan = TilingPlan.analyze_generic_op(op, (0, 0))
+    plan = TilingPlan.analyze(op, (0, 0))
 
     assert plan.loop_ranges == ()
     assert plan.tiled_dims == ()
@@ -128,7 +128,7 @@ def test_tiling_plan_rejects_negative_tile_size():
     op = _generic_2d_copy_op()
 
     with pytest.raises(ValueError, match="negative tile sizes"):
-        TilingPlan.analyze_generic_op(op, (-1, 0))
+        TilingPlan.analyze(op, (-1, 0))
 
 
 def test_tiling_plan_accepts_tensor_operands():
@@ -138,7 +138,7 @@ def test_tiling_plan_accepts_tensor_operands():
         result_types=(TensorType(f32, [4, 5]),),
     )
 
-    plan = TilingPlan.analyze_generic_op(op, (2, 0))
+    plan = TilingPlan.analyze(op, (2, 0))
 
     assert plan.loop_ranges == (4, 5)
     assert plan.tiled_dims == (0,)
@@ -148,7 +148,7 @@ def test_tiling_plan_accepts_tensor_operands():
 def test_tiling_plan_tiles_linalg_index():
     op = _generic_2d_copy_op(use_index=True)
 
-    plan = TilingPlan.analyze_generic_op(op, (2, 0))
+    plan = TilingPlan.analyze(op, (2, 0))
 
     assert plan.tiled_dims == (0,)
 
@@ -161,7 +161,7 @@ def test_tiling_plan_tiles_a_non_parallel_iterator():
         ]
     )
 
-    plan = TilingPlan.analyze_generic_op(op, (0, 2))
+    plan = TilingPlan.analyze(op, (0, 2))
 
     assert plan.tiled_dims == (1,)
 
@@ -170,7 +170,7 @@ def test_tiling_plan_rejects_operand_that_is_neither_memref_nor_tensor():
     op = _generic_2d_copy_op(input_type=VectorType(f32, [4, 5]))
 
     with pytest.raises(NotImplementedError, match="neither memrefs nor tensors"):
-        TilingPlan.analyze_generic_op(op, (2, 0))
+        TilingPlan.analyze(op, (2, 0))
 
 
 def test_tiling_plan_rejects_mixed_memref_and_tensor_operands():
@@ -182,7 +182,7 @@ def test_tiling_plan_rejects_mixed_memref_and_tensor_operands():
     )
 
     with pytest.raises(ValueError, match="mix of memref and tensor operands"):
-        TilingPlan.analyze_generic_op(op, (2, 0))
+        TilingPlan.analyze(op, (2, 0))
 
 
 def test_tiling_plan_rejects_mixed_memref_and_tensor_outputs():
@@ -208,7 +208,7 @@ def test_tiling_plan_rejects_mixed_memref_and_tensor_outputs():
     )
 
     with pytest.raises(ValueError, match="mix of memref and tensor operands"):
-        TilingPlan.analyze_generic_op(op, (2, 0))
+        TilingPlan.analyze(op, (2, 0))
 
 
 def test_tiling_plan_marks_a_dynamic_range_partial():
@@ -219,7 +219,7 @@ def test_tiling_plan_marks_a_dynamic_range_partial():
         output_type=MemRefType(f32, [DYNAMIC_INDEX, 5]),
     )
 
-    plan = TilingPlan.analyze_generic_op(op, (2, 0))
+    plan = TilingPlan.analyze(op, (2, 0))
 
     assert plan.tiled_dims == (0,)
     assert plan.partial_tiled_dims == frozenset({0})
@@ -232,7 +232,7 @@ def test_tiling_plan_tiles_a_dim_whose_tile_size_is_not_static():
     # Tiling by zero means leaving a dimension alone, and a size that is not
     # known until the op runs cannot be shown to be zero, so the dimension is
     # tiled. It cannot be shown to divide the range either, so it is partial.
-    plan = TilingPlan.analyze_generic_op(op, (tile_size, 0))
+    plan = TilingPlan.analyze(op, (tile_size, 0))
 
     assert plan.tiled_dims == (0,)
     assert plan.partial_tiled_dims == frozenset({0})
@@ -252,14 +252,14 @@ def test_tiling_plan_rejects_non_projected_permutation_map():
     )
 
     with pytest.raises(ValueError, match="non-projected-permutation indexing maps"):
-        TilingPlan.analyze_generic_op(op, (2, 0))
+        TilingPlan.analyze(op, (2, 0))
 
 
 def test_tiling_plan_marks_dims_with_a_leftover_tile():
     op = _generic_2d_copy_op()
 
     # Dim 0 has range 4 and tile size 3, so its last tile holds one element.
-    plan = TilingPlan.analyze_generic_op(op, (3, 0))
+    plan = TilingPlan.analyze(op, (3, 0))
 
     assert plan.tiled_dims == (0,)
     assert plan.partial_tiled_dims == frozenset({0})
@@ -269,7 +269,7 @@ def test_tiling_plan_marks_no_dims_partial_when_tiles_divide():
     op = _generic_2d_copy_op()
 
     # Range 4 divides by tile size 2, so every tile is whole.
-    plan = TilingPlan.analyze_generic_op(op, (2, 0))
+    plan = TilingPlan.analyze(op, (2, 0))
 
     assert plan.tiled_dims == (0,)
     assert plan.partial_tiled_dims == frozenset()
@@ -279,7 +279,7 @@ def test_tiling_plan_marks_a_tile_larger_than_its_range_partial():
     op = _generic_2d_copy_op()
 
     # A tile bigger than the range gives one iteration covering the whole range.
-    plan = TilingPlan.analyze_generic_op(op, (8, 0))
+    plan = TilingPlan.analyze(op, (8, 0))
 
     assert plan.partial_tiled_dims == frozenset({0})
 
@@ -465,9 +465,9 @@ def test_build_tile_loops_threads_iter_args():
         assert loop.body.block.args[1].type == init.type
 
 
-def test_tile_linalg_generic_returns_false_without_tiled_dims():
+def test_tile_structured_op_returns_false_without_tiled_dims():
     op = _generic_2d_copy_op()
     ModuleOp([op])
     rewriter = PatternRewriter(op)
 
-    assert not tile_linalg_generic(rewriter, op, (0, 0))
+    assert not tile_structured_op(rewriter, op, (0, 0))

--- a/xdsl/dialects/linalg/transforms/tiling.py
+++ b/xdsl/dialects/linalg/transforms/tiling.py
@@ -101,12 +101,12 @@ class TilingPlan:
     tile_sizes: tuple[SSAValue | int, ...]
 
     @staticmethod
-    def analyze_generic_op(
-        op: linalg.ops.GenericOp,
+    def analyze(
+        op: linalg.abstract_ops.LinalgStructuredOperation,
         tile_sizes: Sequence[SSAValue | int],
     ) -> "TilingPlan":
         """
-        Analyze one supported `linalg.generic` and return a `TilingPlan`.
+        Analyze one supported structured linalg op and return a `TilingPlan`.
         """
 
         num_loops = op.get_num_loops()
@@ -132,7 +132,7 @@ class TilingPlan:
                 tile_sizes=normalized_tile_sizes,
             )
 
-        loop_ranges = _verify_generic_is_tileable(
+        loop_ranges = _verify_is_tileable(
             op,
             normalized_tile_sizes,
             tiled_dims,
@@ -166,13 +166,13 @@ class TilingPlan:
         )
 
 
-def _verify_generic_is_tileable(
-    op: linalg.ops.GenericOp,
+def _verify_is_tileable(
+    op: linalg.abstract_ops.LinalgStructuredOperation,
     tile_sizes: Sequence[SSAValue | int],
     tiled_dims: Sequence[int],
 ) -> tuple[int, ...]:
     """
-    Check whether a `linalg.generic` is safe to tile.
+    Check whether a structured linalg op is safe to tile.
     """
 
     if any(
@@ -189,7 +189,7 @@ def _verify_generic_is_tileable(
         isa(operand_type, TensorType) for operand_type in operand_types
     ):
         raise ValueError(
-            "tiling linalg.generic with a mix of memref and tensor operands is "
+            "tiling a linalg op with a mix of memref and tensor operands is "
             "not supported"
         )
 
@@ -208,20 +208,20 @@ def _verify_generic_is_tileable(
             raw_operand_type, TensorType
         ):
             raise NotImplementedError(
-                "tiling linalg.generic with operands that are neither memrefs nor "
+                "tiling a linalg op with operands that are neither memrefs nor "
                 "tensors is not supported yet"
             )
 
         if not indexing_map.is_projected_permutation():
             raise ValueError(
-                "tiling linalg.generic with non-projected-permutation indexing maps is not supported yet"
+                "tiling a linalg op with non-projected-permutation indexing maps is not supported yet"
             )
 
     return op.get_static_loop_ranges()
 
 
 def _loop_range_sources(
-    op: linalg.ops.GenericOp, plan: TilingPlan
+    op: linalg.abstract_ops.LinalgStructuredOperation, plan: TilingPlan
 ) -> dict[int, tuple[SSAValue, int]]:
     """
     Say where the range of each tiled loop can be read from when it is not known
@@ -291,7 +291,7 @@ def _build_tile_loops(
     Return:
         - `loops`: the outer `scf.for` ops, outermost first
         - `tiled_loop_ivs`: a map from loop dimensions to induction variables
-        - `current_insertion_point`: the place to insert `tiled subview` and the `tiled generic`
+        - `current_insertion_point`: the place to insert `tiled subview` and the tiled op
     """
 
     index = IndexType()
@@ -514,7 +514,7 @@ def _build_tiled_insert(
 
 def _offset_tiled_indices(
     rewriter: PatternRewriter,
-    tiled_op: linalg.ops.GenericOp,
+    tiled_op: linalg.abstract_ops.LinalgStructuredOperation,
     tiled_loop_ivs: dict[int, SSAValue],
 ) -> None:
     """
@@ -548,16 +548,16 @@ def _offset_tiled_indices(
         )
 
 
-def tile_linalg_generic(
+def tile_structured_op(
     rewriter: PatternRewriter,
-    op: linalg.ops.GenericOp,
+    op: linalg.abstract_ops.LinalgStructuredOperation,
     tile_sizes: Sequence[SSAValue | int],
 ) -> bool:
     """
-    Rewrite supported `linalg.generic` ops into tiled formed.
+    Rewrite supported structured linalg ops into tiled form.
     """
     try:
-        plan = TilingPlan.analyze_generic_op(op, tile_sizes)
+        plan = TilingPlan.analyze(op, tile_sizes)
     except (ValueError, NotImplementedError) as e:
         raise PassFailedException(str(e)) from e
 
@@ -608,16 +608,19 @@ def tile_linalg_generic(
     ]
 
     tiled_outputs = tiled_operands[num_inputs:]
-    tiled_generic = linalg.ops.GenericOp(
-        tiled_operands[:num_inputs],
-        tiled_outputs,
-        op.body.clone(),
-        op.get_indexing_maps(),
-        op.get_iterator_types(),
-        tuple(value.type for value in tiled_outputs) if has_tensor_outputs else (),
+    # A tile is the same op over its slices, whatever op that is, so it is built
+    # as one of those rather than as a generic. A named op says what it computes
+    # by which op it is, which tiling it has no reason to take away from it.
+    tiled_op = type(op).create(
+        operands=tiled_operands,
+        result_types=(
+            tuple(value.type for value in tiled_outputs) if has_tensor_outputs else ()
+        ),
+        properties=dict(op.properties),
+        regions=[op.body.clone()],
     )
-    rewriter.insert(tiled_generic, inner_ip)
-    _offset_tiled_indices(rewriter, tiled_generic, tiled_loop_ivs)
+    rewriter.insert(tiled_op, inner_ip)
+    _offset_tiled_indices(rewriter, tiled_op, tiled_loop_ivs)
 
     # Memref outputs are written through their subview, so only tensor outputs
     # need their computed tile written back into the value being carried.
@@ -627,7 +630,7 @@ def tile_linalg_generic(
                 rewriter, inner_ip, tiled_result, destination, parameters
             )
             for tiled_result, destination, parameters in zip(
-                tiled_generic.res, carried, slice_parameters[num_inputs:], strict=True
+                tiled_op.res, carried, slice_parameters[num_inputs:], strict=True
             )
         )
         if has_tensor_outputs

--- a/xdsl/transforms/test_linalg_tiling.py
+++ b/xdsl/transforms/test_linalg_tiling.py
@@ -8,7 +8,7 @@ from xdsl.dialects.builtin import (
     IntegerType,
     ModuleOp,
 )
-from xdsl.dialects.linalg.transforms.tiling import tile_linalg_generic
+from xdsl.dialects.linalg.transforms.tiling import tile_structured_op
 from xdsl.ir import SSAValue
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
@@ -21,9 +21,9 @@ from xdsl.rewriter import InsertPoint
 from xdsl.utils.hints import isa
 
 
-class TileLinalgGenericFromAttributePattern(RewritePattern):
+class TileLinalgFromAttributePattern(RewritePattern):
     """
-    Rewrite supported `linalg.generic` ops annotated with `test_tile_sizes` into
+    Rewrite supported structured linalg ops annotated with `test_tile_sizes` into
     tiled form.
 
     A tile size is normally taken straight from that attribute. Dimensions named
@@ -34,7 +34,10 @@ class TileLinalgGenericFromAttributePattern(RewritePattern):
 
     @op_type_rewrite_pattern
     def match_and_rewrite(
-        self, op: linalg.ops.GenericOp, rewriter: PatternRewriter, /
+        self,
+        op: linalg.abstract_ops.LinalgStructuredOperation,
+        rewriter: PatternRewriter,
+        /,
     ) -> None:
 
         tile_sizes_attr = op.attributes.get("test_tile_sizes")
@@ -52,19 +55,19 @@ class TileLinalgGenericFromAttributePattern(RewritePattern):
                 rewriter.insert(tile_size_op, InsertPoint.before(op))
                 tile_sizes[dim] = tile_size_op.res[0]
 
-        tile_linalg_generic(rewriter, op, tile_sizes)
+        tile_structured_op(rewriter, op, tile_sizes)
 
 
 @dataclass(frozen=True)
 class TestLinalgTilingPass(ModulePass):
     """
-    Tile supported memref-based `linalg.generic` ops annotated with `test_tile_sizes`.
+    Tile supported structured linalg ops annotated with `test_tile_sizes`.
     """
 
     name = "test-linalg-tiling"
 
     def apply(self, ctx: Context, op: ModuleOp) -> None:
         PatternRewriteWalker(
-            TileLinalgGenericFromAttributePattern(),
+            TileLinalgFromAttributePattern(),
             apply_recursively=False,
         ).rewrite_module(op)


### PR DESCRIPTION
Ticks `named Linalg ops such as linalg.matmul` on #6140.

Tiling only took a `linalg.generic`, so a `linalg.matmul` had to be turned into one before it could be tiled, which loses what the op says it computes.

Everything the tiling reads is on `LinalgStructuredOperation`, the base a named op shares with a generic: its indexing maps, its iterator types, its loop ranges, and the operands it reads and writes. It takes one of those now rather than a generic in particular.

The tile itself is built as the op being tiled rather than as a generic, so a matmul tiles into a nest of matmuls over the slices:

```mlir
scf.for %5 = %0 to %1 step %3 {
  scf.for %6 = %0 to %2 step %4 {
    %7 = memref.subview %A[%5, 0] [2, 6] [1, 1] : memref<4x6xf32> to memref<2x6xf32, strided<[6, 1], offset: ?>>
    %8 = memref.subview %B[0, %6] [6, 2] [1, 1] : memref<6x4xf32> to memref<6x2xf32, strided<[4, 1], offset: ?>>
    %9 = memref.subview %C[%5, %6] [2, 2] [1, 1] : memref<4x4xf32> to memref<2x2xf32, strided<[4, 1], offset: ?>>
    linalg.matmul ins(%7, %8 : ...) outs(%9 : ...)
  }
}
```

This is what upstream does, whose `getTiledImplementation` reaches the tiled op by `clone(b, linalgOp, resultTensorTypes, tiledOperands)`, taking its result types from the tiled operands as this does. A named op says what it computes by which op it is, and tiling has no reason to take that away from it, nor to leave later passes matching a generic where a matmul was.

The properties come across, which is where a named op keeps its indexing maps. The attributes do not, as they did not before this.

### Tests

Two cases: a matmul over memrefs tiled over both of its parallel dimensions, and one over tensors tiled over the dimension it reduces, so that the tiles accumulate into the value the loop carries. Both check the tile is still a `linalg.matmul`.

I checked these have teeth by building the tile as a generic, which fails them.
