### PR TITLE
core: (Assembly Format) remove return value from parse

### DIFF
--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -3852,9 +3852,8 @@ def test_qualified_attr():
 
 @irdl_custom_directive
 class Hello(CustomDirective):
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState):
         parser.parse_keyword("hello")
-        return True
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
         state.print_whitespace(printer)
@@ -3890,7 +3889,7 @@ class Bars(CustomDirective):
 
     var: VariadicOperandVariable
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState):
         first = parser.parse_optional_unresolved_operand()
         if first is None:
             operands = []
@@ -3899,7 +3898,6 @@ class Bars(CustomDirective):
             while parser.parse_optional_punctuation("|"):
                 operands.append(parser.parse_unresolved_operand())
         self.var.set(state, operands)
-        return bool(operands)
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
         operands = self.var.get(op)
@@ -3945,7 +3943,7 @@ def test_non_upper_classvar():
         class BadClassVar(CustomDirective):  # pyright: ignore[reportUnusedClass]
             bad: ClassVar
 
-            def parse(self, parser: Parser, state: ParsingState) -> bool:
+            def parse(self, parser: Parser, state: ParsingState) -> None:
                 raise NotImplementedError()
 
             def print(
@@ -3966,7 +3964,7 @@ def test_bad_parameter():
         class BadParam(CustomDirective):  # pyright: ignore[reportUnusedClass]
             int_param: int
 
-            def parse(self, parser: Parser, state: ParsingState) -> bool:
+            def parse(self, parser: Parser, state: ParsingState) -> None:
                 raise NotImplementedError()
 
             def print(
@@ -3988,8 +3986,8 @@ class EmptyDirectiveWithParams(CustomDirective):
     operand_types: TypeDirective
     results: TypeDirective
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
-        return True
+    def parse(self, parser: Parser, state: ParsingState):
+        pass
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
         pass

--- a/xdsl/dialects/acc.py
+++ b/xdsl/dialects/acc.py
@@ -922,7 +922,7 @@ class DeviceTypeOperands(CustomDirective):
         self.operands.set(state, ())
         self.operand_types.set(state, ())
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState):
         triples = parser.parse_comma_separated_list(
             parser.Delimiter.NONE, lambda: _parse_operand_with_dt(parser)
         )
@@ -930,7 +930,6 @@ class DeviceTypeOperands(CustomDirective):
         self.operands.set(state, operands)
         self.operand_types.set(state, types)
         self.device_types.set(state, ArrayAttr(device_types))
-        return True
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
         operands = self.operands.get(op)
@@ -1060,7 +1059,7 @@ class DeviceTypeOperandsWithKeywordOnly(CustomDirective):
         self.operands.set(state, ())
         self.operand_types.set(state, ())
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState):
         operands, types, device_types, keyword_only = _parse_dt_kw_only_body(parser)
         self.operands.set(state, operands)
         self.operand_types.set(state, types)
@@ -1068,7 +1067,6 @@ class DeviceTypeOperandsWithKeywordOnly(CustomDirective):
             self.device_types.set(state, device_types)
         if keyword_only is not None:
             self.keyword_only.set(state, keyword_only)
-        return True
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
         _print_dt_kw_only_body(
@@ -1105,7 +1103,7 @@ class NumGangs(CustomDirective):
         self.operands.set(state, ())
         self.operand_types.set(state, ())
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState):
         groups = parser.parse_comma_separated_list(
             parser.Delimiter.NONE, lambda: _parse_num_gangs_group(parser)
         )
@@ -1114,7 +1112,6 @@ class NumGangs(CustomDirective):
         self.operand_types.set(state, types)
         self.device_types.set(state, ArrayAttr(dts))
         self.segments.set(state, DenseArrayBase.from_list(i32, segs))
-        return True
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
         operands = self.operands.get(op)
@@ -1286,7 +1283,7 @@ class WaitClause(CustomDirective):
         self.operands.set(state, ())
         self.operand_types.set(state, ())
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState):
         operands, types, dts, segs, devnum, kw_only = _parse_wait_body(parser)
         self.operands.set(state, operands)
         self.operand_types.set(state, types)
@@ -1298,7 +1295,6 @@ class WaitClause(CustomDirective):
             self.has_devnum.set(state, devnum)
         if kw_only is not None:
             self.keyword_only.set(state, kw_only)
