### PR TITLE
CI: enable RUF003 lint rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,6 @@ lint.ignore = [
   # Help welcome removing ignores below
   # https://github.com/xdslproject/xdsl/issues/5927
   "RUF002", # https://docs.astral.sh/ruff/rules/ambiguous-unicode-character-docstring
-  "RUF003", # https://docs.astral.sh/ruff/rules/ambiguous-unicode-character-comment
   "RUF012", # https://docs.astral.sh/ruff/rules/mutable-class-default
 ]
 lint.per-file-ignores."**/filecheck/*" = [ "E501", "F811", "F841" ]


### PR DESCRIPTION
Fixes the RUF003 item in #5927.

RUF003 was previously enabled and its existing violations were fixed in #6267, but the rule is currently back in `lint.ignore` in `pyproject.toml`.

The current tree is already RUF003-clean, so this removes the stale ignore to restore enforcement.

Validation:

- `ruff check . --select RUF003 --no-cache`
- verified RUF003 detects an ambiguous Unicode character in a temporary comment probe
- `git diff --check`