### PR TITLE
backend: (x86) make the allocatable register set depend on the target

### DIFF
--- a/tests/backend/x86/test_register_stack.py
+++ b/tests/backend/x86/test_register_stack.py
@@ -1,6 +1,7 @@
 import pytest
 
 from xdsl.backend.register_stack import OutOfRegisters
+from xdsl.backend.x86.arch import AVX2, AVX512, UNKNOWN, X86Arch
 from xdsl.backend.x86.register_stack import X86RegisterStack
 from xdsl.dialects import x86
 
@@ -67,3 +68,44 @@ def test_vector_registers_share_one_pool():
 
     with pytest.raises(OutOfRegisters):
         stack.pop(x86.registers.AVX2RegisterType)
+
+
+def test_default_stack_stops_at_the_vex_boundary():
+    """
+    Without a target the allocator must assume VEX, which reaches ymm0-15 only.
+
+    ymm16-31 exist in the register file but can only be named through EVEX, so
+    handing them out by default emits instructions the target may not decode.
+    """
+    register_stack = X86RegisterStack.get()
+
+    for _ in range(16):
+        register_stack.pop(x86.AVX2RegisterType)
+
+    with pytest.raises(OutOfRegisters):
+        register_stack.pop(x86.AVX2RegisterType)
+
+
+@pytest.mark.parametrize(
+    "arch, expected",
+    [(UNKNOWN, 16), (AVX2, 16), (AVX512, 32)],
+)
+def test_vector_registers_available_per_arch(arch: X86Arch, expected: int):
+    """AVX-512 is the only target that can name the upper half of the bank."""
+    register_stack = X86RegisterStack.get_for_arch(arch)
+
+    for _ in range(expected):
+        register_stack.pop(x86.AVX2RegisterType)
+
+    with pytest.raises(OutOfRegisters):
+        register_stack.pop(x86.AVX2RegisterType)
+
+
+@pytest.mark.parametrize("arch", [UNKNOWN, AVX2, AVX512])
+def test_general_purpose_registers_do_not_vary_by_arch(arch: X86Arch):
+    """Only the vector half of the set is target dependent."""
+    assert [
+        reg
+        for reg in arch.default_allocatable_registers()
+        if isinstance(reg, x86.registers.Reg64Type)
+    ] == list(x86.registers.Reg64Type.allocatable_registers())

--- a/xdsl/backend/x86/arch.py
+++ b/xdsl/backend/x86/arch.py
@@ -55,6 +55,20 @@ class X86Arch(Arch):
                 f"{sorted(_ARCH_BY_NAME)}."
             ) from None
 
+    def default_allocatable_registers(self) -> tuple[X86RegisterType, ...]:
+        """
+        The registers the allocator may use on this target.
+
+        The upper half of each vector bank, xmm16-31 and ymm16-31, is only
+        reachable through EVEX, so it exists on AVX-512 targets and nowhere
+        else. Every vector bank shares one allocation pool, so the vector half
+        is indexed off a single bank rather than listing each of them.
+        """
+        return (
+            *Reg64Type.allocatable_registers(),
+            *AVX2RegisterType.allocatable_registers()[:16],
+        )
+
     def _register_type_for_vector_type(
         self, value_type: VectorType
     ) -> type[X86VectorRegisterType]:
@@ -196,6 +210,12 @@ class AVX512Arch(X86Arch):
         256: AVX2RegisterType,
         512: AVX512RegisterType,
     }
+
+    def default_allocatable_registers(self) -> tuple[X86RegisterType, ...]:
+        return (
+            *Reg64Type.allocatable_registers(),
+            *AVX2RegisterType.allocatable_registers(),
+        )
 
 
 AVX512 = AVX512Arch()

--- a/xdsl/backend/x86/register_stack.py
+++ b/xdsl/backend/x86/register_stack.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from typing_extensions import override
 
 from xdsl.backend.register_stack import RegisterStack
-from xdsl.dialects.x86 import registers
+from xdsl.backend.x86.arch import UNKNOWN, X86Arch
 
 
 @dataclass
@@ -12,13 +12,24 @@ class X86RegisterStack(RegisterStack):
     Available x86-specific registers.
     """
 
-    DEFAULT_ALLOCATABLE_REGISTERS = (
-        *reversed(registers.Reg64Type.allocatable_registers()),
-        *reversed(registers.AVX2RegisterType.allocatable_registers()),
-        *reversed(registers.AVX512RegisterType.allocatable_registers()),
+    DEFAULT_ALLOCATABLE_REGISTERS = tuple(
+        reversed(UNKNOWN.default_allocatable_registers())
     )
 
     @classmethod
     @override
     def default_allocatable_registers(cls):
         return cls.DEFAULT_ALLOCATABLE_REGISTERS
+
+    @classmethod
+    def get_for_arch(cls, arch: X86Arch, *, allow_infinite: bool = False):
+        """
+        Build a stack holding the registers this target can actually encode.
+
+        Handing out the EVEX-only half of a vector bank on a VEX-only target
+        produces assembly that target cannot run.
+        """
+        return cls.get(
+            reversed(arch.default_allocatable_registers()),
+            allow_infinite=allow_infinite,
+        )


### PR DESCRIPTION
Split out of #6363 at your suggestion, so the register set per target can land on its own.

### What it does

`X86Arch.default_allocatable_registers` returns the registers the allocator may use on that target, and `X86RegisterStack.get_for_arch` builds a stack from it.

The default stack listed both `AVX2RegisterType` and `AVX512RegisterType`. Every vector bank shares one allocation pool, so that was never really about banks: it put indices 0 to 31 into the pool unconditionally. The upper half, `xmm16-31` and `ymm16-31`, can only be named through EVEX, so on a VEX-only target the allocator was handing out registers the target cannot encode. This is the register set half of #6358.

| target | vector registers |
| --- | --- |
| `unknown`, the default | `ymm0-15` |
| `avx2` | `ymm0-15` |
| `avx512` | `ymm0-31` |

The general purpose set does not vary by target and is unchanged.

### On the shape you proposed

Went with `default_allocatable_registers` returning the whole set rather than a vector-only helper, and dropped `VECTOR_REGISTER_COUNT`. AVX-512 spells its own set out, so the duplication is one method body and each target reads on its own without chasing a count.

I did keep the vector half indexed off `AVX2RegisterType` rather than listing every bank, since they share the pool and what matters is which indices are available rather than which bank names them. Happy to list them if you would rather.

### Behaviour change

The default drops from thirty two vector registers to sixteen. Nothing in the tree depends on the old default: 5250 unit tests pass, and the filecheck suite passes including `test-vectorize-matmul` and the libxsmm project, both of which stay within sixteen. `tests/dialects/test_universe.py::test_multiverse` fails for me, but it fails on a clean `main` too.

Once this is in I will update #6363 to use the helper.
