### PR TITLE
interpreter: (linalg) Use runtime shapes for structured op bounds

### DIFF
--- a/tests/interpreters/test_linalg_interpreter.py
+++ b/tests/interpreters/test_linalg_interpreter.py
@@ -7,6 +7,7 @@ import pytest
 from xdsl.builder import ImplicitBuilder
 from xdsl.dialects import arith, linalg
 from xdsl.dialects.builtin import (
+    DYNAMIC_INDEX,
     AffineMapAttr,
     DenseArrayBase,
     DenseIntOrFPElementsAttr,
@@ -160,6 +161,74 @@ def test_linalg_generic_scalar():
     interpreter.run_op(op, (a, b, c))
 
     assert c.data == [2, 4, 6, 8, 10, 12]
+
+
+@pytest.mark.parametrize("tensor", [False, True])
+def test_linalg_generic_dynamic_identity_reuses_ir(tensor: bool):
+    interpreter = Interpreter(ModuleOp([]))
+    interpreter.register_implementations(LinalgFunctions())
+    array_type = (TensorType if tensor else MemRefType)(i32, [DYNAMIC_INDEX])
+
+    op = linalg.ops.GenericOp(
+        (create_ssa_value(array_type),),
+        (create_ssa_value(array_type),),
+        Region(Block(arg_types=(i32, i32))),
+        (AffineMapAttr(AffineMap.identity(1)),) * 2,
+        (linalg.attrs.IteratorTypeAttr.parallel(),),
+        (array_type,) if tensor else (),
+    )
+
+    with ImplicitBuilder(op.body) as (a, _):
+        linalg.ops.YieldOp(a)
+    op.verify()
+
+    for values in ([], [1], [1, 2, 3], [1, 2, 3, 4, 5]):
+        input_array = ShapedArray(TypedPtr.new_int32(values), [len(values)])
+        initial_output = ShapedArray(
+            TypedPtr.new_int32([-1] * len(values)), [len(values)]
+        )
+
+        results = interpreter.run_op(op, (input_array, initial_output))
+
+        assert input_array.data == values
+        if tensor:
+            (output_array,) = results
+            assert initial_output.data == [-1] * len(values)
+            assert output_array is not initial_output
+        else:
+            assert results == ()
+            output_array = initial_output
+        assert output_array == ShapedArray(TypedPtr.new_int32(values), [len(values)])
+
+
+def test_linalg_transpose_dynamic_reuses_ir():
+    interpreter = Interpreter(ModuleOp([]))
+    interpreter.register_implementations(LinalgFunctions())
+    op = linalg.ops.TransposeOp(
+        create_ssa_value(TensorType(i32, [DYNAMIC_INDEX, DYNAMIC_INDEX])),
+        create_ssa_value(TensorType(i32, [DYNAMIC_INDEX, DYNAMIC_INDEX])),
+        DenseArrayBase.from_list(i64, [1, 0]),
+        TensorType(i32, [DYNAMIC_INDEX, DYNAMIC_INDEX]),
+    )
+    op.verify()
+
+    for input_shape, values, expected in (
+        ((0, 3), [], []),
+        ((2, 3), [1, 2, 3, 4, 5, 6], [1, 4, 2, 5, 3, 6]),
+    ):
+        output_shape = (input_shape[1], input_shape[0])
+        input_array = ShapedArray(TypedPtr.new_int32(values), list(input_shape))
+        initial_output = ShapedArray(
+            TypedPtr.new_int32([-1] * len(expected)), list(output_shape)
+        )
+
+        (output_array,) = interpreter.run_op(op, (input_array, initial_output))
+
+        assert input_array.data == values
+        assert initial_output.data == [-1] * len(expected)
+        assert output_array == ShapedArray(
+            TypedPtr.new_int32(expected), list(output_shape)
+        )
 
 
 def test_linalg_generic_reduction():

--- a/xdsl/interpreters/linalg.py
+++ b/xdsl/interpreters/linalg.py
@@ -30,7 +30,6 @@ def run_linalg_structured_op(
     output_args = args[inputs_count:]
     results = op.results
     indexing_maps = tuple(attr.data for attr in op.get_indexing_maps())
-    loop_ranges = op.get_static_loop_ranges()
 
     if any(not isinstance(arg, ShapedArray) for arg in output_args):
         raise NotImplementedError("Only shaped out results are implemented")
@@ -43,6 +42,18 @@ def run_linalg_structured_op(
         outputs = output_args
 
     loop_shaped_args = input_args + outputs
+
+    # Static loop ranges use DYNAMIC_INDEX for dynamic dimensions, which makes
+    # ``range`` silently skip every iteration. Infer the operand shape list
+    # from the runtime shaped arguments instead, preserving the existing
+    # shapes-to-loops mapping (and scalar operand handling).
+    runtime_shapes = [
+        dim
+        for arg in loop_shaped_args
+        if isinstance(arg, ShapedArray)
+        for dim in arg.shape
+    ]
+    loop_ranges = op.get_shapes_to_loops_map().eval(runtime_shapes, [])
 
     output_indexing_maps = indexing_maps[inputs_count:]
 


### PR DESCRIPTION
The linalg interpreter currently uses `get_static_loop_ranges()` even when an operand has dynamic dimensions. The resulting negative `DYNAMIC_INDEX` value reaches Python's `range()`, so the operation can return normally without executing its body.

This uses the runtime `ShapedArray` dimensions with the existing shapes-to-loops map instead. Operand order, scalar handling, and buffer/tensor output behavior are preserved. The change is confined to the interpreter; it does not change static shape inference used by compiler passes.

For example, passing this verified program on stdin to `python -m xdsl.tools.xdsl_run --verbose` returns `[0, 0, 0]` before the fix and `[7, 7, 7]` afterward:

```mlir
builtin.module {
  func.func @main() -> tensor<?xi32> {
    %n = arith.constant 3 : index
    %out = tensor.empty(%n) : tensor<?xi32>
    %result = linalg.generic {
      indexing_maps = [affine_map<(i) -> (i)>],
      iterator_types = ["parallel"]
    } outs(%out : tensor<?xi32>) {
    ^bb0(%old: i32):
      %seven = arith.constant 7 : i32
      linalg.yield %seven : i32
    } -> tensor<?xi32>
    func.return %result : tensor<?xi32>
  }
}
```

The added regressions reuse the same dynamic IR at different runtime sizes, including empty arrays. They cover buffer and tensor identity operations, tensor output ownership, and transpose. All three new test cases fail on the original implementation.

Validation on base `22851b409917c940ace3c25d53223aa14b0ee338` plus this patch:

- `pytest tests/interpreters`: 1,053 passed, no failures or skips.
- Focused Ruff, formatting and Pyright checks passed.
- The normal runner reproduction above and its empty-array control passed after the fix.

This does not add support for indexing maps that the existing shapes-to-loops implementation rejects.

Developed and checked with AI assistance.
