### PR TITLE
dialects: (llvm) add fptrunc and LLVM translation

### DIFF
--- a/tests/dialects/test_llvm.py
+++ b/tests/dialects/test_llvm.py
@@ -505,6 +505,13 @@ def test_fpext_op():
     assert op.result.type == builtin.f64  # wider type
 
 
+def test_fptrunc_op():
+    val = create_ssa_value(builtin.f64)
+    op = llvm.FPTruncOp(val, builtin.f32)
+    assert op.arg == val
+    assert op.result.type == builtin.f32
+
+
 def test_trunc_op_handles_missing_overflow_property():
     # verify printer handles manually deleted overflowflags gracefully
     op = llvm.TruncOp(create_ssa_value(builtin.i64), builtin.i32)

--- a/tests/filecheck/backend/llvm/convert_op.mlir
+++ b/tests/filecheck/backend/llvm/convert_op.mlir
@@ -503,7 +503,7 @@ builtin.module attributes {llvm.target_triple = "test-test-test"} {
   // CHECK-NEXT:   unreachable
   // CHECK-NEXT: }
 
-  llvm.func @casts(%arg0: i32, %arg1: i64, %arg2: !llvm.ptr, %arg3: f32) {
+  llvm.func @casts(%arg0: i32, %arg1: i64, %arg2: !llvm.ptr, %arg3: f32) -> f32 {
     %0 = llvm.trunc %arg1 : i64 to i32
     %1 = llvm.zext %arg0 : i32 to i64
     %2 = llvm.sext %arg0 : i32 to i64
@@ -512,10 +512,11 @@ builtin.module attributes {llvm.target_triple = "test-test-test"} {
     %5 = llvm.bitcast %arg1 : i64 to f64
     %6 = llvm.fpext %arg3 : f32 to f64
     %7 = llvm.sitofp %arg0 : i32 to f32
-    llvm.return
+    %8 = llvm.fptrunc %6 : f64 to f32
+    llvm.return %8 : f32
   }
 
-  // CHECK: define void @"casts"(i32 %".1", i64 %".2", ptr %".3", float %".4")
+  // CHECK: define float @"casts"(i32 %".1", i64 %".2", ptr %".3", float %".4")
   // CHECK-NEXT: {
   // CHECK-NEXT: {{.[0-9]+}}:
   // CHECK-NEXT:   {{%.+}} = trunc i64 %".2" to i32
@@ -524,9 +525,10 @@ builtin.module attributes {llvm.target_triple = "test-test-test"} {
   // CHECK-NEXT:   {{%.+}} = ptrtoint ptr %".3" to i64
   // CHECK-NEXT:   {{%.+}} = inttoptr i64 %".2" to ptr
   // CHECK-NEXT:   {{%.+}} = bitcast i64 %".2" to double
-  // CHECK-NEXT:   {{%.+}} = fpext float %".4" to double
+  // CHECK-NEXT:   [[EXT:%.+]] = fpext float %".4" to double
   // CHECK-NEXT:   {{%.+}} = sitofp i32 %".1" to float
-  // CHECK-NEXT:   ret void
+  // CHECK-NEXT:   [[TRUNC:%.+]] = fptrunc double [[EXT]] to float
+  // CHECK-NEXT:   ret float [[TRUNC]]
   // CHECK-NEXT: }
 
   llvm.func @casts_with_flags(%arg0: i32, %arg1: i64) {

--- a/tests/filecheck/dialects/llvm/example.mlir
+++ b/tests/filecheck/dialects/llvm/example.mlir
@@ -99,6 +99,10 @@ builtin.module {
 
 // CHECK-NEXT: %fval3 = llvm.fpext %fval : f32 to f64
 
+  %fval4 = llvm.fptrunc %fval3 : f64 to f32
+
+// CHECK-NEXT: %fval4 = llvm.fptrunc %fval3 : f64 to f32
+
   %vec1 = "test.op"() : () -> vector<4xf32>
   %vec2 = "test.op"() : () -> vector<4xf32>
   %shuf = llvm.shufflevector %vec1, %vec2 [0, 1, 2, 3] : vector<4xf32>

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/arithmetic.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/arithmetic.mlir
@@ -66,4 +66,7 @@ builtin.module {
 
     %frem = llvm.frem %f1, %f1 : f32
     // CHECK: llvm.frem [[f1]], [[f1]] : f32
+
+    %fptrunc = llvm.fptrunc %f1 : f32 to f16
+    // CHECK: llvm.fptrunc [[f1]] : f32 to f16
 }

--- a/xdsl/backend/llvm/convert_op.py
+++ b/xdsl/backend/llvm/convert_op.py
@@ -106,6 +106,7 @@ _CAST_OP_NAMES: dict[type[Operation], str] = {
     llvm.IntToPtrOp: "inttoptr",
     llvm.BitcastOp: "bitcast",
     llvm.FPExtOp: "fpext",
+    llvm.FPTruncOp: "fptrunc",
     llvm.SIToFPOp: "sitofp",
 }
 

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -3057,6 +3057,11 @@ class FPExtOp(GenericCastOp):
 
 
 @irdl_op_definition
+class FPTruncOp(GenericCastOp):
+    name = "llvm.fptrunc"
+
+
+@irdl_op_definition
 class FAbsOp(IRDLOperation):
     T: ClassVar = VarConstraint("T", AnyFloatConstr | VectorType.constr(AnyFloatConstr))
 
@@ -3809,6 +3814,7 @@ LLVM = Dialect(
         FMulOp,
         FNegOp,
         FPExtOp,
+        FPTruncOp,
         FPowOp,
         FRemOp,
         FSinOp,


### PR DESCRIPTION
Adds `llvm.fptrunc` and its LLVM translation, mirroring the existing `fpext` support.

This lets exojit narrow `f64` inputs for `expf` without defining its own op and monkey-patching the backend’s private cast map.

Related to #6073.