### PR TITLE
testing: remove empty CHECK-NEXT

### DIFF
--- a/tests/filecheck/dialects/pdl/pdl_operation.mlir
+++ b/tests/filecheck/dialects/pdl/pdl_operation.mlir
@@ -11,7 +11,7 @@ pdl.pattern @unboundedOperation : benefit(1) {
 // CHECK: %{{.*}} = pdl.operation
 
 pdl.pattern @boundedOperation : benefit(1) {
-  %type = pdl.type 
+  %type = pdl.type
   %types = pdl.types
 
   %operand = pdl.operand
@@ -40,4 +40,3 @@ pdl.pattern @noresultsOperation : benefit(1) {
 // CHECK-NEXT:     %root_2 = pdl.operation "test.op"
 // CHECK-NEXT:     pdl.rewrite %root_2 with "test_rewriter"(%root_2 : !pdl.operation)
 // CHECK-NEXT:  }
-// CHECK-NEXT:   

--- a/tests/filecheck/transforms/apply-pdl/apply_pdl_build_type.mlir
+++ b/tests/filecheck/transforms/apply-pdl/apply_pdl_build_type.mlir
@@ -1,6 +1,6 @@
 // RUN: xdsl-opt %s -p apply-pdl | filecheck %s
 
-%x = "test.op"() : () -> (i32) 
+%x = "test.op"() : () -> (i32)
 
 pdl.pattern : benefit(1) {
     %in_type = pdl.type: i32
@@ -24,4 +24,3 @@ pdl.pattern : benefit(1) {
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
-// CHECK-NEXT:  

--- a/tests/filecheck/transforms/apply-pdl/apply_pdl_polymorphic.mlir
+++ b/tests/filecheck/transforms/apply-pdl/apply_pdl_polymorphic.mlir
@@ -22,4 +22,3 @@ pdl.pattern : benefit(1) {
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
-// CHECK-NEXT:  


### PR DESCRIPTION
`CHECK-NEXT` with an empty string will not be supported by `filecheck` in the next version, favouring `CHECK-EMPTY`. However, the places where this was actually used didn't seem very meaningful, so I've just removed them.

Also contains some driveby whitespace cleanup.