-        return True
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
         _print_wait_body(
@@ -1349,7 +1345,7 @@ class KernelEnvironmentClauses(CustomDirective):
 
     _CLAUSE_KEYWORDS = ("dataOperands", "async", "wait")
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState):
         self.set_empty(state)
         seen: set[str] = set()
         while (
@@ -1386,7 +1382,6 @@ class KernelEnvironmentClauses(CustomDirective):
                     self.wait_has_devnum.set(state, devnum)
                 if kw_only is not None:
                     self.wait_only.set(state, kw_only)
-        return True
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
         if data_operands := self.data_clause_operands.get(op):
@@ -1446,17 +1441,16 @@ class OperandWithKeywordOnly(CustomDirective):
         self.operand.set(state, None)
         self.operand_type.set(state, ())
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState):
         if not parser.parse_optional_punctuation("("):
             self.attr.set(state, UnitAttr())
             self.operand.set(state, None)
             self.operand_type.set(state, ())
-            return True
-        operand, ty = _parse_typed_operand(parser)
-        parser.parse_punctuation(")")
-        self.operand.set(state, operand)
-        self.operand_type.set(state, (ty,))
-        return True
+        else:
+            operand, ty = _parse_typed_operand(parser)
+            parser.parse_punctuation(")")
+            self.operand.set(state, operand)
+            self.operand_type.set(state, (ty,))
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
         # Mirror upstream's `if (attr) return;`: when the bare-keyword
@@ -1497,23 +1491,22 @@ class OperandsWithKeywordOnly(CustomDirective):
         self.operands.set(state, ())
         self.operand_types.set(state, ())
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState):
         if not parser.parse_optional_punctuation("("):
             self.attr.set(state, UnitAttr())
             self.operands.set(state, ())
             self.operand_types.set(state, ())
-            return True
-        operands = parser.parse_comma_separated_list(
-            parser.Delimiter.NONE, parser.parse_unresolved_operand
-        )
-        parser.parse_punctuation(":")
-        types = parser.parse_comma_separated_list(
-            parser.Delimiter.NONE, parser.parse_type
-        )
-        parser.parse_punctuation(")")
-        self.operands.set(state, operands)
-        self.operand_types.set(state, types)
-        return True
+        else:
+            operands = parser.parse_comma_separated_list(
+                parser.Delimiter.NONE, parser.parse_unresolved_operand
+            )
+            parser.parse_punctuation(":")
+            types = parser.parse_comma_separated_list(
+                parser.Delimiter.NONE, parser.parse_type
+            )
+            parser.parse_punctuation(")")
+            self.operands.set(state, operands)
+            self.operand_types.set(state, types)
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
         if self.attr.get(op) is not None:
@@ -1549,16 +1542,13 @@ class AtomicIfClause(CustomDirective):
         self.if_cond.set(state, None)
         self.if_cond_type.set(state, ())
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState):
         self.set_empty(state)
-        if parser.parse_optional_keyword("if") is None:
-            return True
-        parser.parse_punctuation("(")
-        operand = parser.parse_unresolved_operand()
-        parser.parse_punctuation(")")
-        self.if_cond.set(state, operand)
-        self.if_cond_type.set(state, (i1,))
-        return True
+        if parser.parse_optional_keyword("if"):
+            with parser.in_parens():
+                operand = parser.parse_unresolved_operand()
+            self.if_cond.set(state, operand)
+            self.if_cond_type.set(state, (i1,))
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
         if_cond = self.if_cond.get(op)
@@ -1599,7 +1589,7 @@ class AccVar(CustomDirective):
     acc_var: OperandVariable
     acc_var_type: TypeDirective
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState):
         if parser.parse_optional_keyword("accPtr") is None:
             parser.parse_keyword("accVar")
         with parser.in_parens():
@@ -1608,7 +1598,6 @@ class AccVar(CustomDirective):
             ty = parser.parse_type()
         self.acc_var.set(state, operand)
         self.acc_var_type.set(state, (ty,))
-        return True
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
         state.print_whitespace(printer)
@@ -1638,7 +1627,7 @@ class Var(CustomDirective):
     var_type: TypeDirective
     var_type_attr: AttributeVariable
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState):
         if parser.parse_optional_keyword("varPtr") is None:
             parser.parse_keyword("var")
         with parser.in_parens():
