### PR TITLE
interpreter: (scf) Implement more `scf` ops - `while`, `condition`, `index_switch`

### DIFF
--- a/tests/interpreters/test_scf_interpreter.py
+++ b/tests/interpreters/test_scf_interpreter.py
@@ -30,12 +30,12 @@ def test_if():
 
             @Builder.implicit_region
             def true_region():
-                one = arith.ConstantOp.from_int_and_width(1, 32)
+                one = arith.ConstantOp.from_int_and_width(1, i32)
                 scf.YieldOp(one)
 
             @Builder.implicit_region
             def false_region():
-                zero = arith.ConstantOp.from_int_and_width(0, 32)
+                zero = arith.ConstantOp.from_int_and_width(0, i32)
                 scf.YieldOp(zero)
 
             result = scf.IfOp(cond, (i32,), true_region, false_region)
@@ -179,7 +179,7 @@ def square_or_default_op():
 
         @Builder.implicit_region
         def default_region():
-            default = arith.ConstantOp.from_int_and_width(-1, 32)
+            default = arith.ConstantOp.from_int_and_width(-1, i32)
             scf.YieldOp(default)
 
         case_regions: list[Region] = []
@@ -187,7 +187,7 @@ def square_or_default_op():
 
             @Builder.implicit_region
             def case_region(i: int = i):
-                square = arith.ConstantOp.from_int_and_width(i * i, 32)
+                square = arith.ConstantOp.from_int_and_width(i * i, i32)
                 scf.YieldOp(square)
 
             case_regions.append(case_region)

--- a/tests/interpreters/test_scf_interpreter.py
+++ b/tests/interpreters/test_scf_interpreter.py
@@ -2,12 +2,12 @@ import pytest
 
 from xdsl.builder import Builder, ImplicitBuilder
 from xdsl.dialects import arith, func, scf
-from xdsl.dialects.builtin import IndexType, ModuleOp, i1, i32
+from xdsl.dialects.builtin import DenseArrayBase, IndexType, ModuleOp, i1, i32, i64
 from xdsl.interpreter import Interpreter, OpCounter
 from xdsl.interpreters.arith import ArithFunctions
 from xdsl.interpreters.func import FuncFunctions
 from xdsl.interpreters.scf import ScfFunctions
-from xdsl.ir import BlockArgument
+from xdsl.ir import BlockArgument, Region
 
 index = IndexType()
 
@@ -157,5 +157,72 @@ def test_while_tracer():
         "scf.yield": 5,
         "arith.cmpi": 6,
         "arith.addi": 10,
+        "func.return": 1,
+    }
+
+
+def square_or_default_fn(n: int) -> int:
+    """
+    Python implementation of square_or_default_op
+    """
+    cases = {3: 9, 1: 1, 5: 25}
+    return cases.get(n, -1)
+
+
+@ModuleOp
+@Builder.implicit_region
+def square_or_default_op():
+    cases = [3, 1, 5]  # deliberately out of order and non-contiguous
+    with ImplicitBuilder(func.FuncOp("square_or_default", ((index,), (i32,))).body) as (
+        n,
+    ):
+
+        @Builder.implicit_region
+        def default_region():
+            default = arith.ConstantOp.from_int_and_width(-1, 32)
+            scf.YieldOp(default)
+
+        case_regions: list[Region] = []
+        for i in cases:
+
+            @Builder.implicit_region
+            def case_region(i: int = i):
+                square = arith.ConstantOp.from_int_and_width(i * i, 32)
+                scf.YieldOp(square)
+
+            case_regions.append(case_region)
+
+        result = scf.IndexSwitchOp(
+            n,
+            DenseArrayBase.from_list(i64, cases),
+            default_region,
+            case_regions,
+            (i32,),
+        )
+        func.ReturnOp(result)
+
+
+@pytest.mark.parametrize(
+    ("n", "res"), [(0, -1), (1, 1), (2, -1), (3, 9), (4, -1), (5, 25)]
+)
+def test_index_switch_via_square_or_default(n: int, res: int):
+    assert res == square_or_default_fn(n)
+    assert res == scf_interp(square_or_default_op, "square_or_default", n)
+
+
+@pytest.mark.parametrize(("n", "res"), [(3, 9), (4, -1)])
+def test_index_switch_tracer(n: int, res: int):
+    tracer = OpCounter()
+    interpreter = Interpreter(square_or_default_op.clone(), listeners=(tracer,))
+    interpreter.register_implementations(ScfFunctions())
+    interpreter.register_implementations(FuncFunctions())
+    interpreter.register_implementations(ArithFunctions())
+
+    (result,) = interpreter.call_op("square_or_default", (n,))
+    assert result == res
+    assert dict(tracer.ops) == {
+        "scf.index_switch": 1,
+        "arith.constant": 1,
+        "scf.yield": 1,
         "func.return": 1,
     }

