### PR TITLE
dialects: (linalg) tile through any affine indexing map

### DIFF
--- a/tests/filecheck/transforms/linalg-tiling-reject-unsupported.mlir
+++ b/tests/filecheck/transforms/linalg-tiling-reject-unsupported.mlir
@@ -59,24 +59,6 @@ builtin.module {
 // -----
 
 builtin.module {
-  %input = "test.op"() : () -> memref<4x4xf32>
-  %output = "test.op"() : () -> memref<4x4xf32>
-  linalg.generic {
-      indexing_maps = [
-          affine_map<(i, j) -> (i + j)>,
-          affine_map<(i, j) -> (i, j)>
-      ],
-      iterator_types = ["parallel", "parallel"]
-  } ins(%input : memref<4x4xf32>) outs(%output : memref<4x4xf32>) attrs = {test_tile_sizes = array<i32: 2, 2>} {
-  ^bb0(%in: f32, %out: f32):
-      linalg.yield %in : f32
-  }
-}
-// CHECK: tiling a linalg op with non-projected-permutation indexing maps is not supported yet
-
-// -----
-
-builtin.module {
   %input = "test.op"() : () -> memref<4x4xf32, affine_map<(d0, d1) -> (d0 * 4 + d1)>>
   %output = "test.op"() : () -> memref<4x4xf32, affine_map<(d0, d1) -> (d0 * 4 + d1)>>
   linalg.generic {

--- a/tests/filecheck/transforms/linalg-tiling.mlir
+++ b/tests/filecheck/transforms/linalg-tiling.mlir
@@ -607,3 +607,113 @@ linalg.matmul {test_tile_sizes = array<i32: 2, 2, 0>} ins(%A, %B : memref<4x6xf3
 // CHECK-NEXT:   }
 // CHECK-NEXT:   "test.op"(%D) : (tensor<4x4xf32>) -> ()
 // CHECK-NEXT: }
+
+// -----
+
+// An indexing map result that reads more than one loop, so that the operand
+// dimension it addresses is not one loop's to tile. It is read from where the
+// tiled loop is and spans the loops it reads together, the tile of 2 in the
+// first and the whole 4 of the second reaching 5 elements.
+
+%A, %C = "test.op"() : () -> (memref<8xf32>, memref<4x4xf32>)
+
+linalg.generic {
+  indexing_maps = [affine_map<(d0, d1) -> (d0 + d1)>, affine_map<(d0, d1) -> (d0, d1)>],
+  iterator_types = ["parallel", "parallel"]
+} ins(%A : memref<8xf32>) outs(%C : memref<4x4xf32>) attrs = {test_tile_sizes = array<i32: 2, 0>} {
+^bb0(%a: f32, %c: f32):
+  linalg.yield %a : f32
+}
+
+// CHECK:      builtin.module {
+// CHECK-NEXT:   %A, %C = "test.op"() : () -> (memref<8xf32>, memref<4x4xf32>)
+// CHECK-NEXT:   %0 = arith.constant 0 : index
+// CHECK-NEXT:   %1 = arith.constant 4 : index
+// CHECK-NEXT:   %2 = arith.constant 2 : index
+// CHECK-NEXT:   scf.for %3 = %0 to %1 step %2 {
+// CHECK-NEXT:     %4 = memref.subview %A[%3] [5] [1] : memref<8xf32> to memref<5xf32, strided<[1], offset: ?>>
+// CHECK-NEXT:     %5 = memref.subview %C[%3, 0] [2, 4] [1, 1] : memref<4x4xf32> to memref<2x4xf32, strided<[4, 1], offset: ?>>
+// CHECK-NEXT:     linalg.generic {indexing_maps = [affine_map<(d0, d1) -> ((d0 + d1))>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%4 : memref<5xf32, strided<[1], offset: ?>>) outs(%5 : memref<2x4xf32, strided<[4, 1], offset: ?>>) {
+// CHECK-NEXT:     ^bb0(%a: f32, %c: f32):
+// CHECK-NEXT:       linalg.yield %a : f32
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+
+// -----
+
+// A result that steps through its operand rather than walking it, and one that
+// is offset by a constant. The stride is left at one and taken up by the size,
+// which spans what the tile reaches, and the constant drops out of the offset,
+// which the operand is not moved along by.
+
+%A, %B, %C = "test.op"() : () -> (memref<16xf32>, memref<16xf32>, memref<8xf32>)
+
+linalg.generic {
+  indexing_maps = [affine_map<(d0) -> (d0 * 2)>, affine_map<(d0) -> (d0 + 3)>, affine_map<(d0) -> (d0)>],
+  iterator_types = ["parallel"]
+} ins(%A, %B : memref<16xf32>, memref<16xf32>) outs(%C : memref<8xf32>) attrs = {test_tile_sizes = array<i32: 4>} {
+^bb0(%a: f32, %b: f32, %c: f32):
+  %s = arith.addf %a, %b : f32
+  linalg.yield %s : f32
+}
+
+// CHECK:      builtin.module {
+// CHECK-NEXT:   %A, %B, %C = "test.op"() : () -> (memref<16xf32>, memref<16xf32>, memref<8xf32>)
+// CHECK-NEXT:   %0 = arith.constant 0 : index
+// CHECK-NEXT:   %1 = arith.constant 8 : index
+// CHECK-NEXT:   %2 = arith.constant 4 : index
+// CHECK-NEXT:   scf.for %3 = %0 to %1 step %2 {
+// CHECK-NEXT:     %4 = affine.apply affine_map<(d0) -> ((d0 * 2))> (%3)
+// CHECK-NEXT:     %5 = memref.subview %A[%4] [7] [1] : memref<16xf32> to memref<7xf32, strided<[1], offset: ?>>
+// CHECK-NEXT:     %6 = memref.subview %B[%3] [7] [1] : memref<16xf32> to memref<7xf32, strided<[1], offset: ?>>
+// CHECK-NEXT:     %7 = memref.subview %C[%3] [4] [1] : memref<8xf32> to memref<4xf32, strided<[1], offset: ?>>
+// CHECK-NEXT:     linalg.generic {indexing_maps = [affine_map<(d0) -> ((d0 * 2))>, affine_map<(d0) -> ((d0 + 3))>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%5, %6 : memref<7xf32, strided<[1], offset: ?>>, memref<7xf32, strided<[1], offset: ?>>) outs(%7 : memref<4xf32, strided<[1], offset: ?>>) {
+// CHECK-NEXT:     ^bb0(%a: f32, %b: f32, %c: f32):
+// CHECK-NEXT:       %s = arith.addf %a, %b : f32
+// CHECK-NEXT:       linalg.yield %s : f32
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+
+// -----
+
+// One operand read two ways at once, where a tile size divides one loop and not
+// the other. The first dimension is read from both loops and spans a tile of
+// each, which the loop it does not divide leaves running to a size worked out as
+// the op runs. The second is read from the loop that is divided alone, so its
+// span is known here and no work is left for the op to do.
+
+%A, %C = "test.op"() : () -> (memref<9x7xf32>, memref<6x4xf32>)
+
+linalg.generic {
+  indexing_maps = [affine_map<(d0, d1) -> (d0 + d1, d1 * 2)>, affine_map<(d0, d1) -> (d0, d1)>],
+  iterator_types = ["parallel", "parallel"]
+} ins(%A : memref<9x7xf32>) outs(%C : memref<6x4xf32>) attrs = {test_tile_sizes = array<i32: 4, 2>} {
+^bb0(%a: f32, %c: f32):
+  linalg.yield %a : f32
+}
+
+// CHECK:      builtin.module {
+// CHECK-NEXT:   %A, %C = "test.op"() : () -> (memref<9x7xf32>, memref<6x4xf32>)
+// CHECK-NEXT:   %0 = arith.constant 0 : index
+// CHECK-NEXT:   %1 = arith.constant 6 : index
+// CHECK-NEXT:   %2 = arith.constant 4 : index
+// CHECK-NEXT:   %3 = arith.constant 4 : index
+// CHECK-NEXT:   %4 = arith.constant 2 : index
+// CHECK-NEXT:   scf.for %5 = %0 to %1 step %3 {
+// CHECK-NEXT:     scf.for %6 = %0 to %2 step %4 {
+// CHECK-NEXT:       %7 = affine.min affine_map<(d0, d1, d2) -> (d0, (d1 + (d2 * -1)))> (%3, %1, %5)
+// CHECK-NEXT:       %8 = affine.apply affine_map<(d0) -> ((d0 + -1))> (%7)
+// CHECK-NEXT:       %9 = affine.apply affine_map<(d0, d1) -> ((d0 + d1))> (%5, %6)
+// CHECK-NEXT:       %10 = affine.apply affine_map<(d0) -> ((d0 + 2))> (%8)
+// CHECK-NEXT:       %11 = affine.apply affine_map<(d0, d1) -> ((d1 * 2))> (%5, %6)
+// CHECK-NEXT:       %12 = memref.subview %A[%9, %11] [%10, 3] [1, 1] : memref<9x7xf32> to memref<?x3xf32, strided<[7, 1], offset: ?>>
+// CHECK-NEXT:       %13 = memref.subview %C[%5, %6] [%7, 2] [1, 1] : memref<6x4xf32> to memref<?x2xf32, strided<[4, 1], offset: ?>>
+// CHECK-NEXT:       linalg.generic {indexing_maps = [affine_map<(d0, d1) -> ((d0 + d1), (d1 * 2))>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%12 : memref<?x3xf32, strided<[7, 1], offset: ?>>) outs(%13 : memref<?x2xf32, strided<[4, 1], offset: ?>>) {
+// CHECK-NEXT:       ^bb0(%a: f32, %c: f32):
+// CHECK-NEXT:         linalg.yield %a : f32
+// CHECK-NEXT:       }
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT: }

--- a/tests/transforms/test_linalg_tiling_helpers.py
+++ b/tests/transforms/test_linalg_tiling_helpers.py
@@ -239,7 +239,7 @@ def test_tiling_plan_tiles_a_dim_whose_tile_size_is_not_static():
     assert plan.tile_sizes == (tile_size, 0)
 
 
-def test_tiling_plan_rejects_non_projected_permutation_map():
+def test_tiling_plan_accepts_non_projected_permutation_map():
     i = AffineExpr.dimension(0)
     j = AffineExpr.dimension(1)
 
@@ -251,8 +251,32 @@ def test_tiling_plan_rejects_non_projected_permutation_map():
         ],
     )
 
-    with pytest.raises(ValueError, match="non-projected-permutation indexing maps"):
-        TilingPlan.analyze(op, (2, 0))
+    plan = TilingPlan.analyze(op, (2, 0))
+
+    assert plan.tiled_dims == (0,)
+    # The input reads both loops in one result, which no single loop range can
+    # be read back from, so no loop dimension is recorded for it.
+    assert plan.operand_infos[0].loop_dims == (None,)
+    assert plan.operand_infos[1].loop_dims == (0, 1)
+
+
+def test_slice_parameters_span_a_result_reading_two_loops():
+    i = AffineExpr.dimension(0)
+    j = AffineExpr.dimension(1)
+    iv = create_ssa_value(IndexType())
+
+    # d0 + d1 over a tile of 2 in d0 and the whole of d1, which is 5 long, is
+    # read from where d0 is and spans the two of them together, 2 + 5 - 1.
+    parameters = _compute_slice(
+        AffineMap(2, 0, (i + j,)),
+        MemRefType(f32, [8]),
+        {0: iv},
+        {0: 2},
+        loop_ranges=(4, 5),
+    )
+
+    assert parameters.sizes == (6,)
+    assert parameters.strides == (1,)
 
 
 def test_tiling_plan_marks_dims_with_a_leftover_tile():
@@ -284,13 +308,33 @@ def test_tiling_plan_marks_a_tile_larger_than_its_range_partial():
     assert plan.partial_tiled_dims == frozenset({0})
 
 
+def _compute_slice(
+    indexing_map: AffineMap,
+    source_type: MemRefType[Attribute] | TensorType[Attribute],
+    tiled_loop_ivs: dict[int, SSAValue],
+    effective_tile_sizes: dict[int, SSAValue | int],
+    loop_ranges: Sequence[int] = (4, 5),
+) -> SliceParameters:
+    """Compute one operand's slice, into a module the built ops can go in."""
+    op = _generic_2d_copy_op()
+    ModuleOp([op])
+    return SliceParameters.compute(
+        PatternRewriter(op),
+        InsertPoint.before(op),
+        indexing_map,
+        OperandTileInfo.analyze(indexing_map, source_type),
+        tiled_loop_ivs,
+        effective_tile_sizes,
+        loop_ranges,
+    )
+
+
 def test_slice_parameters_compute_tiled_and_untiled_dims():
     source_type = MemRefType(f32, [4, 5])
     iv = create_ssa_value(IndexType())
     indexing_map = AffineMap.from_callable(lambda i, j: (i, j))
-    operand_info = OperandTileInfo.analyze(indexing_map, source_type)
 
-    parameters = SliceParameters.compute(indexing_map, operand_info, {0: iv}, {0: 2})
+    parameters = _compute_slice(indexing_map, source_type, {0: iv}, {0: 2})
 
     # Dim 0's loop is tiled, so it starts at the induction variable and spans one
     # tile; dim 1's loop is not, so it starts at zero and spans the whole operand.
@@ -302,9 +346,8 @@ def test_slice_parameters_compute_tiled_and_untiled_dims():
 def test_slice_parameters_compute_without_tiled_dims():
     source_type = MemRefType(f32, [4, 5])
     indexing_map = AffineMap.from_callable(lambda i, j: (i, j))
-    operand_info = OperandTileInfo.analyze(indexing_map, source_type)
 
-    parameters = SliceParameters.compute(indexing_map, operand_info, {}, {})
+    parameters = _compute_slice(indexing_map, source_type, {}, {})
 
     # Nothing is tiled, so the slice covers the whole operand.
     assert parameters.offsets == (0, 0)
@@ -317,9 +360,8 @@ def test_slice_parameters_compute_follows_indexing_map():
     source_type = MemRefType(f32, [5, 4])
     iv = create_ssa_value(IndexType())
     indexing_map = AffineMap.from_callable(lambda i, j: (j, i))
-    operand_info = OperandTileInfo.analyze(indexing_map, source_type)
 
-    parameters = SliceParameters.compute(indexing_map, operand_info, {0: iv}, {0: 2})
+    parameters = _compute_slice(indexing_map, source_type, {0: iv}, {0: 2})
 
     assert parameters.offsets == (0, iv)
     assert parameters.sizes == (5, 2)
@@ -334,8 +376,7 @@ def _tiled_slice_for(source_type: MemRefType[Attribute] | TensorType[Attribute])
     operand = create_ssa_value(source_type)
     iv = create_ssa_value(IndexType())
     indexing_map = AffineMap.from_callable(lambda i, j: (i, j))
-    operand_info = OperandTileInfo.analyze(indexing_map, source_type)
-    parameters = SliceParameters.compute(indexing_map, operand_info, {0: iv}, {0: 2})
+    parameters = _compute_slice(indexing_map, source_type, {0: iv}, {0: 2})
 
     result = _build_tiled_slice(
         rewriter, InsertPoint.before(op), operand, source_type, parameters
@@ -377,8 +418,7 @@ def _tiled_insert_for(
 
     iv = create_ssa_value(IndexType())
     indexing_map = AffineMap.from_callable(lambda i, j: (i, j))
-    operand_info = OperandTileInfo.analyze(indexing_map, destination_type)
-    parameters = SliceParameters.compute(indexing_map, operand_info, {0: iv}, {0: 2})
+    parameters = _compute_slice(indexing_map, destination_type, {0: iv}, {0: 2})
 
     destination = create_ssa_value(destination_type)
     tiled_value = create_ssa_value(

--- a/xdsl/dialects/linalg/transforms/tiling.py
+++ b/xdsl/dialects/linalg/transforms/tiling.py
@@ -15,7 +15,12 @@ from xdsl.dialects.builtin import (
 )
 from xdsl.dialects.utils import split_dynamic_index_list
 from xdsl.ir import Attribute, Block, Region, SSAValue
-from xdsl.ir.affine import AffineDimExpr, AffineExpr, AffineMap
+from xdsl.ir.affine import (
+    AffineConstantExpr,
+    AffineDimExpr,
+    AffineExpr,
+    AffineMap,
+)
 from xdsl.pattern_rewriter import PatternRewriter
 from xdsl.rewriter import InsertPoint
 from xdsl.utils.exceptions import PassFailedException
@@ -60,11 +65,13 @@ class OperandTileInfo:
     """
     This records how one operand should be sliced when we enter a tile.
     - `source_type` keeps the original type.
-    - `loop_dims` the loop dimension that comes from each indexing-map.
+    - `loop_dims` the loop dimension each indexing-map result reads, where it
+      reads exactly one, and `None` where it reads an expression over several or
+      none, which no single loop range can be read back from.
     """
 
     source_type: MemRefType[Attribute] | TensorType[Attribute]
-    loop_dims: tuple[int, ...]
+    loop_dims: tuple[int | None, ...]
 
     @staticmethod
     def analyze(
@@ -76,7 +83,8 @@ class OperandTileInfo:
         """
 
         loop_dims = tuple(
-            cast(AffineDimExpr, expr).position for expr in indexing_map.results
+            expr.position if isinstance(expr, AffineDimExpr) else None
+            for expr in indexing_map.results
         )
         return OperandTileInfo(source_type, loop_dims)
 
@@ -200,8 +208,7 @@ def _verify_is_tileable(
     # reduction associating as it did before, so this holds for a reduction that
     # cannot be reassociated, such as one over floats.
 
-    indexing_maps = tuple(attr.data for attr in op.get_indexing_maps())
-    for operand, indexing_map in zip(op.operands, indexing_maps, strict=True):
+    for operand in op.operands:
         raw_operand_type = operand.type
 
         if not isa(raw_operand_type, MemRefType) and not isa(
@@ -212,12 +219,30 @@ def _verify_is_tileable(
                 "tensors is not supported yet"
             )
 
-        if not indexing_map.is_projected_permutation():
+    loop_ranges = op.get_static_loop_ranges()
+
+    # The bounds of the `scf.for` we build come from `loop_ranges`. One that is
+    # dynamic is read at runtime instead, with a `memref.dim` or `tensor.dim` on
+    # an operand, so we need an indexing map result that is exactly `dN` to tell
+    # us which operand to read and which of its dimensions. A result like
+    # `d0 + d1` names no single dimension to read, so a dynamic loop reachable
+    # only that way is rejected.
+    indexing_maps = tuple(attr.data for attr in op.get_indexing_maps())
+    readable_dims = {
+        expr.position
+        for indexing_map in indexing_maps
+        for expr in indexing_map.results
+        if isinstance(expr, AffineDimExpr)
+    }
+    for dim in tiled_dims:
+        if loop_ranges[dim] < 0 and dim not in readable_dims:
             raise ValueError(
-                "tiling a linalg op with non-projected-permutation indexing maps is not supported yet"
+                "tiling a linalg op dimension whose range is not known until "
+                "it runs and that no indexing map reads on its own is not "
+                "supported yet"
             )
 
-    return op.get_static_loop_ranges()
+    return loop_ranges
 
 
 def _loop_range_sources(
@@ -370,6 +395,71 @@ def _build_effective_tile_sizes(
     return effective
 
 
+def _apply_affine_expr(
+    rewriter: PatternRewriter,
+    insertion_point: InsertPoint,
+    expr: AffineExpr,
+    values: Sequence[SSAValue | int],
+) -> SSAValue | int:
+    """
+    Evaluate one result of an indexing map, given a value per loop dimension.
+
+    Returns either an `int`, when the answer is known here, or an SSA value.
+
+    An `affine.apply` is only built when one is needed. A result that is just
+    `dN` is the value given for that dimension, and one whose values are all
+    ints is worked out here. Otherwise the int values are written into the map
+    as constants, and only the SSA ones are passed to the op as operands.
+    """
+
+    if isinstance(expr, AffineDimExpr):
+        return values[expr.position]
+
+    if all(isinstance(value, int) for value in values):
+        return expr.eval(cast(Sequence[int], values), ())
+
+    replacements: list[AffineExpr] = []
+    operands: list[SSAValue] = []
+    for value in values:
+        if isinstance(value, int):
+            replacements.append(AffineExpr.constant(value))
+        else:
+            replacements.append(AffineExpr.dimension(len(operands)))
+            operands.append(value)
+
+    substituted = expr.replace_dims_and_symbols(replacements, ())
+
+    # Writing the known values in can leave a map with nothing left to compute,
+    # so return the value directly rather than emitting an `affine.apply` that
+    # only forwards one operand or yields a constant.
+    if isinstance(substituted, AffineConstantExpr):
+        return substituted.value
+    if isinstance(substituted, AffineDimExpr):
+        return operands[substituted.position]
+
+    apply_op = affine.ApplyOp(
+        operands,
+        AffineMapAttr(AffineMap(len(operands), 0, (substituted,))),
+    )
+    rewriter.insert(apply_op, insertion_point)
+    return apply_op.result
+
+
+def _decrement(
+    rewriter: PatternRewriter,
+    insertion_point: InsertPoint,
+    value: SSAValue | int,
+) -> SSAValue | int:
+    """
+    Turn a count of elements into the index of its last one, `n` into `n - 1`,
+    building an `affine.apply` when the count is not known here.
+    """
+
+    return _apply_affine_expr(
+        rewriter, insertion_point, AffineExpr.dimension(0) - 1, (value,)
+    )
+
+
 @dataclass(frozen=True)
 class SliceParameters:
     """
@@ -386,33 +476,90 @@ class SliceParameters:
 
     @staticmethod
     def compute(
+        rewriter: PatternRewriter,
+        insertion_point: InsertPoint,
         indexing_map: AffineMap,
         operand_info: OperandTileInfo,
         tiled_loop_ivs: dict[int, SSAValue],
         effective_tile_sizes: dict[int, SSAValue | int],
+        loop_ranges: Sequence[int],
     ) -> "SliceParameters":
         """
-        Compute where the current tile sits within one operand.
+        Compute the offsets and sizes for one operand's `memref.subview` or
+        `tensor.extract_slice`.
 
-        Each result of the indexing map addresses one dimension of the operand.
-        A dimension whose loop is tiled starts at that loop's induction variable
-        and spans the current tile, and a dimension whose loop is not tiled
-        starts at zero and spans the whole operand.
+        There is one offset and one size per operand dimension, and the indexing
+        map has one result per operand dimension saying how the loops reach it.
+
+        - A result that no tiled loop appears in is not sliced at all: offset 0,
+          and the whole dimension for its size.
+        - A result that is just `dN`, for a tiled loop, takes that loop's
+          induction variable as its offset and its tile size as its size.
+        - Any other result, `d0 + d1` or `d0 * 2`, gets both from an
+          `affine.apply`. Its offset evaluates the result with each tiled loop at
+          its induction variable and the rest at zero, less what it evaluates to
+          with every loop at zero. Its size evaluates it at the last index each
+          loop reaches inside the tile, plus one to turn that index back into a
+          count.
         """
 
         source_shape = operand_info.source_type.get_shape()
+        num_loops = indexing_map.num_dims
+
+        # The induction variable of each tiled loop, and zero for the rest.
+        starts: tuple[SSAValue | int, ...] = tuple(
+            tiled_loop_ivs.get(dim, 0) for dim in range(num_loops)
+        )
+        zeros = (0,) * num_loops
+        # The last index each loop reaches inside the tile. This costs an
+        # `affine.apply` per loop, so it is built once, and only if some result
+        # turns out to need it.
+        extents: tuple[SSAValue | int, ...] | None = None
 
         offsets: list[SSAValue | int] = []
         sizes: list[SSAValue | int] = []
         for result_index, expr in enumerate(indexing_map.results):
-            assert isinstance(expr, AffineDimExpr)
-            loop_dim = operand_info.loop_dims[result_index]
-            if loop_dim in tiled_loop_ivs:
-                offsets.append(tiled_loop_ivs[loop_dim])
-                sizes.append(effective_tile_sizes[loop_dim])
-            else:
+            if not (expr.used_dims() & tiled_loop_ivs.keys()):
                 offsets.append(0)
                 sizes.append(source_shape[result_index])
+                continue
+
+            # `dN` on its own: the slice starts at that loop's induction
+            # variable and is one tile long. The general case below computes
+            # exactly this, so taking it here just avoids emitting an
+            # `affine.apply` to say so.
+            if isinstance(expr, AffineDimExpr):
+                offsets.append(tiled_loop_ivs[expr.position])
+                sizes.append(effective_tile_sizes[expr.position])
+                continue
+
+            if extents is None:
+                extents = tuple(
+                    _decrement(
+                        rewriter,
+                        insertion_point,
+                        effective_tile_sizes.get(dim, size),
+                    )
+                    for dim, size in enumerate(loop_ranges[:num_loops])
+                )
+
+            # Take off what the result evaluates to with every loop at zero, so
+            # that a constant the map adds does not shift the slice: the tiled op
+            # applies the same map inside the slice and adds it back there.
+            # Taking it off the expression rather than off the value it produces
+            # keeps this to a single `affine.apply`.
+            at_zero = expr.eval(zeros, ())
+            offsets.append(
+                _apply_affine_expr(
+                    rewriter,
+                    insertion_point,
+                    expr if at_zero == 0 else expr - at_zero,
+                    starts,
+                )
+            )
+            sizes.append(
+                _apply_affine_expr(rewriter, insertion_point, expr + 1, extents)
+            )
 
         return SliceParameters(tuple(offsets), tuple(sizes), (1,) * len(source_shape))
 
@@ -584,7 +731,13 @@ def tile_structured_op(
 
     slice_parameters = tuple(
         SliceParameters.compute(
-            indexing_map.data, operand_info, tiled_loop_ivs, effective_tile_sizes
+            rewriter,
+            inner_ip,
+            indexing_map.data,
+            operand_info,
+            tiled_loop_ivs,
+            effective_tile_sizes,
+            plan.loop_ranges,
         )
         for operand_info, indexing_map in zip(
             plan.operand_infos, op.get_indexing_maps(), strict=True


### PR DESCRIPTION
Ticks `more general affine indexing maps` on #6140, the last of the boxes on it.

Tiling required every indexing map to be a projected permutation, so each result had to read one loop dimension and nothing else. A map that reached its operand by anything else, a sum of two loops, a stride through it, an offset into it, was rejected rather than tiled.

A result is read now where the tile starts, and spans what the tile reaches:

- its **offset** is the result evaluated where each tiled loop sits at its induction variable and every other loop sits at zero. What the result reads at zero is taken off, dropping whatever it adds on top, which the operand is not moved along by. The tiled op applies the same map within its slice, so the slice starts where the loops put it rather than where the result lands.
- its **size** is that same result read at the last position of the tile rather than the first, which is one before the size of each loop, with one added back to count positions rather than measure between them.

So `(d0, d1) -> (d0 + d1)` over a tile of 2 in `d0` and the whole 4 of `d1` is read from where `d0` is, and spans the two of them together:

```mlir
%4 = memref.subview %A[%3] [5] [1] : memref<8xf32> to memref<5xf32, strided<[1], offset: ?>>
```

and `(d0) -> (d0 * 2)` steps through its operand, which the size takes up rather than the stride, since the loop is what does the stepping:

```mlir
%4 = affine.apply affine_map<(d0) -> ((d0 * 2))> (%3)
%5 = memref.subview %A[%4] [7] [1] : memref<16xf32> to memref<7xf32, strided<[1], offset: ?>>
```

For a result reading one loop this works out to the induction variable and the tile size, which it is left as, so a map that was already handled is tiled into exactly what it was tiled into before. That is why no existing test changes.

This is what upstream computes in `computeSliceParameters`, including taking the offset off the expression rather than off what the expression works out to, which leaves nothing to take off for a result that only adds.

Upstream also clamps each slice against its operand, unless the size divides evenly or is one. This does not, because it does not need to: the extents it maps are already `min(tile, ub - iv)` by the time a result sees them, where upstream's are the raw tile sizes. The last position a tile reaches is `expr(starts + extents)`, and `starts[d] + extents[d]` is at most `range[d] - 1`, so no tile reaches past what the untiled op did.

A loop range that is not known until the op runs is read back off the operand a loop addresses, which needs a result that reads that loop and nothing else. One that no map reads on its own cannot be found this way, and is rejected.

### Tests

Two cases, being what a result can do that a projected permutation cannot: one reading two loops at once, and one that both steps through its operand and is offset into it.

I checked these have teeth by not taking the offset off, and by leaving the size measuring between positions rather than counting them, each of which fails them.

There is a unit test for the span of a result reading two loops, and one that the plan records no loop dimension for a result no single loop range can be read back from.

The case rejecting a map that is not a projected permutation goes from the rejection tests, and the unit test that asserted the rejection now asserts the plan tiles it instead.
