### PR TITLE
core: move EnumAttribute to dialect utilities

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,7 @@ lint.flake8-tidy-imports.banned-api."typing.TypeVar".msg = "Use typing_extension
 lint.flake8-tidy-imports.banned-api."xdsl.dialects.utils.bit_enum_attribute".msg = "Use xdsl.dialects.utils instead"
 lint.flake8-tidy-imports.banned-api."xdsl.dialects.utils.dimension_list".msg = "Use xdsl.dialects.utils instead"
 lint.flake8-tidy-imports.banned-api."xdsl.dialects.utils.dynamic_index_list".msg = "Use xdsl.dialects.utils instead"
+lint.flake8-tidy-imports.banned-api."xdsl.dialects.utils.enum_attribute".msg = "Use xdsl.dialects.utils instead"
 lint.flake8-tidy-imports.banned-api."xdsl.dialects.utils.fast_math".msg = "Use xdsl.dialects.utils instead"
 lint.flake8-tidy-imports.banned-api."xdsl.dialects.utils.format".msg = "Use xdsl.dialects.utils instead"
 lint.flake8-tidy-imports.banned-api."xdsl.ir.affine.affine_expr".msg = "Use xdsl.ir.affine instead"

--- a/tests/irdl/test_attribute_definition.py
+++ b/tests/irdl/test_attribute_definition.py
@@ -26,16 +26,14 @@ from xdsl.dialects.builtin import (
     i32,
 )
 from xdsl.dialects.test import Test
-from xdsl.dialects.utils import BitEnumAttribute
+from xdsl.dialects.utils import BitEnumAttribute, EnumAttribute
 from xdsl.ir import (
     Attribute,
     AttributeInvT,
     BuiltinAttribute,
     Data,
-    EnumAttribute,
     ParametrizedAttribute,
     SpacedOpaqueSyntaxAttribute,
-    StrEnum,
     TypedAttribute,
 )
 from xdsl.irdl import (
@@ -61,6 +59,7 @@ from xdsl.parser import AttrParser, Parser
 from xdsl.printer import Printer
 from xdsl.utils.exceptions import PyRDLAttrDefinitionError, VerifyException
 from xdsl.utils.hints import isa
+from xdsl.utils.str_enum import StrEnum
 
 
 def test_wrong_attribute_type():

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -1532,3 +1532,23 @@ def test_region_verify_block_parent_pointer_mismatch():
         match="Parent pointer of block does not refer to containing region",
     ):
         region.verify()
+
+
+def test_deprecated_enum_attribute_imports_are_available():
+    with pytest.warns(
+        DeprecationWarning,
+        match="Importing 'EnumAttribute' from 'xdsl.ir' is deprecated",
+    ):
+        from xdsl.ir import EnumAttribute
+
+    with pytest.warns(
+        DeprecationWarning,
+        match="Importing 'StrEnum' from 'xdsl.ir' is deprecated",
+    ):
+        from xdsl.ir import StrEnum
+
+    from xdsl.dialects.utils import EnumAttribute as NewEnumAttribute
+    from xdsl.utils.str_enum import StrEnum as NewStrEnum
+
+    assert EnumAttribute is NewEnumAttribute
+    assert StrEnum is NewStrEnum

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -1543,12 +1543,16 @@ def test_deprecated_enum_attribute_imports_are_available():
 
     with pytest.warns(
         DeprecationWarning,
-        match="Importing 'StrEnum' from 'xdsl.ir' is deprecated",
+        match="Importing 'EnumType' from 'xdsl.ir' is deprecated",
     ):
-        from xdsl.ir import StrEnum
+        from xdsl.ir import EnumType
 
-    from xdsl.dialects.utils import EnumAttribute as NewEnumAttribute
-    from xdsl.utils.str_enum import StrEnum as NewStrEnum
+    from xdsl.dialects.utils import (
+        EnumAttribute as NewEnumAttribute,
+    )
+    from xdsl.dialects.utils import (
+        EnumType as NewEnumType,
+    )
 
     assert EnumAttribute is NewEnumAttribute
-    assert StrEnum is NewStrEnum
+    assert EnumType is NewEnumType

--- a/xdsl/dialects/acc.py
+++ b/xdsl/dialects/acc.py
@@ -32,17 +32,19 @@ from xdsl.dialects.builtin import (
     i1,
     i32,
 )