--- a/tests/interpreters/test_scf_interpreter.py
+++ b/tests/interpreters/test_scf_interpreter.py
@@ -12,6 +12,40 @@ from xdsl.ir import BlockArgument
 index = IndexType()
 
 
+def scf_interp(module_op: ModuleOp, func_name: str, n: int) -> int:
+    module_op.verify()
+    interpreter = Interpreter(module_op)
+    interpreter.register_implementations(ScfFunctions())
+    interpreter.register_implementations(FuncFunctions())
+    interpreter.register_implementations(ArithFunctions())
+    (result,) = interpreter.call_op(func_name, (n,))
+    return result
+
+
+def test_if():
+    @ModuleOp
+    @Builder.implicit_region
+    def module_op():
+        with ImplicitBuilder(func.FuncOp("indicator", ((i1,), (i32,))).body) as (cond,):
+
+            @Builder.implicit_region
+            def true_region():
+                one = arith.ConstantOp.from_int_and_width(1, 32)
+                scf.YieldOp(one)
+
+            @Builder.implicit_region
+            def false_region():
+                zero = arith.ConstantOp.from_int_and_width(0, 32)
+                scf.YieldOp(zero)
+
+            result = scf.IfOp(cond, (i32,), true_region, false_region)
+
+            func.ReturnOp(result)
+
+    assert scf_interp(module_op, "indicator", True) == 1
+    assert scf_interp(module_op, "indicator", False) == 0
+
+
 def sum_to_for_fn(n: int) -> int:
     """
     Python implementation of sum_to_for_op
@@ -40,46 +74,12 @@ def sum_to_for_op():
         func.ReturnOp(result)
 
 
-def scf_interp(module_op: ModuleOp, func_name: str, n: int) -> int:
-    module_op.verify()
-    interpreter = Interpreter(module_op)
-    interpreter.register_implementations(ScfFunctions())
-    interpreter.register_implementations(FuncFunctions())
-    interpreter.register_implementations(ArithFunctions())
-    (result,) = interpreter.call_op(func_name, (n,))
-    return result
-
-
 @pytest.mark.parametrize("n,res", [(0, 0), (1, 0), (2, 1), (3, 3), (4, 6), (5, 10)])
-def test_sum_to(n: int, res: int):
+def test_for_via_sum_to(n: int, res: int):
     assert res == scf_interp(sum_to_for_op, "sum_to", n)
 
 
-def test_if():
-    @ModuleOp
-    @Builder.implicit_region
-    def module_op():
-        with ImplicitBuilder(func.FuncOp("indicator", ((i1,), (i32,))).body) as (cond,):
-
-            @Builder.implicit_region
-            def true_region():
-                one = arith.ConstantOp.from_int_and_width(1, 32)
-                scf.YieldOp(one)
-
-            @Builder.implicit_region
-            def false_region():
-                zero = arith.ConstantOp.from_int_and_width(0, 32)
-                scf.YieldOp(zero)
-
-            result = scf.IfOp(cond, (i32,), true_region, false_region)
-
-            func.ReturnOp(result)
-
-    assert scf_interp(module_op, "indicator", True) == 1
-    assert scf_interp(module_op, "indicator", False) == 0
-
-
-def test_tracer():
+def test_for_tracer():
     tracer = OpCounter()
     interpreter = Interpreter(sum_to_for_op.clone(), listeners=(tracer,))
     interpreter.register_implementations(ScfFunctions())
@@ -93,5 +93,69 @@ def test_tracer():
         "scf.for": 1,
         "scf.yield": 5,
         "arith.addi": 5,
+        "func.return": 1,
+    }
+
+
+def sum_to_while_fn(ub: int) -> int:
+    """
+    Python implementation of sum_to_while_op
+    """
+    acc = 0
+    i = 0
+    while i != ub:
+        acc += i
+        i += 1
+    return acc
+
+
+@ModuleOp
+@Builder.implicit_region
+def sum_to_while_op():
+    with ImplicitBuilder(func.FuncOp("sum_to", ((index,), (index,))).body) as (ub,):
+        zero = arith.ConstantOp.from_int_and_width(0, index)
+
+        @Builder.implicit_region((index, index))
+        def before_region(args: tuple[BlockArgument, ...]):
+            (i, acc) = args
+            cond = arith.CmpiOp(i, ub, "ne")
+            scf.ConditionOp(cond, i, acc)
+
+        @Builder.implicit_region((index, index))
+        def after_region(args: tuple[BlockArgument, ...]):
+            (i, acc) = args
+            one = arith.ConstantOp.from_int_and_width(1, index)
+            new_acc = arith.AddiOp(acc, i)
+            new_i = arith.AddiOp(i, one)
+            scf.YieldOp(new_i, new_acc)
+
+        result = scf.WhileOp((zero, zero), (index, index), before_region, after_region)
+        func.ReturnOp(result.res[1])
+
+
+@pytest.mark.parametrize(
+    ("n", "res"), [(0, 0), (1, 0), (2, 1), (3, 3), (4, 6), (5, 10)]
+)
+def test_while_via_sum_to(n: int, res: int):
+    assert res == sum_to_while_fn(ub=n)
+    assert res == scf_interp(sum_to_while_op, "sum_to", n)
+
+
+def test_while_tracer():
+    tracer = OpCounter()
+    interpreter = Interpreter(sum_to_while_op.clone(), listeners=(tracer,))
+    interpreter.register_implementations(ScfFunctions())
+    interpreter.register_implementations(FuncFunctions())
+    interpreter.register_implementations(ArithFunctions())
+    (result,) = interpreter.call_op("sum_to", (5,))
+
+    assert result == 10
+    assert dict(tracer.ops) == {
+        "arith.constant": 6,
+        "scf.while": 1,
+        "scf.condition": 6,
+        "scf.yield": 5,
+        "arith.cmpi": 6,
+        "arith.addi": 10,
         "func.return": 1,
     }

--- a/xdsl/interpreters/scf.py
+++ b/xdsl/interpreters/scf.py
@@ -68,7 +68,21 @@ class ScfFunctions(InterpreterFunctions):
                 op.after_region, tuple(forwarded_args), "while.after_region"
             )
 
+    @impl(scf.IndexSwitchOp)
     def run_index_switch(
         self, interpreter: Interpreter, op: scf.IndexSwitchOp, args: PythonValues
     ) -> PythonValues:
-        return ()
+        case_to_region_map = dict(
+            zip(op.cases.iter_values(), op.case_regions, strict=True)
+        )
+        index = args[0]
+        default = False
+        if index in case_to_region_map:
+            region = case_to_region_map[index]
+        else:
+            default = True
+            region = op.default_region
+        yielded_results = interpreter.run_ssacfg_region(
+            region, (), f"index_switch.case {'default' if default else index}"
+        )
+        return yielded_results

--- a/xdsl/interpreters/scf.py
+++ b/xdsl/interpreters/scf.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 from xdsl.dialects import scf
 from xdsl.interpreter import (
     Interpreter,
@@ -16,7 +14,7 @@ from xdsl.interpreter import (
 @register_impls
 class ScfFunctions(InterpreterFunctions):
     @impl(scf.IfOp)
-    def run_if(self, interpreter: Interpreter, op: scf.IfOp, args: tuple[Any, ...]):
+    def run_if(self, interpreter: Interpreter, op: scf.IfOp, args: PythonValues):
         (cond,) = args
         region = op.true_region if cond else op.false_region
         results = interpreter.run_ssacfg_region(region, ())
@@ -38,7 +36,7 @@ class ScfFunctions(InterpreterFunctions):
 
     @impl_terminator(scf.YieldOp)
     def run_br(
-        self, interpreter: Interpreter, op: scf.YieldOp, args: tuple[Any, ...]
+        self, interpreter: Interpreter, op: scf.YieldOp, args: PythonValues
     ) -> tuple[TerminatorValue, PythonValues]:
         return ReturnedValues(args), ()
 

--- a/xdsl/interpreters/scf.py
+++ b/xdsl/interpreters/scf.py
@@ -6,6 +6,7 @@ from xdsl.interpreter import (
     InterpreterFunctions,
     PythonValues,
     ReturnedValues,
+    TerminatorValue,
     impl,
     impl_terminator,
     register_impls,
@@ -36,13 +37,15 @@ class ScfFunctions(InterpreterFunctions):
         return loop_args
 
     @impl_terminator(scf.YieldOp)
-    def run_br(self, interpreter: Interpreter, op: scf.YieldOp, args: tuple[Any, ...]):
+    def run_br(
+        self, interpreter: Interpreter, op: scf.YieldOp, args: tuple[Any, ...]
+    ) -> tuple[TerminatorValue, PythonValues]:
         return ReturnedValues(args), ()
 
     @impl_terminator(scf.ConditionOp)
     def run_condition(
         self, interpreter: Interpreter, op: scf.ConditionOp, args: PythonValues
-    ) -> PythonValues:
+    ) -> tuple[TerminatorValue, PythonValues]:
         return ReturnedValues(args), ()
 
     @impl(scf.WhileOp)
@@ -65,3 +68,8 @@ class ScfFunctions(InterpreterFunctions):
                 after_region, (*results,), "while.after_region"
             )
         return results[1:]
+
+    def run_index_switch(
+        self, interpreter: Interpreter, op: scf.IndexSwitchOp, args: PythonValues
+    ) -> PythonValues:
+        return ()

--- a/xdsl/interpreters/scf.py
+++ b/xdsl/interpreters/scf.py
@@ -25,8 +25,8 @@ class ScfFunctions(InterpreterFunctions):
     def run_for(
         self, interpreter: Interpreter, op: scf.ForOp, args: PythonValues
     ) -> PythonValues:
-        lb, ub, step, *loop_args = args
-        loop_args = tuple(loop_args)
+        lb, ub, step, *packed_args = args
+        loop_args = tuple(packed_args)
 
         for i in range(lb, ub, step):
             loop_args = interpreter.run_ssacfg_region(

--- a/xdsl/interpreters/scf.py
+++ b/xdsl/interpreters/scf.py
@@ -52,22 +52,21 @@ class ScfFunctions(InterpreterFunctions):
     def run_while(
         self, interpreter: Interpreter, op: scf.WhileOp, args: PythonValues
     ) -> PythonValues:
-        results = args
+        loop_args = args
 
         while True:
-            before_region = op.before_region
-            results = interpreter.run_ssacfg_region(
-                before_region, (*results,), "while.before_region"
+            # while "before" region is terminated by an scf.condition op, of which `args[0]` is the i1 condition operand and
+            # `args[1:]` are the values forwarded to the after-region (if the condition holds) or returned as the results of the
+            # op (otherwise).
+            condition, *forwarded_args = interpreter.run_ssacfg_region(
+                op.before_region, loop_args, "while.before_region"
             )
-            if not results[0]:
-                break
+            if not condition:
+                return tuple(forwarded_args)
 
-            results = results[1:]
-            after_region = op.after_region
-            results = interpreter.run_ssacfg_region(
-                after_region, (*results,), "while.after_region"
+            loop_args = interpreter.run_ssacfg_region(
+                op.after_region, tuple(forwarded_args), "while.after_region"
             )
-        return results[1:]
 
     def run_index_switch(
         self, interpreter: Interpreter, op: scf.IndexSwitchOp, args: PythonValues

--- a/xdsl/interpreters/scf.py
+++ b/xdsl/interpreters/scf.py
@@ -38,3 +38,30 @@ class ScfFunctions(InterpreterFunctions):
     @impl_terminator(scf.YieldOp)
     def run_br(self, interpreter: Interpreter, op: scf.YieldOp, args: tuple[Any, ...]):
         return ReturnedValues(args), ()
+
+    @impl_terminator(scf.ConditionOp)
+    def run_condition(
+        self, interpreter: Interpreter, op: scf.ConditionOp, args: PythonValues
+    ) -> PythonValues:
+        return ReturnedValues(args), ()
+
+    @impl(scf.WhileOp)
+    def run_while(
+        self, interpreter: Interpreter, op: scf.WhileOp, args: PythonValues
+    ) -> PythonValues:
+        results = args
+
+        while True:
+            before_region = op.before_region
+            results = interpreter.run_ssacfg_region(
+                before_region, (*results,), "while.before_region"
+            )
+            if not results[0]:
+                break
+
+            results = results[1:]
+            after_region = op.after_region
+            results = interpreter.run_ssacfg_region(
+                after_region, (*results,), "while.after_region"
+            )
+        return results[1:]

--- a/xdsl/interpreters/scf.py
+++ b/xdsl/interpreters/scf.py
@@ -70,17 +70,15 @@ class ScfFunctions(InterpreterFunctions):
     def run_index_switch(
         self, interpreter: Interpreter, op: scf.IndexSwitchOp, args: PythonValues
     ) -> PythonValues:
-        case_to_region_map = dict(
-            zip(op.cases.iter_values(), op.case_regions, strict=True)
-        )
         index = args[0]
-        default = False
-        if index in case_to_region_map:
-            region = case_to_region_map[index]
-        else:
-            default = True
-            region = op.default_region
-        yielded_results = interpreter.run_ssacfg_region(
-            region, (), f"index_switch.case {'default' if default else index}"
+        cases: tuple[int, ...] = op.cases.get_values()
+        try:
+            case = cases.index(index)
+        except ValueError:
+            return interpreter.run_ssacfg_region(
+                op.default_region, (), "index_switch.case default"
+            )
+
+        return interpreter.run_ssacfg_region(
+            op.case_regions[case], (), f"index_switch.case {case}"
         )
-        return yielded_results


### PR DESCRIPTION
Closes #3910 .

Following https://mlir.llvm.org/docs/Dialects/SCFDialect, implements the interpreter for the `scf` dialect ops: `scf.condition`, `scf.while`, and `scf.index_switch`. Also adds tests (with some rearrangement so that the order of tests matches the implementation of the interpreter itself).