@@ -1653,7 +1642,6 @@ class Var(CustomDirective):
                 self.var_type_attr.set(state, parser.parse_type())
         else:
             self.var_type_attr.set(state, _default_var_type(ty))
-        return True
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
         state.print_whitespace(printer)
@@ -1704,7 +1692,7 @@ class DataEntryOilist(CustomDirective):
 
     _CLAUSE_KEYWORDS = ("varPtrPtr", "bounds", "async", "recipe")
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState):
         self.set_empty(state)
         seen: set[str] = set()
         while (
@@ -1737,7 +1725,6 @@ class DataEntryOilist(CustomDirective):
             else:  # recipe
                 with parser.in_parens():
                     self.recipe.set(state, parser.parse_attribute())
-        return True
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
         var_ptr_ptr = self.var_ptr_ptr.get(op)
@@ -1820,13 +1807,13 @@ class CombinedConstructsLoop(CustomDirective):
     def is_present(self, op: IRDLOperation) -> bool:
         return self.combined.get(op) is not None
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState):
         for kw in self._KEYWORDS:
             if parser.parse_optional_keyword(kw) is not None:
                 self.combined.set(
                     state, CombinedConstructsTypeAttr(self._BY_KEYWORD[kw])
                 )
-                return True
+                return
         parser.raise_error("expected compute construct name")
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
@@ -1862,7 +1849,7 @@ class DeviceTypeOperandsWithSegment(CustomDirective):
         self.operands.set(state, ())
         self.operand_types.set(state, ())
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState):
         groups = parser.parse_comma_separated_list(
             parser.Delimiter.NONE, lambda: _parse_num_gangs_group(parser)
         )
@@ -1871,7 +1858,6 @@ class DeviceTypeOperandsWithSegment(CustomDirective):
         self.operand_types.set(state, types)
         self.device_types.set(state, ArrayAttr(dts))
         self.segments.set(state, DenseArrayBase.from_list(i32, segs))
-        return True
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
         # `is_present = bool(self.operands.get(op))` — when this `print` is
@@ -1987,12 +1973,12 @@ class GangClause(CustomDirective):
         self.operands.set(state, ())
         self.operand_types.set(state, ())
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState):
         if not parser.parse_optional_punctuation("("):
             self.gang_only.set(state, ArrayAttr([DeviceTypeAttr(DeviceType.NONE)]))
             self.operands.set(state, ())
             self.operand_types.set(state, ())
-            return True
+            return
 
         kw_only = parser.parse_optional_comma_separated_list(
             parser.Delimiter.SQUARE, lambda: _parse_device_type_attr(parser)
@@ -2003,7 +1989,7 @@ class GangClause(CustomDirective):
         if parser.parse_optional_punctuation(")"):
             self.operands.set(state, ())
             self.operand_types.set(state, ())
-            return True
+            return
 
         if kw_only is not None:
             parser.parse_punctuation(",")
@@ -2030,7 +2016,6 @@ class GangClause(CustomDirective):
         self.gang_arg_types.set(state, ArrayAttr(arg_types))
         self.device_types.set(state, ArrayAttr(dts))
         self.segments.set(state, DenseArrayBase.from_list(i32, segs))
-        return True
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
         operands = self.operands.get(op)
@@ -2124,7 +2109,7 @@ class LoopControl(CustomDirective):
     step: VariadicOperandVariable
     step_types: TypeDirective
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState):
         if parser.parse_optional_keyword("control") is None:
             self.lowerbound.set(state, ())
             self.lowerbound_types.set(state, ())
@@ -2133,7 +2118,7 @@ class LoopControl(CustomDirective):
             self.step.set(state, ())
             self.step_types.set(state, ())
             self.region.set(state, parser.parse_region())
-            return True
+            return
 
         with parser.in_parens():
             args = parser.parse_comma_separated_list(
@@ -2153,7 +2138,6 @@ class LoopControl(CustomDirective):
         self.step.set(state, st_ops)
         self.step_types.set(state, st_types)
         self.region.set(state, parser.parse_region(args))
-        return True
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
         region = self.region.get(op)
@@ -2238,7 +2222,7 @@ class BindName(CustomDirective):
             or self.bind_str_name.get(op) is not None
         )
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState):
         id_names: list[SymbolRefAttr] = []
         str_names: list[StringAttr] = []
         id_dts: list[DeviceTypeAttr] = []
