### PR TITLE
jit: extract the JIT context and backend interface

### DIFF
--- a/tests/filecheck/projects/pyjit/two_plus_two.py
+++ b/tests/filecheck/projects/pyjit/two_plus_two.py
@@ -27,119 +27,23 @@ The ``Callable[...]`` argument to :meth:`JITContext.jit` is the ABI signature us
 for marshalling. It is passed explicitly so annotations need not be evaluated.
 """
 
-import abc
 from collections.abc import Callable
-from ctypes import c_double
 from dataclasses import dataclass
-from typing import ParamSpec
 
 import llvmlite
 import llvmlite.binding
 import llvmlite.ir as llvm_ir
-from typing_extensions import TypeForm, TypeVar
 
 from xdsl.backend.llvm.convert import convert_module
 from xdsl.context import Context
 from xdsl.dialects import arith, builtin, func, llvm
-from xdsl.frontend.pyast.context import PyASTContext
-from xdsl.jit.c_type_context import CTypeContext, register_builtin_ctypes
-from xdsl.jit.function import (
-    CFunc,
-    CFuncType,
-    RawJITFunc,
-    WrappedJITFunc,
-    wrap_jit_func,
-)
+from xdsl.jit.c_type_context import register_builtin_ctypes
+from xdsl.jit.context import JITBackend, JITContext, register_builtin_type_maps
+from xdsl.jit.function import CFunc, CFuncType, RawJITFunc
 from xdsl.jit.llvm.c_type_context import register_llvm_ctypes, to_c_func_type
-from xdsl.jit.py_type_context import PyTypeContext, TypeMap
 from xdsl.passes import ModulePass, PassPipeline
 from xdsl.traits import SymbolTable
 from xdsl.transforms.mlir_opt import MLIROptPass
-
-P = ParamSpec("P")
-R = TypeVar("R")
-
-# --- Driver / backend interface (xdsl.jit) ---
-
-
-class JITBackend(abc.ABC):
-    """
-    Compile a module symbol to a :class:`RawJITFunc`.
-
-    Implementations receive the module produced by the frontend, lower it to the
-    backend’s dialect, and bind ``symbol`` for native calls.
-    """
-
-    c_type_context: CTypeContext
-    """IR type attribute to ctypes type registry."""
-
-    def __init__(self):
-        """Initialize an empty :class:`CTypeContext`."""
-        super().__init__()
-        self.c_type_context = CTypeContext()
-
-    @abc.abstractmethod
-    def jit(
-        self,
-        mlir_module: builtin.ModuleOp,
-        symbol: str,
-        ir_context: Context,
-    ) -> RawJITFunc:
-        """Lower ``mlir_module`` and JIT-compile ``symbol``."""
-        ...
-
-
-class JITContext:
-    """
-    Configure frontend, Python ctypes bridges, and backend into a ``@jit`` decorator.
-
-    Authors register types, operations, and dialects on :attr:`pyast_ctx`, extend
-    type converters for ABI types, and supply a :class:`JITBackend`. End users apply
-    :meth:`jit`.
-    """
-
-    pyast_ctx: PyASTContext
-    """Frontend used to parse Python functions into IR."""
-
-    py_type_context: PyTypeContext
-    """Python value to ctypes marshalling registry."""
-
-    jit_backend: JITBackend
-    """Backend that lowers IR and produces a :class:`RawJITFunc`."""
-
-    def __init__(self, jit_backend: JITBackend):
-        """Create empty frontend and type-converter state around ``jit_backend``."""
-        self.pyast_ctx = PyASTContext()
-        self.py_type_context = PyTypeContext()
-        self.jit_backend = jit_backend
-
-    def jit(
-        self, signature: TypeForm[Callable[P, R]]
-    ) -> Callable[[Callable[P, R]], WrappedJITFunc[P, R]]:
-        """Return a decorator that JIT-compiles a function with ``signature``."""
-
-        def inner(func: Callable[P, R]) -> WrappedJITFunc[P, R]:
-            parsed_program = self.pyast_ctx.parse_program(func)
-            raw = self.jit_backend.jit(
-                parsed_program.module,
-                parsed_program.name,
-                self.pyast_ctx.ir_context,
-            )
-            return wrap_jit_func(raw, func, signature, self.py_type_context)
-
-        return inner
-
-
-def register_default_type_conversion(ctx: JITContext) -> None:
-    """
-    Register type bridges on ``ctx``, e.g. ``float`` / ``f64`` / ``c_double``.
-
-    Updates the frontend type map and the :class:`PyTypeContext` together. The
-    backend registers the IR side on its own :class:`CTypeContext`.
-    """
-    ctx.pyast_ctx.register_type(float, builtin.f64)
-    ctx.py_type_context.register_type_map(TypeMap(float, c_double, c_double, float))
-
 
 # --- LLVM / llvmlite backend (xdsl.jit.llvm) ---
 
@@ -255,7 +159,7 @@ ctx.pyast_ctx.register_dialect(arith.Arith)
 ctx.pyast_ctx.register_dialect(builtin.Builtin)
 ctx.pyast_ctx.register_dialect(func.Func)
 
-register_default_type_conversion(ctx)
+register_builtin_type_maps(ctx)
 
 # --- Example: end-user code ---
 

--- a/tests/jit/test_context.py
+++ b/tests/jit/test_context.py
@@ -1,0 +1,80 @@
+import ctypes
+from collections.abc import Callable
+
+import pytest
+
+from xdsl.context import Context
+from xdsl.dialects import arith, builtin, func
+from xdsl.frontend.pyast.program import PyASTProgram
+from xdsl.jit.context import JITBackend, JITContext, register_builtin_type_maps
+from xdsl.jit.function import RawJITFunc
+from xdsl.jit.py_type_context import TypeMap
+from xdsl.traits import SymbolTable
+
+
+def subtract(lhs: float, rhs: float, /) -> float:
+    return lhs - rhs
+
+
+class StubJITBackend(JITBackend):
+    # records its inputs and binds `subtract` instead of compiling
+    mlir_module: builtin.ModuleOp
+    symbol: str
+    ir_context: Context
+    raw_func: RawJITFunc
+
+    def jit(
+        self,
+        mlir_module: builtin.ModuleOp,
+        symbol: str,
+        ir_context: Context,
+    ) -> RawJITFunc:
+        self.mlir_module = mlir_module
+        self.symbol = symbol
+        self.ir_context = ir_context
+        c_func_type = ctypes.CFUNCTYPE(
+            ctypes.c_double, ctypes.c_double, ctypes.c_double
+        )
+        self.raw_func = RawJITFunc(c_func_type, c_func_type(subtract))
+        return self.raw_func
+
+
+@pytest.fixture
+def backend() -> StubJITBackend:
+    return StubJITBackend()
+
+
+@pytest.fixture
+def jit_context(backend: StubJITBackend) -> JITContext:
+    context = JITContext(backend)
+    context.pyast_ctx.register_function(float.__add__, arith.AddfOp)
+    register_builtin_type_maps(context)
+    return context
+
+
+def test_jit_compiles_and_wraps(jit_context: JITContext, backend: StubJITBackend):
+    @jit_context.jit(Callable[[float, float], float])
+    def plus(a: float, b: float) -> float:
+        return a + b
+
+    assert backend.symbol == "plus"
+    assert backend.ir_context is jit_context.pyast_ctx.ir_context
+    assert isinstance(
+        SymbolTable.lookup_symbol(backend.mlir_module, "plus"), func.FuncOp
+    )
+    assert plus(3.0, 4.0) == -1.0  # `subtract` and not `plus` in mock backend
+    assert plus.raw_func is backend.raw_func
+    assert not isinstance(plus.original_func, PyASTProgram)
+
+
+def test_each_backend_owns_its_c_type_context():
+    first, second = StubJITBackend(), StubJITBackend()
+    first.c_type_context.register_ctype(builtin.Float64Type, lambda _: ctypes.c_double)
+    assert second.c_type_context.registry == {}
+
+
+def test_register_builtin_type_maps(jit_context: JITContext):
+    assert jit_context.pyast_ctx.type_registry.get_annotation(builtin.f64) is float
+    assert jit_context.py_type_context.type_map(float) == TypeMap(
+        float, ctypes.c_double, ctypes.c_double, float
+    )

--- a/xdsl/jit/context.py
+++ b/xdsl/jit/context.py
@@ -1,0 +1,101 @@
+import abc
+from collections.abc import Callable
+from ctypes import c_double
+from typing import ParamSpec
+
+from typing_extensions import TypeForm, TypeVar
+
+from xdsl.context import Context
+from xdsl.dialects import builtin
+from xdsl.frontend.pyast.context import PyASTContext
+from xdsl.jit.c_type_context import CTypeContext
+from xdsl.jit.function import RawJITFunc, WrappedJITFunc, wrap_jit_func
+from xdsl.jit.py_type_context import PyTypeContext, TypeMap
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+
+class JITBackend(abc.ABC):
+    """
+    Compile a module symbol to a :class:`~xdsl.jit.function.RawJITFunc`.
+
+    Implementations receive the module produced by the frontend, lower it to the
+    backend’s dialect, and bind ``symbol`` for native calls.
+    """
+
+    c_type_context: CTypeContext
+    """IR type attribute to ctypes type registry."""
+
+    def __init__(self):
+        """Initialize an empty :class:`~xdsl.jit.c_type_context.CTypeContext`."""
+        super().__init__()
+        self.c_type_context = CTypeContext()
+
+    @abc.abstractmethod
+    def jit(
+        self,
+        mlir_module: builtin.ModuleOp,
+        symbol: str,
+        ir_context: Context,
+    ) -> RawJITFunc:
+        """Lower ``mlir_module`` and JIT-compile ``symbol``."""
+        ...
+
+
+class JITContext:
+    """
+    Configure frontend, Python ctypes bridges, and backend into a ``@jit`` decorator.
+
+    Authors register types, operations, and dialects on :attr:`pyast_ctx`, extend
+    type converters for ABI types, and supply a :class:`JITBackend`. End users apply
+    :meth:`jit`.
+    """
+
+    pyast_ctx: PyASTContext
+    """Frontend used to parse Python functions into IR."""
+
+    py_type_context: PyTypeContext
+    """Python value to ctypes marshalling registry."""
+
+    jit_backend: JITBackend
+    """Backend that lowers IR and produces a :class:`~xdsl.jit.function.RawJITFunc`."""
+
+    def __init__(self, jit_backend: JITBackend):
+        """Create empty frontend and type-converter state around ``jit_backend``."""
+        self.pyast_ctx = PyASTContext()
+        self.py_type_context = PyTypeContext()
+        self.jit_backend = jit_backend
+
+    def jit(
+        self, signature: TypeForm[Callable[P, R]]
+    ) -> Callable[[Callable[P, R]], WrappedJITFunc[P, R]]:
+        """
+        Return a decorator that JIT-compiles a function with ``signature``.
+
+        ``signature`` is the ABI used for marshalling. It is passed explicitly so
+        that annotations need not be evaluated.
+        """
+
+        def inner(func: Callable[P, R]) -> WrappedJITFunc[P, R]:
+            parsed_program = self.pyast_ctx.parse_program(func)
+            raw = self.jit_backend.jit(
+                parsed_program.module,
+                parsed_program.name,
+                self.pyast_ctx.ir_context,
+            )
+            return wrap_jit_func(raw, func, signature, self.py_type_context)
+
+        return inner
+
+
+def register_builtin_type_maps(ctx: JITContext) -> None:
+    """
+    Register type bridges on ``ctx``, e.g. ``float`` / ``f64`` / ``c_double``.
+
+    Updates the frontend type map and the
+    :class:`~xdsl.jit.py_type_context.PyTypeContext` together. The backend registers
+    the IR side on its own :class:`~xdsl.jit.c_type_context.CTypeContext`.
+    """
+    ctx.pyast_ctx.register_type(float, builtin.f64)
+    ctx.py_type_context.register_type_map(TypeMap(float, c_double, c_double, float))


### PR DESCRIPTION
Moves the JIT context and backend interface out of the pyjit prototype and tests them with a silly mock JIT backend.