### PR TITLE
core: (Assembly Format) use parser position for optional group

### DIFF
--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -1470,17 +1470,20 @@ class OptionalGroupDirective(FormatDirective):
 
     def parse(self, parser: Parser, state: ParsingState) -> bool:
         # If the first element was parsed, parse the then-elements as usual
-        if ret := self.then_first.parse_optional(parser, state):
+        start_pos = parser.pos
+        self.then_first.parse_optional(parser, state)
+        if start_pos != parser.pos:
             for element in self.then_elements:
                 element.parse(parser, state)
             for element in self.else_elements:
                 element.set_empty(state)
+            return True
         else:
             for element in self.then_elements:
                 element.set_empty(state)
             for element in self.else_elements:
                 element.parse(parser, state)
-        return ret
+            return False
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
         if self.anchor.is_present(op):


### PR DESCRIPTION
It has occurred to me that an optional group continues parsing exactly when the first element parses something, and this is a property that is easily checkable with the parser position.

This should allow us to delete all the boolean outputs from parsing, which were effectively self certifying whether anything was parsed. I can include that in this PR if wanted but was going to do a follow up.