@@ -2266,7 +2250,6 @@ class BindName(CustomDirective):
         if str_names:
             self.bind_str_name.set(state, ArrayAttr(str_names))
             self.bind_str_name_device_type.set(state, ArrayAttr(str_dts))
-        return True
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
         # Concatenate the (id-name, dt) and (str-name, dt) sequences in that
@@ -2320,10 +2303,10 @@ class RoutineGangClause(CustomDirective):
     def is_present(self, op: IRDLOperation) -> bool:
         return self.gang.get(op) is not None or self.gang_dim.get(op) is not None
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState):
         if not parser.parse_optional_punctuation("("):
             self.gang.set(state, ArrayAttr([DeviceTypeAttr(DeviceType.NONE)]))
-            return True
+            return
 
         kw_only = parser.parse_optional_comma_separated_list(
             parser.Delimiter.SQUARE, lambda: _parse_device_type_attr(parser)
@@ -2331,7 +2314,7 @@ class RoutineGangClause(CustomDirective):
         if kw_only is not None:
             self.gang.set(state, ArrayAttr(kw_only))
             if parser.parse_optional_punctuation(")"):
-                return True
+                return
             parser.parse_punctuation(",")
 
         gang_dim_attrs: list[Attribute] = []
@@ -2350,7 +2333,6 @@ class RoutineGangClause(CustomDirective):
         # one element, so `gang_dim_attrs` is always non-empty here.
         self.gang_dim.set(state, ArrayAttr(gang_dim_attrs))
         self.gang_dim_device_type.set(state, ArrayAttr(gang_dim_dt_attrs))
-        return True
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
         gang = self.gang.get(op)
@@ -2416,10 +2398,10 @@ class DeviceTypeArrayClause(CustomDirective):
         # `hasDeviceTypeValues`-gated emission.
         return isa(attr := self.device_types.get(op), ArrayAttr) and bool(attr.data)
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState):
         if not parser.parse_optional_punctuation("("):
             self.device_types.set(state, ArrayAttr([DeviceTypeAttr(DeviceType.NONE)]))
-            return True
+            return
 
         attrs = parser.parse_optional_comma_separated_list(
             parser.Delimiter.SQUARE, lambda: _parse_device_type_attr(parser)
@@ -2428,7 +2410,6 @@ class DeviceTypeArrayClause(CustomDirective):
         self.device_types.set(
             state, ArrayAttr(attrs) if attrs is not None else ArrayAttr(())
         )
-        return True
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
         # `is_present` guarantees a non-empty ArrayAttr.

--- a/xdsl/dialects/cf.py
+++ b/xdsl/dialects/cf.py
@@ -222,7 +222,7 @@ class SwitchOpCases(CustomDirective):
         (block, ops, types) = cls._parse_case_body(parser)
         return (i, block, ops, types)
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState):
         parser.parse_keyword("default")
         (default_block, default_operands, default_operand_types) = (
             self._parse_case_body(parser)
@@ -257,7 +257,6 @@ class SwitchOpCases(CustomDirective):
             self.case_operands.set_empty(state)
             self.case_operand_types.set_empty(state)
             self.case_operand_segments.set(state, DenseArrayBase.from_list(i32, ()))
-        return True
 
     @staticmethod
     def _print_case(

--- a/xdsl/dialects/pdl_interp.py
+++ b/xdsl/dialects/pdl_interp.py
@@ -959,7 +959,7 @@ class RangeTypeDirective(CustomDirective):
     arguments_type: TypeDirective
     result_type: TypeDirective
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState):
         args_inner = self.arguments_type.inner
         assert isinstance(args_inner, VariadicOperandVariable)
 
@@ -975,13 +975,11 @@ class RangeTypeDirective(CustomDirective):
                 element_type = first_type
             result_type = RangeType(element_type)
             self.result_type.set(state, (result_type,))
-            return False  # No input consumed during inference
         else:
             # Parse `: type` for result when no arguments
             parser.parse_punctuation(":")
             result_type = parser.parse_type()
             self.result_type.set(state, (result_type,))
-            return True
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
         arg_types = self.arguments_type.get(op)

--- a/xdsl/dialects/utils/dimension_list.py
+++ b/xdsl/dialects/utils/dimension_list.py
@@ -34,15 +34,13 @@ class DimensionList(CustomDirective):
 
     dimensions: AttributeVariable
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState):
         dims = []
 
         if not parse_empty_dimension_list_directive(parser):
             dims = parser.parse_dimension_list()
 
         self.dimensions.set(state, DenseArrayBase[I64].from_list(i64, dims))
