### PR TITLE
core: (Assembly Format) fix parsing for keyword/punctuation

### DIFF
--- a/tests/filecheck/dialects/arm_neon/test_ops.mlir
+++ b/tests/filecheck/dialects/arm_neon/test_ops.mlir
@@ -32,7 +32,7 @@ arm_neon.dvars.st1 %v1, %v2, %v3, %v4 [%x1] S {comment = "st1 op"} : (!arm_neon.
 // CHECK-ASM: ld1 {v11.4S, v12.4S, v13.4S, v14.4S}, [x1] # ld1 op
 %v11, %v12, %v13, %v14 = arm_neon.dvars.ld1 [%x1] S {comment = "ld1 op"} : !arm.reg<x1> -> (!arm_neon.reg<v11>, !arm_neon.reg<v12>, !arm_neon.reg<v13>, !arm_neon.reg<v14>)
 
-// CHECK: %ds_dup = arm_neon.ds.dup %x1 S {comment = "Duplicate general-purpose register to vector"} : !arm.reg<x1> -> (!arm_neon.reg<v1>)
+// CHECK: %ds_dup = arm_neon.ds.dup %x1 S {comment = "Duplicate general-purpose register to vector"} : !arm.reg<x1> -> !arm_neon.reg<v1>
 // CHECK-ASM: dup v1.4S, x1 # Duplicate general-purpose register to vector
 %ds_dup = arm_neon.ds.dup %x1 S {comment = "Duplicate general-purpose register to vector"} : !arm.reg<x1> -> !arm_neon.reg<v1>
 

--- a/tests/filecheck/dialects/tosa/ops.mlir
+++ b/tests/filecheck/dialects/tosa/ops.mlir
@@ -184,8 +184,8 @@ func.func @test_reduce_sum(%arg0: tensor<31x5x3xf32>) -> tensor<1x5x3xf32> {
 // -----
 // CHECK-LABEL: cond_if
 func.func @test_cond_if(%arg0: tensor<i1>, %arg1: tensor<3x4x5xf32>) -> tensor<3x4x5xf32> {
-  // CHECK: {{%.*}} = tosa.cond_if {{%.*}} -> (tensor<3x4x5xf32>) {
-  %0 = tosa.cond_if %arg0: tensor<i1> -> (tensor<3x4x5xf32>) {
+  // CHECK: {{%.*}} = tosa.cond_if {{%.*}} -> tensor<3x4x5xf32> {
+  %0 = tosa.cond_if %arg0: tensor<i1> -> tensor<3x4x5xf32> {
     // CHECK-NEXT: tosa.yield {{%.*}} : tensor<3x4x5xf32>
     tosa.yield %arg1 : tensor<3x4x5xf32>
     // CHECK-NEXT: } else {

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/tosa/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/tosa/ops.mlir
@@ -198,8 +198,8 @@ func.func @test_reduce_sum(%arg0: tensor<31x5x3xf32>) -> tensor<1x5x3xf32> {
 // -----
 // CHECK-LABEL: cond_if
 func.func @test_cond_if(%arg0: tensor<i1>, %arg1: tensor<3x4x5xf32>) -> tensor<3x4x5xf32> {
-  // CHECK: {{%.*}} = tosa.cond_if {{%.*}} -> (tensor<3x4x5xf32>) {
-  %0 = tosa.cond_if %arg0: tensor<i1> -> (tensor<3x4x5xf32>) {
+  // CHECK: {{%.*}} = tosa.cond_if {{%.*}} -> tensor<3x4x5xf32> {
+  %0 = tosa.cond_if %arg0: tensor<i1> -> tensor<3x4x5xf32> {
     // CHECK-NEXT: tosa.yield {{%.*}} : tensor<3x4x5xf32>
     tosa.yield %arg1 : tensor<3x4x5xf32>
     // CHECK-NEXT: } else {

--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -4071,3 +4071,41 @@ def test_optional_anchor_dynamic_index_list(program: str, generic_program: str):
 
     check_roundtrip(program, ctx)
     check_equivalence(program, generic_program, ctx)
+
+
+def test_keywords_are_non_optional():
+    @irdl_op_definition
+    class NonOptionalKeyword(IRDLOperation):
+        name = "test.non_optional_keyword"
+
+        assembly_format = "`keyword` attr-dict"
+
+    ctx = Context()
+    ctx.load_op(NonOptionalKeyword)
+
+    parser = Parser(ctx, "test.non_optional_keyword keyword")
+    parser.parse_op()
+
+    parser = Parser(ctx, "test.non_optional_keyword")
+
+    with pytest.raises(ParseError, match="Expected 'keyword'"):
+        parser.parse_op()
+
+
+def test_punctuation_is_non_optional():
+    @irdl_op_definition
+    class NonOptionalPunctuation(IRDLOperation):
+        name = "test.non_optional_punctuation"
+
+        assembly_format = "`:` attr-dict"
+
+    ctx = Context()
+    ctx.load_op(NonOptionalPunctuation)
+
+    parser = Parser(ctx, "test.non_optional_punctuation :")
+    parser.parse_op()
+
+    parser = Parser(ctx, "test.non_optional_punctuation")
+
+    with pytest.raises(ParseError, match="Expected ':'"):
+        parser.parse_op()

--- a/xdsl/dialects/arm_neon.py
+++ b/xdsl/dialects/arm_neon.py
@@ -340,7 +340,7 @@ class DSDupOp(ARMInstruction):
     d = result_def(NEONRegisterType)
     arrangement = prop_def(NeonArrangementAttr)
 
-    assembly_format = "$s $arrangement attr-dict `:` type($s) `->` `(` type($d) `)`"
+    assembly_format = "$s $arrangement attr-dict `:` type($s) `->` type($d)"
 
     def __init__(
         self,

--- a/xdsl/dialects/tosa.py
+++ b/xdsl/dialects/tosa.py
@@ -45,6 +45,13 @@ from xdsl.irdl import (
     var_operand_def,
     var_result_def,
 )
+from xdsl.irdl.declarative_assembly_format import (
+    CustomDirective,
+    ParsingState,
+    PrintingState,
+    TypeDirective,
+    irdl_custom_directive,
+)
 from xdsl.parser import AttrParser, Parser
 from xdsl.printer import Printer
 from xdsl.traits import (
@@ -609,6 +616,27 @@ class YieldOp(IRDLOperation):
     assembly_format = "$inputs attr-dict `:` type($inputs)"
 
 
+@irdl_custom_directive
+class Outputs(CustomDirective):
+    results: TypeDirective
+
+    def parse(self, parser: Parser, state: ParsingState) -> None:
+        if parser.parse_optional_punctuation("("):
+            self.results.inner.parse_types(parser, state)
+            parser.parse_punctuation(")")
+        else:
+            self.results.inner.parse_single_type(parser, state)
+
+    def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
+        state.print_whitespace(printer)
+        types = self.results.inner.get_types(op)
+        if len(types) == 1:
+            printer.print_attribute(types[0])
+        else:
+            with printer.in_parens():
+                printer.print_list(types, printer.print_attribute)
+
+
 @irdl_op_definition
 class IfOp(IRDLOperation):
     """
@@ -631,7 +659,9 @@ class IfOp(IRDLOperation):
         SingleBlockImplicitTerminator(YieldOp),
     )
 
-    assembly_format = "$cond `:` type($cond) `->` `(` type($output) `)` $true_region `else` $false_region attr-dict"
+    custom_directives = (Outputs,)
+
+    assembly_format = "$cond `:` type($cond) `->` custom<Outputs>(type($output)) $true_region `else` $false_region attr-dict"
 
 
 ################################################################################

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -1384,6 +1384,9 @@ class PunctuationDirective(FormatDirective):
     """The punctuation that should be printed/parsed."""
 
     def parse(self, parser: Parser, state: ParsingState):
+        parser.parse_punctuation(self.punctuation)
+
+    def parse_optional(self, parser: Parser, state: ParsingState) -> None:
         parser.parse_optional_punctuation(self.punctuation)
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
@@ -1420,6 +1423,9 @@ class KeywordDirective(FormatDirective):
     """The identifier that should be printed."""
 
     def parse(self, parser: Parser, state: ParsingState):
+        parser.parse_keyword(self.keyword)
+
+    def parse_optional(self, parser: Parser, state: ParsingState) -> None:
         parser.parse_optional_keyword(self.keyword)
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:


### PR DESCRIPTION
Fixes the `parse` and adds `parse_optional` methods for `KeywordDirective` and `PunctuationDirective`, making these no longer accept the empty string outside of optional groups.

This revealed two bugs in `arm_neon` and `tosa`. I've tried to fix both in the a way that seems to make the most sense to me, but it would be good if these could be checked.

Stacked on top of #6424 