-from xdsl.dialects.utils import AbstractYieldOperation, BitEnumAttribute
+from xdsl.dialects.utils import (
+    AbstractYieldOperation,
+    BitEnumAttribute,
+    EnumAttribute,
+)
 from xdsl.ir import (
     Attribute,
     Dialect,
-    EnumAttribute,
     Operation,
     ParametrizedAttribute,
     Region,
     SpacedOpaqueSyntaxAttribute,
     SSAValue,
-    StrEnum,
     TypeAttribute,
 )
 from xdsl.irdl import (
@@ -90,6 +92,7 @@ from xdsl.traits import (
 )
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.hints import isa
+from xdsl.utils.str_enum import StrEnum
 
 
 class DeviceType(StrEnum):

--- a/xdsl/dialects/arm_neon.py
+++ b/xdsl/dialects/arm_neon.py
@@ -15,14 +15,13 @@ from xdsl.dialects.builtin import (
     f64,
     i8,
 )
+from xdsl.dialects.utils import EnumAttribute
 from xdsl.ir import (
     Attribute,
     Dialect,
-    EnumAttribute,
     Operation,
     SpacedOpaqueSyntaxAttribute,
     SSAValue,
-    StrEnum,
 )
 from xdsl.irdl import (
     VarConstraint,
@@ -37,6 +36,7 @@ from xdsl.irdl import (
     var_result_def,
 )
 from xdsl.utils.exceptions import VerifyException
+from xdsl.utils.str_enum import StrEnum
 
 ARM_NEON_INDEX_BY_NAME = {f"v{i}": i for i in range(0, 32)}
 

--- a/xdsl/dialects/csl.py
+++ b/xdsl/dialects/csl.py
@@ -39,12 +39,11 @@ from xdsl.dialects.builtin import (
     i8,
     i16,
 )
-from xdsl.dialects.utils import parse_func_op_like, print_func_op_like
+from xdsl.dialects.utils import EnumAttribute, parse_func_op_like, print_func_op_like
 from xdsl.ir import (
     Attribute,
     Block,
     Dialect,
-    EnumAttribute,
     Operation,
     Region,
     SpacedOpaqueSyntaxAttribute,

--- a/xdsl/dialects/gpu.py
+++ b/xdsl/dialects/gpu.py
@@ -17,17 +17,16 @@ from xdsl.dialects.builtin import (
     i32,
     i64,
 )
+from xdsl.dialects.utils import EnumAttribute
 from xdsl.ir import (
     Attribute,
     Block,
     Dialect,
-    EnumAttribute,
     Operation,
     ParametrizedAttribute,
     Region,
     SpacedOpaqueSyntaxAttribute,
     SSAValue,
-    StrEnum,
     TypeAttribute,
 )
 from xdsl.irdl import (
@@ -59,6 +58,7 @@ from xdsl.traits import (
     SymbolTable,
 )
 from xdsl.utils.exceptions import VerifyException
+from xdsl.utils.str_enum import StrEnum
 
 
 @irdl_attr_definition

--- a/xdsl/dialects/irdl/irdl.py
+++ b/xdsl/dialects/irdl/irdl.py
@@ -15,11 +15,11 @@ from xdsl.dialects.builtin import (
     SymbolRefAttr,
     UnitAttr,
 )
+from xdsl.dialects.utils import EnumAttribute
 from xdsl.ir import (
     Attribute,
     Block,
     Dialect,
-    EnumAttribute,
     ParametrizedAttribute,
     Region,
     SpacedOpaqueSyntaxAttribute,

--- a/xdsl/dialects/linalg/attrs.py
+++ b/xdsl/dialects/linalg/attrs.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from enum import auto
 
-from xdsl.ir import EnumAttribute
+from xdsl.dialects.utils import EnumAttribute
 from xdsl.irdl import irdl_attr_definition
 from xdsl.parser import AttrParser
 from xdsl.printer import Printer

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -43,6 +43,7 @@ from xdsl.dialects.builtin import (
 )
 from xdsl.dialects.utils import (
     BitEnumAttribute,
+    EnumAttribute,
     FastMathAttrBase,
     FastMathFlag,
     parse_dynamic_index_list_without_types,
@@ -54,7 +55,6 @@ from xdsl.ir import (
     Attribute,
     Block,
     Dialect,
-    EnumAttribute,
     Operation,
     ParametrizedAttribute,
     Region,

--- a/xdsl/dialects/math_xdsl.py
+++ b/xdsl/dialects/math_xdsl.py
@@ -10,7 +10,8 @@ at some point when they have matured.
 
 from enum import auto
 
-from xdsl.ir import Attribute, Dialect, EnumAttribute, SpacedOpaqueSyntaxAttribute
+from xdsl.dialects.utils import EnumAttribute
+from xdsl.ir import Attribute, Dialect, SpacedOpaqueSyntaxAttribute
 from xdsl.irdl import (
     IRDLOperation,
     irdl_attr_definition,

--- a/xdsl/dialects/memref_stream.py
+++ b/xdsl/dialects/memref_stream.py
@@ -26,11 +26,10 @@ from xdsl.dialects.builtin import (
     MemRefType,
     StringAttr,
 )
-from xdsl.dialects.utils import AbstractYieldOperation
+from xdsl.dialects.utils import AbstractYieldOperation, EnumAttribute
 from xdsl.ir import (
     Attribute,
     Dialect,
-    EnumAttribute,
     ParametrizedAttribute,
     Region,
     SSAValue,

--- a/xdsl/dialects/omp.py
+++ b/xdsl/dialects/omp.py
@@ -21,14 +21,16 @@ from xdsl.dialects.builtin import (
     i32,
     i64,
 )
-from xdsl.dialects.utils import AbstractYieldOperation, BitEnumAttribute
+from xdsl.dialects.utils import (
+    AbstractYieldOperation,
+    BitEnumAttribute,
+    EnumAttribute,
+)
 from xdsl.ir import (
     Attribute,
     Dialect,
-    EnumAttribute,
     ParametrizedAttribute,
     SpacedOpaqueSyntaxAttribute,
-    StrEnum,
     TypeAttribute,
 )
 from xdsl.irdl import (
@@ -69,6 +71,7 @@ from xdsl.traits import (
     SymbolOpInterface,
 )
 from xdsl.utils.exceptions import VerifyException
+from xdsl.utils.str_enum import StrEnum
 
 
 class OpenMPOffloadMappingFlags(IntFlag):

--- a/xdsl/dialects/shard.py
+++ b/xdsl/dialects/shard.py
@@ -20,11 +20,10 @@ from xdsl.dialects.builtin import (
     i16,
     i64,
 )
-from xdsl.dialects.utils import DimensionList, DynamicIndexList
+from xdsl.dialects.utils import DimensionList, DynamicIndexList, EnumAttribute
 from xdsl.ir import (
     Attribute,
     Dialect,
-    EnumAttribute,
     OpaqueSyntaxAttribute,
     ParametrizedAttribute,
     SpacedOpaqueSyntaxAttribute,

--- a/xdsl/dialects/tosa.py
+++ b/xdsl/dialects/tosa.py
@@ -21,10 +21,10 @@ from xdsl.dialects.builtin import (
     TensorType,
     i1,
 )
+from xdsl.dialects.utils import EnumAttribute
 from xdsl.ir import (
     Attribute,
     Dialect,
-    EnumAttribute,
     SSAValue,
     TypeAttribute,
 )

--- a/xdsl/dialects/transform.py
+++ b/xdsl/dialects/transform.py
@@ -20,13 +20,13 @@ from xdsl.dialects.builtin import (
 from xdsl.dialects.func import FuncOpCallableInterface
 from xdsl.dialects.utils import (
     AbstractYieldOperation,
+    EnumAttribute,
     parse_func_op_like,
     print_func_op_like,
 )
 from xdsl.ir import (
     Attribute,
     Dialect,
-    EnumAttribute,
     ParametrizedAttribute,
     Region,
     SSAValue,

--- a/xdsl/dialects/utils/__init__.py
+++ b/xdsl/dialects/utils/__init__.py
@@ -4,5 +4,6 @@
 from .bit_enum_attribute import *  # noqa: TID251
 from .dimension_list import *  # noqa: TID251
 from .dynamic_index_list import *  # noqa: TID251
+from .enum_attribute import *
 from .fast_math import *  # noqa: TID251
 from .format import *  # noqa: TID251

--- a/xdsl/dialects/utils/__init__.py
+++ b/xdsl/dialects/utils/__init__.py
@@ -4,6 +4,6 @@
 from .bit_enum_attribute import *  # noqa: TID251
 from .dimension_list import *  # noqa: TID251
 from .dynamic_index_list import *  # noqa: TID251
-from .enum_attribute import *
+from .enum_attribute import *  # noqa: TID251
 from .fast_math import *  # noqa: TID251
 from .format import *  # noqa: TID251

--- a/xdsl/dialects/utils/enum_attribute.py
+++ b/xdsl/dialects/utils/enum_attribute.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from typing import ClassVar, cast, get_args, get_origin
+
+from typing_extensions import TypeVar
+
+from xdsl.ir import Data
+from xdsl.parser import AttrParser
+from xdsl.printer import Printer
+from xdsl.utils.str_enum import StrEnum
+
+EnumType = TypeVar("EnumType", bound=StrEnum)
+
+
+class EnumAttribute(Data[EnumType]):
+    """
+    Helper for Enum Attributes. Takes a StrEnum type parameter, and defines
+    parsing/printing automatically from its values, restricted to be parsable as
+    identifiers.
+
+    example:
+    ```python
+    class MyEnum(StrEnum):
+        First = auto()
+        Second = auto()
+
+    class MyEnumAttribute(EnumAttribute[MyEnum], SpacedOpaqueSyntaxAttribute):
+        name = "example.my_enum"
+    ```
+    To use this attribute suffices to have a textual representation
+    of `example<my_enum first>` and ``example<my_enum second>``
+
+    """
+
+    enum_type: ClassVar[type[StrEnum]]
+
+    def __init_subclass__(cls) -> None:
+        """
+        Extract and store the Enum type used by the subclass for use in
+        parsing/printing.
+
+        Subclass implementations are also constrained to keep implementations
+        reasonable, unless more complex use cases appear.
+
+        The constraint(s) are:
+        - Only direct, specialized inheritance is allowed. That is, using a
+        subclass of EnumAttribute as a base class is *not supported*.
+        This simplifies type-hacking code and I don't see it being too
+        restrictive anytime soon.
+        """
+        super().__init_subclass__()
+
+        orig_bases = getattr(cls, "__orig_bases__")
+        enumattr = next(b for b in orig_bases if get_origin(b) is EnumAttribute)
+        enum_type = get_args(enumattr)[0]
+        if isinstance(enum_type, TypeVar):
+            raise TypeError("Only direct inheritance from EnumAttribute is allowed.")
+
+        cls.enum_type = enum_type
+
+    def print_parameter(self, printer: Printer) -> None:
+        printer.print_identifier_or_string_literal(self.data.value)
+
+    @classmethod
+    def parse_parameter(cls, parser: AttrParser) -> EnumType:
+        return cast(EnumType, parser.parse_str_enum(cls.enum_type))

--- a/xdsl/dialects/vector.py
+++ b/xdsl/dialects/vector.py
@@ -35,6 +35,7 @@ from xdsl.dialects.builtin import (
 )
 from xdsl.dialects.utils import (
     DynamicIndexList,
+    EnumAttribute,
     get_dynamic_index_list,
     split_dynamic_index_list,
     verify_dynamic_index_list,
@@ -42,7 +43,6 @@ from xdsl.dialects.utils import (
 from xdsl.ir import (
     Attribute,
     Dialect,
-    EnumAttribute,
     Operation,
     SSAValue,
 )

--- a/xdsl/ir/__init__.py
+++ b/xdsl/ir/__init__.py
@@ -7,24 +7,17 @@ from .core import *  # noqa: TID251
 
 
 def __getattr__(name: str):
-    if name == "EnumAttribute":
-        from xdsl.dialects.utils.enum_attribute import EnumAttribute
+    if name in ("EnumAttribute", "EnumType"):
+        from xdsl.dialects.utils.enum_attribute import (  # noqa: TID251
+            EnumAttribute,
+            EnumType,
+        )
 
         warnings.warn(
-            "Importing 'EnumAttribute' from 'xdsl.ir' is deprecated. "
-            "Please use 'from xdsl.dialects.utils import EnumAttribute' instead.",
+            f"Importing '{name}' from 'xdsl.ir' is deprecated. "
+            f"Please use 'from xdsl.dialects.utils import {name}' instead.",
             DeprecationWarning,
             stacklevel=2,
         )
-        return EnumAttribute
-    if name == "StrEnum":
-        from xdsl.utils.str_enum import StrEnum
-
-        warnings.warn(
-            "Importing 'StrEnum' from 'xdsl.ir' is deprecated. "
-            "Please use 'from xdsl.utils.str_enum import StrEnum' instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return StrEnum
+        return EnumAttribute if name == "EnumAttribute" else EnumType
     raise AttributeError(f"module '{__name__}' has no attribute '{name}'")

--- a/xdsl/ir/__init__.py
+++ b/xdsl/ir/__init__.py
@@ -1,4 +1,30 @@
+import warnings
+
 # TID 251 enforces to not import from core
 # We need to skip it here to allow importing from here instead.
 # If adding banned imports, add them also to pyproject.toml.
 from .core import *  # noqa: TID251
+
+
+def __getattr__(name: str):
+    if name == "EnumAttribute":
+        from xdsl.dialects.utils.enum_attribute import EnumAttribute
+
+        warnings.warn(
+            "Importing 'EnumAttribute' from 'xdsl.ir' is deprecated. "
+            "Please use 'from xdsl.dialects.utils import EnumAttribute' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return EnumAttribute
+    if name == "StrEnum":
+        from xdsl.utils.str_enum import StrEnum
+
+        warnings.warn(
+            "Importing 'StrEnum' from 'xdsl.ir' is deprecated. "
+            "Please use 'from xdsl.utils.str_enum import StrEnum' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return StrEnum
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -22,8 +22,6 @@ from typing import (
     NoReturn,
     TypeAlias,
     cast,
-    get_args,
-    get_origin,
     overload,
 )
 
@@ -32,7 +30,6 @@ from typing_extensions import Self, TypeVar
 from xdsl.dialect_interfaces import DialectInterface
 from xdsl.traits import IsTerminator, NoTerminator, OpTrait, OpTraitInvT
 from xdsl.utils.exceptions import VerifyException
-from xdsl.utils.str_enum import StrEnum
 
 # Used for cyclic dependencies in type hints
 if TYPE_CHECKING:
@@ -252,63 +249,6 @@ class Data(Attribute, ABC, Generic[DataElement]):
     @abstractmethod
     def print_parameter(self, printer: Printer) -> None:
         """Print the attribute parameter."""
-
-
-EnumType = TypeVar("EnumType", bound=StrEnum)
-
-
-class EnumAttribute(Data[EnumType]):
-    """
-    Core helper for Enum Attributes. Takes a StrEnum type parameter, and defines
-    parsing/printing automatically from its values, restricted to be parsable as
-    identifiers.
-
-    example:
-    ```python
-    class MyEnum(StrEnum):
-        First = auto()
-        Second = auto()
-
-    class MyEnumAttribute(EnumAttribute[MyEnum], SpacedOpaqueSyntaxAttribute):
-        name = "example.my_enum"
-    ```
-    To use this attribute suffices to have a textual representation
-    of `example<my_enum first>` and ``example<my_enum second>``
-
-    """
-
-    enum_type: ClassVar[type[StrEnum]]
-
-    def __init_subclass__(cls) -> None:
-        """
-        Extract and store the Enum type used by the subclass for use in
-        parsing/printing.
-
-        Subclass implementations are also constrained to keep implementations
-        reasonable, unless more complex use cases appear.
-
-        The constraint(s) are:
-        - Only direct, specialized inheritance is allowed. That is, using a
-        subclass of EnumAttribute as a base class is *not supported*.
-        This simplifies type-hacking code and I don't see it being too
-        restrictive anytime soon.
-        """
-        super().__init_subclass__()
-
-        orig_bases = getattr(cls, "__orig_bases__")
-        enumattr = next(b for b in orig_bases if get_origin(b) is EnumAttribute)
-        enum_type = get_args(enumattr)[0]
-        if isinstance(enum_type, TypeVar):
-            raise TypeError("Only direct inheritance from EnumAttribute is allowed.")
-
-        cls.enum_type = enum_type
-
-    def print_parameter(self, printer: Printer) -> None:
-        printer.print_identifier_or_string_literal(self.data.value)
-
-    @classmethod
-    def parse_parameter(cls, parser: AttrParser) -> EnumType:
-        return cast(EnumType, parser.parse_str_enum(cls.enum_type))
 
 
 @dataclass(frozen=True, init=False)


### PR DESCRIPTION
Fixes #3753

## Summary
- move `EnumAttribute` from `ir.core` to `dialects.utils`
- update dialect and test imports to the new owner
- import `StrEnum` from its canonical utility module

This follows the placement established for `BitEnumAttribute` in #5813.

## Validation
- pre-commit — passed
- Pyright — 0 errors
- pytest — 5,265 passed, 1 skipped
- FileCheck — 606 tests
- Toy — 8 tests
- runnable notebook tests — passed

AI-assisted; reviewed and validated by me.
