### PR TITLE
dialects: (linalg) Give select its indexing maps and iterator types

### DIFF
--- a/tests/filecheck/transforms/linalg_generalize_named_ops.mlir
+++ b/tests/filecheck/transforms/linalg_generalize_named_ops.mlir
@@ -2,8 +2,10 @@
 
 //CHECK:   %lhs, %rhs, %out = "test.op"() : () -> (memref<4x5xf32>, memref<4x5xf32>, memref<4x5xf32>)
 //CHECK-NEXT:   %a, %b, %c = "test.op"() : () -> (memref<2x3xf32>, memref<3x4xf32>, memref<2x4xf32>)
+//CHECK-NEXT:   %cond, %t, %f, %res = "test.op"() : () -> (memref<4x5xi1>, memref<4x5xf32>, memref<4x5xf32>, memref<4x5xf32>)
 %lhs, %rhs, %out = "test.op"() : () -> (memref<4x5xf32>, memref<4x5xf32>, memref<4x5xf32>)
 %a, %b, %c = "test.op"() : () -> (memref<2x3xf32>, memref<3x4xf32>, memref<2x4xf32>)
+%cond, %t, %f, %res = "test.op"() : () -> (memref<4x5xi1>, memref<4x5xf32>, memref<4x5xf32>, memref<4x5xf32>)
 
 //CHECK-NEXT:   linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%lhs, %rhs : memref<4x5xf32>, memref<4x5xf32>) outs(%out : memref<4x5xf32>) {
 //CHECK-NEXT:   ^bb0(%0: f32, %1: f32, %2: f32):
@@ -19,3 +21,10 @@ linalg.add ins(%lhs, %rhs : memref<4x5xf32>, memref<4x5xf32>) outs(%out : memref
 //CHECK-NEXT:     linalg.yield %8 : f32
 //CHECK-NEXT:   }
 linalg.matmul ins(%a, %b : memref<2x3xf32>, memref<3x4xf32>) outs(%c : memref<2x4xf32>)
+
+//CHECK-NEXT:   linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%cond, %t, %f : memref<4x5xi1>, memref<4x5xf32>, memref<4x5xf32>) outs(%res : memref<4x5xf32>) {
+//CHECK-NEXT:   ^bb0(%9: i1, %10: f32, %11: f32, %12: f32):
+//CHECK-NEXT:     %13 = arith.select %9, %10, %11 : f32
+//CHECK-NEXT:     linalg.yield %13 : f32
+//CHECK-NEXT:   }
+linalg.select ins(%cond, %t, %f : memref<4x5xi1>, memref<4x5xf32>, memref<4x5xf32>) outs(%res : memref<4x5xf32>)

--- a/xdsl/dialects/linalg/ops.py
+++ b/xdsl/dialects/linalg/ops.py
@@ -541,7 +541,7 @@ class SqrtOp(ElementwiseOperation, NamedOperation):
 
 
 @irdl_op_definition
-class SelectOp(NamedOperation):
+class SelectOp(ElementwiseOperation):
     """
     Chooses one value based on a binary condition supplied as its first operand.
 
@@ -582,15 +582,6 @@ class SelectOp(NamedOperation):
             YieldOp(result)
 
         return hidden_region
-
-    def get_indexing_maps(self) -> ArrayAttr[AffineMapAttr]:
-        raise NotImplementedError
-
-    def get_default_indexing_maps(self) -> Sequence[AffineMap]:
-        raise NotImplementedError
-
-    def get_iterator_types(self) -> ArrayAttr[IteratorTypeAttr]:
-        raise NotImplementedError
 
 
 @irdl_op_definition


### PR DESCRIPTION
linalg.select raises NotImplementedError from get_indexing_maps, get_default_indexing_maps and get_iterator_types, so anything that asks a named op about its structure falls over on it. Generalizing a linalg.select is one case where that happens.

Select is elementwise, so it can inherit from ElementwiseOperation and drop the three overrides. The identity maps and the parallel iterator types come from there.

The generalize test now covers a select, and it fails without this change.

Split out of #6427, where superlopuh suggested landing these methods first so the verifier there does not have to work around select being unimplemented.