-
-        return True
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
         state.print_whitespace(printer)

--- a/xdsl/dialects/utils/dynamic_index_list.py
+++ b/xdsl/dialects/utils/dynamic_index_list.py
@@ -230,13 +230,12 @@ class DynamicIndexList(CustomDirective):
     dynamic_position: VariadicOperandVariable
     static_position: AttributeVariable
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState):
         dynamic, static = parse_dynamic_index_list_without_types(
             parser, self.DYNAMIC_INDEX
         )
         self.dynamic_position.set(state, dynamic)
         self.static_position.set(state, DenseArrayBase.from_list(i64, static))
-        return True
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
         state.print_whitespace(printer)

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -298,17 +298,17 @@ class FormatDirective(Directive, ABC):
     """A format directive for operation format."""
 
     @abstractmethod
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState) -> None:
         """
-        Parses the directive, returning True if input was consumed.
+        Parses the directive.
         """
         ...
 
-    def parse_optional(self, parser: Parser, state: ParsingState) -> bool:
+    def parse_optional(self, parser: Parser, state: ParsingState) -> None:
         """
-        Parses an optional directive, returning False if not present.
+        Optionally parses a directive.
         """
-        return self.parse(parser, state)
+        self.parse(parser, state)
 
     @abstractmethod
     def print(
@@ -365,9 +365,9 @@ class TypeableDirective(Directive, ABC):
         ...
 
     @abstractmethod
-    def parse_types(self, parser: Parser, state: ParsingState) -> bool:
+    def parse_types(self, parser: Parser, state: ParsingState) -> None:
         """
-        Parses types for the directive, returning True if input was consumed.
+        Parses types for the directive.
         """
         ...
 
@@ -393,8 +393,8 @@ class TypeDirective(FormatDirective):
     def set(self, state: ParsingState, types: Sequence[Attribute]):
         self.inner.set_types(state, types)
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
-        return self.inner.parse_types(parser, state)
+    def parse(self, parser: Parser, state: ParsingState):
+        self.inner.parse_types(parser, state)
 
     def get(self, op: IRDLOperation) -> Sequence[Attribute]:
         return self.inner.get_types(op)
@@ -484,16 +484,16 @@ class AttrDictDirective(FormatDirective):
     This is used to keep compatibility with MLIR which allows that.
     """
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState):
         if self.with_keyword:
-            res = parser.parse_optional_attr_dict_with_keyword()
-            if res is None:
-                res = {}
+            attrs = parser.parse_optional_attr_dict_with_keyword()
+            if attrs is None:
+                attrs = {}
             else:
-                res = dict(res.data)
+                attrs = dict(attrs.data)
         else:
-            res = parser.parse_optional_attr_dict()
-        defined_reserved_keys = self.reserved_attr_names & res.keys()
+            attrs = parser.parse_optional_attr_dict()
+        defined_reserved_keys = self.reserved_attr_names & attrs.keys()
         if defined_reserved_keys:
             parser.raise_error(
                 f"attributes {', '.join(defined_reserved_keys)} are defined in other parts of the "
@@ -501,11 +501,10 @@ class AttrDictDirective(FormatDirective):
                 "dictionary."
             )
 
-        props = tuple(k for k in res.keys() if k in self.expected_properties)
+        props = tuple(k for k in attrs.keys() if k in self.expected_properties)
         for name in props:
-            state.properties[name] = res.pop(name)
-        state.attributes |= res
-        return bool(res) or bool(props)
+            state.properties[name] = attrs.pop(name)
+        state.attributes |= attrs
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
         if not op.attributes.keys().isdisjoint(self.expected_properties):
@@ -563,14 +562,12 @@ class OperandVariable(VariableDirective, OperandDirective):
     def set_types(self, state: ParsingState, types: Sequence[Attribute]):
         state.operand_types[self.index] = types
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState):
         operand = parser.parse_unresolved_operand()
         self.set(state, operand)
-        return True
 
-    def parse_types(self, parser: Parser, state: ParsingState) -> bool:
+    def parse_types(self, parser: Parser, state: ParsingState):
         self.set_types(state, (parser.parse_type(),))
-        return True
 
     def parse_single_type(self, parser: Parser, state: ParsingState) -> None:
         self.parse_types(parser, state)
@@ -600,16 +597,15 @@ class VariadicOperandVariable(VariadicVariable, OperandDirective):
     def set_types(self, state: ParsingState, types: Sequence[Attribute]):
         state.operand_types[self.index] = types
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState):
         operands = parser.parse_optional_undelimited_comma_separated_list(
             parser.parse_optional_unresolved_operand, parser.parse_unresolved_operand
         )
         if operands is None:
             operands = []
         self.set(state, operands)
-        return bool(operands)
 
-    def parse_types(self, parser: Parser, state: ParsingState) -> bool:
+    def parse_types(self, parser: Parser, state: ParsingState):
         types = parser.parse_optional_undelimited_comma_separated_list(
             parser.parse_optional_type, parser.parse_type
         )
@@ -617,7 +613,6 @@ class VariadicOperandVariable(VariadicVariable, OperandDirective):
         if ret:
             types = ()
         self.set_types(state, types)
-        return ret
 
     def parse_single_type(self, parser: Parser, state: ParsingState) -> None:
         state.operand_types[self.index] = (parser.parse_type(),)
@@ -652,15 +647,13 @@ class OptionalOperandVariable(OptionalVariable, OperandDirective):
     def set_types(self, state: ParsingState, types: Sequence[Attribute]):
         state.operand_types[self.index] = types
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState):
         operand = parser.parse_optional_unresolved_operand()
         self.set(state, operand)
-        return bool(operand)
 
-    def parse_types(self, parser: Parser, state: ParsingState) -> bool:
+    def parse_types(self, parser: Parser, state: ParsingState):
         type = parser.parse_optional_type()
         self.set_types(state, () if type is None else (type,))
-        return type is None
 
     def parse_single_type(self, parser: Parser, state: ParsingState) -> None:
         self.set_types(state, (parser.parse_type(),))
@@ -738,7 +731,7 @@ class OperandsDirective(OperandsOrResultDirective, FormatDirective):
             types,
         )
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState):
         pos_start = parser.pos
         operands = (
             parser.parse_optional_undelimited_comma_separated_list(
@@ -758,9 +751,8 @@ class OperandsDirective(OperandsOrResultDirective, FormatDirective):
             )
         except VerifyException as e:
             parser.raise_error(str(e), at_position=pos_start, end_position=parser.pos)
-        return bool(operands)
 
-    def parse_types(self, parser: Parser, state: ParsingState) -> bool:
+    def parse_types(self, parser: Parser, state: ParsingState):
         pos_start = parser.pos
         types = (
             parser.parse_optional_undelimited_comma_separated_list(
@@ -773,7 +765,6 @@ class OperandsDirective(OperandsOrResultDirective, FormatDirective):
             self.set_types(state, types)
         except VerifyException as e:
             parser.raise_error(str(e), at_position=pos_start, end_position=parser.pos)
-        return bool(types)
 
     def parse_single_type(self, parser: Parser, state: ParsingState) -> None:
         pos_start = parser.pos
@@ -807,9 +798,8 @@ class ResultVariable(VariableDirective, TypeableDirective):
     def set_types(self, state: ParsingState, types: Sequence[Attribute]):
         state.result_types[self.index] = types
 
-    def parse_types(self, parser: Parser, state: ParsingState) -> bool:
+    def parse_types(self, parser: Parser, state: ParsingState):
         self.set_types(state, (parser.parse_type(),))
-        return True
 
     def parse_single_type(self, parser: Parser, state: ParsingState) -> None:
         self.parse_types(parser, state)
@@ -830,12 +820,11 @@ class VariadicResultVariable(VariadicVariable, TypeableDirective):
     def set_types(self, state: ParsingState, types: Sequence[Attribute]):
         state.result_types[self.index] = types
 
-    def parse_types(self, parser: Parser, state: ParsingState) -> bool:
+    def parse_types(self, parser: Parser, state: ParsingState):
         types = parser.parse_optional_undelimited_comma_separated_list(
             parser.parse_optional_type, parser.parse_type
         )
         self.set_types(state, () if types is None else types)
-        return types is None
 
     def parse_single_type(self, parser: Parser, state: ParsingState) -> None:
         state.result_types[self.index] = (parser.parse_type(),)
@@ -855,10 +844,9 @@ class OptionalResultVariable(OptionalVariable, TypeableDirective):
     def set_types(self, state: ParsingState, types: Sequence[Attribute]):
         state.result_types[self.index] = types
 
-    def parse_types(self, parser: Parser, state: ParsingState) -> bool:
+    def parse_types(self, parser: Parser, state: ParsingState):
         type = parser.parse_optional_type()
         self.set_types(state, () if type is None else (type,))
-        return type is not None
 
     def parse_single_type(self, parser: Parser, state: ParsingState) -> None:
         self.set_types(state, (parser.parse_type(),))
@@ -886,7 +874,7 @@ class ResultsDirective(OperandsOrResultDirective):
             types,
         )
 
-    def parse_types(self, parser: Parser, state: ParsingState) -> bool:
+    def parse_types(self, parser: Parser, state: ParsingState):
         pos_start = parser.pos
         types = (
             parser.parse_optional_undelimited_comma_separated_list(
@@ -899,7 +887,6 @@ class ResultsDirective(OperandsOrResultDirective):
             self.set_types(state, types)
         except VerifyException as e:
             parser.raise_error(str(e), at_position=pos_start, end_position=parser.pos)
-        return bool(types)
 
     def parse_single_type(self, parser: Parser, state: ParsingState) -> None:
         pos_start = parser.pos
@@ -929,18 +916,15 @@ class FunctionalTypeDirective(FormatDirective):
     operand_typeable_directive: TypeableDirective
     result_typeable_directive: TypeableDirective
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
-        if not parser.parse_optional_punctuation("("):
-            return False
-        self.operand_typeable_directive.parse_types(parser, state)
-        parser.parse_punctuation(")")
+    def parse(self, parser: Parser, state: ParsingState):
+        with parser.in_parens():
+            self.operand_typeable_directive.parse_types(parser, state)
         parser.parse_punctuation("->")
         if parser.parse_optional_punctuation("("):
             self.result_typeable_directive.parse_types(parser, state)
             parser.parse_punctuation(")")
         else:
             self.result_typeable_directive.parse_single_type(parser, state)
-        return True
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
         state.print_whitespace(printer)
@@ -974,17 +958,14 @@ class RegionVariable(RegionDirective, VariableDirective):
     def set(self, state: ParsingState, region: Region):
         state.regions[self.index] = (region,)
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState):
         self.set(state, parser.parse_region())
-        return True
 
-    def parse_optional(self, parser: Parser, state: ParsingState) -> bool:
+    def parse_optional(self, parser: Parser, state: ParsingState):
         region = parser.parse_optional_region()
-        res = region is None
-        if res:
+        if region is None:
             region = Region()
         self.set(state, region)
-        return res
 
     def get(self, op: IRDLOperation) -> Region:
         return getattr(op, self.name)
@@ -1018,7 +999,7 @@ class VariadicRegionVariable(RegionDirective, VariadicVariable):
     def set(self, state: ParsingState, region: Sequence[Region]):
         state.regions[self.index] = region
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState):
         regions: list[Region] = []
         current_region = parser.parse_optional_region()
         while current_region is not None:
@@ -1026,10 +1007,9 @@ class VariadicRegionVariable(RegionDirective, VariadicVariable):
             current_region = parser.parse_optional_region()
 
         self.set(state, regions)
-        return bool(regions)
 
-    def parse_optional(self, parser: Parser, state: ParsingState) -> bool:
-        return self.parse(parser, state)
+    def parse_optional(self, parser: Parser, state: ParsingState):
+        self.parse(parser, state)
 
     def get(self, op: IRDLOperation) -> Sequence[Region]:
         return getattr(op, self.name)
@@ -1055,13 +1035,12 @@ class OptionalRegionVariable(RegionDirective, OptionalVariable):
     def set(self, state: ParsingState, region: Region | None):
         state.regions[self.index] = () if region is None else (region,)
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState):
         region = parser.parse_optional_region()
         self.set(state, region)
-        return region is not None
 
-    def parse_optional(self, parser: Parser, state: ParsingState) -> bool:
-        return self.parse(parser, state)
+    def parse_optional(self, parser: Parser, state: ParsingState):
+        self.parse(parser, state)
 
     def get(self, op: IRDLOperation) -> Region | None:
         return getattr(op, self.name)
@@ -1094,12 +1073,9 @@ class SuccessorVariable(VariableDirective, SuccessorDirective):
     def set(self, state: ParsingState, successor: Successor):
         state.successors[self.index] = (successor,)
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState):
         successor = parser.parse_successor()
-
         self.set(state, successor)
-
-        return True
 
     def get(self, op: IRDLOperation) -> Successor:
         return getattr(op, self.name)
@@ -1119,17 +1095,14 @@ class VariadicSuccessorVariable(VariadicVariable, SuccessorDirective):
     def set(self, state: ParsingState, successors: Sequence[Successor]):
         state.successors[self.index] = successors
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState):
         successors = (
             parser.parse_optional_undelimited_comma_separated_list(
                 parser.parse_optional_successor, parser.parse_successor
             )
             or []
         )
-
         self.set(state, successors)
-
-        return bool(successors)
 
     def get(self, op: IRDLOperation) -> Sequence[Successor]:
         return getattr(op, self.name)
@@ -1155,10 +1128,9 @@ class OptionalSuccessorVariable(OptionalVariable, SuccessorDirective):
     def set(self, state: ParsingState, successor: Successor | None):
         state.successors[self.index] = () if successor is None else (successor,)
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState):
         successor = parser.parse_optional_successor()
         self.set(state, successor)
-        return successor is not None
 
     def get(self, op: IRDLOperation) -> Successor | None:
         return getattr(op, self.name)
@@ -1202,12 +1174,10 @@ class AttributeVariable(FormatDirective):
         else:
             return parser.parse_attribute()
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState):
         attr = self.parse_attr(parser)
-        if attr is None:
-            return False
-        self.set(state, attr)
-        return True
+        if attr is not None:
+            self.set(state, attr)
 
     def get(self, op: IRDLOperation) -> Attribute | None:
         if self.is_property:
@@ -1348,9 +1318,8 @@ class OptionalUnitAttrVariable(AttributeVariable):
     def __init__(self, name: str, is_property: bool):
         super().__init__(name, is_property, True, None)
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState):
         self.set(state, UnitAttr())
-        return True
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
         return
@@ -1392,8 +1361,8 @@ class WhitespaceDirective(FormatDirective):
     whitespace: Literal[" ", "\n", ""]
     """The whitespace that should be printed."""
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
-        return False
+    def parse(self, parser: Parser, state: ParsingState):
+        pass
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
         _print_whitespace(printer, state, self.whitespace)
@@ -1414,8 +1383,8 @@ class PunctuationDirective(FormatDirective):
     punctuation: PunctuationSpelling
     """The punctuation that should be printed/parsed."""
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
-        return parser.parse_optional_punctuation(self.punctuation) is not None
+    def parse(self, parser: Parser, state: ParsingState):
+        parser.parse_optional_punctuation(self.punctuation)
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
         emit_space = False
@@ -1450,8 +1419,8 @@ class KeywordDirective(FormatDirective):
     keyword: str
     """The identifier that should be printed."""
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
-        return parser.parse_optional_keyword(self.keyword) is not None
+    def parse(self, parser: Parser, state: ParsingState):
+        parser.parse_optional_keyword(self.keyword)
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
         _print_keyword(printer, state, self.keyword)
@@ -1468,7 +1437,7 @@ class OptionalGroupDirective(FormatDirective):
     then_elements: tuple[FormatDirective, ...]
     else_elements: tuple[FormatDirective, ...]
 
-    def parse(self, parser: Parser, state: ParsingState) -> bool:
+    def parse(self, parser: Parser, state: ParsingState):
         # If the first element was parsed, parse the then-elements as usual
         start_pos = parser.pos
         self.then_first.parse_optional(parser, state)
@@ -1477,13 +1446,11 @@ class OptionalGroupDirective(FormatDirective):
                 element.parse(parser, state)
             for element in self.else_elements:
                 element.set_empty(state)
-            return True
         else:
             for element in self.then_elements:
                 element.set_empty(state)
             for element in self.else_elements:
                 element.parse(parser, state)
-            return False
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
         if self.anchor.is_present(op):


### PR DESCRIPTION
Removes the now unnecessary return value from `parse`. Fairly big diff as this touches all the custom directives.

Stacked on #6423 